### PR TITLE
watchOS: live streak + today's distance refresh, cleaner header

### DIFF
--- a/app/Mile A Day Watch Watch App/ContentView.swift
+++ b/app/Mile A Day Watch Watch App/ContentView.swift
@@ -79,11 +79,13 @@ struct WatchPressStyle: ButtonStyle {
 struct ContentView: View {
     @EnvironmentObject var healthManager: HealthKitManager
     @EnvironmentObject var userManager: UserManager
+    @Environment(\.scenePhase) private var scenePhase
 
     @State private var showWorkoutView = false
     @State private var selectedActivityType: HKWorkoutActivityType = .running
     @State private var locationType: HKWorkoutSessionLocationType = .outdoor
     @State private var ringPulse: Bool = false
+    @State private var isRefreshing: Bool = false
 
     private var goalDistance: Double {
         userManager.currentUser.goalMiles > 0 ? userManager.currentUser.goalMiles : 1.0
@@ -99,11 +101,13 @@ struct ContentView: View {
 
     private var remainingDistance: Double { max(goalDistance - currentDistance, 0) }
 
-    private var greetingFirstName: String? {
+    /// Returns the user's real first name only — never the default `"You"` placeholder.
+    private var realFirstName: String? {
         let first = userManager.currentUser.firstName?.trimmingCharacters(in: .whitespaces) ?? ""
         if !first.isEmpty { return first }
-        let fallback = userManager.currentUser.name.split(separator: " ").first.map(String.init) ?? ""
-        return fallback.isEmpty ? nil : fallback
+        let storedName = userManager.currentUser.name.trimmingCharacters(in: .whitespaces)
+        guard !storedName.isEmpty, storedName.lowercased() != "you" else { return nil }
+        return storedName.split(separator: " ").first.map(String.init)
     }
 
     var body: some View {
@@ -144,43 +148,80 @@ struct ContentView: View {
             )
         }
         .onAppear {
-            healthManager.fetchTodaysDistance()
+            refreshAll()
             // Gentle pulse on the ring when not yet complete — adds life to the screen.
             withAnimation(.easeInOut(duration: 2.0).repeatForever(autoreverses: true)) {
                 ringPulse.toggle()
             }
         }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active { refreshAll() }
+        }
         .onChange(of: showWorkoutView) { oldValue, newValue in
             if oldValue && !newValue {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    healthManager.fetchTodaysDistance()
-                }
+                // HK takes a beat to finalize the finished workout before it shows
+                // up in queries — refresh once immediately and once shortly after
+                // so distance + streak both settle to the post-workout truth.
+                refreshAll()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { refreshAll() }
             }
+        }
+    }
+
+    /// Re-pulls today's distance and recomputes the streak from HealthKit.
+    private func refreshAll() {
+        guard !isRefreshing else { return }
+        isRefreshing = true
+        healthManager.refreshWatchSummary()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+            self.isRefreshing = false
         }
     }
 
     // MARK: - Header
 
     private var header: some View {
-        VStack(spacing: 1) {
-            HStack(spacing: 4) {
-                if let name = greetingFirstName {
-                    Text("Hey, ")
-                        .foregroundColor(WatchTheme.textSecondary)
-                    + Text(name)
-                        .foregroundColor(WatchTheme.textPrimary)
+        VStack(spacing: 3) {
+            // Top brand row — small wordmark + weekday/date, single line.
+            HStack(spacing: 6) {
+                Image(systemName: "figure.run.circle.fill")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(WatchTheme.primaryButton)
+                Text("MILE A DAY")
+                    .font(.system(size: 9, weight: .heavy, design: .rounded))
+                    .foregroundColor(WatchTheme.textPrimary.opacity(0.85))
+                    .tracking(1.4)
+            }
+
+            // Personal line — uses the real first name only; defaults to a clean
+            // date string when no name is configured (avoids the "Hey, You" look).
+            Group {
+                if let name = realFirstName {
+                    (
+                        Text(greetingPrefix())
+                            .foregroundColor(WatchTheme.textSecondary)
+                        + Text(", \(name)")
+                            .foregroundColor(WatchTheme.textPrimary)
+                    )
                 } else {
-                    Text("Mile A Day")
-                        .foregroundColor(WatchTheme.textPrimary)
+                    Text(Date(), format: .dateTime.weekday(.wide).month(.abbreviated).day())
+                        .foregroundColor(WatchTheme.textSecondary)
                 }
             }
-            .font(.system(size: 13, weight: .semibold, design: .rounded))
+            .font(.system(size: 12, weight: .semibold, design: .rounded))
             .lineLimit(1)
             .minimumScaleFactor(0.7)
+        }
+    }
 
-            Text(Date(), format: .dateTime.weekday(.wide).month().day())
-                .font(.system(size: 10, weight: .medium, design: .rounded))
-                .foregroundColor(WatchTheme.textTertiary)
+    /// Time-of-day greeting prefix so the personal line doesn't always say "Hey".
+    private func greetingPrefix() -> String {
+        let hour = Calendar.current.component(.hour, from: Date())
+        switch hour {
+        case 5..<12: return "Good morning"
+        case 12..<17: return "Good afternoon"
+        case 17..<22: return "Good evening"
+        default: return "Hi"
         }
     }
 

--- a/app/Mile A Day/Models/HealthKitManager.swift
+++ b/app/Mile A Day/Models/HealthKitManager.swift
@@ -1264,4 +1264,94 @@ class HealthKitManager: ObservableObject {
         return workout.endDate
         #endif
     }
-} 
+
+    #if os(watchOS)
+    // MARK: - Watch Summary Refresh
+    /// Refreshes today's distance and the current streak from HealthKit. The watch
+    /// app can't rely on iOS pushing fresh values, so it queries HK directly each
+    /// time the home screen appears or returns to the foreground.
+    func refreshWatchSummary() {
+        if !isAuthorized {
+            requestAuthorization { [weak self] ok in
+                guard ok else { return }
+                self?.refreshWatchSummary()
+            }
+            return
+        }
+
+        fetchTodaysDistance()
+        recalculateWatchStreak()
+    }
+
+    /// Fetches the last year of running/walking workouts and recomputes the streak
+    /// in-line using the same threshold as iOS (>= 0.95 mi qualifies a day). Stays
+    /// self-contained because the iOS streak-calculation extension isn't compiled
+    /// into the watch target.
+    func recalculateWatchStreak() {
+        guard isAuthorized else { return }
+
+        let runningPredicate = HKQuery.predicateForWorkouts(with: .running)
+        let walkingPredicate = HKQuery.predicateForWorkouts(with: .walking)
+        let typePredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [runningPredicate, walkingPredicate])
+
+        let oneYearAgo = Calendar.current.date(byAdding: .day, value: -365, to: Date()) ?? Date.distantPast
+        let datePredicate = HKQuery.predicateForSamples(withStart: oneYearAgo, end: Date(), options: .strictStartDate)
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [typePredicate, datePredicate])
+
+        let sort = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
+
+        let query = HKSampleQuery(
+            sampleType: HKObjectType.workoutType(),
+            predicate: predicate,
+            limit: HKObjectQueryNoLimit,
+            sortDescriptors: [sort]
+        ) { [weak self] _, samples, _ in
+            guard let self = self else { return }
+            let workouts = (samples as? [HKWorkout]) ?? []
+            let byDay = self.groupWorkoutsByDeviceDay(workouts: workouts)
+
+            // Per-day mile totals, then qualifying days (>= 0.95 mi).
+            let calendar = Calendar.current
+            let today = calendar.startOfDay(for: Date())
+            var qualifying: Set<Date> = []
+            for (date, dayWorkouts) in byDay {
+                let miles = dayWorkouts.reduce(0.0) { sum, w in
+                    sum + (w.totalDistance?.doubleValue(for: HKUnit.mile()) ?? 0)
+                }
+                if miles >= 0.95 { qualifying.insert(date) }
+            }
+
+            // Walk back from today counting consecutive qualifying days. If today
+            // doesn't qualify yet, the streak still includes yesterday's chain —
+            // matches iOS behavior, so the streak doesn't read 0 first thing in
+            // the morning before the user has run.
+            var streak = 0
+            var probe = today
+            if qualifying.contains(probe) {
+                streak += 1
+                probe = calendar.date(byAdding: .day, value: -1, to: probe) ?? probe
+            } else {
+                probe = calendar.date(byAdding: .day, value: -1, to: probe) ?? probe
+            }
+            while qualifying.contains(probe) {
+                streak += 1
+                guard let prev = calendar.date(byAdding: .day, value: -1, to: probe) else { break }
+                probe = prev
+                if streak > 1000 { break }
+            }
+
+            DispatchQueue.main.async {
+                self.retroactiveStreak = streak
+                self.cachedRetroactiveStreak = streak
+                self.saveCachedData()
+                if !self.hasIndexOrStreakLoaded {
+                    self.hasIndexOrStreakLoaded = true
+                    self.checkInitialDataReady()
+                }
+            }
+        }
+
+        healthStore.execute(query)
+    }
+    #endif
+}


### PR DESCRIPTION
Fixes the watch showing a stale streak and stale today's-distance until the user starts/finishes a workout.

HealthKitManager (watchOS-only addition)
- refreshWatchSummary(): waits for HK auth if needed, then re-pulls today's distance and recomputes the streak. iOS code path is unaffected (#if guards).
- recalculateWatchStreak(): queries the last 365 days of running/walking workouts directly from HealthKit and walks back from today counting days with >= 0.95 mi — same threshold as iOS. Inlined (doesn't depend on the iOS-only StreakCalculation extension, which isn't compiled into the watch target). Writes through to cachedRetroactiveStreak + UserDefaults so the cached value stays in sync.

ContentView
- onAppear and scenePhase=.active both trigger refreshAll() so re-opening the watch app always shows the truth, not yesterday's cache.
- After the workout sheet dismisses, refresh twice (immediate + 1s) — HK takes a beat to finalize the new workout before queries can see it.
- realFirstName filters out the default "You" placeholder, so the header never reads "Hey, You".
- Header redesign: small brand wordmark row with a red figure-run icon and "MILE A DAY" tracked uppercase; below it, a time-of-day greeting ("Good morning, Robert") when a real name is set, otherwise a clean weekday/date string. Feels personal without the default-name awkwardness.