### PR TITLE
Fix missing Stop Workout button on smaller screens / larger fonts

### DIFF
--- a/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
@@ -213,59 +213,78 @@ struct WorkoutTrackingView: View {
         // so they're always on screen regardless of device size or Dynamic Type.
         // Only the metrics in the middle scroll if they can't all fit, so nobody
         // ever has to scroll to find how to end their workout.
-        VStack(spacing: 0) {
-            HStack {
-                Button(action: { dismiss() }) {
-                    HStack(spacing: 8) {
-                        Image(systemName: "chevron.left")
-                            .font(.title3)
-                            .fontWeight(.semibold)
-                        Text("Dashboard")
-                            .font(.body)
-                            .fontWeight(.medium)
-                    }
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 12)
-                }
-                Spacer()
-            }
-            .padding(.top, 16)
-
-            // Scrollable metrics. The inner stack is pinned to at least the
-            // viewport height (measured below) so the metrics stay vertically
-            // centered when they fit, but collapse the Spacers and scroll when
-            // they don't — without ever pushing the Stop button off-screen.
-            ScrollView {
-                VStack(spacing: 40) {
-                    Spacer(minLength: 0)
-
-                    distanceDisplay
-
-                    progressRing
-
-                    timeDisplay
-
-                    Spacer(minLength: 0)
-                }
-                .frame(maxWidth: .infinity, minHeight: trackingMetricsHeight)
-            }
-            .scrollBounceBehavior(.basedOnSize)
-            .background(
-                GeometryReader { geo in
-                    Color.clear
-                        .onAppear { trackingMetricsHeight = geo.size.height }
-                        .onChange(of: geo.size.height) { _, newValue in
-                            trackingMetricsHeight = newValue
+        GeometryReader { screen in
+            VStack(spacing: 0) {
+                HStack {
+                    Button(action: { dismiss() }) {
+                        HStack(spacing: 8) {
+                            Image(systemName: "chevron.left")
+                                .font(.title3)
+                                .fontWeight(.semibold)
+                            Text("Dashboard")
+                                .font(.body)
+                                .fontWeight(.medium)
                         }
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 12)
+                    }
+                    Spacer()
                 }
-            )
+                .padding(.top, 16)
 
-            stopButton
+                // Scrollable metrics. The inner stack is pinned to at least the
+                // viewport height (measured below) so the metrics stay vertically
+                // centered when they fit, but collapse the Spacers and scroll when
+                // they don't — without ever pushing the Stop button off-screen.
+                // Spacing and ring size adapt to the screen height so compact
+                // devices fit without scrolling while large ones keep the airy look.
+                ScrollView {
+                    VStack(spacing: metricSpacing(for: screen.size.height)) {
+                        Spacer(minLength: 0)
+
+                        distanceDisplay
+
+                        progressRing(diameter: ringDiameter(for: screen.size.height))
+
+                        timeDisplay
+
+                        Spacer(minLength: 0)
+                    }
+                    .frame(maxWidth: .infinity, minHeight: trackingMetricsHeight)
+                    // Keep scrolled content from butting up against the pinned button.
+                    .padding(.bottom, 8)
+                }
+                .scrollBounceBehavior(.basedOnSize)
+                .background(
+                    GeometryReader { geo in
+                        Color.clear
+                            .onAppear { trackingMetricsHeight = geo.size.height }
+                            .onChange(of: geo.size.height) { _, newValue in
+                                trackingMetricsHeight = newValue
+                            }
+                    }
+                )
+
+                stopButton
+            }
         }
         .opacity(showCompletion || showPreviousProgress ? 0 : 1)
         .overlay(previousProgressOverlay)
         .overlay(goalCompletionOverlay)
+    }
+
+    /// Vertical spacing between the metric blocks, tightened on shorter screens.
+    private func metricSpacing(for screenHeight: CGFloat) -> CGFloat {
+        guard screenHeight > 0 else { return 40 }
+        return screenHeight < 700 ? 24 : 40
+    }
+
+    /// Progress-ring diameter, scaled to the screen so it shrinks on small devices
+    /// (down to 150pt) and caps at the original 200pt on larger ones.
+    private func ringDiameter(for screenHeight: CGFloat) -> CGFloat {
+        guard screenHeight > 0 else { return 200 }
+        return min(200, max(150, screenHeight * 0.26))
     }
 
     // MARK: - Tracking Sub-Views
@@ -299,11 +318,11 @@ struct WorkoutTrackingView: View {
         }
     }
 
-    private var progressRing: some View {
+    private func progressRing(diameter: CGFloat) -> some View {
         ZStack {
             Circle()
                 .stroke(Color.white.opacity(0.2), lineWidth: 12)
-                .frame(width: 200, height: 200)
+                .frame(width: diameter, height: diameter)
 
             Circle()
                 .trim(from: 0, to: progress)
@@ -315,7 +334,7 @@ struct WorkoutTrackingView: View {
                     ),
                     style: StrokeStyle(lineWidth: 12, lineCap: .round)
                 )
-                .frame(width: 200, height: 200)
+                .frame(width: diameter, height: diameter)
                 .rotationEffect(.degrees(-90))
                 .animation(.easeOut(duration: 0.5), value: progress)
 

--- a/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
@@ -34,6 +34,7 @@ struct WorkoutTrackingView: View {
     @State private var showEndWorkoutError = false // Show error alert when end fails
     @State private var endWorkoutErrorMessage = "" // Error message for end workout failure
     @State private var endWorkoutTimeoutTask: DispatchWorkItem? // Timeout for end workout flow
+    @State private var trackingMetricsHeight: CGFloat = 0 // Measured height of the scrollable metrics area
     @State private var workoutSession: HKWorkoutSession?
     @State private var workoutBuilder: HKWorkoutBuilder?
     @State private var workoutActivity: Activity<WorkoutActivityAttributes>?
@@ -207,33 +208,36 @@ struct WorkoutTrackingView: View {
     // MARK: - Active Tracking
 
     private var activeTrackingContent: some View {
-        // Wrap the tracking UI in a ScrollView so every element — most importantly
-        // the Stop Workout button — stays reachable regardless of screen size or
-        // Dynamic Type. The inner stack is pinned to at least the available height,
-        // so on roomy screens it keeps the spread-out look (Spacers expand), but
-        // when the content is taller than the screen the Spacers collapse and the
-        // whole thing scrolls instead of clipping the button off-screen.
-        GeometryReader { proxy in
+        // The two controls a user can never lose access to — the back button and,
+        // critically, the Stop Workout button — are PINNED outside the scroll area
+        // so they're always on screen regardless of device size or Dynamic Type.
+        // Only the metrics in the middle scroll if they can't all fit, so nobody
+        // ever has to scroll to find how to end their workout.
+        VStack(spacing: 0) {
+            HStack {
+                Button(action: { dismiss() }) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "chevron.left")
+                            .font(.title3)
+                            .fontWeight(.semibold)
+                        Text("Dashboard")
+                            .font(.body)
+                            .fontWeight(.medium)
+                    }
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 12)
+                }
+                Spacer()
+            }
+            .padding(.top, 16)
+
+            // Scrollable metrics. The inner stack is pinned to at least the
+            // viewport height (measured below) so the metrics stay vertically
+            // centered when they fit, but collapse the Spacers and scroll when
+            // they don't — without ever pushing the Stop button off-screen.
             ScrollView {
                 VStack(spacing: 40) {
-                    HStack {
-                        Button(action: { dismiss() }) {
-                            HStack(spacing: 8) {
-                                Image(systemName: "chevron.left")
-                                    .font(.title3)
-                                    .fontWeight(.semibold)
-                                Text("Dashboard")
-                                    .font(.body)
-                                    .fontWeight(.medium)
-                            }
-                            .foregroundColor(.white)
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, 12)
-                        }
-                        Spacer()
-                    }
-                    .padding(.top, 16)
-
                     Spacer(minLength: 0)
 
                     distanceDisplay
@@ -243,12 +247,21 @@ struct WorkoutTrackingView: View {
                     timeDisplay
 
                     Spacer(minLength: 0)
-
-                    stopButton
                 }
-                .frame(maxWidth: .infinity, minHeight: proxy.size.height)
+                .frame(maxWidth: .infinity, minHeight: trackingMetricsHeight)
             }
             .scrollBounceBehavior(.basedOnSize)
+            .background(
+                GeometryReader { geo in
+                    Color.clear
+                        .onAppear { trackingMetricsHeight = geo.size.height }
+                        .onChange(of: geo.size.height) { _, newValue in
+                            trackingMetricsHeight = newValue
+                        }
+                }
+            )
+
+            stopButton
         }
         .opacity(showCompletion || showPreviousProgress ? 0 : 1)
         .overlay(previousProgressOverlay)

--- a/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
@@ -207,36 +207,48 @@ struct WorkoutTrackingView: View {
     // MARK: - Active Tracking
 
     private var activeTrackingContent: some View {
-        VStack(spacing: 40) {
-            HStack {
-                Button(action: { dismiss() }) {
-                    HStack(spacing: 8) {
-                        Image(systemName: "chevron.left")
-                            .font(.title3)
-                            .fontWeight(.semibold)
-                        Text("Dashboard")
-                            .font(.body)
-                            .fontWeight(.medium)
+        // Wrap the tracking UI in a ScrollView so every element — most importantly
+        // the Stop Workout button — stays reachable regardless of screen size or
+        // Dynamic Type. The inner stack is pinned to at least the available height,
+        // so on roomy screens it keeps the spread-out look (Spacers expand), but
+        // when the content is taller than the screen the Spacers collapse and the
+        // whole thing scrolls instead of clipping the button off-screen.
+        GeometryReader { proxy in
+            ScrollView {
+                VStack(spacing: 40) {
+                    HStack {
+                        Button(action: { dismiss() }) {
+                            HStack(spacing: 8) {
+                                Image(systemName: "chevron.left")
+                                    .font(.title3)
+                                    .fontWeight(.semibold)
+                                Text("Dashboard")
+                                    .font(.body)
+                                    .fontWeight(.medium)
+                            }
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, 12)
+                        }
+                        Spacer()
                     }
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 12)
+                    .padding(.top, 16)
+
+                    Spacer(minLength: 0)
+
+                    distanceDisplay
+
+                    progressRing
+
+                    timeDisplay
+
+                    Spacer(minLength: 0)
+
+                    stopButton
                 }
-                Spacer()
+                .frame(maxWidth: .infinity, minHeight: proxy.size.height)
             }
-            .padding(.top, 16)
-
-            Spacer()
-
-            distanceDisplay
-
-            progressRing
-
-            timeDisplay
-
-            Spacer()
-
-            stopButton
+            .scrollBounceBehavior(.basedOnSize)
         }
         .opacity(showCompletion || showPreviousProgress ? 0 : 1)
         .overlay(previousProgressOverlay)


### PR DESCRIPTION
## Problem

On the active workout (in-progress tracking) screen, some users had **no Stop Workout button** — leaving them stuck in a workout they couldn't end.

The tracking UI (`activeTrackingContent` in `WorkoutTrackingView.swift`) was a plain `VStack` with large, fixed-size elements (80pt distance number, 200pt progress ring, 48pt timer) and **no scroll container**. On smaller devices or with larger Dynamic Type, the content was taller than the screen, so the centered `VStack` overflowed and clipped both the back button (top) and the Stop Workout button (bottom) off-screen.

This matches the reported case: one phone showed the full screen with the button, another (smaller screen) showed the content with the button cut off entirely.

## Fix

**The Stop Workout button (and the back button) are now pinned outside the scroll area, so they're always on screen** — regardless of device size or Dynamic Type. Users never have to scroll to find how to end their workout; the never-ending-workout trap is eliminated entirely.

Layout:
- **Back button** — fixed at top.
- **Metrics** (distance, progress ring, timer) — in the middle, in a `ScrollView`. They stay vertically centered when they fit (via a measured min-height) and scroll only if they can't all fit.
- **Stop Workout button** — fixed at the bottom, always visible.

## Notes

- Per project rules the iOS app builds via Xcode only, so this wasn't compiled from CLI. It uses only standard SwiftUI APIs; `.scrollBounceBehavior` is iOS 16.4+ (the app already targets iOS 17+).

https://claude.ai/code/session_01AbQCRc7BqCU8EkqyX9d8NV

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbQCRc7BqCU8EkqyX9d8NV)_