### PR TITLE
Fix HealthKitManager.shared static-init reentrancy crash

### DIFF
--- a/app/Mile A Day/Models/HealthKitManager.swift
+++ b/app/Mile A Day/Models/HealthKitManager.swift
@@ -303,8 +303,15 @@ class HealthKitManager: ObservableObject {
     @Published var todaysDistance: Double = 0.0 {
         didSet {
             #if os(iOS)
-            // Sync the latest distance to the paired Apple Watch.
-            MADWatchBridge.shared.pushSnapshotIfReady()
+            // Sync the latest distance to the paired Apple Watch. Deferred to the
+            // next runloop because this didSet fires inside HealthKitManager.init
+            // (loadCachedData + workout-index hydration). pushSnapshotIfReady reads
+            // HealthKitManager.shared; calling it synchronously during the
+            // singleton's own static init re-enters dispatch_once and traps with
+            // EXC_BREAKPOINT.
+            DispatchQueue.main.async {
+                MADWatchBridge.shared.pushSnapshotIfReady()
+            }
             #endif
         }
     }
@@ -318,8 +325,12 @@ class HealthKitManager: ObservableObject {
             #if os(iOS)
             // The iPhone has the authoritative streak (full HK history + workout
             // index); the watch only sees what HealthKit has synced locally, so
-            // push every change so the watch can show the same number.
-            MADWatchBridge.shared.pushSnapshotIfReady()
+            // push every change so the watch can show the same number. Deferred
+            // for the same reason as todaysDistance above — this fires during
+            // HealthKitManager.shared static init and must not re-enter it.
+            DispatchQueue.main.async {
+                MADWatchBridge.shared.pushSnapshotIfReady()
+            }
             #endif
         }
     }


### PR DESCRIPTION
## Summary

Fixes the `EXC_BREAKPOINT` crash captured in Xcode at `HealthKitManager.swift:304` (the `didSet` on `todaysDistance`).

The `didSet` observers on `todaysDistance` and `retroactiveStreak` synchronously called `MADWatchBridge.shared.pushSnapshotIfReady()`, which in turn reads `HealthKitManager.shared`. Because both `didSet` observers also fire **during** `HealthKitManager.init()` (via `loadCachedData()` and the workout-index hydration), the first access to `HealthKitManager.shared` could re-enter its own in-progress `dispatch_once` and trap.

## Trigger sequence (paired-watch device)

1. `Mile_A_DayApp.init()` calls `MADBackgroundService.shared.registerBackgroundTasks()`.
2. `MADBackgroundService`'s instance-property `healthManager = HealthKitManager()` runs `HealthKitManager.init()` (a non-shared instance). That init ends with `MADWatchBridge.shared.activate()` — sets `isActivated = true`.
3. `RootView` later constructs another `HealthKitManager()` for its `@StateObject`. In that init, `retroactiveStreak`'s `didSet` calls `MADWatchBridge.shared.pushSnapshotIfReady()` — now past the `isActivated` guard.
4. `pushSnapshotIfReady` reads `HealthKitManager.shared` — first-time access starts the singleton's `dispatch_once`.
5. The singleton's own init sets `retroactiveStreak` (from cache), the same `didSet` fires, and `pushSnapshotIfReady` reads `HealthKitManager.shared` again → re-enters the in-progress `dispatch_once` → `EXC_BREAKPOINT`.

The Thread 1 backtrace in the Xcode screenshot matches this exactly: `_dispatch_once_wait → HealthKitManager.shared → MADWatchBridge.pushSnapshot → retroactiveStreak.didSet → HealthKitManager.init → _dispatch_once_callout → HealthKitManager.shared → MADWatchBridge.pushSnapshot → retroactiveStreak.didSet → HealthKitManager.init`.

## Fix

Defer the bridge push in both `didSet` observers to the next runloop with `DispatchQueue.main.async`. By the time the queued block runs, the singleton's `dispatch_once` has completed, so reading `HealthKitManager.shared` from `pushSnapshotIfReady` is safe. `pushSnapshotIfReady` is already idempotent (it dedupes via `lastPushedHash`), so a coalesced/delayed push is functionally equivalent.

## Test plan

- [ ] Build the iOS target in Xcode.
- [ ] Launch the app on a device with a paired Apple Watch and the Mile A Day watch app installed — the previous crash reliably reproduced on first cold launch after sign-in.
- [ ] Confirm the home screen renders with the cached streak/today's distance.
- [ ] Confirm the watch still receives streak / today's distance / goal updates (force a value change and verify `[MADWatchBridge]` activity).
- [ ] Confirm no regression on devices without a paired watch (the `isPaired/isWatchAppInstalled` guard in `pushSnapshotIfReady` should still no-op).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkhByzA9gEePuEWxHj96d9)_