### PR TITLE
Add pinned-badges showcase on user profiles and fix navbar trophy

### DIFF
--- a/app/Mile A Day/Models/User.swift
+++ b/app/Mile A Day/Models/User.swift
@@ -707,6 +707,7 @@ struct Badge: Identifiable, Codable {
     var isNew: Bool = true
     var isLocked: Bool = false
     var isHidden: Bool = false // Secret badges that don't show requirements until earned
+    var pinSlot: Int? = nil // 0..2 when pinned to profile showcase, nil otherwise
     
     /// Extracts the numeric requirement from the badge ID (e.g. "miles_500" → 500)
     var numericValue: Int {

--- a/app/Mile A Day/Models/UserManager.swift
+++ b/app/Mile A Day/Models/UserManager.swift
@@ -321,6 +321,45 @@ class UserManager: ObservableObject {
         return currentUser.badges.contains { $0.isNew }
     }
 
+    /// Pinned badges for the local user's profile showcase, sorted by pin slot ascending.
+    var pinnedBadges: [Badge] {
+        currentUser.badges
+            .filter { $0.pinSlot != nil }
+            .sorted { ($0.pinSlot ?? 0) < ($1.pinSlot ?? 0) }
+    }
+
+    /// Replace the user's pinned badges. `badgeIds` order becomes pin slot 0..2 (max 3).
+    /// Optimistically updates local state, then pushes to the server.
+    @MainActor
+    func setPinnedBadges(_ badgeIds: [String]) async {
+        #if !os(watchOS)
+        guard let userId = currentUser.backendUserId else { return }
+        let clamped = Array(badgeIds.prefix(3))
+
+        let originalBadges = currentUser.badges
+        applyPinSlots(clamped)
+        saveUserData()
+
+        do {
+            let dtos = try await BadgeAPIService.setPinnedBadges(userId: userId, badgeIds: clamped)
+            let fresh = dtos.map { $0.toBadge() }
+            currentUser.badges = fresh
+            saveUserData()
+        } catch {
+            print("[UserManager] setPinnedBadges failed: \(error)")
+            currentUser.badges = originalBadges
+            saveUserData()
+        }
+        #endif
+    }
+
+    private func applyPinSlots(_ badgeIds: [String]) {
+        let slotByBadgeId = Dictionary(uniqueKeysWithValues: badgeIds.enumerated().map { ($1, $0) })
+        for i in 0..<currentUser.badges.count {
+            currentUser.badges[i].pinSlot = slotByBadgeId[currentUser.badges[i].id]
+        }
+    }
+
     /// Fetch the user's earned badges from the backend. Server is authoritative.
     /// Safe to call on every workout-upload completion and on Badges view appear.
     func refreshBadgesFromServer() async {

--- a/app/Mile A Day/Services/BadgeAPIService.swift
+++ b/app/Mile A Day/Services/BadgeAPIService.swift
@@ -30,12 +30,14 @@ enum BadgeAPIService {
         let isHidden: Bool
         let earnedAt: Date
         let isNew: Bool
+        let pinSlot: Int?
         let triggeringWorkoutId: String?
     }
 
     private struct CatalogResponse: Codable { let badges: [CatalogBadgeDTO] }
     private struct UserBadgesResponse: Codable { let userId: String; let badges: [UserBadgeDTO] }
     private struct MarkViewedResponse: Codable { let updated: Int }
+    private struct SetPinsRequest: Codable { let pinnedBadgeIds: [String] }
 
     // MARK: - API
 
@@ -66,6 +68,18 @@ enum BadgeAPIService {
         )
         return response.updated
     }
+
+    /// Replace the user's pinned badges. Order in `badgeIds` becomes pin slot 0..2.
+    static func setPinnedBadges(userId: String, badgeIds: [String]) async throws -> [UserBadgeDTO] {
+        let bodyData = try JSONEncoder().encode(SetPinsRequest(pinnedBadgeIds: badgeIds))
+        let response: UserBadgesResponse = try await APIClient.fancyFetch(
+            endpoint: "/users/\(userId)/badges/pins",
+            method: .PUT,
+            body: bodyData,
+            responseType: UserBadgesResponse.self
+        )
+        return response.badges
+    }
 }
 
 // MARK: - DTO → client-model conversion
@@ -80,7 +94,8 @@ extension BadgeAPIService.UserBadgeDTO {
             dateAwarded: earnedAt,
             isNew: isNew,
             isLocked: false,
-            isHidden: isHidden
+            isHidden: isHidden,
+            pinSlot: pinSlot
         )
     }
 }

--- a/app/Mile A Day/Views/BadgesView.swift
+++ b/app/Mile A Day/Views/BadgesView.swift
@@ -4,12 +4,19 @@ struct BadgesView: View {
     @ObservedObject var userManager: UserManager
     /// Optional badge to immediately drill into when this screen first appears.
     let initialBadge: Badge?
-    
+    /// Filter to apply when the screen first appears (e.g. `.new` from the trophy nav).
+    var initialFilter: BadgeFilter = .all
+
     @State private var showConfetti = false
     @State private var selectedFilter: BadgeFilter = .all
     @State private var selectedBadge: Badge?
     @State private var isShowingDetail = false
-    
+    /// Snapshot of badge IDs that were `isNew` when this screen first appeared.
+    /// We keep them visible under the "New" filter even after `markBadgesAsViewed()` flips
+    /// the local flag, so the filter doesn't empty out as soon as the user lands here.
+    @State private var newBadgeIdsAtOpen: Set<String> = []
+    @State private var didFirstAppear = false
+
     var body: some View {
         ZStack {
             // Gradient background
@@ -40,6 +47,16 @@ struct BadgesView: View {
         .navigationTitle("Medals")
         .navigationBarTitleDisplayMode(.large)
         .onAppear {
+            // Snapshot "new" badge IDs BEFORE we mark them viewed so the New filter
+            // and any badges that were unread keep their visual treatment on this visit.
+            if !didFirstAppear {
+                didFirstAppear = true
+                newBadgeIdsAtOpen = Set(
+                    userManager.currentUser.badges.filter { $0.isNew }.map { $0.id }
+                )
+                selectedFilter = initialFilter
+            }
+
             // Show confetti for new badges
             if userManager.hasNewBadges {
                 showConfetti = true
@@ -218,7 +235,10 @@ struct BadgesView: View {
             // Show only earned secret/hidden badges
             return earnedHiddenBadges
         case .new:
-            return allBadges.filter { $0.isNew && !$0.isLocked }
+            // Use the on-open snapshot so the list survives mark-as-viewed.
+            let pool = allBadges + earnedHiddenBadges
+            let snapshot = newBadgeIdsAtOpen
+            return pool.filter { ($0.isNew || snapshot.contains($0.id)) && !$0.isLocked }
         }
     }
     

--- a/app/Mile A Day/Views/Components/FriendBadgeCompareView.swift
+++ b/app/Mile A Day/Views/Components/FriendBadgeCompareView.swift
@@ -1,0 +1,321 @@
+import SwiftUI
+
+/// Friend-profile badge surface:
+/// - Shows the friend's pinned showcase (3 slots).
+/// - Lists the full catalog with each entry shown as owned (vivid) or locked (greyed) for the friend,
+///   so the viewer can see at a glance what they share and what's left to earn.
+struct FriendBadgeCompareView: View {
+    let ownerDisplayName: String
+    /// Friend's earned badges (already converted with pinSlot populated).
+    let earnedBadges: [Badge]
+    /// Public catalog (excludes hidden badges the viewer hasn't seen).
+    let catalogBadges: [Badge]
+    /// Optional: badges the local viewer has earned. Used to compute the "you don't have" highlight.
+    let viewerEarnedBadgeIds: Set<String>
+
+    @State private var selectedFilter: CompareFilter = .all
+    @State private var selectedBadge: Badge?
+    @State private var isShowingDetail = false
+
+    enum CompareFilter: String, CaseIterable, Hashable {
+        case all = "All"
+        case theyHave = "They have"
+        case youMissing = "You're missing"
+
+        var icon: String {
+            switch self {
+            case .all: return "square.grid.2x2"
+            case .theyHave: return "checkmark.seal.fill"
+            case .youMissing: return "questionmark.circle"
+            }
+        }
+    }
+
+    private var earnedById: [String: Badge] {
+        Dictionary(uniqueKeysWithValues: earnedBadges.map { ($0.id, $0) })
+    }
+
+    private var pinned: [Badge] {
+        earnedBadges
+            .filter { $0.pinSlot != nil }
+            .sorted { ($0.pinSlot ?? 0) < ($1.pinSlot ?? 0) }
+    }
+
+    private var ownedCount: Int { earnedBadges.filter { !$0.isHidden }.count }
+    private var totalVisibleCount: Int { catalogBadges.count }
+
+    /// Friend's earned hidden badges that aren't in the public catalog. Appended so the friend
+    /// gets credit for them, without leaking the existence of unearned hidden badges.
+    private var earnedHidden: [Badge] {
+        earnedBadges.filter { $0.isHidden && !catalogBadges.contains(where: { c in c.id == $0.id }) }
+    }
+
+    /// Merged display list for the grid: catalog entries (resolved as owned or locked) + any earned-only hidden.
+    private var allDisplayBadges: [Badge] {
+        var list: [Badge] = []
+        for cat in catalogBadges {
+            if let earned = earnedById[cat.id] {
+                list.append(earned)
+            } else {
+                var locked = cat
+                locked.isLocked = true
+                locked.isNew = false
+                list.append(locked)
+            }
+        }
+        list.append(contentsOf: earnedHidden)
+        return list
+    }
+
+    private var filteredBadges: [Badge] {
+        switch selectedFilter {
+        case .all:
+            return allDisplayBadges
+        case .theyHave:
+            return allDisplayBadges.filter { !$0.isLocked }
+        case .youMissing:
+            // Friend has it, viewer doesn't.
+            return allDisplayBadges.filter { !$0.isLocked && !viewerEarnedBadgeIds.contains($0.id) }
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
+            PinnedBadgesShowcase(
+                pinnedBadges: pinned,
+                onManageTapped: nil,
+                onBadgeTapped: { badge in
+                    selectedBadge = badge
+                    isShowingDetail = true
+                },
+                ownerDisplayName: ownerDisplayName
+            )
+
+            VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
+                HStack(spacing: MADTheme.Spacing.sm) {
+                    Image(systemName: "rosette")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(MADTheme.Colors.redGradient)
+                    Text("Medals")
+                        .font(MADTheme.Typography.headline)
+                        .foregroundColor(.primary)
+                    Spacer()
+                    Text("\(ownedCount) / \(totalVisibleCount)")
+                        .font(MADTheme.Typography.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 10) {
+                        ForEach(CompareFilter.allCases, id: \.self) { filter in
+                            CompareFilterChip(
+                                title: filter.rawValue,
+                                icon: filter.icon,
+                                isSelected: selectedFilter == filter
+                            ) {
+                                withAnimation(.spring(response: 0.3)) {
+                                    selectedFilter = filter
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if filteredBadges.isEmpty {
+                    emptyState
+                } else {
+                    LazyVGrid(
+                        columns: [GridItem(.flexible(), spacing: 16), GridItem(.flexible(), spacing: 16)],
+                        spacing: 16
+                    ) {
+                        ForEach(filteredBadges, id: \.id) { badge in
+                            Button {
+                                selectedBadge = badge
+                                isShowingDetail = true
+                            } label: {
+                                ZStack(alignment: .topLeading) {
+                                    PremiumBadgeCard(badge: badge)
+                                    if !badge.isLocked && !viewerEarnedBadgeIds.contains(badge.id) {
+                                        youDontHaveTag
+                                    }
+                                }
+                            }
+                            .buttonStyle(BadgeCardButtonStyle())
+                        }
+                    }
+                }
+            }
+            .padding(MADTheme.Spacing.md)
+            .madLiquidGlass()
+        }
+        .navigationDestination(isPresented: $isShowingDetail) {
+            if let badge = selectedBadge {
+                FriendBadgeDetailView(badge: badge, ownerDisplayName: ownerDisplayName)
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: selectedFilter == .youMissing ? "checkmark.circle" : "trophy")
+                .font(.system(size: 40))
+                .foregroundColor(.white.opacity(0.3))
+            Text(emptyStateText)
+                .font(MADTheme.Typography.caption)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, MADTheme.Spacing.xl)
+    }
+
+    private var emptyStateText: String {
+        switch selectedFilter {
+        case .all: return "No medals yet."
+        case .theyHave: return "\(ownerDisplayName) hasn't earned any medals yet."
+        case .youMissing: return "You're all caught up — no medals here that you haven't earned."
+        }
+    }
+
+    private var youDontHaveTag: some View {
+        Text("YOU'RE MISSING")
+            .font(.system(size: 8, weight: .black, design: .rounded))
+            .tracking(0.6)
+            .foregroundColor(.white)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(
+                Capsule()
+                    .fill(MADTheme.Colors.madRed)
+            )
+            .padding(6)
+    }
+}
+
+private struct CompareFilterChip: View {
+    let title: String
+    let icon: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .semibold))
+                Text(title)
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+            }
+            .foregroundColor(isSelected ? .white : .white.opacity(0.6))
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(
+                Capsule()
+                    .fill(isSelected ? MADTheme.Colors.madRed : Color.white.opacity(0.08))
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// Lightweight read-only badge detail for friend profiles (the existing `BadgeDetailView`
+/// is tightly coupled to the local user's `UserManager`).
+private struct FriendBadgeDetailView: View {
+    let badge: Badge
+    let ownerDisplayName: String
+
+    var body: some View {
+        ZStack {
+            MADTheme.Colors.appBackgroundGradient.ignoresSafeArea()
+
+            ScrollView {
+                VStack(spacing: MADTheme.Spacing.lg) {
+                    ZStack {
+                        if !badge.isLocked {
+                            Circle()
+                                .fill(
+                                    RadialGradient(
+                                        colors: [badge.rarity.color.opacity(0.4), badge.rarity.color.opacity(0)],
+                                        center: .center,
+                                        startRadius: 30,
+                                        endRadius: 100
+                                    )
+                                )
+                                .frame(width: 200, height: 200)
+                        }
+
+                        Circle()
+                            .fill(
+                                LinearGradient(
+                                    colors: badge.isLocked
+                                        ? [Color(white: 0.25), Color(white: 0.15)]
+                                        : medalGradientColors(for: badge),
+                                    startPoint: .topLeading,
+                                    endPoint: .bottomTrailing
+                                )
+                            )
+                            .frame(width: 140, height: 140)
+                            .overlay(
+                                Circle()
+                                    .stroke(
+                                        badge.isLocked ? Color.white.opacity(0.1) : Color.white.opacity(0.5),
+                                        lineWidth: 3
+                                    )
+                            )
+                            .shadow(color: badge.isLocked ? .clear : badge.rarity.color.opacity(0.4), radius: 18, x: 0, y: 8)
+
+                        Image(systemName: badge.isLocked ? "lock.fill" : iconName(for: badge))
+                            .font(.system(size: 50, weight: .semibold))
+                            .foregroundColor(badge.isLocked ? .white.opacity(0.35) : .white)
+                    }
+                    .padding(.top, MADTheme.Spacing.lg)
+
+                    VStack(spacing: 6) {
+                        Text(badge.name)
+                            .font(.system(size: 26, weight: .bold, design: .rounded))
+                            .foregroundColor(.primary)
+                            .multilineTextAlignment(.center)
+
+                        Text(badge.rarity.rawValue.uppercased())
+                            .font(.system(size: 11, weight: .black, design: .rounded))
+                            .tracking(1.5)
+                            .foregroundColor(badge.rarity.color)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 5)
+                            .background(Capsule().fill(badge.rarity.color.opacity(0.15)))
+                    }
+
+                    Text(badge.description)
+                        .font(MADTheme.Typography.body)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, MADTheme.Spacing.lg)
+
+                    if !badge.isLocked {
+                        VStack(spacing: 4) {
+                            Text("EARNED BY \(ownerDisplayName.uppercased())")
+                                .font(.system(size: 10, weight: .bold, design: .rounded))
+                                .tracking(1.2)
+                                .foregroundColor(.secondary)
+                            Text(badge.dateAwarded.formattedShortDate)
+                                .font(.system(size: 14, weight: .semibold, design: .rounded))
+                                .foregroundColor(.primary)
+                        }
+                        .padding(.top, MADTheme.Spacing.sm)
+                    } else {
+                        Text("\(ownerDisplayName) hasn't earned this yet.")
+                            .font(MADTheme.Typography.caption)
+                            .foregroundColor(.secondary)
+                            .padding(.top, MADTheme.Spacing.sm)
+                    }
+
+                    Spacer(minLength: 60)
+                }
+                .padding(.horizontal, MADTheme.Spacing.md)
+            }
+        }
+        .navigationTitle(badge.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+    }
+}

--- a/app/Mile A Day/Views/Components/ManagePinnedBadgesSheet.swift
+++ b/app/Mile A Day/Views/Components/ManagePinnedBadgesSheet.swift
@@ -1,0 +1,236 @@
+import SwiftUI
+
+/// Sheet that lets the user pick up to 3 earned badges to pin to their profile showcase.
+/// Tap to select/deselect; selection order determines pin order (1, 2, 3).
+struct ManagePinnedBadgesSheet: View {
+    @ObservedObject var userManager: UserManager
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var selected: [String] = []
+    @State private var isSaving = false
+
+    private var earnedBadges: [Badge] {
+        userManager.currentUser.badges
+            .filter { !$0.isLocked }
+            .sorted { lhs, rhs in
+                // Pinned badges first (preserve current order), then most recently earned.
+                let lp = lhs.pinSlot ?? Int.max
+                let rp = rhs.pinSlot ?? Int.max
+                if lp != rp { return lp < rp }
+                return lhs.dateAwarded > rhs.dateAwarded
+            }
+    }
+
+    private let maxPins = 3
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                MADTheme.Colors.appBackgroundGradient.ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    headerBanner
+
+                    ScrollView {
+                        if earnedBadges.isEmpty {
+                            emptyState
+                                .padding(.top, 60)
+                                .padding(.horizontal, MADTheme.Spacing.lg)
+                        } else {
+                            LazyVGrid(
+                                columns: [GridItem(.flexible(), spacing: 16), GridItem(.flexible(), spacing: 16)],
+                                spacing: 16
+                            ) {
+                                ForEach(earnedBadges) { badge in
+                                    BadgePickerCard(
+                                        badge: badge,
+                                        selectionIndex: selectionIndex(for: badge.id),
+                                        atCapacity: selected.count >= maxPins && !selected.contains(badge.id)
+                                    ) {
+                                        toggle(badge.id)
+                                    }
+                                }
+                            }
+                            .padding(MADTheme.Spacing.md)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Showcase")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundColor(MADTheme.Colors.madRed)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(isSaving ? "Saving…" : "Save") {
+                        save()
+                    }
+                    .foregroundColor(MADTheme.Colors.madRed)
+                    .fontWeight(.semibold)
+                    .disabled(isSaving || !isDirty)
+                }
+            }
+        }
+        .onAppear {
+            selected = userManager.pinnedBadges.map { $0.id }
+        }
+    }
+
+    private var headerBanner: some View {
+        VStack(spacing: 6) {
+            Text("Pin up to \(maxPins) medals")
+                .font(.system(size: 16, weight: .bold, design: .rounded))
+                .foregroundColor(.primary)
+
+            Text("Tap a medal to add or remove. The order you tap is the order they'll appear.")
+                .font(MADTheme.Typography.caption)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, MADTheme.Spacing.lg)
+
+            Text("\(selected.count) of \(maxPins) selected")
+                .font(.system(size: 12, weight: .semibold, design: .rounded))
+                .foregroundColor(selected.isEmpty ? .secondary : MADTheme.Colors.madRed)
+                .padding(.top, 4)
+        }
+        .padding(.vertical, MADTheme.Spacing.md)
+        .frame(maxWidth: .infinity)
+        .background(Color.white.opacity(0.04))
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: MADTheme.Spacing.md) {
+            Image(systemName: "trophy")
+                .font(.system(size: 60))
+                .foregroundColor(.white.opacity(0.3))
+            Text("No medals yet")
+                .font(.system(size: 18, weight: .bold, design: .rounded))
+                .foregroundColor(.primary)
+            Text("Earn medals by running, then come back to pin your favorites.")
+                .font(MADTheme.Typography.caption)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    private var isDirty: Bool {
+        selected != userManager.pinnedBadges.map { $0.id }
+    }
+
+    private func selectionIndex(for badgeId: String) -> Int? {
+        if let idx = selected.firstIndex(of: badgeId) {
+            return idx + 1
+        }
+        return nil
+    }
+
+    private func toggle(_ badgeId: String) {
+        if let idx = selected.firstIndex(of: badgeId) {
+            selected.remove(at: idx)
+        } else if selected.count < maxPins {
+            selected.append(badgeId)
+        }
+    }
+
+    private func save() {
+        guard !isSaving else { return }
+        isSaving = true
+        let toSave = selected
+        Task { @MainActor in
+            await userManager.setPinnedBadges(toSave)
+            isSaving = false
+            dismiss()
+        }
+    }
+}
+
+private struct BadgePickerCard: View {
+    let badge: Badge
+    let selectionIndex: Int?
+    let atCapacity: Bool
+    let onTap: () -> Void
+
+    var isSelected: Bool { selectionIndex != nil }
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 10) {
+                ZStack {
+                    Circle()
+                        .fill(
+                            LinearGradient(
+                                colors: medalGradientColors(for: badge),
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                        )
+                        .frame(width: 64, height: 64)
+                        .overlay(
+                            Circle()
+                                .stroke(Color.white.opacity(0.4), lineWidth: 1.5)
+                        )
+                        .shadow(color: badge.rarity.color.opacity(0.35), radius: 8, x: 0, y: 4)
+
+                    Image(systemName: iconName(for: badge))
+                        .font(.system(size: 24, weight: .semibold))
+                        .foregroundStyle(
+                            LinearGradient(
+                                colors: [.white, .white.opacity(0.85)],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+
+                    if let idx = selectionIndex {
+                        ZStack {
+                            Circle()
+                                .fill(MADTheme.Colors.madRed)
+                                .frame(width: 26, height: 26)
+                                .overlay(Circle().stroke(Color.white, lineWidth: 2))
+                            Text("\(idx)")
+                                .font(.system(size: 13, weight: .bold, design: .rounded))
+                                .foregroundColor(.white)
+                        }
+                        .offset(x: 26, y: -26)
+                    }
+                }
+                .frame(width: 90, height: 90)
+
+                Text(badge.name)
+                    .font(.system(size: 13, weight: .bold, design: .rounded))
+                    .foregroundColor(.primary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                    .frame(height: 34, alignment: .top)
+
+                Text(badge.rarity.rawValue.uppercased())
+                    .font(.system(size: 9, weight: .black, design: .rounded))
+                    .tracking(1.0)
+                    .foregroundColor(badge.rarity.color)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(Capsule().fill(badge.rarity.color.opacity(0.15)))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, MADTheme.Spacing.md)
+            .padding(.horizontal, MADTheme.Spacing.sm)
+            .background(
+                RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
+                    .fill(isSelected ? MADTheme.Colors.madRed.opacity(0.12) : Color.white.opacity(0.05))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
+                            .stroke(
+                                isSelected ? MADTheme.Colors.madRed.opacity(0.6) : Color.white.opacity(0.08),
+                                lineWidth: isSelected ? 1.5 : 1
+                            )
+                    )
+            )
+            .opacity(atCapacity ? 0.45 : 1.0)
+        }
+        .buttonStyle(BadgeCardButtonStyle())
+        .disabled(atCapacity)
+    }
+}

--- a/app/Mile A Day/Views/Components/PinnedBadgesShowcase.swift
+++ b/app/Mile A Day/Views/Components/PinnedBadgesShowcase.swift
@@ -1,0 +1,209 @@
+import SwiftUI
+
+/// Profile showcase that displays up to 3 pinned badges side-by-side.
+/// Used on both the local user's profile (with manage affordance) and friend profiles (read-only).
+struct PinnedBadgesShowcase: View {
+    /// Pinned badges, already ordered by pin slot ascending.
+    let pinnedBadges: [Badge]
+    /// When non-nil, an "Edit" pencil appears; tapping it invokes this closure.
+    let onManageTapped: (() -> Void)?
+    /// Tapping a filled slot.
+    let onBadgeTapped: ((Badge) -> Void)?
+    /// Display name for empty-state copy. Pass `nil` for the local user (we'll say "you").
+    let ownerDisplayName: String?
+
+    private static let slotCount = 3
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
+            HStack(spacing: MADTheme.Spacing.sm) {
+                Image(systemName: "pin.fill")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(MADTheme.Colors.redGradient)
+                Text("Showcase")
+                    .font(MADTheme.Typography.headline)
+                    .foregroundColor(.primary)
+                Spacer()
+                if let onManageTapped {
+                    Button(action: onManageTapped) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "pencil")
+                                .font(.system(size: 12, weight: .semibold))
+                            Text(pinnedBadges.isEmpty ? "Add" : "Edit")
+                                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                        }
+                        .foregroundColor(MADTheme.Colors.madRed)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Capsule().fill(MADTheme.Colors.madRed.opacity(0.15)))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            HStack(spacing: MADTheme.Spacing.sm) {
+                ForEach(0..<Self.slotCount, id: \.self) { slot in
+                    if slot < pinnedBadges.count {
+                        let badge = pinnedBadges[slot]
+                        Button {
+                            onBadgeTapped?(badge)
+                        } label: {
+                            PinnedBadgeSlotFilled(badge: badge)
+                        }
+                        .buttonStyle(BadgeCardButtonStyle())
+                        .disabled(onBadgeTapped == nil)
+                    } else {
+                        PinnedBadgeSlotEmpty(isInteractive: onManageTapped != nil) {
+                            onManageTapped?()
+                        }
+                    }
+                }
+            }
+
+            if pinnedBadges.isEmpty {
+                Text(emptyStateText)
+                    .font(MADTheme.Typography.caption)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .padding(MADTheme.Spacing.md)
+        .madLiquidGlass()
+    }
+
+    private var emptyStateText: String {
+        if onManageTapped != nil {
+            return "Pin up to 3 of your favorite medals to show off on your profile."
+        }
+        if let name = ownerDisplayName {
+            return "\(name) hasn't pinned any medals yet."
+        }
+        return "No pinned medals yet."
+    }
+}
+
+private struct PinnedBadgeSlotFilled: View {
+    let badge: Badge
+
+    var body: some View {
+        VStack(spacing: 8) {
+            ZStack {
+                Circle()
+                    .fill(
+                        RadialGradient(
+                            colors: [badge.rarity.color.opacity(0.35), badge.rarity.color.opacity(0)],
+                            center: .center,
+                            startRadius: 15,
+                            endRadius: 45
+                        )
+                    )
+                    .frame(width: 90, height: 90)
+
+                Circle()
+                    .fill(
+                        LinearGradient(
+                            colors: medalGradientColors(for: badge),
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .frame(width: 64, height: 64)
+                    .overlay(
+                        Circle()
+                            .stroke(
+                                LinearGradient(
+                                    colors: [Color.white.opacity(0.55), badge.rarity.color.opacity(0.35)],
+                                    startPoint: .topLeading,
+                                    endPoint: .bottomTrailing
+                                ),
+                                lineWidth: 2
+                            )
+                    )
+                    .shadow(color: badge.rarity.color.opacity(0.4), radius: 10, x: 0, y: 4)
+
+                Image(systemName: iconName(for: badge))
+                    .font(.system(size: 26, weight: .semibold))
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [.white, .white.opacity(0.85)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                    .shadow(color: .black.opacity(0.3), radius: 2, x: 0, y: 2)
+            }
+            .frame(width: 90, height: 90)
+
+            Text(badge.name)
+                .font(.system(size: 11, weight: .bold, design: .rounded))
+                .foregroundColor(.white)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .frame(height: 28, alignment: .top)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+private struct PinnedBadgeSlotEmpty: View {
+    let isInteractive: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 8) {
+                ZStack {
+                    Circle()
+                        .strokeBorder(
+                            style: StrokeStyle(lineWidth: 1.5, dash: [6, 4])
+                        )
+                        .foregroundColor(.white.opacity(0.25))
+                        .frame(width: 64, height: 64)
+
+                    Image(systemName: isInteractive ? "plus" : "pin")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundColor(.white.opacity(0.35))
+                }
+                .frame(width: 90, height: 90)
+
+                Text(" ")
+                    .font(.system(size: 11, weight: .bold, design: .rounded))
+                    .frame(height: 28)
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.plain)
+        .disabled(!isInteractive)
+    }
+}
+
+// MARK: - Visual helpers (mirrors PremiumBadgeCard styling so the showcase looks consistent)
+
+func iconName(for badge: Badge) -> String {
+    if badge.id.starts(with: "streak_") || badge.id.starts(with: "consistency_") {
+        return "flame.fill"
+    } else if badge.id.starts(with: "miles_") {
+        return "figure.run"
+    } else if badge.id.starts(with: "pace_") {
+        return "bolt.fill"
+    } else if badge.id.starts(with: "daily_") {
+        return "figure.run.circle.fill"
+    } else if badge.id.starts(with: "challenge_") {
+        return "trophy.fill"
+    } else if badge.id.starts(with: "hidden_") || badge.id.starts(with: "secret_") || badge.id.starts(with: "special_") {
+        return "sparkles"
+    }
+    return "star.fill"
+}
+
+func medalGradientColors(for badge: Badge) -> [Color] {
+    switch badge.rarity {
+    case .legendary:
+        return [Color(red: 1.0, green: 0.84, blue: 0.0), Color(red: 0.85, green: 0.45, blue: 0.0)]
+    case .rare:
+        return [Color(red: 0.7, green: 0.4, blue: 1.0), Color(red: 0.5, green: 0.15, blue: 0.85)]
+    case .common:
+        return [Color(red: 0.4, green: 0.7, blue: 1.0), Color(red: 0.15, green: 0.45, blue: 0.85)]
+    }
+}

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -257,7 +257,7 @@ struct DashboardView: View {
 
             ToolbarItemGroup(placement: .topBarTrailing) {
                 if userManager.hasNewBadges {
-                    NavigationLink(destination: BadgesView(userManager: userManager, initialBadge: nil)) {
+                    NavigationLink(destination: BadgesView(userManager: userManager, initialBadge: nil, initialFilter: .new)) {
                         Image(systemName: "trophy.fill")
                             .foregroundStyle(.yellow)
                     }

--- a/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
+++ b/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
@@ -4,10 +4,13 @@ import SwiftUI
 struct UserProfileDetailView: View {
     let user: BackendUser
     let friendService: FriendService
+    @ObservedObject private var userManager = UserManager.shared
     @Environment(\.dismiss) private var dismiss
 
     @State private var userStats: UserStats?
     @State private var userBadges: [Badge] = []
+    @State private var catalogBadges: [Badge] = []
+    @State private var hasLoadedBadges = false
     @State private var friendWorkouts: [FriendWorkout] = []
     @State private var isLoadingStats = false
     @State private var isPrivate = false
@@ -44,9 +47,14 @@ struct UserProfileDetailView: View {
                         FriendTodayChallengeRow(today: today)
                     }
 
-                    // Badges Section
-                    if !isPrivate && !userBadges.isEmpty {
-                        FriendBadgesView(badges: userBadges)
+                    // Badges Section — pinned showcase + owned/not-owned compare grid.
+                    if !isPrivate && hasLoadedBadges && !isCurrentUser() && !catalogBadges.isEmpty {
+                        FriendBadgeCompareView(
+                            ownerDisplayName: user.username ?? user.displayName,
+                            earnedBadges: userBadges,
+                            catalogBadges: catalogBadges,
+                            viewerEarnedBadgeIds: Set(userManager.currentUser.badges.filter { !$0.isLocked }.map { $0.id })
+                        )
                     }
 
                     // Recent Workouts Section
@@ -89,6 +97,27 @@ struct UserProfileDetailView: View {
         }
         .task {
             await loadFriendTodayChallenge()
+        }
+        .task {
+            await loadBadges()
+        }
+    }
+
+    private func loadBadges() async {
+        guard !isCurrentUser() else { return }
+        async let earnedTask = BadgeAPIService.fetchUserBadges(userId: user.user_id)
+        async let catalogTask = BadgeAPIService.fetchCatalog()
+        do {
+            let earnedDtos = try await earnedTask
+            let catalogDtos = try await catalogTask
+            await MainActor.run {
+                self.userBadges = earnedDtos.map { $0.toBadge() }
+                self.catalogBadges = catalogDtos.map { $0.toLockedBadge() }
+                self.hasLoadedBadges = true
+            }
+        } catch {
+            print("[UserProfileDetailView] loadBadges failed: \(error)")
+            await MainActor.run { self.hasLoadedBadges = true }
         }
     }
 
@@ -267,7 +296,6 @@ struct UserProfileDetailView: View {
 
                     friendWorkouts = workouts
                     hasLoadedInitial = true
-                    userBadges = []
                     isLoadingStats = false
                 }
 

--- a/app/Mile A Day/Views/Profile/ProfileView.swift
+++ b/app/Mile A Day/Views/Profile/ProfileView.swift
@@ -8,6 +8,8 @@ struct ProfileView: View {
     @State private var activeSheet: ProfileSheetType?
     @State private var showingLogoutConfirmation = false
     @State private var currentProfileImage: UIImage?
+    @State private var showingManagePins = false
+    @State private var pinnedBadgeForDetail: Badge?
 
     enum ProfileSheetType: String, Identifiable {
         case totalMiles, fastestPace, mostMiles
@@ -20,6 +22,14 @@ struct ProfileView: View {
             VStack(spacing: MADTheme.Spacing.lg) {
                 // Profile Header (matches friend profile style)
                 profileHeader
+
+                // Pinned medals showcase
+                PinnedBadgesShowcase(
+                    pinnedBadges: userManager.pinnedBadges,
+                    onManageTapped: { showingManagePins = true },
+                    onBadgeTapped: { badge in pinnedBadgeForDetail = badge },
+                    ownerDisplayName: nil
+                )
 
                 // Streak & Goal Row
                 streakAndGoalRow
@@ -63,6 +73,17 @@ struct ProfileView: View {
             case .privacySettings:
                 PrivacySettingsView()
             }
+        }
+        .sheet(isPresented: $showingManagePins) {
+            ManagePinnedBadgesSheet(userManager: userManager)
+        }
+        .sheet(item: $pinnedBadgeForDetail) { badge in
+            NavigationStack {
+                BadgeDetailView(badge: badge, userManager: userManager)
+            }
+        }
+        .task {
+            await userManager.refreshBadgesFromServer()
         }
         .alert("Sign Out", isPresented: $showingLogoutConfirmation) {
             Button("Cancel", role: .cancel) { }

--- a/backend/scripts/badges-schema.sql
+++ b/backend/scripts/badges-schema.sql
@@ -40,6 +40,16 @@ CREATE INDEX IF NOT EXISTS idx_user_badges_user     ON user_badges(user_id);
 CREATE INDEX IF NOT EXISTS idx_user_badges_user_new ON user_badges(user_id) WHERE is_new = TRUE;
 CREATE INDEX IF NOT EXISTS idx_user_badges_workout  ON user_badges(triggering_workout_id);
 
+-- 3a. user pinned badges (showcase). pin_slot in [0,2], unique per user.
+ALTER TABLE user_badges
+    ADD COLUMN IF NOT EXISTS pin_slot INTEGER;
+DO $$ BEGIN
+    ALTER TABLE user_badges
+        ADD CONSTRAINT user_badges_pin_slot_range CHECK (pin_slot IS NULL OR (pin_slot >= 0 AND pin_slot <= 2));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_badges_user_pin_slot
+    ON user_badges(user_id, pin_slot) WHERE pin_slot IS NOT NULL;
+
 -- 4. challenge catalog
 CREATE TABLE IF NOT EXISTS daily_challenges (
     challenge_key         TEXT PRIMARY KEY,

--- a/backend/src/controllers/badgeController.ts
+++ b/backend/src/controllers/badgeController.ts
@@ -1,53 +1,118 @@
-import { Request, Response } from 'express';
-import { AuthenticatedRequest } from '../middleware/auth.js';
-import { getCatalog, getUserBadges, markBadgesViewed } from '../services/badgeService.js';
-import { areFriends } from '../services/friendshipService.js';
-import hasRequiredKeys from '../utils/hasRequiredKeys.js';
+import { Request, Response } from "express";
+import { AuthenticatedRequest } from "../middleware/auth.js";
+import {
+  getCatalog,
+  getUserBadges,
+  markBadgesViewed,
+  setPinnedBadges,
+  BadgePinError,
+} from "../services/badgeService.js";
+import { areFriends } from "../services/friendshipService.js";
+import hasRequiredKeys from "../utils/hasRequiredKeys.js";
 
 export async function getPublicCatalog(_req: Request, res: Response) {
-	try {
-		const badges = await getCatalog(false);
-		return res.status(200).json({ badges });
-	} catch (err: any) {
-		console.error('Error getting badge catalog:', err.message);
-		return res.status(500).json({ error: 'Error getting badge catalog: ' + err.message });
-	}
+  try {
+    const badges = await getCatalog(false);
+    return res.status(200).json({ badges });
+  } catch (err: any) {
+    console.error("Error getting badge catalog:", err.message);
+    return res
+      .status(500)
+      .json({ error: "Error getting badge catalog: " + err.message });
+  }
 }
 
-export async function getBadgesForUser(req: AuthenticatedRequest, res: Response) {
-	if (!hasRequiredKeys(['userId'], req, res)) return;
+export async function getBadgesForUser(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  if (!hasRequiredKeys(["userId"], req, res)) return;
 
-	try {
-		const requesterId = req.userId;
-		const targetUserId = req.params.userId;
+  try {
+    const requesterId = req.userId;
+    const targetUserId = req.params.userId;
 
-		if (!requesterId) {
-			return res.status(401).json({ error: 'Authentication required' });
-		}
+    if (!requesterId) {
+      return res.status(401).json({ error: "Authentication required" });
+    }
 
-		if (requesterId !== targetUserId) {
-			const allowed = await areFriends(requesterId, targetUserId);
-			if (!allowed) {
-				return res.status(403).json({ error: 'Access denied — not friends with this user' });
-			}
-		}
+    if (requesterId !== targetUserId) {
+      const allowed = await areFriends(requesterId, targetUserId);
+      if (!allowed) {
+        return res
+          .status(403)
+          .json({ error: "Access denied — not friends with this user" });
+      }
+    }
 
-		const badges = await getUserBadges(targetUserId);
-		return res.status(200).json({ userId: targetUserId, badges });
-	} catch (err: any) {
-		console.error('Error getting user badges:', err.message);
-		return res.status(500).json({ error: 'Error getting user badges: ' + err.message });
-	}
+    const badges = await getUserBadges(targetUserId);
+    return res.status(200).json({ userId: targetUserId, badges });
+  } catch (err: any) {
+    console.error("Error getting user badges:", err.message);
+    return res
+      .status(500)
+      .json({ error: "Error getting user badges: " + err.message });
+  }
 }
 
 export async function markViewed(req: AuthenticatedRequest, res: Response) {
-	if (!hasRequiredKeys(['userId'], req, res)) return;
+  if (!hasRequiredKeys(["userId"], req, res)) return;
 
-	try {
-		const updated = await markBadgesViewed(req.params.userId);
-		return res.status(200).json({ updated });
-	} catch (err: any) {
-		console.error('Error marking badges viewed:', err.message);
-		return res.status(500).json({ error: 'Error marking badges viewed: ' + err.message });
-	}
+  try {
+    const updated = await markBadgesViewed(req.params.userId);
+    return res.status(200).json({ updated });
+  } catch (err: any) {
+    console.error("Error marking badges viewed:", err.message);
+    return res
+      .status(500)
+      .json({ error: "Error marking badges viewed: " + err.message });
+  }
+}
+
+export async function setPinnedBadgesForUser(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  if (!hasRequiredKeys(["userId"], req, res)) return;
+
+  try {
+    const targetUserId = req.params.userId;
+    const raw = (req.body as any)?.pinnedBadgeIds;
+
+    if (!Array.isArray(raw)) {
+      return res
+        .status(400)
+        .json({ error: "pinnedBadgeIds must be an array of badge IDs" });
+    }
+
+    if (raw.length > 3) {
+      return res.status(400).json({ error: "At most 3 badges can be pinned" });
+    }
+
+    const ids: string[] = [];
+    const seen = new Set<string>();
+    for (const entry of raw) {
+      if (typeof entry !== "string" || entry.length === 0) {
+        return res
+          .status(400)
+          .json({ error: "pinnedBadgeIds must contain non-empty strings" });
+      }
+      if (seen.has(entry)) {
+        return res.status(400).json({ error: "pinnedBadgeIds must be unique" });
+      }
+      seen.add(entry);
+      ids.push(entry);
+    }
+
+    const badges = await setPinnedBadges(targetUserId, ids);
+    return res.status(200).json({ userId: targetUserId, badges });
+  } catch (err: any) {
+    if (err instanceof BadgePinError) {
+      return res.status(400).json({ error: err.message });
+    }
+    console.error("Error setting pinned badges:", err.message);
+    return res
+      .status(500)
+      .json({ error: "Error setting pinned badges: " + err.message });
+  }
 }

--- a/backend/src/routes/badgesRoutes.ts
+++ b/backend/src/routes/badgesRoutes.ts
@@ -1,14 +1,28 @@
-import { Router } from 'express';
-import { getPublicCatalog, getBadgesForUser, markViewed } from '../controllers/badgeController.js';
-import { requireSelfAccess } from '../middleware/auth.js';
+import { Router } from "express";
+import {
+  getPublicCatalog,
+  getBadgesForUser,
+  markViewed,
+  setPinnedBadgesForUser,
+} from "../controllers/badgeController.js";
+import { requireSelfAccess } from "../middleware/auth.js";
 
 // Public router — only mount before authenticateToken.
 export const publicBadgesRouter = Router();
-publicBadgesRouter.get('/catalog', getPublicCatalog);
+publicBadgesRouter.get("/catalog", getPublicCatalog);
 
 // Authenticated router — mount after authenticateToken.
 const router = Router();
-router.get('/:userId/badges', getBadgesForUser);
-router.post('/:userId/badges/mark-viewed', requireSelfAccess('userId'), markViewed);
+router.get("/:userId/badges", getBadgesForUser);
+router.post(
+  "/:userId/badges/mark-viewed",
+  requireSelfAccess("userId"),
+  markViewed,
+);
+router.put(
+  "/:userId/badges/pins",
+  requireSelfAccess("userId"),
+  setPinnedBadgesForUser,
+);
 
 export default router;

--- a/backend/src/services/badgeService.ts
+++ b/backend/src/services/badgeService.ts
@@ -1,11 +1,11 @@
-import { PostgresService } from './DbService.js';
+import { PostgresService } from "./DbService.js";
 import type {
-	Badge,
-	UserBadge,
-	UserAggregates,
-	RewardEvaluationResult
-} from '../types/badge.js';
-import { evaluateChallengesForBatch } from './dailyChallengeService.js';
+  Badge,
+  UserBadge,
+  UserAggregates,
+  RewardEvaluationResult,
+} from "../types/badge.js";
+import { evaluateChallengesForBatch } from "./dailyChallengeService.js";
 
 const db = PostgresService.getInstance();
 
@@ -14,292 +14,382 @@ const STREAK_QUALIFYING_DISTANCE = 0.95;
 // ─── Catalog reads ──────────────────────────────────────────────────
 
 export async function getCatalog(includeHidden: boolean): Promise<Badge[]> {
-	const rows = await db.query<any>(
-		`SELECT badge_id, category, name, description, icon, rarity, requirement, is_hidden, sort_order
+  const rows = await db.query<any>(
+    `SELECT badge_id, category, name, description, icon, rarity, requirement, is_hidden, sort_order
 		FROM badges
-		${includeHidden ? '' : 'WHERE is_hidden = FALSE'}
-		ORDER BY sort_order ASC`
-	);
-	return rows.map(rowToBadge);
+		${includeHidden ? "" : "WHERE is_hidden = FALSE"}
+		ORDER BY sort_order ASC`,
+  );
+  return rows.map(rowToBadge);
 }
 
 export async function getUserBadges(userId: string): Promise<UserBadge[]> {
-	const rows = await db.query<any>(
-		`SELECT
-			ub.badge_id, ub.earned_at, ub.is_new, ub.triggering_workout_id, ub.progress_snapshot,
+  const rows = await db.query<any>(
+    `SELECT
+			ub.badge_id, ub.earned_at, ub.is_new, ub.pin_slot, ub.triggering_workout_id, ub.progress_snapshot,
 			b.category, b.name, b.description, b.icon, b.rarity, b.requirement, b.is_hidden
 		FROM user_badges ub
 		JOIN badges b ON b.badge_id = ub.badge_id
 		WHERE ub.user_id = $1
 		ORDER BY ub.earned_at DESC`,
-		[userId]
-	);
-	return rows.map(rowToUserBadge);
+    [userId],
+  );
+  return rows.map(rowToUserBadge);
+}
+
+const MAX_PINNED_BADGES = 3;
+
+export async function setPinnedBadges(
+  userId: string,
+  badgeIds: string[],
+): Promise<UserBadge[]> {
+  const ids = badgeIds.slice(0, MAX_PINNED_BADGES);
+
+  if (ids.length > 0) {
+    const earnedRows = await db.query<{ badge_id: string }>(
+      `SELECT badge_id FROM user_badges WHERE user_id = $1 AND badge_id = ANY($2::text[])`,
+      [userId, ids],
+    );
+    const earnedSet = new Set(earnedRows.map((r) => r.badge_id));
+    const missing = ids.filter((id) => !earnedSet.has(id));
+    if (missing.length > 0) {
+      throw new BadgePinError(
+        `Cannot pin un-earned badge(s): ${missing.join(", ")}`,
+      );
+    }
+  }
+
+  const queries = [
+    {
+      query: `UPDATE user_badges SET pin_slot = NULL WHERE user_id = $1 AND pin_slot IS NOT NULL`,
+      params: [userId],
+    },
+    ...ids.map((badgeId, slot) => ({
+      query: `UPDATE user_badges SET pin_slot = $3 WHERE user_id = $1 AND badge_id = $2`,
+      params: [userId, badgeId, slot],
+    })),
+  ];
+  await db.transaction(queries);
+
+  return getUserBadges(userId);
+}
+
+export class BadgePinError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BadgePinError";
+  }
 }
 
 export async function markBadgesViewed(userId: string): Promise<number> {
-	const rows = await db.query<{ id: number }>(
-		`UPDATE user_badges SET is_new = FALSE WHERE user_id = $1 AND is_new = TRUE RETURNING id`,
-		[userId]
-	);
-	return rows.length;
+  const rows = await db.query<{ id: number }>(
+    `UPDATE user_badges SET is_new = FALSE WHERE user_id = $1 AND is_new = TRUE RETURNING id`,
+    [userId],
+  );
+  return rows.length;
 }
 
 // ─── Aggregate computation ──────────────────────────────────────────
 
-export async function computeAggregates(userId: string): Promise<UserAggregates> {
-	const [streakRow, totalsRow, paceRow, bestDayRow, ccRow] = await Promise.all([
-		computeCurrentStreak(userId),
-		db.query<{ total_miles: string | null }>(
-			`SELECT COALESCE(SUM(distance),0)::text AS total_miles FROM workouts WHERE user_id = $1`,
-			[userId]
-		),
-		db.query<{ min_pace: string | null }>(
-			`SELECT MIN(s.split_pace)::text AS min_pace
+export async function computeAggregates(
+  userId: string,
+): Promise<UserAggregates> {
+  const [streakRow, totalsRow, paceRow, bestDayRow, ccRow] = await Promise.all([
+    computeCurrentStreak(userId),
+    db.query<{ total_miles: string | null }>(
+      `SELECT COALESCE(SUM(distance),0)::text AS total_miles FROM workouts WHERE user_id = $1`,
+      [userId],
+    ),
+    db.query<{ min_pace: string | null }>(
+      `SELECT MIN(s.split_pace)::text AS min_pace
 			FROM workout_splits s JOIN workouts w ON w.workout_id = s.workout_id
 			WHERE w.user_id = $1 AND s.split_pace > 0 AND s.split_distance >= 0.95`,
-			[userId]
-		),
-		db.query<{ best_day: string | null }>(
-			`SELECT COALESCE(MAX(day_total),0)::text AS best_day FROM (
+      [userId],
+    ),
+    db.query<{ best_day: string | null }>(
+      `SELECT COALESCE(MAX(day_total),0)::text AS best_day FROM (
 				SELECT SUM(distance) AS day_total FROM workouts WHERE user_id = $1 GROUP BY local_date
 			) t`,
-			[userId]
-		),
-		db.query<{ count: string }>(
-			`SELECT COUNT(*)::text AS count FROM user_challenge_completions WHERE user_id = $1`,
-			[userId]
-		)
-	]);
+      [userId],
+    ),
+    db.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM user_challenge_completions WHERE user_id = $1`,
+      [userId],
+    ),
+  ]);
 
-	const minPaceSeconds = paceRow[0]?.min_pace ? parseFloat(paceRow[0].min_pace) : 0;
-	return {
-		currentStreak: streakRow,
-		totalMiles: parseFloat(totalsRow[0]?.total_miles ?? '0') || 0,
-		fastestSplitPaceMinMi: minPaceSeconds > 0 ? minPaceSeconds / 60.0 : 0,
-		mostMilesInOneDay: parseFloat(bestDayRow[0]?.best_day ?? '0') || 0,
-		challengeCompletionsCount: parseInt(ccRow[0]?.count ?? '0', 10) || 0
-	};
+  const minPaceSeconds = paceRow[0]?.min_pace
+    ? parseFloat(paceRow[0].min_pace)
+    : 0;
+  return {
+    currentStreak: streakRow,
+    totalMiles: parseFloat(totalsRow[0]?.total_miles ?? "0") || 0,
+    fastestSplitPaceMinMi: minPaceSeconds > 0 ? minPaceSeconds / 60.0 : 0,
+    mostMilesInOneDay: parseFloat(bestDayRow[0]?.best_day ?? "0") || 0,
+    challengeCompletionsCount: parseInt(ccRow[0]?.count ?? "0", 10) || 0,
+  };
 }
 
 // Longest trailing run of consecutive local_dates where SUM(distance) >= 0.95.
 // "Current streak" = ending at the most recent qualifying day (not necessarily today).
 async function computeCurrentStreak(userId: string): Promise<number> {
-	const rows = await db.query<{ local_date: string; total: string }>(
-		`SELECT local_date::text AS local_date, SUM(distance)::text AS total
+  const rows = await db.query<{ local_date: string; total: string }>(
+    `SELECT local_date::text AS local_date, SUM(distance)::text AS total
 		FROM workouts
 		WHERE user_id = $1
 		GROUP BY local_date
 		ORDER BY local_date DESC`,
-		[userId]
-	);
-	if (rows.length === 0) return 0;
+    [userId],
+  );
+  if (rows.length === 0) return 0;
 
-	// Skip leading days until we find a qualifying one — that's the streak endpoint.
-	let i = 0;
-	while (i < rows.length && parseFloat(rows[i].total) < STREAK_QUALIFYING_DISTANCE) i++;
-	if (i >= rows.length) return 0;
+  // Skip leading days until we find a qualifying one — that's the streak endpoint.
+  let i = 0;
+  while (
+    i < rows.length &&
+    parseFloat(rows[i].total) < STREAK_QUALIFYING_DISTANCE
+  )
+    i++;
+  if (i >= rows.length) return 0;
 
-	let streak = 1;
-	let prevDate = rows[i].local_date;
-	for (let j = i + 1; j < rows.length; j++) {
-		const currDate = rows[j].local_date;
-		if (!isPreviousDay(currDate, prevDate)) break;
-		if (parseFloat(rows[j].total) < STREAK_QUALIFYING_DISTANCE) break;
-		streak++;
-		prevDate = currDate;
-	}
-	return streak;
+  let streak = 1;
+  let prevDate = rows[i].local_date;
+  for (let j = i + 1; j < rows.length; j++) {
+    const currDate = rows[j].local_date;
+    if (!isPreviousDay(currDate, prevDate)) break;
+    if (parseFloat(rows[j].total) < STREAK_QUALIFYING_DISTANCE) break;
+    streak++;
+    prevDate = currDate;
+  }
+  return streak;
 }
 
 function isPreviousDay(earlierYmd: string, laterYmd: string): boolean {
-	const [y1, m1, d1] = earlierYmd.split('-').map(n => parseInt(n, 10));
-	const [y2, m2, d2] = laterYmd.split('-').map(n => parseInt(n, 10));
-	const earlier = Date.UTC(y1, m1 - 1, d1);
-	const later = Date.UTC(y2, m2 - 1, d2);
-	return later - earlier === 86400000;
+  const [y1, m1, d1] = earlierYmd.split("-").map((n) => parseInt(n, 10));
+  const [y2, m2, d2] = laterYmd.split("-").map((n) => parseInt(n, 10));
+  const earlier = Date.UTC(y1, m1 - 1, d1);
+  const later = Date.UTC(y2, m2 - 1, d2);
+  return later - earlier === 86400000;
 }
 
 // ─── Evaluator ──────────────────────────────────────────────────────
 
 export async function evaluateForUser(
-	userId: string,
-	newWorkoutIds: string[]
+  userId: string,
+  newWorkoutIds: string[],
 ): Promise<{ newlyEarnedBadges: UserBadge[] }> {
-	const [aggregates, catalog, earned] = await Promise.all([
-		computeAggregates(userId),
-		getCatalog(true),
-		getEarnedBadgeIds(userId)
-	]);
+  const [aggregates, catalog, earned] = await Promise.all([
+    computeAggregates(userId),
+    getCatalog(true),
+    getEarnedBadgeIds(userId),
+  ]);
 
-	const triggeringWorkoutId = newWorkoutIds[newWorkoutIds.length - 1] ?? null;
-	const snapshot = {
-		streak: aggregates.currentStreak,
-		totalMiles: roundTo(aggregates.totalMiles, 2),
-		fastestMilePace: roundTo(aggregates.fastestSplitPaceMinMi, 3),
-		mostMilesInOneDay: roundTo(aggregates.mostMilesInOneDay, 2),
-		challengeCompletions: aggregates.challengeCompletionsCount
-	};
+  const triggeringWorkoutId = newWorkoutIds[newWorkoutIds.length - 1] ?? null;
+  const snapshot = {
+    streak: aggregates.currentStreak,
+    totalMiles: roundTo(aggregates.totalMiles, 2),
+    fastestMilePace: roundTo(aggregates.fastestSplitPaceMinMi, 3),
+    mostMilesInOneDay: roundTo(aggregates.mostMilesInOneDay, 2),
+    challengeCompletions: aggregates.challengeCompletionsCount,
+  };
 
-	const toInsert: { badgeId: string; aggregateOnly: boolean }[] = [];
+  const toInsert: { badgeId: string; aggregateOnly: boolean }[] = [];
 
-	for (const badge of catalog) {
-		if (earned.has(badge.badgeId)) continue;
-		const result = evaluatePredicate(badge, aggregates);
-		if (result.earned) {
-			toInsert.push({ badgeId: badge.badgeId, aggregateOnly: result.aggregateOnly });
-		}
-	}
+  for (const badge of catalog) {
+    if (earned.has(badge.badgeId)) continue;
+    const result = evaluatePredicate(badge, aggregates);
+    if (result.earned) {
+      toInsert.push({
+        badgeId: badge.badgeId,
+        aggregateOnly: result.aggregateOnly,
+      });
+    }
+  }
 
-	if (toInsert.length === 0) {
-		return { newlyEarnedBadges: [] };
-	}
+  if (toInsert.length === 0) {
+    return { newlyEarnedBadges: [] };
+  }
 
-	const queries = toInsert.map(({ badgeId, aggregateOnly }) => ({
-		query: `INSERT INTO user_badges (user_id, badge_id, triggering_workout_id, progress_snapshot)
+  const queries = toInsert.map(({ badgeId, aggregateOnly }) => ({
+    query: `INSERT INTO user_badges (user_id, badge_id, triggering_workout_id, progress_snapshot)
 			VALUES ($1, $2, $3, $4)
 			ON CONFLICT (user_id, badge_id) DO NOTHING`,
-		params: [
-			userId,
-			badgeId,
-			aggregateOnly ? null : triggeringWorkoutId,
-			JSON.stringify(snapshot)
-		]
-	}));
-	await db.transaction(queries);
+    params: [
+      userId,
+      badgeId,
+      aggregateOnly ? null : triggeringWorkoutId,
+      JSON.stringify(snapshot),
+    ],
+  }));
+  await db.transaction(queries);
 
-	const insertedIds = toInsert.map(t => t.badgeId);
-	const newlyEarnedBadges = await db.query<any>(
-		`SELECT
-			ub.badge_id, ub.earned_at, ub.is_new, ub.triggering_workout_id, ub.progress_snapshot,
+  const insertedIds = toInsert.map((t) => t.badgeId);
+  const newlyEarnedBadges = await db.query<any>(
+    `SELECT
+			ub.badge_id, ub.earned_at, ub.is_new, ub.pin_slot, ub.triggering_workout_id, ub.progress_snapshot,
 			b.category, b.name, b.description, b.icon, b.rarity, b.requirement, b.is_hidden
 		FROM user_badges ub
 		JOIN badges b ON b.badge_id = ub.badge_id
 		WHERE ub.user_id = $1 AND ub.badge_id = ANY($2::text[])
 		ORDER BY ub.earned_at DESC`,
-		[userId, insertedIds]
-	);
+    [userId, insertedIds],
+  );
 
-	return { newlyEarnedBadges: newlyEarnedBadges.map(rowToUserBadge) };
+  return { newlyEarnedBadges: newlyEarnedBadges.map(rowToUserBadge) };
 }
 
 async function getEarnedBadgeIds(userId: string): Promise<Set<string>> {
-	const rows = await db.query<{ badge_id: string }>(
-		`SELECT badge_id FROM user_badges WHERE user_id = $1`,
-		[userId]
-	);
-	return new Set(rows.map(r => r.badge_id));
+  const rows = await db.query<{ badge_id: string }>(
+    `SELECT badge_id FROM user_badges WHERE user_id = $1`,
+    [userId],
+  );
+  return new Set(rows.map((r) => r.badge_id));
 }
 
 // Returns { earned: bool, aggregateOnly: bool }.
 // aggregateOnly = badge derives from aggregates and can't be pinned to a single workout.
-function evaluatePredicate(badge: Badge, agg: UserAggregates): { earned: boolean; aggregateOnly: boolean } {
-	const req = badge.requirement !== null ? Number(badge.requirement) : null;
+function evaluatePredicate(
+  badge: Badge,
+  agg: UserAggregates,
+): { earned: boolean; aggregateOnly: boolean } {
+  const req = badge.requirement !== null ? Number(badge.requirement) : null;
 
-	switch (badge.category) {
-		case 'streak':
-			return { earned: req !== null && agg.currentStreak >= req, aggregateOnly: false };
-		case 'miles':
-			return { earned: req !== null && agg.totalMiles >= req, aggregateOnly: false };
-		case 'pace':
-			return {
-				earned: req !== null && agg.fastestSplitPaceMinMi > 0 && agg.fastestSplitPaceMinMi <= req,
-				aggregateOnly: false
-			};
-		case 'daily_distance':
-			return { earned: req !== null && agg.mostMilesInOneDay >= req, aggregateOnly: false };
-		case 'challenge':
-			return { earned: req !== null && agg.challengeCompletionsCount >= req, aggregateOnly: false };
-		case 'special':
-			if (badge.badgeId === 'special_first_mile') {
-				return { earned: agg.totalMiles >= 1.0, aggregateOnly: false };
-			}
-			if (badge.badgeId === 'special_first_week') {
-				return { earned: agg.currentStreak >= 7 && agg.totalMiles >= 7.0, aggregateOnly: true };
-			}
-			return { earned: false, aggregateOnly: true };
-		case 'hidden':
-			return { earned: evaluateHidden(badge.badgeId, agg), aggregateOnly: true };
-		default:
-			return { earned: false, aggregateOnly: true };
-	}
+  switch (badge.category) {
+    case "streak":
+      return {
+        earned: req !== null && agg.currentStreak >= req,
+        aggregateOnly: false,
+      };
+    case "miles":
+      return {
+        earned: req !== null && agg.totalMiles >= req,
+        aggregateOnly: false,
+      };
+    case "pace":
+      return {
+        earned:
+          req !== null &&
+          agg.fastestSplitPaceMinMi > 0 &&
+          agg.fastestSplitPaceMinMi <= req,
+        aggregateOnly: false,
+      };
+    case "daily_distance":
+      return {
+        earned: req !== null && agg.mostMilesInOneDay >= req,
+        aggregateOnly: false,
+      };
+    case "challenge":
+      return {
+        earned: req !== null && agg.challengeCompletionsCount >= req,
+        aggregateOnly: false,
+      };
+    case "special":
+      if (badge.badgeId === "special_first_mile") {
+        return { earned: agg.totalMiles >= 1.0, aggregateOnly: false };
+      }
+      if (badge.badgeId === "special_first_week") {
+        return {
+          earned: agg.currentStreak >= 7 && agg.totalMiles >= 7.0,
+          aggregateOnly: true,
+        };
+      }
+      return { earned: false, aggregateOnly: true };
+    case "hidden":
+      return {
+        earned: evaluateHidden(badge.badgeId, agg),
+        aggregateOnly: true,
+      };
+    default:
+      return { earned: false, aggregateOnly: true };
+  }
 }
 
 function evaluateHidden(badgeId: string, agg: UserAggregates): boolean {
-	const pace = agg.fastestSplitPaceMinMi;
-	switch (badgeId) {
-		case 'hidden_perfect_10':
-			return agg.mostMilesInOneDay >= 10.0 && agg.mostMilesInOneDay < 10.1;
-		case 'hidden_lucky_7':
-			return agg.currentStreak === 7 && agg.mostMilesInOneDay >= 7.0;
-		case 'hidden_double_trouble':
-			return agg.totalMiles >= 22.0 && agg.totalMiles < 23.0;
-		case 'hidden_century_double':
-			return agg.currentStreak >= 100 && agg.totalMiles >= 100;
-		case 'hidden_speed_endurance':
-			return pace > 0 && pace <= 8.0 && agg.mostMilesInOneDay >= 5.0;
-		case 'hidden_marathon_pace':
-			return pace > 0 && pace <= 10.0 && agg.mostMilesInOneDay >= 26.2;
-		case 'hidden_triple_threat':
-			return agg.currentStreak >= 30 && agg.totalMiles >= 30 && agg.mostMilesInOneDay >= 3.0;
-		case 'hidden_50_50':
-			return agg.currentStreak >= 50 && agg.totalMiles >= 50;
-		case 'hidden_year_miles':
-			return agg.totalMiles >= 365;
-		case 'hidden_thousand_club':
-			return agg.currentStreak >= 1000 || agg.totalMiles >= 1000;
-		case 'hidden_pace_perfect':
-			return pace > 0 && pace <= 7.0 && agg.mostMilesInOneDay >= 10.0;
-		default:
-			return false;
-	}
+  const pace = agg.fastestSplitPaceMinMi;
+  switch (badgeId) {
+    case "hidden_perfect_10":
+      return agg.mostMilesInOneDay >= 10.0 && agg.mostMilesInOneDay < 10.1;
+    case "hidden_lucky_7":
+      return agg.currentStreak === 7 && agg.mostMilesInOneDay >= 7.0;
+    case "hidden_double_trouble":
+      return agg.totalMiles >= 22.0 && agg.totalMiles < 23.0;
+    case "hidden_century_double":
+      return agg.currentStreak >= 100 && agg.totalMiles >= 100;
+    case "hidden_speed_endurance":
+      return pace > 0 && pace <= 8.0 && agg.mostMilesInOneDay >= 5.0;
+    case "hidden_marathon_pace":
+      return pace > 0 && pace <= 10.0 && agg.mostMilesInOneDay >= 26.2;
+    case "hidden_triple_threat":
+      return (
+        agg.currentStreak >= 30 &&
+        agg.totalMiles >= 30 &&
+        agg.mostMilesInOneDay >= 3.0
+      );
+    case "hidden_50_50":
+      return agg.currentStreak >= 50 && agg.totalMiles >= 50;
+    case "hidden_year_miles":
+      return agg.totalMiles >= 365;
+    case "hidden_thousand_club":
+      return agg.currentStreak >= 1000 || agg.totalMiles >= 1000;
+    case "hidden_pace_perfect":
+      return pace > 0 && pace <= 7.0 && agg.mostMilesInOneDay >= 10.0;
+    default:
+      return false;
+  }
 }
 
 // ─── Orchestrator called from workout upload ────────────────────────
 
 export async function evaluateWorkoutRewards(
-	userId: string,
-	newWorkoutIds: string[]
+  userId: string,
+  newWorkoutIds: string[],
 ): Promise<RewardEvaluationResult> {
-	const newChallengeCompletions = await evaluateChallengesForBatch(userId, newWorkoutIds);
-	const { newlyEarnedBadges } = await evaluateForUser(userId, newWorkoutIds);
-	return { newlyEarnedBadges, newChallengeCompletions };
+  const newChallengeCompletions = await evaluateChallengesForBatch(
+    userId,
+    newWorkoutIds,
+  );
+  const { newlyEarnedBadges } = await evaluateForUser(userId, newWorkoutIds);
+  return { newlyEarnedBadges, newChallengeCompletions };
 }
 
 // ─── Row mappers ────────────────────────────────────────────────────
 
 function rowToBadge(row: any): Badge {
-	return {
-		badgeId: row.badge_id,
-		category: row.category,
-		name: row.name,
-		description: row.description,
-		icon: row.icon,
-		rarity: row.rarity,
-		requirement: row.requirement !== null ? Number(row.requirement) : null,
-		isHidden: row.is_hidden,
-		sortOrder: row.sort_order
-	};
+  return {
+    badgeId: row.badge_id,
+    category: row.category,
+    name: row.name,
+    description: row.description,
+    icon: row.icon,
+    rarity: row.rarity,
+    requirement: row.requirement !== null ? Number(row.requirement) : null,
+    isHidden: row.is_hidden,
+    sortOrder: row.sort_order,
+  };
 }
 
 function rowToUserBadge(row: any): UserBadge {
-	return {
-		badgeId: row.badge_id,
-		category: row.category,
-		name: row.name,
-		description: row.description,
-		icon: row.icon,
-		rarity: row.rarity,
-		requirement: row.requirement !== null ? Number(row.requirement) : null,
-		isHidden: row.is_hidden,
-		earnedAt: row.earned_at instanceof Date ? row.earned_at.toISOString() : String(row.earned_at),
-		isNew: row.is_new,
-		triggeringWorkoutId: row.triggering_workout_id,
-		progressSnapshot: row.progress_snapshot
-	};
+  return {
+    badgeId: row.badge_id,
+    category: row.category,
+    name: row.name,
+    description: row.description,
+    icon: row.icon,
+    rarity: row.rarity,
+    requirement: row.requirement !== null ? Number(row.requirement) : null,
+    isHidden: row.is_hidden,
+    earnedAt:
+      row.earned_at instanceof Date
+        ? row.earned_at.toISOString()
+        : String(row.earned_at),
+    isNew: row.is_new,
+    pinSlot: row.pin_slot ?? null,
+    triggeringWorkoutId: row.triggering_workout_id,
+    progressSnapshot: row.progress_snapshot,
+  };
 }
 
 function roundTo(n: number, places: number): number {
-	const m = Math.pow(10, places);
-	return Math.round(n * m) / m;
+  const m = Math.pow(10, places);
+  return Math.round(n * m) / m;
 }

--- a/backend/src/types/badge.ts
+++ b/backend/src/types/badge.ts
@@ -1,90 +1,103 @@
-export type BadgeCategory = 'streak' | 'miles' | 'pace' | 'daily_distance' | 'challenge' | 'special' | 'hidden';
-export type BadgeRarity = 'common' | 'rare' | 'legendary';
-export type DailyChallengeType = 'pace' | 'distance' | 'time' | 'activity' | 'steps';
+export type BadgeCategory =
+  | "streak"
+  | "miles"
+  | "pace"
+  | "daily_distance"
+  | "challenge"
+  | "special"
+  | "hidden";
+export type BadgeRarity = "common" | "rare" | "legendary";
+export type DailyChallengeType =
+  | "pace"
+  | "distance"
+  | "time"
+  | "activity"
+  | "steps";
 
 export interface Badge {
-	badgeId: string;
-	category: BadgeCategory;
-	name: string;
-	description: string;
-	icon: string;
-	rarity: BadgeRarity;
-	requirement: number | null;
-	isHidden: boolean;
-	sortOrder: number;
+  badgeId: string;
+  category: BadgeCategory;
+  name: string;
+  description: string;
+  icon: string;
+  rarity: BadgeRarity;
+  requirement: number | null;
+  isHidden: boolean;
+  sortOrder: number;
 }
 
 export interface UserBadge {
-	badgeId: string;
-	category: BadgeCategory;
-	name: string;
-	description: string;
-	icon: string;
-	rarity: BadgeRarity;
-	requirement: number | null;
-	isHidden: boolean;
-	earnedAt: string;
-	isNew: boolean;
-	triggeringWorkoutId: string | null;
-	progressSnapshot: Record<string, unknown> | null;
+  badgeId: string;
+  category: BadgeCategory;
+  name: string;
+  description: string;
+  icon: string;
+  rarity: BadgeRarity;
+  requirement: number | null;
+  isHidden: boolean;
+  earnedAt: string;
+  isNew: boolean;
+  pinSlot: number | null;
+  triggeringWorkoutId: string | null;
+  progressSnapshot: Record<string, unknown> | null;
 }
 
 export interface DailyChallenge {
-	key: string;
-	title: string;
-	description: string;
-	icon: string;
-	gradientStart: string;
-	gradientEnd: string;
-	type: DailyChallengeType;
+  key: string;
+  title: string;
+  description: string;
+  icon: string;
+  gradientStart: string;
+  gradientEnd: string;
+  type: DailyChallengeType;
 }
 
 export interface TodaysChallengeResponse {
-	localDate: string;
-	challenge: DailyChallenge;
-	progress: number;
-	completed: boolean;
-	completedAt: string | null;
+  localDate: string;
+  challenge: DailyChallenge;
+  progress: number;
+  completed: boolean;
+  completedAt: string | null;
 }
 
 export interface ChallengeCompletionHistoryItem {
-	localDate: string;
-	challengeKey: string;
-	title: string;
-	icon: string;
-	completingWorkoutId: string | null;
-	completedAt: string;
+  localDate: string;
+  challengeKey: string;
+  title: string;
+  icon: string;
+  completingWorkoutId: string | null;
+  completedAt: string;
 }
 
 export interface ChallengeCompletionsResponse {
-	totalCompleted: number;
-	currentStreak: number;
-	completions: ChallengeCompletionHistoryItem[];
+  totalCompleted: number;
+  currentStreak: number;
+  completions: ChallengeCompletionHistoryItem[];
 }
 
 export interface FriendTodayChallengeResponse {
-	userId: string;
-	localDate: string;
-	completed: boolean;
-	challengeKey: string | null;
+  userId: string;
+  localDate: string;
+  completed: boolean;
+  challengeKey: string | null;
 }
 
 export interface NewChallengeCompletion {
-	localDate: string;
-	challengeKey: string;
-	challengeTitle: string;
-	completingWorkoutId: string | null;
+  localDate: string;
+  challengeKey: string;
+  challengeTitle: string;
+  completingWorkoutId: string | null;
 }
 
 export interface RewardEvaluationResult {
-	newlyEarnedBadges: UserBadge[];
-	newChallengeCompletions: NewChallengeCompletion[];
+  newlyEarnedBadges: UserBadge[];
+  newChallengeCompletions: NewChallengeCompletion[];
 }
 
 export interface UserAggregates {
-	currentStreak: number;
-	totalMiles: number;
-	fastestSplitPaceMinMi: number;
-	mostMilesInOneDay: number;
-	challengeCompletionsCount: number;
+  currentStreak: number;
+  totalMiles: number;
+  fastestSplitPaceMinMi: number;
+  mostMilesInOneDay: number;
+  challengeCompletionsCount: number;
 }


### PR DESCRIPTION
- Backend: add pin_slot column on user_badges, PUT /users/:userId/badges/pins endpoint, include pinSlot in GET /users/:userId/badges payload.
- iOS: surface a 3-slot Showcase on the local user's profile with a manage sheet to pick which earned medals to pin; replace the never-populated friend badges section with a pinned showcase plus an owned-vs-locked compare grid that highlights medals the viewer is still missing.
- Fix the navbar trophy: tapping it now lands on the Badges view filtered to newly unlocked medals, with an on-open snapshot so the filter survives the automatic mark-as-viewed.