### PR TITLE
Add headline yearly milestone celebration

### DIFF
--- a/app/Mile A Day/Managers/CelebrationManager.swift
+++ b/app/Mile A Day/Managers/CelebrationManager.swift
@@ -258,6 +258,8 @@ enum CelebrationType: Identifiable, Equatable {
     case postGoalWorkout(stats: GoalCompletionStats)
     case badgeUnlocked(badge: Badge)
     case milestone(title: String, description: String, icon: String)
+    /// Headline yearly streak celebration — fired at every multiple of 365 days.
+    case yearMilestone(info: YearlyMilestoneInfo)
 
     var id: String {
         switch self {
@@ -269,6 +271,8 @@ enum CelebrationType: Identifiable, Equatable {
             return "badge-\(badge.id)"
         case .milestone(let title, _, _):
             return "milestone-\(title)"
+        case .yearMilestone(let info):
+            return "year-milestone-\(info.years)"
         }
     }
 
@@ -282,6 +286,8 @@ enum CelebrationType: Identifiable, Equatable {
             return b1.id == b2.id
         case (.milestone(let t1, _, _), .milestone(let t2, _, _)):
             return t1 == t2
+        case (.yearMilestone(let i1), .yearMilestone(let i2)):
+            return i1.years == i2.years
         default:
             return false
         }
@@ -402,6 +408,7 @@ class CelebrationManager: ObservableObject {
     /// Priority for ordering celebrations: lower = shown first
     private func priority(of celebration: CelebrationType) -> Int {
         switch celebration {
+        case .yearMilestone: return -1 // Headline moment — always first
         case .goalCompleted: return 0
         case .postGoalWorkout: return 1
         case .badgeUnlocked: return 2

--- a/app/Mile A Day/Models/UserManager.swift
+++ b/app/Mile A Day/Models/UserManager.swift
@@ -335,11 +335,17 @@ class UserManager: ObservableObject {
                 currentUser.badges = fetched
                 saveUserData()
 
+                // Decide whether a yearly headline celebration is owed BEFORE we
+                // queue any badge celebrations. If yes, suppress the matching
+                // 365/730/etc. badge popups so they don't pile on top.
+                let yearlyOwed = checkAndQueueYearlyCelebration()
+                let suppressedBadgeIDs: Set<String> = yearlyOwed ? suppressedBadgeIDsForYearly() : []
+
                 // Celebrate freshly-earned badges (not previously present).
                 let today = Calendar.current.startOfDay(for: Date())
                 for badge in fetched {
                     let earnedToday = Calendar.current.startOfDay(for: badge.dateAwarded) == today
-                    if earnedToday && !existingIds.contains(badge.id) {
+                    if earnedToday && !existingIds.contains(badge.id) && !suppressedBadgeIDs.contains(badge.id) {
                         CelebrationManager.shared.addCelebration(.badgeUnlocked(badge: badge))
                     }
                 }
@@ -348,6 +354,50 @@ class UserManager: ObservableObject {
             print("[UserManager] refreshBadgesFromServer failed: \(error)")
         }
         #endif
+    }
+
+    // MARK: - Yearly milestone
+
+    /// Persists the highest year-boundary streak we've already celebrated (e.g. 365, 730, 1095…).
+    /// `-1` is the uninitialized sentinel so existing users with mid-year streaks aren't
+    /// retroactively flooded with year-1/2/3 animations on first launch with this feature.
+    @AppStorage("lastCelebratedYearMilestoneStreak") private var lastCelebratedYearMilestoneStreak: Int = -1
+
+    /// Returns true if a yearly celebration was queued.
+    @discardableResult
+    private func checkAndQueueYearlyCelebration() -> Bool {
+        let streak = currentUser.streak
+        let currentYearBoundary = (streak / 365) * 365
+
+        // First-run init: skip retroactively firing for users whose streak already
+        // crossed year boundaries before this feature shipped.
+        if lastCelebratedYearMilestoneStreak == -1 {
+            lastCelebratedYearMilestoneStreak = currentYearBoundary
+            return false
+        }
+
+        guard currentYearBoundary >= 365,
+              currentYearBoundary > lastCelebratedYearMilestoneStreak
+        else { return false }
+
+        let years = currentYearBoundary / 365
+        let startDate = Calendar.current.date(byAdding: .day, value: -streak, to: Date())
+        let info = YearlyMilestoneInfo(
+            years: years,
+            totalMiles: currentUser.totalMiles,
+            totalStreakDays: streak,
+            streakStartDate: startDate
+        )
+
+        CelebrationManager.shared.addCelebration(.yearMilestone(info: info))
+        lastCelebratedYearMilestoneStreak = currentYearBoundary
+        return true
+    }
+
+    /// Streak-badge IDs that should be silenced when a yearly celebration is firing
+    /// for the same milestone day.
+    private func suppressedBadgeIDsForYearly() -> Set<String> {
+        ["streak_365", "streak_730"]
     }
 
     /// Legacy shim — kept so existing callers compile. Delegates to the server-side fetch.

--- a/app/Mile A Day/Views/Celebrations/CelebrationContainerView.swift
+++ b/app/Mile A Day/Views/Celebrations/CelebrationContainerView.swift
@@ -40,6 +40,9 @@ struct CelebrationContainerView: View {
                 description: description,
                 icon: icon
             )
+
+        case .yearMilestone(let info):
+            YearlyMilestoneCelebrationView(info: info)
         }
     }
 }

--- a/app/Mile A Day/Views/Celebrations/YearlyMilestoneCelebrationView.swift
+++ b/app/Mile A Day/Views/Celebrations/YearlyMilestoneCelebrationView.swift
@@ -1,0 +1,503 @@
+//
+//  YearlyMilestoneCelebrationView.swift
+//  Mile A Day
+//
+//  Headline celebration for completing a full year (or every subsequent year).
+//  Multi-phase choreography designed to feel exceptional and shareable.
+//
+
+import SwiftUI
+
+// MARK: - Info struct
+
+/// Snapshot of the user's state at the moment they crossed a year boundary.
+struct YearlyMilestoneInfo: Equatable {
+    let years: Int
+    let totalMiles: Double
+    let totalStreakDays: Int
+    /// Approximate date the current streak began (today minus streak days).
+    let streakStartDate: Date?
+}
+
+// MARK: - View
+
+struct YearlyMilestoneCelebrationView: View {
+    let info: YearlyMilestoneInfo
+    @ObservedObject var manager = CelebrationManager.shared
+
+    // Phase flags
+    @State private var phase1_rays = false
+    @State private var phase2_calendar = false
+    @State private var phase2_yearNumber = false
+    @State private var phase3_confetti = false
+    @State private var phase3_fireworks = false
+    @State private var phase4_stats = false
+    @State private var phase4_buttons = false
+
+    // Continuous effects
+    @State private var sustainedShimmer = false
+    @State private var yearNumberScale: CGFloat = 0.2
+    @State private var yearNumberRotation: Double = 90
+    @State private var yearNumberOpacity: Double = 0
+
+    // Calendar flip
+    @State private var calendarDay: Int = 1
+    @State private var calendarFlipProgress: Double = 0
+    @State private var calendarOpacity: Double = 0
+
+    // Backstop
+    @State private var hasStarted = false
+    @State private var skipVisible = false
+
+    // Haptics
+    private let tapHaptic = UIImpactFeedbackGenerator(style: .light)
+    private let mediumHaptic = UIImpactFeedbackGenerator(style: .medium)
+    private let heavyHaptic = UIImpactFeedbackGenerator(style: .heavy)
+    private let successHaptic = UINotificationFeedbackGenerator()
+
+    private var palette: YearPalette { YearPalette.forYear(info.years) }
+
+    private var totalDaysInWindow: Int {
+        // Show "of 365" for year 1, "of 730" for year 2, etc.
+        info.years * 365
+    }
+
+    private var subtitle: String {
+        switch info.years {
+        case 1:  return "365 days. One full year. Legendary."
+        case 2:  return "Two full years. You're built different."
+        case 3:  return "Three years strong. Pure dedication."
+        case 4:  return "Four years and counting. Unstoppable."
+        case 5:  return "Half a decade of showing up."
+        case 10: return "A full decade of miles. You are a legend."
+        case 25: return "Twenty-five years. A lifetime of dedication."
+        default: return "\(info.years) full years of showing up."
+        }
+    }
+
+    private var headline: String {
+        info.years == 1 ? "ONE YEAR" : "\(info.years) YEARS"
+    }
+
+    private var shareText: String {
+        let miles = Int(info.totalMiles.rounded())
+        return "I just hit \(info.years == 1 ? "1 YEAR" : "\(info.years) YEARS") of running a mile every day on Mile A Day. \(miles) miles and counting. 🏃"
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack {
+                LinearGradient(
+                    colors: palette.backgroundGradient,
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .ignoresSafeArea()
+
+                if phase1_rays {
+                    GoldenRaysEffect(color: palette.primary)
+                        .ignoresSafeArea()
+                        .transition(.opacity)
+                }
+
+                if phase3_confetti {
+                    YearlyConfettiView(colors: palette.confettiColors, particleCount: 110)
+                        .ignoresSafeArea()
+                        .transition(.opacity)
+                }
+
+                if phase3_fireworks {
+                    FireworksShow(palette: palette)
+                        .ignoresSafeArea()
+                        .transition(.opacity)
+                }
+
+                if phase4_stats {
+                    FloatingStarsEffect(color: palette.primary, starCount: 24)
+                        .opacity(0.55)
+                        .ignoresSafeArea()
+                }
+
+                content(in: geo)
+
+                if skipVisible {
+                    skipButton
+                }
+            }
+        }
+        .onAppear {
+            guard !hasStarted else { return }
+            hasStarted = true
+            tapHaptic.prepare(); mediumHaptic.prepare(); heavyHaptic.prepare(); successHaptic.prepare()
+            runChoreography()
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private func content(in geo: GeometryProxy) -> some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 60)
+
+            ZStack {
+                if phase2_calendar && !phase2_yearNumber {
+                    CalendarFlipCard(
+                        palette: palette,
+                        dayNumber: calendarDay,
+                        totalDays: totalDaysInWindow,
+                        flipProgress: calendarFlipProgress
+                    )
+                    .frame(width: 240, height: 220)
+                    .opacity(calendarOpacity)
+                    .transition(.scale(scale: 0.7).combined(with: .opacity))
+                }
+
+                if phase2_yearNumber {
+                    yearNumeralBlock
+                        .transition(.scale.combined(with: .opacity))
+                }
+            }
+            .frame(height: 320)
+
+            Spacer(minLength: 12)
+
+            if phase4_stats {
+                statsCard
+                    .padding(.horizontal, MADTheme.Spacing.lg)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+
+            Spacer(minLength: 16)
+
+            if phase4_buttons {
+                buttonRow
+                    .padding(.horizontal, MADTheme.Spacing.lg)
+                    .padding(.bottom, MADTheme.Spacing.xl)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+    }
+
+    // MARK: - Year numeral
+
+    @ViewBuilder
+    private var yearNumeralBlock: some View {
+        VStack(spacing: 6) {
+            Text(eyebrowLabel)
+                .font(.system(size: 16, weight: .heavy, design: .rounded))
+                .tracking(8)
+                .foregroundColor(palette.accent.opacity(0.85))
+
+            Text(headline)
+                .font(.system(size: info.years > 9 ? 96 : 120, weight: .black, design: .rounded))
+                .foregroundStyle(
+                    LinearGradient(colors: palette.textGradient, startPoint: .top, endPoint: .bottom)
+                )
+                .scaleEffect(yearNumberScale)
+                .rotation3DEffect(
+                    .degrees(yearNumberRotation),
+                    axis: (x: 1, y: 0, z: 0),
+                    perspective: 0.7
+                )
+                .opacity(yearNumberOpacity)
+                .shadow(color: palette.primary.opacity(0.55), radius: 30, x: 0, y: 0)
+                .modifier(YearNumberShimmer(active: sustainedShimmer, color: palette.accent))
+
+            Text(subtitle)
+                .font(.system(size: 19, weight: .bold, design: .rounded))
+                .foregroundColor(palette.accent)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, MADTheme.Spacing.lg)
+                .padding(.top, 6)
+                .opacity(yearNumberOpacity)
+        }
+    }
+
+    private var eyebrowLabel: String {
+        info.years == 1 ? "STREAK COMPLETE" : "ANOTHER YEAR DOWN"
+    }
+
+    // MARK: - Stats card
+
+    @ViewBuilder
+    private var statsCard: some View {
+        HStack(spacing: 0) {
+            statColumn(
+                value: "\(Int(info.totalMiles.rounded()))",
+                label: info.totalMiles == 1 ? "Mile" : "Miles"
+            )
+            statDivider
+            statColumn(
+                value: "\(info.totalStreakDays)",
+                label: "Day Streak"
+            )
+            statDivider
+            statColumn(
+                value: streakStartLabel,
+                label: "Began"
+            )
+        }
+        .padding(.vertical, MADTheme.Spacing.md)
+        .padding(.horizontal, MADTheme.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .overlay(
+                    RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
+                        .strokeBorder(palette.primary.opacity(0.4), lineWidth: 1)
+                )
+        )
+    }
+
+    private func statColumn(value: String, label: String) -> some View {
+        VStack(spacing: 4) {
+            Text(value)
+                .font(.system(size: 22, weight: .bold, design: .rounded))
+                .foregroundStyle(
+                    LinearGradient(colors: palette.textGradient, startPoint: .top, endPoint: .bottom)
+                )
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+            Text(label.uppercased())
+                .font(.system(size: 11, weight: .heavy, design: .rounded))
+                .tracking(1.2)
+                .foregroundColor(palette.accent.opacity(0.75))
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var statDivider: some View {
+        Rectangle()
+            .fill(palette.primary.opacity(0.25))
+            .frame(width: 1, height: 32)
+    }
+
+    private var streakStartLabel: String {
+        guard let start = info.streakStartDate else { return "—" }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, yyyy"
+        return formatter.string(from: start)
+    }
+
+    // MARK: - Buttons
+
+    @ViewBuilder
+    private var buttonRow: some View {
+        VStack(spacing: 12) {
+            ShareLink(item: shareText) {
+                HStack(spacing: 8) {
+                    Image(systemName: "square.and.arrow.up.fill")
+                    Text("Share This Win")
+                }
+                .font(.system(size: 17, weight: .bold, design: .rounded))
+                .foregroundColor(palette.backgroundGradient.first ?? .black)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(
+                    RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
+                        .fill(
+                            LinearGradient(
+                                colors: [palette.primary, palette.secondary],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                        )
+                        .shadow(color: palette.primary.opacity(0.6), radius: 16, x: 0, y: 6)
+                )
+            }
+
+            Button {
+                manager.dismissCurrentCelebration()
+            } label: {
+                Text("Keep Going")
+                    .font(.system(size: 17, weight: .semibold, design: .rounded))
+                    .foregroundColor(palette.accent)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
+                            .strokeBorder(palette.primary.opacity(0.5), lineWidth: 1)
+                    )
+            }
+        }
+    }
+
+    // MARK: - Skip
+
+    private var skipButton: some View {
+        VStack {
+            HStack {
+                Spacer()
+                Button {
+                    manager.dismissCurrentCelebration()
+                } label: {
+                    Text("Skip")
+                        .font(.system(size: 14, weight: .semibold, design: .rounded))
+                        .foregroundColor(palette.accent.opacity(0.6))
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 6)
+                        .background(
+                            Capsule().fill(.ultraThinMaterial)
+                        )
+                }
+                .padding(.trailing, 16)
+                .padding(.top, 8)
+            }
+            Spacer()
+        }
+        .transition(.opacity)
+    }
+
+    // MARK: - Choreography
+
+    private func runChoreography() {
+        // Phase 1: rays + first soft haptic
+        withAnimation(.easeOut(duration: 0.8)) {
+            phase1_rays = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { tapHaptic.impactOccurred(intensity: 0.6) }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.85) { tapHaptic.impactOccurred(intensity: 0.8) }
+
+        // Phase 2a: calendar appears at ~1.4s
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
+            withAnimation(.spring(response: 0.45, dampingFraction: 0.78)) {
+                phase2_calendar = true
+                calendarOpacity = 1
+            }
+            startCalendarFlipping()
+            // Allow user to skip after the calendar appears.
+            withAnimation(.easeIn(duration: 0.4).delay(0.3)) { skipVisible = true }
+        }
+
+        // Phase 2b: year numeral at ~3.6s (after calendar lands)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.6) {
+            withAnimation(.easeOut(duration: 0.3)) {
+                calendarOpacity = 0
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                phase2_yearNumber = true
+                yearNumberOpacity = 0.0
+                yearNumberScale = 0.4
+                yearNumberRotation = 90
+                mediumHaptic.impactOccurred()
+
+                withAnimation(.easeOut(duration: 0.5)) {
+                    yearNumberOpacity = 1
+                }
+                withAnimation(.spring(response: 0.7, dampingFraction: 0.55)) {
+                    yearNumberScale = 1.0
+                    yearNumberRotation = 0
+                }
+            }
+        }
+
+        // Phase 3: climax — confetti + fireworks + chord at ~4.5s
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4.5) {
+            withAnimation(.easeOut(duration: 0.4)) {
+                phase3_confetti = true
+                phase3_fireworks = true
+            }
+            heavyHaptic.impactOccurred()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) { heavyHaptic.impactOccurred() }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.36) { heavyHaptic.impactOccurred() }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.55) { successHaptic.notificationOccurred(.success) }
+            // Sustained shimmer over numeral
+            sustainedShimmer = true
+        }
+
+        // Phase 4: stats + buttons at ~6.0s
+        DispatchQueue.main.asyncAfter(deadline: .now() + 6.0) {
+            withAnimation(.spring(response: 0.55, dampingFraction: 0.82)) {
+                phase4_stats = true
+            }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 6.5) {
+            withAnimation(.spring(response: 0.55, dampingFraction: 0.82)) {
+                phase4_buttons = true
+            }
+        }
+    }
+
+    /// Animates the calendar through every day of the year via shrinking time slices.
+    /// Uses a manually scheduled sequence so users can see the count visibly racing,
+    /// rather than a single linear interpolation that would look static at high counts.
+    private func startCalendarFlipping() {
+        let target = totalDaysInWindow
+        // ~2.0 seconds total, ~80 visible "ticks" with eased acceleration then deceleration
+        let tickCount = 80
+        let totalDuration: Double = 2.0
+        for i in 0...tickCount {
+            // Ease in-out so it speeds up then slows on landing
+            let t = Double(i) / Double(tickCount)
+            let eased = easeInOut(t)
+            let day = max(1, Int(round(eased * Double(target))))
+            // Distribute timing in eased bands so visible count looks like a real accelerator
+            let scheduledAt = totalDuration * easeInOutTiming(t)
+            DispatchQueue.main.asyncAfter(deadline: .now() + scheduledAt) {
+                calendarDay = day
+                if i.isMultiple(of: 8) { tapHaptic.impactOccurred(intensity: 0.4) }
+                withAnimation(.linear(duration: 0.04)) {
+                    calendarFlipProgress = (i.isMultiple(of: 2) ? 1 : -1)
+                }
+            }
+        }
+        // Land on final number with a satisfying thump
+        DispatchQueue.main.asyncAfter(deadline: .now() + totalDuration + 0.05) {
+            calendarDay = target
+            withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
+                calendarFlipProgress = 0
+            }
+            mediumHaptic.impactOccurred()
+        }
+    }
+
+    private func easeInOut(_ t: Double) -> Double {
+        // Smoothstep
+        let clamped = max(0, min(1, t))
+        return clamped * clamped * (3 - 2 * clamped)
+    }
+
+    private func easeInOutTiming(_ t: Double) -> Double {
+        // A slightly stronger ease so the early ticks fly by and the last few linger
+        let clamped = max(0, min(1, t))
+        return clamped < 0.5
+            ? 2 * clamped * clamped
+            : 1 - pow(-2 * clamped + 2, 2) / 2
+    }
+}
+
+#Preview("Year 1") {
+    YearlyMilestoneCelebrationView(
+        info: YearlyMilestoneInfo(
+            years: 1,
+            totalMiles: 412.7,
+            totalStreakDays: 365,
+            streakStartDate: Calendar.current.date(byAdding: .day, value: -365, to: Date())
+        )
+    )
+}
+
+#Preview("Year 3") {
+    YearlyMilestoneCelebrationView(
+        info: YearlyMilestoneInfo(
+            years: 3,
+            totalMiles: 1284.5,
+            totalStreakDays: 1095,
+            streakStartDate: Calendar.current.date(byAdding: .day, value: -1095, to: Date())
+        )
+    )
+}
+
+#Preview("Year 10") {
+    YearlyMilestoneCelebrationView(
+        info: YearlyMilestoneInfo(
+            years: 10,
+            totalMiles: 4280,
+            totalStreakDays: 3650,
+            streakStartDate: Calendar.current.date(byAdding: .day, value: -3650, to: Date())
+        )
+    )
+}

--- a/app/Mile A Day/Views/Celebrations/YearlyParticleEffects.swift
+++ b/app/Mile A Day/Views/Celebrations/YearlyParticleEffects.swift
@@ -1,0 +1,515 @@
+//
+//  YearlyParticleEffects.swift
+//  Mile A Day
+//
+//  Visual effects reserved for the once-a-year milestone celebration.
+//  Designed to feel premium and distinct from the per-badge celebrations.
+//
+
+import SwiftUI
+
+// MARK: - Palette
+
+/// Per-year color palette. Each year evolves the look so subsequent years feel
+/// fresh, but every year retains the same lavish choreography (no year is "lesser").
+struct YearPalette {
+    let primary: Color
+    let secondary: Color
+    let accent: Color
+    let textGradient: [Color]
+    let confettiColors: [Color]
+    let backgroundGradient: [Color]
+    let label: String
+
+    static func forYear(_ year: Int) -> YearPalette {
+        switch max(1, year) {
+        case 1:
+            return YearPalette(
+                primary:   Color(red: 1.00, green: 0.84, blue: 0.30),
+                secondary: Color(red: 0.95, green: 0.62, blue: 0.18),
+                accent:    Color(red: 1.00, green: 0.95, blue: 0.65),
+                textGradient: [
+                    Color(red: 1.00, green: 0.97, blue: 0.78),
+                    Color(red: 1.00, green: 0.84, blue: 0.30),
+                    Color(red: 0.85, green: 0.55, blue: 0.10)
+                ],
+                confettiColors: [
+                    Color(red: 1.00, green: 0.84, blue: 0.30),
+                    Color(red: 1.00, green: 0.93, blue: 0.55),
+                    Color(red: 0.92, green: 0.62, blue: 0.10),
+                    .white
+                ],
+                backgroundGradient: [
+                    Color(red: 0.10, green: 0.07, blue: 0.04),
+                    Color(red: 0.18, green: 0.12, blue: 0.04),
+                    Color(red: 0.05, green: 0.03, blue: 0.02)
+                ],
+                label: "Gold"
+            )
+        case 2:
+            return YearPalette(
+                primary:   Color(red: 0.97, green: 0.66, blue: 0.62),
+                secondary: Color(red: 0.85, green: 0.42, blue: 0.45),
+                accent:    Color(red: 1.00, green: 0.85, blue: 0.80),
+                textGradient: [
+                    Color(red: 1.00, green: 0.92, blue: 0.88),
+                    Color(red: 0.97, green: 0.66, blue: 0.62),
+                    Color(red: 0.78, green: 0.36, blue: 0.40)
+                ],
+                confettiColors: [
+                    Color(red: 0.97, green: 0.66, blue: 0.62),
+                    Color(red: 1.00, green: 0.85, blue: 0.80),
+                    Color(red: 0.80, green: 0.40, blue: 0.45),
+                    Color(red: 1.00, green: 0.93, blue: 0.88)
+                ],
+                backgroundGradient: [
+                    Color(red: 0.10, green: 0.05, blue: 0.05),
+                    Color(red: 0.16, green: 0.07, blue: 0.08),
+                    Color(red: 0.05, green: 0.02, blue: 0.03)
+                ],
+                label: "Rose Gold"
+            )
+        case 3:
+            return YearPalette(
+                primary:   Color(red: 0.85, green: 0.88, blue: 0.93),
+                secondary: Color(red: 0.62, green: 0.66, blue: 0.74),
+                accent:    .white,
+                textGradient: [
+                    .white,
+                    Color(red: 0.88, green: 0.92, blue: 0.96),
+                    Color(red: 0.55, green: 0.62, blue: 0.72)
+                ],
+                confettiColors: [
+                    Color(red: 0.92, green: 0.94, blue: 0.97),
+                    Color(red: 0.70, green: 0.74, blue: 0.82),
+                    .white,
+                    Color(red: 0.45, green: 0.52, blue: 0.62)
+                ],
+                backgroundGradient: [
+                    Color(red: 0.06, green: 0.07, blue: 0.10),
+                    Color(red: 0.10, green: 0.12, blue: 0.16),
+                    Color(red: 0.03, green: 0.04, blue: 0.06)
+                ],
+                label: "Platinum"
+            )
+        case 4:
+            return YearPalette(
+                primary:   Color(red: 0.40, green: 0.65, blue: 0.98),
+                secondary: Color(red: 0.18, green: 0.40, blue: 0.85),
+                accent:    Color(red: 0.85, green: 0.93, blue: 1.00),
+                textGradient: [
+                    Color(red: 0.92, green: 0.96, blue: 1.00),
+                    Color(red: 0.40, green: 0.65, blue: 0.98),
+                    Color(red: 0.10, green: 0.30, blue: 0.78)
+                ],
+                confettiColors: [
+                    Color(red: 0.40, green: 0.65, blue: 0.98),
+                    Color(red: 0.85, green: 0.93, blue: 1.00),
+                    Color(red: 0.18, green: 0.40, blue: 0.85),
+                    .white
+                ],
+                backgroundGradient: [
+                    Color(red: 0.04, green: 0.06, blue: 0.12),
+                    Color(red: 0.06, green: 0.10, blue: 0.20),
+                    Color(red: 0.02, green: 0.03, blue: 0.07)
+                ],
+                label: "Sapphire"
+            )
+        case 5...9:
+            return YearPalette(
+                primary:   Color(red: 0.75, green: 0.95, blue: 1.00),
+                secondary: Color(red: 0.45, green: 0.85, blue: 0.95),
+                accent:    .white,
+                textGradient: [
+                    .white,
+                    Color(red: 0.85, green: 0.97, blue: 1.00),
+                    Color(red: 0.40, green: 0.80, blue: 0.95)
+                ],
+                confettiColors: [
+                    .white,
+                    Color(red: 0.75, green: 0.95, blue: 1.00),
+                    Color(red: 0.45, green: 0.85, blue: 0.95),
+                    Color(red: 0.92, green: 0.98, blue: 1.00)
+                ],
+                backgroundGradient: [
+                    Color(red: 0.04, green: 0.08, blue: 0.10),
+                    Color(red: 0.06, green: 0.12, blue: 0.16),
+                    Color(red: 0.02, green: 0.04, blue: 0.06)
+                ],
+                label: "Diamond"
+            )
+        default:
+            return YearPalette(
+                primary:   Color(red: 0.95, green: 0.55, blue: 0.95),
+                secondary: Color(red: 0.40, green: 0.85, blue: 0.95),
+                accent:    Color(red: 1.00, green: 0.92, blue: 0.55),
+                textGradient: [
+                    Color(red: 1.00, green: 0.55, blue: 0.85),
+                    Color(red: 0.55, green: 0.50, blue: 1.00),
+                    Color(red: 0.40, green: 0.95, blue: 0.85),
+                    Color(red: 1.00, green: 0.92, blue: 0.55)
+                ],
+                confettiColors: [
+                    Color(red: 1.00, green: 0.55, blue: 0.85),
+                    Color(red: 0.55, green: 0.50, blue: 1.00),
+                    Color(red: 0.40, green: 0.95, blue: 0.85),
+                    Color(red: 1.00, green: 0.92, blue: 0.55),
+                    .white
+                ],
+                backgroundGradient: [
+                    Color(red: 0.05, green: 0.04, blue: 0.10),
+                    Color(red: 0.10, green: 0.06, blue: 0.14),
+                    Color(red: 0.02, green: 0.02, blue: 0.05)
+                ],
+                label: "Holographic"
+            )
+        }
+    }
+}
+
+// MARK: - Golden Rays
+
+/// Slow rotating radial light beams emanating from screen center.
+/// Used in Phase 1 to build anticipation.
+struct GoldenRaysEffect: View {
+    let color: Color
+    var rayCount: Int = 16
+
+    @State private var rotation: Double = 0
+    @State private var opacity: Double = 0
+
+    var body: some View {
+        GeometryReader { geo in
+            let maxDim = max(geo.size.width, geo.size.height) * 1.5
+            ZStack {
+                // Soft center glow
+                RadialGradient(
+                    colors: [color.opacity(0.55), color.opacity(0.15), .clear],
+                    center: .center,
+                    startRadius: 0,
+                    endRadius: maxDim * 0.45
+                )
+                .blendMode(.screen)
+
+                // Rays
+                ForEach(0..<rayCount, id: \.self) { i in
+                    Rectangle()
+                        .fill(
+                            LinearGradient(
+                                colors: [color.opacity(0.0), color.opacity(0.55), color.opacity(0.0)],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                        .frame(width: 80, height: maxDim)
+                        .rotationEffect(.degrees(Double(i) * (360.0 / Double(rayCount))))
+                        .blendMode(.screen)
+                }
+                .rotationEffect(.degrees(rotation))
+            }
+            .frame(width: geo.size.width, height: geo.size.height)
+            .opacity(opacity)
+        }
+        .allowsHitTesting(false)
+        .onAppear {
+            withAnimation(.easeOut(duration: 1.2)) { opacity = 1.0 }
+            withAnimation(.linear(duration: 28).repeatForever(autoreverses: false)) {
+                rotation = 360
+            }
+        }
+    }
+}
+
+// MARK: - Fireworks
+
+/// A single firework: radial particle burst with trail fade.
+struct FireworkBurstView: View {
+    let position: CGPoint
+    let colors: [Color]
+    let particleCount: Int
+    let delay: Double
+
+    @State private var animate = false
+    @State private var visible = false
+
+    var body: some View {
+        ZStack {
+            ForEach(0..<particleCount, id: \.self) { i in
+                let angle = Double(i) * (2 * .pi / Double(particleCount))
+                let distance: CGFloat = animate ? CGFloat.random(in: 90...160) : 0
+                Circle()
+                    .fill(colors.randomElement() ?? .white)
+                    .frame(width: 6, height: 6)
+                    .shadow(color: colors.randomElement()?.opacity(0.8) ?? .white, radius: 4)
+                    .offset(x: cos(angle) * distance, y: sin(angle) * distance)
+                    .opacity(animate ? 0 : 1)
+            }
+        }
+        .position(position)
+        .opacity(visible ? 1 : 0)
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                visible = true
+                withAnimation(.easeOut(duration: 1.1)) { animate = true }
+            }
+        }
+    }
+}
+
+/// Multiple fireworks bursting at staggered positions during the climax.
+struct FireworksShow: View {
+    let palette: YearPalette
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack {
+                FireworkBurstView(
+                    position: CGPoint(x: geo.size.width * 0.20, y: geo.size.height * 0.28),
+                    colors: palette.confettiColors,
+                    particleCount: 20,
+                    delay: 0.0
+                )
+                FireworkBurstView(
+                    position: CGPoint(x: geo.size.width * 0.80, y: geo.size.height * 0.32),
+                    colors: palette.confettiColors,
+                    particleCount: 22,
+                    delay: 0.18
+                )
+                FireworkBurstView(
+                    position: CGPoint(x: geo.size.width * 0.30, y: geo.size.height * 0.72),
+                    colors: palette.confettiColors,
+                    particleCount: 20,
+                    delay: 0.34
+                )
+                FireworkBurstView(
+                    position: CGPoint(x: geo.size.width * 0.78, y: geo.size.height * 0.68),
+                    colors: palette.confettiColors,
+                    particleCount: 22,
+                    delay: 0.50
+                )
+                FireworkBurstView(
+                    position: CGPoint(x: geo.size.width * 0.50, y: geo.size.height * 0.18),
+                    colors: palette.confettiColors,
+                    particleCount: 24,
+                    delay: 0.70
+                )
+            }
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+// MARK: - Yearly Confetti
+
+/// Premium confetti shower — denser, longer-falling, mixed shapes.
+struct YearlyConfettiPiece: Identifiable {
+    let id = UUID()
+    let x: CGFloat
+    let startY: CGFloat
+    let endY: CGFloat
+    let color: Color
+    let size: CGFloat
+    let rotation: Double
+    let rotationSpeed: Double
+    let swayAmplitude: CGFloat
+    let swaySpeed: Double
+    let delay: Double
+    let duration: Double
+    let shape: ConfettiShape
+}
+
+enum ConfettiShape: CaseIterable {
+    case rectangle, circle, triangle, roundedSquare
+}
+
+struct YearlyConfettiView: View {
+    let colors: [Color]
+    let particleCount: Int
+
+    @State private var pieces: [YearlyConfettiPiece] = []
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack {
+                ForEach(pieces) { piece in
+                    YearlyConfettiPieceView(piece: piece, screenHeight: geo.size.height)
+                }
+            }
+            .frame(width: geo.size.width, height: geo.size.height)
+            .onAppear { generate(in: geo.size) }
+        }
+        .allowsHitTesting(false)
+    }
+
+    private func generate(in size: CGSize) {
+        pieces = (0..<particleCount).map { _ in
+            YearlyConfettiPiece(
+                x: CGFloat.random(in: 0...size.width),
+                startY: CGFloat.random(in: -size.height * 0.4 ... -20),
+                endY: size.height + 80,
+                color: colors.randomElement() ?? .white,
+                size: CGFloat.random(in: 6...14),
+                rotation: Double.random(in: 0...360),
+                rotationSpeed: Double.random(in: 180...720) * (Bool.random() ? 1 : -1),
+                swayAmplitude: CGFloat.random(in: 12...40),
+                swaySpeed: Double.random(in: 1.0...2.4),
+                delay: Double.random(in: 0...0.6),
+                duration: Double.random(in: 2.6...4.2),
+                shape: ConfettiShape.allCases.randomElement() ?? .rectangle
+            )
+        }
+    }
+}
+
+private struct YearlyConfettiPieceView: View {
+    let piece: YearlyConfettiPiece
+    let screenHeight: CGFloat
+    @State private var falling = false
+    @State private var sway: CGFloat = 0
+    @State private var rotation: Double = 0
+
+    var body: some View {
+        confettiShape
+            .frame(width: piece.size, height: piece.size * (piece.shape == .rectangle ? 1.6 : 1.0))
+            .rotationEffect(.degrees(piece.rotation + rotation))
+            .position(
+                x: piece.x + sway,
+                y: falling ? piece.endY : piece.startY
+            )
+            .onAppear {
+                DispatchQueue.main.asyncAfter(deadline: .now() + piece.delay) {
+                    withAnimation(.easeIn(duration: piece.duration)) {
+                        falling = true
+                    }
+                    withAnimation(.linear(duration: piece.duration).repeatForever(autoreverses: false)) {
+                        rotation = piece.rotationSpeed
+                    }
+                    withAnimation(.easeInOut(duration: piece.swaySpeed).repeatForever(autoreverses: true)) {
+                        sway = piece.swayAmplitude
+                    }
+                }
+            }
+    }
+
+    @ViewBuilder
+    private var confettiShape: some View {
+        switch piece.shape {
+        case .rectangle:     Rectangle().fill(piece.color)
+        case .circle:        Circle().fill(piece.color)
+        case .triangle:      Triangle().fill(piece.color)
+        case .roundedSquare: RoundedRectangle(cornerRadius: 2).fill(piece.color)
+        }
+    }
+}
+
+private struct Triangle: Shape {
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        p.move(to: CGPoint(x: rect.midX, y: rect.minY))
+        p.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        p.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        p.closeSubpath()
+        return p
+    }
+}
+
+// MARK: - Shimmer overlay
+
+/// A continuously sweeping highlight that gives the year numeral a "trophy" feel.
+struct YearNumberShimmer: ViewModifier {
+    let active: Bool
+    let color: Color
+    @State private var phase: CGFloat = -1.0
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(
+                LinearGradient(
+                    colors: [
+                        .clear,
+                        color.opacity(0.85),
+                        .clear
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                .blendMode(.screen)
+                .mask(content)
+                .offset(x: phase * 300)
+                .opacity(active ? 1 : 0)
+            )
+            .onChange(of: active) { _, newValue in
+                if newValue {
+                    withAnimation(.linear(duration: 2.4).repeatForever(autoreverses: false)) {
+                        phase = 1.5
+                    }
+                }
+            }
+    }
+}
+
+// MARK: - Calendar Flip
+
+/// A "365 days" calendar that rapidly flips through every day of the year,
+/// landing on the milestone day. Visual metaphor for completing a full year.
+struct CalendarFlipCard: View {
+    let palette: YearPalette
+    let dayNumber: Int
+    let totalDays: Int
+    /// 0...1 — drives the page flip.
+    let flipProgress: Double
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            palette.accent.opacity(0.20),
+                            palette.primary.opacity(0.10),
+                            palette.secondary.opacity(0.05)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 22, style: .continuous)
+                        .strokeBorder(
+                            LinearGradient(
+                                colors: [palette.primary.opacity(0.7), palette.secondary.opacity(0.3)],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            ),
+                            lineWidth: 1.5
+                        )
+                )
+                .shadow(color: palette.primary.opacity(0.45), radius: 22, x: 0, y: 0)
+
+            VStack(spacing: 4) {
+                Text("DAY")
+                    .font(.system(size: 16, weight: .heavy, design: .rounded))
+                    .tracking(6)
+                    .foregroundColor(palette.accent.opacity(0.9))
+
+                Text("\(dayNumber)")
+                    .font(.system(size: 92, weight: .black, design: .rounded))
+                    .foregroundStyle(
+                        LinearGradient(colors: palette.textGradient, startPoint: .top, endPoint: .bottom)
+                    )
+                    .contentTransition(.numericText())
+                    .animation(.easeOut(duration: 0.05), value: dayNumber)
+
+                Text("of \(totalDays)")
+                    .font(.system(size: 14, weight: .semibold, design: .rounded))
+                    .foregroundColor(palette.accent.opacity(0.65))
+            }
+            .padding(20)
+        }
+        .rotation3DEffect(
+            .degrees(flipProgress * 14),
+            axis: (x: 1, y: 0, z: 0),
+            perspective: 0.6
+        )
+    }
+}

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -91,6 +91,20 @@ struct DashboardView: View {
         )
     }
 
+    /// Build a yearly milestone test payload using realistic-ish stats from the user.
+    private func triggerYearlyTest(years: Int) {
+        celebrationManager.clearAll()
+        let totalDays = years * 365
+        let lifetimeMiles = max(userManager.currentUser.totalMiles, Double(totalDays) * 1.15)
+        let info = YearlyMilestoneInfo(
+            years: years,
+            totalMiles: lifetimeMiles,
+            totalStreakDays: max(userManager.currentUser.streak, totalDays),
+            streakStartDate: Calendar.current.date(byAdding: .day, value: -totalDays, to: Date())
+        )
+        celebrationManager.addCelebration(.yearMilestone(info: info))
+    }
+
     /// Group today's workouts by activity type into breakdowns
     private func buildWorkoutBreakdowns() -> [WorkoutBreakdown] {
         var byType: [HKWorkoutActivityType: (distance: Double, duration: TimeInterval)] = [:]
@@ -276,6 +290,20 @@ struct DashboardView: View {
                             }
                         } label: {
                             Label("Test Badge Unlock", systemImage: "trophy.fill")
+                        }
+
+                        Divider()
+
+                        Menu {
+                            Button("Year 1 (Gold)")          { triggerYearlyTest(years: 1) }
+                            Button("Year 2 (Rose Gold)")     { triggerYearlyTest(years: 2) }
+                            Button("Year 3 (Platinum)")      { triggerYearlyTest(years: 3) }
+                            Button("Year 4 (Sapphire)")      { triggerYearlyTest(years: 4) }
+                            Button("Year 5 (Diamond)")       { triggerYearlyTest(years: 5) }
+                            Button("Year 10 (Holographic)")  { triggerYearlyTest(years: 10) }
+                            Button("Year 25 (Holographic)")  { triggerYearlyTest(years: 25) }
+                        } label: {
+                            Label("Test Year Milestone", systemImage: "calendar.badge.plus")
                         }
 
                         Divider()


### PR DESCRIPTION
Multi-phase ~8-second animation that fires when a user's streak crosses a multiple of 365 days. Replaces the generic streak_365 / streak_730 badge popup on those days so the year boundary feels distinct from a normal milestone.

- Phase 1: golden rays radiate from center with light haptics
- Phase 2: calendar card flips through every day of the year, then a giant "YEAR N" numeral assembles via 3D flip
- Phase 3: confetti + fireworks + heavy haptic chord climax
- Phase 4: stats card (miles / day streak / streak start date) and a Share/Continue row slide in

Palette evolves per year so subsequent years feel fresh while the choreography stays equally lavish: gold (1) → rose gold (2) → platinum (3) → sapphire (4) → diamond (5–9) → holographic (10+). Skip button appears after the calendar phase.

UserManager queues the celebration after badge sync and uses an AppStorage sentinel so existing users with mid-year streaks aren't flooded with retroactive year-1/2/3 animations on first launch.

Admin test menu in the dashboard exposes Year 1/2/3/4/5/10/25 triggers for QA.