### PR TITLE
watchOS: redesign with MAD theme, paginated tracker, countdown + recap

### DIFF
--- a/app/Mile A Day Watch Watch App/ContentView.swift
+++ b/app/Mile A Day Watch Watch App/ContentView.swift
@@ -1,51 +1,137 @@
 import SwiftUI
 import HealthKit
 
+// MARK: - Watch Theme
+// Mirrors `MADTheme` from the iOS app so the watch feels like a tiny version
+// of the phone app — same red brand palette, same rounded type, same vibe.
+enum WatchTheme {
+    // Brand
+    static let madRed = Color(red: 0.85, green: 0.25, blue: 0.35)
+    static let madRedDeep = Color(red: 0.70, green: 0.18, blue: 0.27)
+    static let madRedBright = Color(red: 0.95, green: 0.32, blue: 0.42)
+
+    // Status
+    static let success = Color(red: 0.30, green: 0.82, blue: 0.45)
+    static let successDeep = Color(red: 0.18, green: 0.62, blue: 0.32)
+    static let warning = Color(red: 1.00, green: 0.65, blue: 0.10)
+
+    // Neutrals
+    static let surfaceHigh = Color.white.opacity(0.14)
+    static let surface = Color.white.opacity(0.08)
+    static let surfaceLow = Color.white.opacity(0.05)
+    static let hairline = Color.white.opacity(0.18)
+    static let textPrimary = Color.white
+    static let textSecondary = Color.white.opacity(0.62)
+    static let textTertiary = Color.white.opacity(0.42)
+
+    // Backgrounds — tinted near-black with a hint of red, mirroring iOS `appBackgroundGradient`.
+    static let appBackground = LinearGradient(
+        colors: [
+            Color(red: 0.16, green: 0.07, blue: 0.10),
+            Color(red: 0.08, green: 0.03, blue: 0.05),
+            Color.black
+        ],
+        startPoint: .top,
+        endPoint: .bottom
+    )
+
+    static let primaryButton = LinearGradient(
+        colors: [madRedBright, madRedDeep],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    static let successGradient = LinearGradient(
+        colors: [success, successDeep],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    static let progressGradient = AngularGradient(
+        colors: [madRedBright, warning, madRedBright, madRedDeep, madRedBright],
+        center: .center,
+        startAngle: .degrees(-90),
+        endAngle: .degrees(270)
+    )
+
+    static let progressGradientComplete = AngularGradient(
+        colors: [success, Color(red: 0.55, green: 0.92, blue: 0.55), success, successDeep, success],
+        center: .center,
+        startAngle: .degrees(-90),
+        endAngle: .degrees(270)
+    )
+}
+
+// MARK: - Reusable Watch Components
+
+/// Press feedback button style for watch — tiny scale + dim on press.
+struct WatchPressStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.96 : 1.0)
+            .opacity(configuration.isPressed ? 0.85 : 1.0)
+            .animation(.spring(response: 0.25, dampingFraction: 0.7), value: configuration.isPressed)
+    }
+}
+
+// MARK: - Content View
+
 struct ContentView: View {
     @EnvironmentObject var healthManager: HealthKitManager
     @EnvironmentObject var userManager: UserManager
+
     @State private var showWorkoutView = false
     @State private var selectedActivityType: HKWorkoutActivityType = .running
-
-    // Theme
-    private let accentRed = Color(red: 217/255, green: 64/255, blue: 63/255)
+    @State private var locationType: HKWorkoutSessionLocationType = .outdoor
+    @State private var ringPulse: Bool = false
 
     private var goalDistance: Double {
         userManager.currentUser.goalMiles > 0 ? userManager.currentUser.goalMiles : 1.0
     }
 
-    private var currentDistance: Double {
-        healthManager.todaysDistance
-    }
+    private var currentDistance: Double { healthManager.todaysDistance }
 
-    private var progress: Double {
-        min(currentDistance / goalDistance, 1.0)
-    }
+    private var progress: Double { min(currentDistance / goalDistance, 1.0) }
 
-    private var isCompleted: Bool {
-        currentDistance >= goalDistance
-    }
+    private var isCompleted: Bool { currentDistance >= goalDistance }
 
-    private var currentStreak: Int {
-        healthManager.retroactiveStreak
+    private var currentStreak: Int { healthManager.retroactiveStreak }
+
+    private var remainingDistance: Double { max(goalDistance - currentDistance, 0) }
+
+    private var greetingFirstName: String? {
+        let first = userManager.currentUser.firstName?.trimmingCharacters(in: .whitespaces) ?? ""
+        if !first.isEmpty { return first }
+        let fallback = userManager.currentUser.name.split(separator: " ").first.map(String.init) ?? ""
+        return fallback.isEmpty ? nil : fallback
     }
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: 14) {
-                // Progress ring with distance
-                progressRing
-                    .padding(.top, 4)
+        ZStack {
+            WatchTheme.appBackground
+                .ignoresSafeArea()
 
-                // Streak pill
-                streakPill
+            ScrollView {
+                VStack(spacing: 12) {
+                    header
+                        .padding(.top, 2)
 
-                // Action buttons
-                actionButtons
-                    .padding(.top, 4)
+                    heroRing
+                        .padding(.top, 2)
+
+                    goalStatus
+
+                    streakPill
+
+                    activityButtons
+                        .padding(.top, 4)
+
+                    locationToggle
+                        .padding(.top, 2)
+                        .padding(.bottom, 4)
+                }
+                .padding(.horizontal, 6)
             }
-            .padding(.horizontal, 8)
-            .padding(.bottom, 16)
         }
         .fullScreenCover(isPresented: $showWorkoutView) {
             WorkoutView(
@@ -53,11 +139,16 @@ struct ContentView: View {
                 userManager: userManager,
                 goalDistance: goalDistance,
                 startingDistance: currentDistance,
-                activityType: selectedActivityType
+                activityType: selectedActivityType,
+                locationType: locationType
             )
         }
         .onAppear {
             healthManager.fetchTodaysDistance()
+            // Gentle pulse on the ring when not yet complete — adds life to the screen.
+            withAnimation(.easeInOut(duration: 2.0).repeatForever(autoreverses: true)) {
+                ringPulse.toggle()
+            }
         }
         .onChange(of: showWorkoutView) { oldValue, newValue in
             if oldValue && !newValue {
@@ -68,47 +159,111 @@ struct ContentView: View {
         }
     }
 
-    // MARK: - Progress Ring
+    // MARK: - Header
 
-    private var progressRing: some View {
+    private var header: some View {
+        VStack(spacing: 1) {
+            HStack(spacing: 4) {
+                if let name = greetingFirstName {
+                    Text("Hey, ")
+                        .foregroundColor(WatchTheme.textSecondary)
+                    + Text(name)
+                        .foregroundColor(WatchTheme.textPrimary)
+                } else {
+                    Text("Mile A Day")
+                        .foregroundColor(WatchTheme.textPrimary)
+                }
+            }
+            .font(.system(size: 13, weight: .semibold, design: .rounded))
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
+
+            Text(Date(), format: .dateTime.weekday(.wide).month().day())
+                .font(.system(size: 10, weight: .medium, design: .rounded))
+                .foregroundColor(WatchTheme.textTertiary)
+        }
+    }
+
+    // MARK: - Hero Ring
+
+    private var heroRing: some View {
         ZStack {
+            // Outer soft glow that breathes when not complete
+            Circle()
+                .stroke(
+                    (isCompleted ? WatchTheme.success : WatchTheme.madRedBright)
+                        .opacity(ringPulse && !isCompleted ? 0.22 : 0.10),
+                    lineWidth: 1
+                )
+                .frame(width: 132, height: 132)
+                .blur(radius: 4)
+
             // Track
             Circle()
-                .stroke(Color.white.opacity(0.1), lineWidth: 12)
-                .frame(width: 120, height: 120)
+                .stroke(Color.white.opacity(0.08), lineWidth: 11)
+                .frame(width: 122, height: 122)
 
             // Progress arc
             Circle()
                 .trim(from: 0, to: progress)
                 .stroke(
-                    AngularGradient(
-                        colors: isCompleted
-                            ? [.green, .green.opacity(0.7), .green]
-                            : [accentRed, .orange, accentRed.opacity(0.6)],
-                        center: .center,
-                        startAngle: .degrees(-90),
-                        endAngle: .degrees(270)
-                    ),
-                    style: StrokeStyle(lineWidth: 12, lineCap: .round)
+                    isCompleted ? WatchTheme.progressGradientComplete : WatchTheme.progressGradient,
+                    style: StrokeStyle(lineWidth: 11, lineCap: .round)
                 )
-                .frame(width: 120, height: 120)
+                .frame(width: 122, height: 122)
                 .rotationEffect(.degrees(-90))
-                .animation(.spring(response: 0.8, dampingFraction: 0.7), value: progress)
+                .animation(.spring(response: 0.9, dampingFraction: 0.75), value: progress)
+                .shadow(
+                    color: (isCompleted ? WatchTheme.success : WatchTheme.madRedBright).opacity(0.35),
+                    radius: 6, x: 0, y: 0
+                )
 
             // Center content
-            VStack(spacing: 1) {
+            VStack(spacing: 0) {
                 if isCompleted {
-                    Image(systemName: "checkmark")
+                    Image(systemName: "checkmark.seal.fill")
                         .font(.system(size: 14, weight: .bold))
-                        .foregroundColor(.green)
+                        .foregroundStyle(WatchTheme.successGradient)
+                        .padding(.bottom, 2)
                 }
                 Text(String(format: "%.2f", currentDistance))
-                    .font(.system(size: 28, weight: .bold, design: .rounded))
-                    .foregroundColor(.white)
-                    .minimumScaleFactor(0.7)
-                Text("/ \(String(format: "%.1f", goalDistance)) mi")
+                    .font(.system(size: 30, weight: .heavy, design: .rounded))
+                    .foregroundColor(WatchTheme.textPrimary)
+                    .contentTransition(.numericText())
+                    .minimumScaleFactor(0.6)
+                    .lineLimit(1)
+                HStack(spacing: 2) {
+                    Text("/")
+                    Text(String(format: "%.1f", goalDistance))
+                    Text("mi")
+                }
+                .font(.system(size: 10, weight: .semibold, design: .rounded))
+                .foregroundColor(WatchTheme.textTertiary)
+            }
+        }
+    }
+
+    // MARK: - Goal Status
+
+    private var goalStatus: some View {
+        Group {
+            if isCompleted {
+                HStack(spacing: 5) {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 10, weight: .bold))
+                    Text("Goal complete!")
+                        .font(.system(size: 12, weight: .semibold, design: .rounded))
+                }
+                .foregroundStyle(WatchTheme.successGradient)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background(
+                    Capsule().fill(WatchTheme.success.opacity(0.16))
+                )
+            } else {
+                Text(String(format: "%.2f mi to goal", remainingDistance))
                     .font(.system(size: 11, weight: .medium, design: .rounded))
-                    .foregroundColor(.white.opacity(0.5))
+                    .foregroundColor(WatchTheme.textSecondary)
             }
         }
     }
@@ -118,71 +273,144 @@ struct ContentView: View {
     private var streakPill: some View {
         HStack(spacing: 6) {
             Image(systemName: "flame.fill")
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(.orange)
+                .font(.system(size: 12, weight: .bold))
+                .foregroundStyle(
+                    LinearGradient(
+                        colors: [WatchTheme.warning, WatchTheme.madRedBright],
+                        startPoint: .top, endPoint: .bottom
+                    )
+                )
             Text("\(currentStreak)")
-                .font(.system(size: 16, weight: .bold, design: .rounded))
-                .foregroundColor(.white)
-            Text("day streak")
-                .font(.system(size: 13, weight: .medium, design: .rounded))
-                .foregroundColor(.white.opacity(0.5))
+                .font(.system(size: 14, weight: .heavy, design: .rounded))
+                .foregroundColor(WatchTheme.textPrimary)
+                .contentTransition(.numericText())
+            Text(currentStreak == 1 ? "day streak" : "day streak")
+                .font(.system(size: 11, weight: .medium, design: .rounded))
+                .foregroundColor(WatchTheme.textSecondary)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 6)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 5)
         .background(
             Capsule()
-                .fill(Color.white.opacity(0.1))
+                .fill(WatchTheme.surface)
+                .overlay(Capsule().stroke(WatchTheme.hairline, lineWidth: 0.5))
         )
     }
 
-    // MARK: - Action Buttons
+    // MARK: - Activity Buttons
 
-    private var actionButtons: some View {
-        HStack(spacing: 10) {
-            // Run button
+    private var activityButtons: some View {
+        VStack(spacing: 8) {
             Button {
-                selectedActivityType = .running
-                showWorkoutView = true
+                start(activity: .running)
             } label: {
-                VStack(spacing: 6) {
-                    Image(systemName: "figure.run")
-                        .font(.system(size: 24, weight: .medium))
-                        .foregroundColor(.white)
-                    Text("Run")
-                        .font(.system(size: 13, weight: .semibold, design: .rounded))
-                        .foregroundColor(.white.opacity(0.8))
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 14)
-                .background(
-                    RoundedRectangle(cornerRadius: 16)
-                        .fill(accentRed)
+                actionButtonLabel(
+                    icon: "figure.run",
+                    title: "Start Run",
+                    style: .primary
                 )
             }
-            .buttonStyle(.plain)
+            .buttonStyle(WatchPressStyle())
 
-            // Walk button
             Button {
-                selectedActivityType = .walking
-                showWorkoutView = true
+                start(activity: .walking)
             } label: {
-                VStack(spacing: 6) {
-                    Image(systemName: "figure.walk")
-                        .font(.system(size: 24, weight: .medium))
-                        .foregroundColor(.white)
-                    Text("Walk")
-                        .font(.system(size: 13, weight: .semibold, design: .rounded))
-                        .foregroundColor(.white.opacity(0.8))
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 14)
-                .background(
-                    RoundedRectangle(cornerRadius: 16)
-                        .fill(Color.white.opacity(0.12))
+                actionButtonLabel(
+                    icon: "figure.walk",
+                    title: "Start Walk",
+                    style: .secondary
                 )
             }
-            .buttonStyle(.plain)
+            .buttonStyle(WatchPressStyle())
         }
+    }
+
+    private enum ActionButtonStyle { case primary, secondary }
+
+    private func actionButtonLabel(icon: String, title: String, style: ActionButtonStyle) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.system(size: 16, weight: .bold))
+            Text(title)
+                .font(.system(size: 15, weight: .bold, design: .rounded))
+            Spacer(minLength: 0)
+            Image(systemName: "chevron.right")
+                .font(.system(size: 11, weight: .heavy))
+                .opacity(0.7)
+        }
+        .foregroundColor(.white)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity)
+        .background(
+            ZStack {
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(style == .primary
+                        ? AnyShapeStyle(WatchTheme.primaryButton)
+                        : AnyShapeStyle(WatchTheme.surfaceHigh))
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .strokeBorder(
+                        style == .primary
+                            ? Color.white.opacity(0.18)
+                            : WatchTheme.hairline,
+                        lineWidth: 0.6
+                    )
+            }
+        )
+        .shadow(
+            color: style == .primary ? WatchTheme.madRedDeep.opacity(0.35) : .clear,
+            radius: 6, x: 0, y: 3
+        )
+    }
+
+    // MARK: - Indoor / Outdoor Toggle
+
+    private var locationToggle: some View {
+        HStack(spacing: 0) {
+            locationChip(option: .outdoor, label: "Outdoor", icon: "location.fill")
+            locationChip(option: .indoor, label: "Indoor", icon: "house.fill")
+        }
+        .padding(3)
+        .background(
+            Capsule()
+                .fill(WatchTheme.surfaceLow)
+                .overlay(Capsule().stroke(WatchTheme.hairline, lineWidth: 0.5))
+        )
+        .frame(maxWidth: .infinity)
+    }
+
+    private func locationChip(option: HKWorkoutSessionLocationType, label: String, icon: String) -> some View {
+        let isSelected = locationType == option
+        return Button {
+            guard locationType != option else { return }
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.75)) {
+                locationType = option
+            }
+            WKInterfaceDevice.current().play(.click)
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.system(size: 9, weight: .bold))
+                Text(label)
+                    .font(.system(size: 10, weight: .semibold, design: .rounded))
+            }
+            .foregroundColor(isSelected ? .white : WatchTheme.textSecondary)
+            .padding(.vertical, 4)
+            .frame(maxWidth: .infinity)
+            .background(
+                Capsule()
+                    .fill(isSelected ? WatchTheme.madRed.opacity(0.85) : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Actions
+
+    private func start(activity: HKWorkoutActivityType) {
+        selectedActivityType = activity
+        WKInterfaceDevice.current().play(.start)
+        showWorkoutView = true
     }
 }
 

--- a/app/Mile A Day Watch Watch App/Mile_A_Day_WatchApp.swift
+++ b/app/Mile A Day Watch Watch App/Mile_A_Day_WatchApp.swift
@@ -11,12 +11,10 @@ struct Mile_A_Day_Watch_Watch_AppApp: App {
             ContentView()
                 .environmentObject(healthManager)
                 .environmentObject(userManager)
+                .preferredColorScheme(.dark)
                 .onAppear {
-                    // Request HealthKit authorization on app launch
                     healthManager.requestAuthorization { authorized in
-                        if authorized {
-                            print("HealthKit authorized on Apple Watch")
-                        } else {
+                        if !authorized {
                             print("HealthKit authorization denied on Apple Watch")
                         }
                     }

--- a/app/Mile A Day Watch Watch App/Views/WatchWorkoutManager.swift
+++ b/app/Mile A Day Watch Watch App/Views/WatchWorkoutManager.swift
@@ -2,16 +2,17 @@ import Foundation
 import HealthKit
 import CoreLocation
 
-class WatchWorkoutManager: NSObject, ObservableObject {
-    // Published properties for UI
-    @Published var distance: Double = 0.0 // in miles
+final class WatchWorkoutManager: NSObject, ObservableObject {
+    // Published UI state
+    @Published var distance: Double = 0.0 // miles
     @Published var elapsedTime: TimeInterval = 0
     @Published var currentHeartRate: Double = 0
     @Published var averageHeartRate: Double = 0
     @Published var calories: Double = 0
     @Published var isPaused: Bool = false
+    @Published var sessionState: HKWorkoutSessionState = .notStarted
 
-    // HealthKit properties
+    // HealthKit
     private let healthStore = HKHealthStore()
     private var session: HKWorkoutSession?
     private var builder: HKLiveWorkoutBuilder?
@@ -22,15 +23,12 @@ class WatchWorkoutManager: NSObject, ObservableObject {
     private var pausedTime: TimeInterval = 0
     private var pauseStartDate: Date?
 
-    // Heart rate tracking
+    // Heart rate samples for averaging
     private var heartRateSamples: [Double] = []
 
-    override init() {
-        super.init()
-    }
+    // MARK: - Lifecycle
 
     func startWorkout(activityType: HKWorkoutActivityType, locationType: HKWorkoutSessionLocationType) {
-        // Request HealthKit authorization
         let typesToShare: Set<HKSampleType> = [
             HKObjectType.workoutType(),
             HKObjectType.quantityType(forIdentifier: .distanceWalkingRunning)!,
@@ -47,10 +45,9 @@ class WatchWorkoutManager: NSObject, ObservableObject {
 
         healthStore.requestAuthorization(toShare: typesToShare, read: typesToRead) { [weak self] success, error in
             guard success else {
-                print("HealthKit authorization failed: \(error?.localizedDescription ?? "Unknown error")")
+                print("HealthKit authorization failed: \(error?.localizedDescription ?? "unknown")")
                 return
             }
-
             DispatchQueue.main.async {
                 self?.setupWorkoutSession(activityType: activityType, locationType: locationType)
             }
@@ -58,53 +55,49 @@ class WatchWorkoutManager: NSObject, ObservableObject {
     }
 
     private func setupWorkoutSession(activityType: HKWorkoutActivityType, locationType: HKWorkoutSessionLocationType) {
-        // Create workout configuration
         let configuration = HKWorkoutConfiguration()
         configuration.activityType = activityType
         configuration.locationType = locationType
 
         do {
-            // Create workout session
             session = try HKWorkoutSession(healthStore: healthStore, configuration: configuration)
             builder = session?.associatedWorkoutBuilder()
 
-            // Set ourselves as delegate
             session?.delegate = self
             builder?.delegate = self
 
-            // Setup data source
             builder?.dataSource = HKLiveWorkoutDataSource(
                 healthStore: healthStore,
                 workoutConfiguration: configuration
             )
 
-            // Start the workout session
-            startDate = Date()
-            session?.startActivity(with: startDate)
-            builder?.beginCollection(withStart: startDate!) { success, error in
+            let start = Date()
+            startDate = start
+            session?.startActivity(with: start)
+            builder?.beginCollection(withStart: start) { _, error in
                 if let error = error {
-                    print("Failed to begin collection: \(error.localizedDescription)")
-                    return
-                }
-
-                if success {
-                    print("Workout collection started successfully")
+                    print("beginCollection failed: \(error.localizedDescription)")
                 }
             }
 
-            // Start timer for elapsed time
             startTimer()
-
         } catch {
             print("Failed to create workout session: \(error.localizedDescription)")
         }
     }
 
     private func startTimer() {
+        timer?.invalidate()
         timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            guard let self = self, let startDate = self.startDate, !self.isPaused else { return }
+            guard let self = self, let startDate = self.startDate else { return }
+            // While paused, freeze the displayed time at the moment of pause.
+            // While running, subtract all accumulated paused time.
             DispatchQueue.main.async {
-                self.elapsedTime = Date().timeIntervalSince(startDate) - self.pausedTime
+                if self.isPaused, let pauseStart = self.pauseStartDate {
+                    self.elapsedTime = pauseStart.timeIntervalSince(startDate) - self.pausedTime
+                } else {
+                    self.elapsedTime = Date().timeIntervalSince(startDate) - self.pausedTime
+                }
             }
         }
     }
@@ -119,42 +112,44 @@ class WatchWorkoutManager: NSObject, ObservableObject {
     func resumeWorkout() {
         guard isPaused else { return }
         isPaused = false
-
-        // Add the paused duration to total paused time
         if let pauseStart = pauseStartDate {
             pausedTime += Date().timeIntervalSince(pauseStart)
         }
         pauseStartDate = nil
-
         session?.resume()
     }
 
     func endWorkout(completion: @escaping (Bool) -> Void) {
-        // Stop timer
         timer?.invalidate()
         timer = nil
 
-        // End the workout session
-        session?.end()
+        // Compute average HR up front so the UI has it even if HK save fails.
+        if !heartRateSamples.isEmpty {
+            averageHeartRate = heartRateSamples.reduce(0, +) / Double(heartRateSamples.count)
+        }
 
-        // Finish building the workout
-        builder?.endCollection(withEnd: Date()) { [weak self] success, error in
+        guard let session = session, let builder = builder else {
+            completion(false)
+            return
+        }
+
+        session.end()
+
+        builder.endCollection(withEnd: Date()) { [weak self] success, error in
             guard success, error == nil else {
-                print("Failed to end collection: \(error?.localizedDescription ?? "Unknown error")")
-                completion(false)
+                print("endCollection failed: \(error?.localizedDescription ?? "unknown")")
+                DispatchQueue.main.async { completion(false) }
                 return
             }
-
-            self?.builder?.finishWorkout { workout, error in
+            builder.finishWorkout { _, error in
                 DispatchQueue.main.async {
                     if let error = error {
-                        print("Failed to finish workout: \(error.localizedDescription)")
+                        print("finishWorkout failed: \(error.localizedDescription)")
                         completion(false)
                     } else {
-                        print("Workout saved successfully to HealthKit")
-                        // Calculate average heart rate
-                        if let heartRateSamples = self?.heartRateSamples, !heartRateSamples.isEmpty {
-                            self?.averageHeartRate = heartRateSamples.reduce(0, +) / Double(heartRateSamples.count)
+                        // Refresh average HR one more time in case samples arrived late.
+                        if let samples = self?.heartRateSamples, !samples.isEmpty {
+                            self?.averageHeartRate = samples.reduce(0, +) / Double(samples.count)
                         }
                         completion(true)
                     }
@@ -169,21 +164,21 @@ class WatchWorkoutManager: NSObject, ObservableObject {
         DispatchQueue.main.async {
             switch statistics.quantityType {
             case HKQuantityType.quantityType(forIdentifier: .distanceWalkingRunning):
-                let distanceUnit = HKUnit.meter()
-                let value = statistics.sumQuantity()?.doubleValue(for: distanceUnit) ?? 0
-                self.distance = value * 0.000621371 // Convert meters to miles
+                let meters = statistics.sumQuantity()?.doubleValue(for: HKUnit.meter()) ?? 0
+                self.distance = meters * 0.000621371
 
             case HKQuantityType.quantityType(forIdentifier: .activeEnergyBurned):
-                let energyUnit = HKUnit.kilocalorie()
-                let value = statistics.sumQuantity()?.doubleValue(for: energyUnit) ?? 0
-                self.calories = value
+                self.calories = statistics.sumQuantity()?.doubleValue(for: HKUnit.kilocalorie()) ?? 0
 
             case HKQuantityType.quantityType(forIdentifier: .heartRate):
-                let heartRateUnit = HKUnit.count().unitDivided(by: HKUnit.minute())
-                let value = statistics.mostRecentQuantity()?.doubleValue(for: heartRateUnit) ?? 0
-                self.currentHeartRate = value
-                if value > 0 {
-                    self.heartRateSamples.append(value)
+                let hrUnit = HKUnit.count().unitDivided(by: HKUnit.minute())
+                let hr = statistics.mostRecentQuantity()?.doubleValue(for: hrUnit) ?? 0
+                self.currentHeartRate = hr
+                if hr > 0 {
+                    self.heartRateSamples.append(hr)
+                }
+                if let avg = statistics.averageQuantity()?.doubleValue(for: hrUnit), avg > 0 {
+                    self.averageHeartRate = avg
                 }
 
             default:
@@ -197,34 +192,18 @@ class WatchWorkoutManager: NSObject, ObservableObject {
 extension WatchWorkoutManager: HKWorkoutSessionDelegate {
     func workoutSession(_ workoutSession: HKWorkoutSession, didChangeTo toState: HKWorkoutSessionState, from fromState: HKWorkoutSessionState, date: Date) {
         DispatchQueue.main.async {
-            switch toState {
-            case .notStarted:
-                print("Workout session not started")
-            case .running:
-                print("Workout session running")
-            case .ended:
-                print("Workout session ended")
-            case .paused:
-                print("Workout session paused")
-            case .prepared:
-                print("Workout session prepared")
-            case .stopped:
-                print("Workout session stopped")
-            @unknown default:
-                print("Workout session in unknown state")
-            }
+            self.sessionState = toState
         }
     }
 
     func workoutSession(_ workoutSession: HKWorkoutSession, didFailWithError error: Error) {
-        print("Workout session failed with error: \(error.localizedDescription)")
+        print("Workout session failed: \(error.localizedDescription)")
     }
 }
 
 // MARK: - HKLiveWorkoutBuilderDelegate
 extension WatchWorkoutManager: HKLiveWorkoutBuilderDelegate {
     func workoutBuilder(_ workoutBuilder: HKLiveWorkoutBuilder, didCollectDataOf collectedTypes: Set<HKSampleType>) {
-        // Update statistics for collected data types
         for type in collectedTypes {
             guard let quantityType = type as? HKQuantityType else { continue }
             let statistics = workoutBuilder.statistics(for: quantityType)
@@ -232,7 +211,5 @@ extension WatchWorkoutManager: HKLiveWorkoutBuilderDelegate {
         }
     }
 
-    func workoutBuilderDidCollectEvent(_ workoutBuilder: HKLiveWorkoutBuilder) {
-        // Handle workout events if needed
-    }
+    func workoutBuilderDidCollectEvent(_ workoutBuilder: HKLiveWorkoutBuilder) { }
 }

--- a/app/Mile A Day Watch Watch App/Views/WorkoutView.swift
+++ b/app/Mile A Day Watch Watch App/Views/WorkoutView.swift
@@ -1,12 +1,20 @@
 import SwiftUI
 import HealthKit
 
+// MARK: - Workout View
+// Apple Workout-style paginated tracker — swipe between three pages:
+//   1. Now Playing (distance + progress ring)
+//   2. Live Stats (time / pace / HR / calories)
+//   3. Controls (pause / end)
+// With a 3-2-1 countdown before tracking begins and a polished recap at the end.
+
 struct WorkoutView: View {
     @ObservedObject var healthManager: HealthKitManager
     @ObservedObject var userManager: UserManager
     let goalDistance: Double
     let startingDistance: Double
     let activityType: HKWorkoutActivityType
+    let locationType: HKWorkoutSessionLocationType
     @Environment(\.dismiss) var dismiss
 
     @StateObject private var workoutManager = WatchWorkoutManager()
@@ -14,32 +22,27 @@ struct WorkoutView: View {
     @State private var workoutStarted = false
     @State private var showEndConfirmation = false
     @State private var goalReached = false
+    @State private var countdownNumber = 3
+    @State private var showCountdown = true
+    @State private var pageSelection: Int = 0
 
-    private var currentDistance: Double {
-        workoutManager.distance
-    }
+    private var currentDistance: Double { workoutManager.distance }
 
-    private var totalDailyDistance: Double {
-        startingDistance + workoutManager.distance
-    }
+    private var totalDailyDistance: Double { startingDistance + workoutManager.distance }
 
-    private var progress: Double {
-        min(totalDailyDistance / goalDistance, 1.0)
-    }
+    private var progress: Double { min(totalDailyDistance / goalDistance, 1.0) }
 
-    private var isCompleted: Bool {
-        totalDailyDistance >= goalDistance
-    }
+    private var isCompleted: Bool { totalDailyDistance >= goalDistance }
 
-    private var activityName: String {
-        activityType == .running ? "Run" : "Walk"
-    }
+    private var activityName: String { activityType == .running ? "Run" : "Walk" }
 
-    // Theme
-    private let accentRed = Color(red: 217/255, green: 64/255, blue: 63/255)
+    private var activityIcon: String { activityType == .running ? "figure.run" : "figure.walk" }
 
     var body: some View {
-        Group {
+        ZStack {
+            WatchTheme.appBackground
+                .ignoresSafeArea()
+
             if showRecap {
                 WorkoutRecapView(
                     distance: currentDistance,
@@ -47,20 +50,25 @@ struct WorkoutView: View {
                     heartRate: workoutManager.averageHeartRate,
                     calories: workoutManager.calories,
                     activityName: activityName,
+                    activityIcon: activityIcon,
                     goalReached: isCompleted,
                     onDismiss: { dismiss() }
                 )
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+            } else if showCountdown {
+                countdownView
+                    .transition(.opacity)
             } else {
-                activeTrackingView
+                trackingPager
+                    .transition(.opacity)
             }
         }
+        .animation(.easeInOut(duration: 0.35), value: showCountdown)
+        .animation(.easeInOut(duration: 0.35), value: showRecap)
         .onAppear {
             if !workoutStarted {
                 workoutStarted = true
-                workoutManager.startWorkout(
-                    activityType: activityType,
-                    locationType: .outdoor
-                )
+                runCountdown()
             }
         }
         .onChange(of: isCompleted) { _, newValue in
@@ -71,179 +79,305 @@ struct WorkoutView: View {
         }
     }
 
-    // MARK: - Active Tracking
+    // MARK: - Countdown
 
-    private var activeTrackingView: some View {
-        VStack(spacing: 0) {
-            // Activity label
-            HStack(spacing: 4) {
-                Image(systemName: activityType == .running ? "figure.run" : "figure.walk")
-                    .font(.system(size: 11, weight: .semibold))
+    private var countdownView: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 5) {
+                Image(systemName: activityIcon)
                 Text(activityName.uppercased())
-                    .font(.system(size: 11, weight: .bold, design: .rounded))
             }
-            .foregroundColor(accentRed)
-            .padding(.top, 6)
+            .font(.system(size: 11, weight: .heavy, design: .rounded))
+            .foregroundColor(WatchTheme.madRedBright)
+            .tracking(1.2)
 
-            Spacer()
-
-            // Central metrics
             ZStack {
-                // Progress ring
                 Circle()
-                    .stroke(Color.white.opacity(0.08), lineWidth: 8)
-                    .frame(width: 130, height: 130)
+                    .stroke(WatchTheme.madRed.opacity(0.18), lineWidth: 4)
+                    .frame(width: 120, height: 120)
 
                 Circle()
-                    .trim(from: 0, to: progress)
-                    .stroke(
-                        isCompleted
-                            ? Color.green
-                            : accentRed,
-                        style: StrokeStyle(lineWidth: 8, lineCap: .round)
-                    )
-                    .frame(width: 130, height: 130)
-                    .rotationEffect(.degrees(-90))
-                    .animation(.easeOut(duration: 0.5), value: progress)
+                    .fill(WatchTheme.madRed.opacity(0.15))
+                    .frame(width: 120, height: 120)
 
-                // Distance in center
-                VStack(spacing: 0) {
-                    Text(String(format: "%.2f", currentDistance))
-                        .font(.system(size: 36, weight: .bold, design: .rounded))
-                        .foregroundColor(.white)
-                        .minimumScaleFactor(0.7)
-                    Text("mi")
-                        .font(.system(size: 13, weight: .semibold, design: .rounded))
-                        .foregroundColor(.white.opacity(0.5))
-                }
+                Text("\(countdownNumber)")
+                    .font(.system(size: 78, weight: .heavy, design: .rounded))
+                    .foregroundStyle(WatchTheme.primaryButton)
+                    .id(countdownNumber) // re-render for transition
+                    .transition(.scale(scale: 0.5).combined(with: .opacity))
             }
 
-            // Goal status
-            if isCompleted {
-                HStack(spacing: 4) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 12))
-                    Text("Goal reached!")
-                        .font(.system(size: 12, weight: .semibold, design: .rounded))
-                }
-                .foregroundColor(.green)
-                .padding(.top, 4)
-            } else {
-                Text("\(String(format: "%.2f", max(goalDistance - totalDailyDistance, 0))) mi to goal")
-                    .font(.system(size: 12, weight: .medium, design: .rounded))
-                    .foregroundColor(.white.opacity(0.4))
-                    .padding(.top, 4)
-            }
-
-            Spacer()
-
-            // Stats row
-            statsRow
-                .padding(.horizontal, 4)
-
-            Spacer()
-
-            // Control buttons
-            controlButtons
-                .padding(.bottom, 8)
+            Text("Get ready")
+                .font(.system(size: 11, weight: .medium, design: .rounded))
+                .foregroundColor(WatchTheme.textTertiary)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func runCountdown() {
+        WKInterfaceDevice.current().play(.start)
+        Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
+            if countdownNumber > 1 {
+                withAnimation(.spring(response: 0.45, dampingFraction: 0.7)) {
+                    countdownNumber -= 1
+                }
+                WKInterfaceDevice.current().play(.click)
+            } else {
+                timer.invalidate()
+                WKInterfaceDevice.current().play(.success)
+                withAnimation { showCountdown = false }
+                workoutManager.startWorkout(activityType: activityType, locationType: locationType)
+            }
+        }
+    }
+
+    // MARK: - Paginated Tracker
+
+    private var trackingPager: some View {
+        TabView(selection: $pageSelection) {
+            nowPlayingPage
+                .tag(0)
+            statsPage
+                .tag(1)
+            controlsPage
+                .tag(2)
+        }
+        .tabViewStyle(.verticalPage)
         .confirmationDialog("End workout?", isPresented: $showEndConfirmation) {
             Button("End Workout", role: .destructive) { endWorkout() }
             Button("Cancel", role: .cancel) { }
         }
     }
 
-    // MARK: - Stats Row
+    // MARK: - Page 1: Now Playing
 
-    private var statsRow: some View {
-        HStack(spacing: 0) {
-            // Time
-            statItem(
-                label: "TIME",
-                value: formattedTime
-            )
-
-            divider
-
-            // Pace
-            statItem(
-                label: "PACE",
-                value: formattedPace
-            )
-
-            if workoutManager.currentHeartRate > 0 {
-                divider
-
-                // Heart rate
-                statItem(
-                    label: "BPM",
-                    value: "\(Int(workoutManager.currentHeartRate))",
-                    valueColor: .red
-                )
-            }
-        }
-    }
-
-    private func statItem(label: String, value: String, valueColor: Color = .white) -> some View {
-        VStack(spacing: 2) {
-            Text(label)
-                .font(.system(size: 9, weight: .semibold, design: .rounded))
-                .foregroundColor(.white.opacity(0.4))
-            Text(value)
-                .font(.system(size: 16, weight: .semibold, design: .rounded))
-                .foregroundColor(valueColor)
-                .minimumScaleFactor(0.8)
-        }
-        .frame(maxWidth: .infinity)
-    }
-
-    private var divider: some View {
-        Rectangle()
-            .fill(Color.white.opacity(0.15))
-            .frame(width: 1, height: 28)
-    }
-
-    // MARK: - Control Buttons
-
-    private var controlButtons: some View {
-        HStack(spacing: 16) {
-            // Pause / Resume
-            Button {
+    private var nowPlayingPage: some View {
+        VStack(spacing: 6) {
+            HStack(spacing: 5) {
+                Image(systemName: activityIcon)
+                Text(activityName.uppercased())
                 if workoutManager.isPaused {
-                    workoutManager.resumeWorkout()
-                } else {
-                    workoutManager.pauseWorkout()
-                }
-                WKInterfaceDevice.current().play(.click)
-            } label: {
-                ZStack {
-                    Circle()
-                        .fill(Color.yellow.opacity(0.9))
-                        .frame(width: 50, height: 50)
-
-                    Image(systemName: workoutManager.isPaused ? "play.fill" : "pause")
-                        .font(.system(size: 18, weight: .bold))
-                        .foregroundColor(.black)
+                    Text("· PAUSED")
+                        .foregroundColor(WatchTheme.warning)
                 }
             }
-            .buttonStyle(.plain)
+            .font(.system(size: 10, weight: .heavy, design: .rounded))
+            .foregroundColor(workoutManager.isPaused ? WatchTheme.warning : WatchTheme.madRedBright)
+            .tracking(1.0)
 
-            // Stop
-            Button {
-                showEndConfirmation = true
-            } label: {
-                ZStack {
-                    Circle()
-                        .fill(Color.red)
-                        .frame(width: 50, height: 50)
+            progressRing
+                .padding(.top, 2)
 
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(Color.white)
-                        .frame(width: 16, height: 16)
+            goalLine
+                .padding(.top, 4)
+
+            pageDots
+                .padding(.top, 4)
+        }
+        .padding(.horizontal, 8)
+    }
+
+    private var progressRing: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.white.opacity(0.08), lineWidth: 9)
+                .frame(width: 128, height: 128)
+
+            Circle()
+                .trim(from: 0, to: progress)
+                .stroke(
+                    isCompleted ? WatchTheme.progressGradientComplete : WatchTheme.progressGradient,
+                    style: StrokeStyle(lineWidth: 9, lineCap: .round)
+                )
+                .frame(width: 128, height: 128)
+                .rotationEffect(.degrees(-90))
+                .animation(.spring(response: 0.6, dampingFraction: 0.8), value: progress)
+                .shadow(
+                    color: (isCompleted ? WatchTheme.success : WatchTheme.madRedBright).opacity(0.35),
+                    radius: 6, x: 0, y: 0
+                )
+
+            VStack(spacing: 0) {
+                Text(String(format: "%.2f", currentDistance))
+                    .font(.system(size: 36, weight: .heavy, design: .rounded))
+                    .foregroundColor(WatchTheme.textPrimary)
+                    .contentTransition(.numericText())
+                    .minimumScaleFactor(0.6)
+                    .lineLimit(1)
+                Text("MI")
+                    .font(.system(size: 11, weight: .heavy, design: .rounded))
+                    .foregroundColor(WatchTheme.textTertiary)
+                    .tracking(1.5)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var goalLine: some View {
+        if isCompleted {
+            HStack(spacing: 4) {
+                Image(systemName: "checkmark.seal.fill")
+                    .font(.system(size: 11, weight: .bold))
+                Text("Goal complete!")
+                    .font(.system(size: 11, weight: .heavy, design: .rounded))
+            }
+            .foregroundStyle(WatchTheme.successGradient)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(WatchTheme.success.opacity(0.18)))
+        } else {
+            Text(String(format: "%.2f mi to goal · %.2f today", max(goalDistance - totalDailyDistance, 0), totalDailyDistance))
+                .font(.system(size: 10, weight: .medium, design: .rounded))
+                .foregroundColor(WatchTheme.textTertiary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+    }
+
+    // MARK: - Page 2: Stats
+
+    private var statsPage: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 4) {
+                Image(systemName: "chart.bar.fill")
+                Text("STATS")
+            }
+            .font(.system(size: 10, weight: .heavy, design: .rounded))
+            .foregroundColor(WatchTheme.textSecondary)
+            .tracking(1.2)
+
+            VStack(spacing: 6) {
+                statRow(icon: "clock.fill", label: "Time", value: formattedTime, tint: WatchTheme.madRedBright)
+                statRow(icon: "speedometer", label: "Pace", value: formattedPace, suffix: "/mi", tint: WatchTheme.warning)
+                if workoutManager.currentHeartRate > 0 {
+                    statRow(icon: "heart.fill", label: "Heart", value: "\(Int(workoutManager.currentHeartRate))", suffix: "bpm", tint: .red)
+                }
+                if workoutManager.calories > 0 {
+                    statRow(icon: "flame.fill", label: "Cal", value: "\(Int(workoutManager.calories))", suffix: "kcal", tint: .orange)
                 }
             }
-            .buttonStyle(.plain)
+
+            pageDots
+                .padding(.top, 2)
+        }
+        .padding(.horizontal, 10)
+    }
+
+    private func statRow(icon: String, label: String, value: String, suffix: String? = nil, tint: Color) -> some View {
+        HStack(spacing: 8) {
+            ZStack {
+                Circle()
+                    .fill(tint.opacity(0.18))
+                    .frame(width: 22, height: 22)
+                Image(systemName: icon)
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundColor(tint)
+            }
+            Text(label)
+                .font(.system(size: 11, weight: .medium, design: .rounded))
+                .foregroundColor(WatchTheme.textSecondary)
+            Spacer(minLength: 4)
+            HStack(alignment: .firstTextBaseline, spacing: 2) {
+                Text(value)
+                    .font(.system(size: 16, weight: .heavy, design: .rounded))
+                    .foregroundColor(WatchTheme.textPrimary)
+                    .contentTransition(.numericText())
+                if let suffix {
+                    Text(suffix)
+                        .font(.system(size: 9, weight: .semibold, design: .rounded))
+                        .foregroundColor(WatchTheme.textTertiary)
+                }
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(WatchTheme.surface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .stroke(WatchTheme.hairline, lineWidth: 0.5)
+                )
+        )
+    }
+
+    // MARK: - Page 3: Controls
+
+    private var controlsPage: some View {
+        VStack(spacing: 10) {
+            HStack(spacing: 4) {
+                Image(systemName: "slider.horizontal.3")
+                Text("CONTROLS")
+            }
+            .font(.system(size: 10, weight: .heavy, design: .rounded))
+            .foregroundColor(WatchTheme.textSecondary)
+            .tracking(1.2)
+
+            HStack(spacing: 14) {
+                // Pause / Resume
+                Button {
+                    if workoutManager.isPaused {
+                        workoutManager.resumeWorkout()
+                    } else {
+                        workoutManager.pauseWorkout()
+                    }
+                    WKInterfaceDevice.current().play(.click)
+                } label: {
+                    controlCircle(
+                        icon: workoutManager.isPaused ? "play.fill" : "pause.fill",
+                        background: WatchTheme.warning,
+                        foreground: .black
+                    )
+                }
+                .buttonStyle(WatchPressStyle())
+
+                // End workout
+                Button {
+                    showEndConfirmation = true
+                } label: {
+                    controlCircle(
+                        icon: "stop.fill",
+                        background: WatchTheme.madRed,
+                        foreground: .white
+                    )
+                }
+                .buttonStyle(WatchPressStyle())
+            }
+            .padding(.top, 2)
+
+            Text(workoutManager.isPaused ? "Tap play to resume" : "Tap pause anytime")
+                .font(.system(size: 10, weight: .medium, design: .rounded))
+                .foregroundColor(WatchTheme.textTertiary)
+
+            pageDots
+                .padding(.top, 2)
+        }
+        .padding(.horizontal, 10)
+    }
+
+    private func controlCircle(icon: String, background: Color, foreground: Color) -> some View {
+        ZStack {
+            Circle()
+                .fill(background.opacity(0.22))
+                .frame(width: 60, height: 60)
+            Circle()
+                .fill(background)
+                .frame(width: 50, height: 50)
+            Image(systemName: icon)
+                .font(.system(size: 18, weight: .heavy))
+                .foregroundColor(foreground)
+        }
+        .shadow(color: background.opacity(0.5), radius: 5, x: 0, y: 2)
+    }
+
+    // MARK: - Page Dots
+
+    private var pageDots: some View {
+        HStack(spacing: 5) {
+            ForEach(0..<3, id: \.self) { i in
+                Circle()
+                    .fill(pageSelection == i ? WatchTheme.madRedBright : Color.white.opacity(0.22))
+                    .frame(width: 4, height: 4)
+            }
         }
     }
 
@@ -253,9 +387,7 @@ struct WorkoutView: View {
         let h = Int(workoutManager.elapsedTime) / 3600
         let m = Int(workoutManager.elapsedTime) / 60 % 60
         let s = Int(workoutManager.elapsedTime) % 60
-        if h > 0 {
-            return String(format: "%d:%02d:%02d", h, m, s)
-        }
+        if h > 0 { return String(format: "%d:%02d:%02d", h, m, s) }
         return String(format: "%d:%02d", m, s)
     }
 
@@ -268,8 +400,12 @@ struct WorkoutView: View {
     }
 
     private func endWorkout() {
+        WKInterfaceDevice.current().play(.stop)
         workoutManager.endWorkout { success in
             if success {
+                showRecap = true
+            } else {
+                // Even on failure, show the recap so the user sees their effort.
                 showRecap = true
             }
         }
@@ -284,18 +420,17 @@ struct WorkoutRecapView: View {
     let heartRate: Double
     let calories: Double
     let activityName: String
+    let activityIcon: String
     let goalReached: Bool
     let onDismiss: () -> Void
 
-    private let accentRed = Color(red: 217/255, green: 64/255, blue: 63/255)
+    @State private var celebrate = false
 
     private var formattedTime: String {
         let h = Int(duration) / 3600
         let m = Int(duration) / 60 % 60
         let s = Int(duration) % 60
-        if h > 0 {
-            return String(format: "%d:%02d:%02d", h, m, s)
-        }
+        if h > 0 { return String(format: "%d:%02d:%02d", h, m, s) }
         return String(format: "%d:%02d", m, s)
     }
 
@@ -309,90 +444,114 @@ struct WorkoutRecapView: View {
 
     var body: some View {
         ScrollView {
-            VStack(spacing: 12) {
-                // Status icon
+            VStack(spacing: 10) {
+                // Hero badge
                 ZStack {
                     Circle()
-                        .fill(goalReached ? Color.green.opacity(0.15) : accentRed.opacity(0.15))
-                        .frame(width: 56, height: 56)
-
-                    Image(systemName: goalReached ? "checkmark" : "figure.run")
-                        .font(.system(size: 24, weight: .bold))
-                        .foregroundColor(goalReached ? .green : accentRed)
+                        .fill(goalReached ? WatchTheme.success.opacity(0.18) : WatchTheme.madRed.opacity(0.18))
+                        .frame(width: 64, height: 64)
+                    Circle()
+                        .fill(goalReached ? WatchTheme.success.opacity(0.12) : WatchTheme.madRed.opacity(0.12))
+                        .frame(width: 82, height: 82)
+                        .blur(radius: 4)
+                    Image(systemName: goalReached ? "checkmark.seal.fill" : activityIcon)
+                        .font(.system(size: 26, weight: .heavy))
+                        .foregroundStyle(goalReached ? WatchTheme.successGradient : WatchTheme.primaryButton)
+                        .scaleEffect(celebrate ? 1.0 : 0.6)
+                        .opacity(celebrate ? 1.0 : 0.0)
+                        .animation(.spring(response: 0.55, dampingFraction: 0.6), value: celebrate)
                 }
-                .padding(.top, 8)
+                .padding(.top, 6)
 
-                // Title
-                Text(goalReached ? "Goal Complete!" : "Workout Done")
-                    .font(.system(size: 17, weight: .bold, design: .rounded))
-                    .foregroundColor(.white)
+                Text(goalReached ? "Goal Complete!" : "Great \(activityName)!")
+                    .font(.system(size: 16, weight: .heavy, design: .rounded))
+                    .foregroundColor(WatchTheme.textPrimary)
+                    .multilineTextAlignment(.center)
 
-                // Primary stat: distance
+                // Primary stat
                 VStack(spacing: 0) {
                     Text(String(format: "%.2f", distance))
-                        .font(.system(size: 38, weight: .bold, design: .rounded))
-                        .foregroundColor(.white)
+                        .font(.system(size: 44, weight: .heavy, design: .rounded))
+                        .foregroundColor(WatchTheme.textPrimary)
+                        .minimumScaleFactor(0.6)
+                        .lineLimit(1)
                     Text("miles")
-                        .font(.system(size: 13, weight: .medium, design: .rounded))
-                        .foregroundColor(.white.opacity(0.5))
+                        .font(.system(size: 11, weight: .semibold, design: .rounded))
+                        .foregroundColor(WatchTheme.textTertiary)
+                        .tracking(1.0)
                 }
 
-                // Stats grid
-                VStack(spacing: 8) {
-                    recapRow(icon: "clock", label: "Duration", value: formattedTime)
-                    recapRow(icon: "speedometer", label: "Avg Pace", value: "\(formattedPace) /mi")
-
+                // Stats card
+                VStack(spacing: 6) {
+                    recapRow(icon: "clock.fill", label: "Duration", value: formattedTime, tint: WatchTheme.madRedBright)
+                    recapRow(icon: "speedometer", label: "Avg Pace", value: "\(formattedPace) /mi", tint: WatchTheme.warning)
                     if heartRate > 0 {
-                        recapRow(icon: "heart.fill", label: "Avg HR", value: "\(Int(heartRate)) bpm", valueColor: .red)
+                        recapRow(icon: "heart.fill", label: "Avg HR", value: "\(Int(heartRate)) bpm", tint: .red)
                     }
-
                     if calories > 0 {
-                        recapRow(icon: "flame.fill", label: "Calories", value: "\(Int(calories)) kcal", valueColor: .orange)
+                        recapRow(icon: "flame.fill", label: "Calories", value: "\(Int(calories)) kcal", tint: .orange)
                     }
                 }
-                .padding(12)
+                .padding(10)
                 .background(
-                    RoundedRectangle(cornerRadius: 14)
-                        .fill(Color.white.opacity(0.08))
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(WatchTheme.surface)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                                .stroke(WatchTheme.hairline, lineWidth: 0.5)
+                        )
                 )
 
                 // Done button
-                Button {
-                    onDismiss()
-                } label: {
-                    Text("Done")
-                        .font(.system(size: 16, weight: .semibold, design: .rounded))
-                        .foregroundColor(.white)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 12)
-                        .background(
-                            RoundedRectangle(cornerRadius: 14)
-                                .fill(accentRed)
-                        )
+                Button(action: onDismiss) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "checkmark")
+                            .font(.system(size: 13, weight: .heavy))
+                        Text("Done")
+                            .font(.system(size: 14, weight: .heavy, design: .rounded))
+                    }
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 11)
+                    .background(
+                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                            .fill(WatchTheme.primaryButton)
+                    )
+                    .shadow(color: WatchTheme.madRedDeep.opacity(0.5), radius: 6, x: 0, y: 3)
                 }
-                .buttonStyle(.plain)
-                .padding(.top, 4)
-                .padding(.bottom, 8)
+                .buttonStyle(WatchPressStyle())
+                .padding(.top, 2)
+                .padding(.bottom, 6)
             }
             .padding(.horizontal, 8)
         }
+        .onAppear {
+            celebrate = true
+            if goalReached {
+                WKInterfaceDevice.current().play(.success)
+            } else {
+                WKInterfaceDevice.current().play(.stop)
+            }
+        }
     }
 
-    private func recapRow(icon: String, label: String, value: String, valueColor: Color = .white) -> some View {
-        HStack {
-            HStack(spacing: 6) {
+    private func recapRow(icon: String, label: String, value: String, tint: Color) -> some View {
+        HStack(spacing: 8) {
+            ZStack {
+                Circle()
+                    .fill(tint.opacity(0.18))
+                    .frame(width: 20, height: 20)
                 Image(systemName: icon)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(.white.opacity(0.4))
-                    .frame(width: 16)
-                Text(label)
-                    .font(.system(size: 13, weight: .regular, design: .rounded))
-                    .foregroundColor(.white.opacity(0.5))
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundColor(tint)
             }
-            Spacer()
+            Text(label)
+                .font(.system(size: 11, weight: .medium, design: .rounded))
+                .foregroundColor(WatchTheme.textSecondary)
+            Spacer(minLength: 4)
             Text(value)
-                .font(.system(size: 14, weight: .semibold, design: .rounded))
-                .foregroundColor(valueColor)
+                .font(.system(size: 13, weight: .heavy, design: .rounded))
+                .foregroundColor(WatchTheme.textPrimary)
         }
     }
 }


### PR DESCRIPTION
Aligns the Apple Watch app's look-and-feel with the iOS app: same red brand palette, rounded type, gradient buttons, glass surfaces. Adds a WatchTheme namespace at the top of ContentView so all three watch files share constants.

Home screen
- Greeting with first name (falls back to brand label) + date
- Brand-styled progress ring with breathing glow and gradient track
- Goal-status capsule (mi-to-go vs goal-complete with sparkles)
- Streak pill with flame gradient
- Full-width Run/Walk action buttons (red gradient + glass) with haptics
- Indoor/Outdoor segmented chip lets the user pick location before starting

Workout tracker (Apple Workout-style)
- 3-2-1 countdown overlay before tracking begins, with haptics + bounce
- Paginated TabView (vertical pages, crown-friendly): 1) Now Playing: activity badge, distance + progress ring, goal banner 2) Stats: time / pace / HR / cal in tinted cards 3) Controls: large pause-resume + end circles
- Page dots, paused-state indicator, success haptic on goal reach

Recap
- Hero badge with gradient + scale-in animation
- Big distance hero, then stats card with tinted rows
- Red gradient Done button with proper shadow

WatchWorkoutManager fixes
- Freeze elapsedTime while paused (previously kept ticking visually until resume, then snapped back)
- Use HK's averageQuantity for HR when available, fall back to sample mean
- Trim noisy session-state logging