### PR TITLE
Fix streak bug for time zone travel

### DIFF
--- a/app/Mile A Day/Views/DashboardView.swift
+++ b/app/Mile A Day/Views/DashboardView.swift
@@ -121,9 +121,11 @@ struct DashboardView: View {
                     syncWidgetData()
                 }
                 
-                // Check if this is the first time opening the app after completing today's goal
-                let today = Calendar.current.startOfDay(for: Date())
-                let lastCompletion = Calendar.current.startOfDay(for: lastGoalCompletionDate)
+                // Check if this is the first time opening the app after completing today's goal (UTC-based)
+                var utcCal = Calendar.current
+                utcCal.timeZone = TimeZone(secondsFromGMT: 0)!
+                let today = utcCal.startOfDay(for: Date())
+                let lastCompletion = utcCal.startOfDay(for: lastGoalCompletionDate)
                 
                 if currentState.isCompleted && today != lastCompletion {
                     // This is the first time opening after completing today's goal

--- a/app/Mile A Day/Views/StepsView.swift
+++ b/app/Mile A Day/Views/StepsView.swift
@@ -149,7 +149,11 @@ struct StepsCalendarView: View {
     @Binding var currentMonth: Date
     let onDateSelected: (Date) -> Void
     
-    private let calendar = Calendar.current
+    private var calendar: Calendar = {
+        var cal = Calendar.current
+        cal.timeZone = TimeZone(secondsFromGMT: 0)!
+        return cal
+    }()
     private let daysInWeek = 7
     private let weeksToShow = 6
     
@@ -253,7 +257,11 @@ struct CalendarDayView: View {
     let isCurrentMonth: Bool
     let onTap: () -> Void
     
-    private let calendar = Calendar.current
+    private var calendar: Calendar = {
+        var cal = Calendar.current
+        cal.timeZone = TimeZone(secondsFromGMT: 0)!
+        return cal
+    }()
     private let stepGoal: Double = 10000
     
     var body: some View {
@@ -325,7 +333,11 @@ struct DateDetailView: View {
     @State private var selectedWorkout: IdentifiableWorkout?
     @State private var currentDate: Date
     
-    private let calendar = Calendar.current
+    private var calendar: Calendar = {
+        var cal = Calendar.current
+        cal.timeZone = TimeZone(secondsFromGMT: 0)!
+        return cal
+    }()
     
     init(date: Date, healthManager: HealthKitManager, userManager: UserManager) {
         self.date = date

--- a/app/Mile A Day/Widgets/StreakCountWidget.swift
+++ b/app/Mile A Day/Widgets/StreakCountWidget.swift
@@ -22,6 +22,12 @@ struct StreakCountProvider: TimelineProvider {
         )
     }
 
+    private var utcCalendar: Calendar {
+        var cal = Calendar.current
+        cal.timeZone = TimeZone(secondsFromGMT: 0)!
+        return cal
+    }
+
     func getSnapshot(in context: Context, completion: @escaping (StreakCountEntry) -> Void) {
         let streak = WidgetDataStore.loadStreak()
         let widgetData = WidgetDataStore.load()
@@ -31,7 +37,7 @@ struct StreakCountProvider: TimelineProvider {
         let progress = widgetData.progress
         
         // Calculate risk status and time remaining
-        let currentHour = Calendar.current.component(.hour, from: Date())
+        let currentHour = utcCalendar.component(.hour, from: Date())
         let isAtRisk = currentHour >= 18 && !isGoalCompleted
         
         // Calculate time until reset if not completed
@@ -58,7 +64,7 @@ struct StreakCountProvider: TimelineProvider {
         let progress = widgetData.progress
         
         // Calculate risk status and time remaining
-        let currentHour = Calendar.current.component(.hour, from: Date())
+        let currentHour = utcCalendar.component(.hour, from: Date())
         let isAtRisk = currentHour >= 18 && !isGoalCompleted
         
         // Calculate time until reset if not completed
@@ -84,10 +90,10 @@ struct StreakCountProvider: TimelineProvider {
     private func calculateTimeUntilReset(isCompleted: Bool) -> String? {
         if isCompleted { return nil }
         
-        let calendar = Calendar.current
+        let calendar = utcCalendar
         let now = Date()
         
-        // Get end of today
+        // Get end of today in UTC
         guard let endOfDay = calendar.date(bySettingHour: 23, minute: 59, second: 59, of: now) else {
             return nil
         }


### PR DESCRIPTION
Update streak and daily goal calculations to use UTC day boundaries to prevent streaks from breaking due to timezone changes when traveling.

The app previously calculated "today" and streak continuity based on the device's current time zone. This caused streaks to incorrectly end for users traveling across time zones, as a completed day in one time zone might be considered incomplete or a different day in another. This change ensures daily progress and streaks are consistently maintained regardless of the user's current geographical location.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a14585d-b5f4-4e68-a779-4a0b8ffa5836">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a14585d-b5f4-4e68-a779-4a0b8ffa5836">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

