### PR TITLE
Fix pre-iOS 26 tab bar, stuck challenge card, stale data syncing, and slow streak

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,222 @@
+# Mile A Day — Code Audit (Bugs, Security, Performance, UX)
+
+A cross-app deep dive across the **backend** (TypeScript/Express/PostgreSQL),
+the **iOS app** (SwiftUI), and the **widgets**. Findings are ranked by priority
+so they can be turned straight into tickets.
+
+This document is a **findings list only** — no fixes have been applied as part of
+producing it.
+
+## How to read this
+
+- **Priority tiers:** `P0` (critical, fix first) → `P3` (low / cleanup).
+- **Confidence:**
+  - ✅ **Verified** — confirmed by reading the actual code.
+  - ⚠️ **Reported** — surfaced by an automated pass, plausible, but not yet
+    hand-verified. Confirm when scoping the ticket.
+- **Locations** are `path:line` where known. Line numbers drift as the code
+  changes — treat them as starting points, not gospel.
+
+Each item explains **what it is**, **why it matters**, and **the direction of a
+fix** (not a prescriptive patch).
+
+---
+
+## P0 — Critical (fix first)
+
+### 1. Per-second writes of full workout state to UserDefaults during active workouts ✅
+- **Where:** `app/Mile A Day/Core/State/InProgressWorkoutStore.swift` (`save` + `synchronize()`); driven by the 1 Hz timer / `flushRoutePoints` in `app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift`.
+- **What:** On every GPS tick / timer tick the entire in-progress workout state — including up to 5,000 route points (hundreds of KB once JSON-encoded) — is re-encoded and written to `UserDefaults`, followed by a forced `synchronize()`.
+- **Why it matters:** `UserDefaults` is a property-list store, not a database. Re-serializing a large blob once per second and force-flushing it: blocks the main thread (jank), drains battery on long outdoor runs, wears flash storage, and risks silent write failures / state corruption as the blob grows. This is the single highest-impact reliability issue in the app.
+- **Fix direction:** Stop persisting the full route on every tick. Persist a small "resume header" (start time, elapsed, cumulative distance) frequently, and append route points to a separate append-only store (file/SQLite) on a throttled cadence. Remove `synchronize()` (deprecated and unnecessary since iOS 13).
+
+### 2. IDOR — workout endpoints have no self/friend authorization ✅
+- **Where:** `backend/src/routes/workoutRoutes.ts:9-12` → `getStreak`, `getRecentWorkouts`, `getUserStats` in `backend/src/controllers/workoutController.ts`.
+- **What:** These routes are mounted after `authenticateToken` but only check that the target user *exists* — not that the requester is that user or a friend. Any authenticated user can read anyone's workout history, distances, dates, and streak by supplying another `userId`.
+- **Why it matters:** Private fitness data is exposed to any logged-in account. It's also an internal inconsistency: the daily-challenge endpoint already gates non-self access with `areFriends` (`dailyChallengeController.ts:23-26`), so these endpoints simply weren't given the same treatment.
+- **Fix direction:** Add `requireSelfAccess('userId')` where only the owner should read, or an explicit "self-or-friend" check (mirroring the challenge controller) where friends are meant to see the data.
+
+### 3. Manual workout entry lets users fabricate data (cheating vector) ✅ (backend gap) / ⚠️ (client)
+- **Where:** `app/Mile A Day/Views/Dashboard/ManualWorkoutEntryView.swift` (validation ~lines 86-90); upload path in `app/Mile A Day/Services/WorkoutService.swift`; backend `uploadWorkouts`.
+- **What:** Client validation only requires `0 < distance < 100` and `duration > 0`, and allows back-dating up to 30 days. "99 miles in 1 second" passes. The backend upload path performs no plausibility validation either.
+- **Why it matters:** Streaks, total miles, leaderboards, and pace PRs can be arbitrarily inflated — corrupting the core competitive loop and any social comparisons built on it.
+- **Fix direction:** Enforce server-side plausibility bounds (max distance per workout, minimum pace floor, date window, per-day caps). Client validation is UX nicety; the authoritative check must live in the backend since the client is untrusted.
+
+### 4. Stacked NotificationCenter observers / un-invalidated timers ⚠️
+- **Where:** `app/Mile A Day/Views/Dashboard/DashboardView.swift` (~351-398) registers `WorkoutIndexReady` and `MAD_OpenWorkoutFromLiveActivity` observers in `onAppear` with no removal; `app/Mile A Day/Views/Dashboard/WorkoutLocationManager.swift` (~234) starts a 1 Hz `Timer` in `onAppear` with no `onDisappear` invalidate.
+- **What:** Every time these views appear (tab switch, navigation pop) a fresh observer/timer is added. Nothing tears the old ones down.
+- **Why it matters:** Observers stack, so a single event fires its handler N times — duplicate celebrations, repeated expensive index rebuilds, and the workout view flipping open unexpectedly. The 1 Hz banner timer keeps running (and reloading state from disk every second) after the banner is gone — battery drain plus a retain cycle.
+- **Fix direction:** Pair every `addObserver`/`scheduledTimer` with cleanup in `onDisappear` (or use the `.onReceive`/structured-concurrency equivalents that auto-cancel). Store observer tokens and remove them.
+
+---
+
+## P1 — High
+
+### 5. 30-day access tokens ✅
+- **Where:** `backend/src/services/tokenService.ts:5` (`ACCESS_TOKEN_EXPIRY = '30d'`).
+- **What:** Access tokens are valid for 30 days and are not checked against the database on each request (stateless verify only).
+- **Why it matters:** A leaked access token is usable for a month and is effectively unrevocable — the refresh-token rotation/revocation system can't help because access tokens never consult server state.
+- **Fix direction:** Shorten access-token lifetime to minutes/hours and lean on the existing refresh flow for renewal.
+
+### 6. Error handler leaks internals to clients ✅
+- **Where:** `backend/src/server.ts:86-92` returns raw `err.message`; many controllers also do `'...: ' + error.message`.
+- **What:** 500 responses include the underlying error text (DB errors, file paths, library internals).
+- **Why it matters:** Information disclosure that helps an attacker map the system; also leaks implementation details to ordinary clients.
+- **Fix direction:** Return a generic message + a correlation id to clients; log full details server-side only.
+
+### 7. JWT secret used with no validation ✅
+- **Where:** `backend/src/services/tokenService.ts:4` (`process.env.APP_JWT_SECRET!`); `backend/src/middleware/auth.ts` encodes it unchecked.
+- **What:** The non-null assertion hides a missing-env-var case. If `APP_JWT_SECRET` is ever unset, `TextEncoder().encode(undefined)` yields the literal bytes of `"undefined"`, and every token is signed/verified with that as the key.
+- **Why it matters:** A silent, catastrophic auth weakness — anyone who guesses the misconfiguration can forge tokens.
+- **Fix direction:** Validate required secrets at boot and crash fast if absent. Never sign/verify with a fallback.
+
+### 8. Unbounded query limits (DoS lever) ✅
+- **Where:** `backend/src/controllers/workoutController.ts:187-201` (`getRecentWorkouts` passes a `null` limit → unbounded rows); `backend/src/controllers/inAppNotificationController.ts:100-101` (`parseInt(limit)` with no cap, no negative/NaN handling).
+- **What:** Clients control result size with no ceiling. `?limit=99999999` (or a negative value) is accepted.
+- **Why it matters:** Memory pressure / DoS, and odd SQL behavior on negative/NaN inputs.
+- **Fix direction:** A `clampLimit`/`clampOffset` helper already exists elsewhere in the codebase — apply it consistently and reject non-numeric/negative input.
+
+### 9. Non-transactional multi-write operations ✅
+- **Where:** `backend/src/services/competitionService.ts:74-91` (`createCompetition` inserts the competition then the owner membership as two separate statements); same class of issue in `backend/src/services/friendshipService.ts` accept-request double-write.
+- **What:** Related writes aren't wrapped in a transaction.
+- **Why it matters:** A failure between statements leaves corrupt partial state — e.g. a competition with no members, or a one-directional friendship.
+- **Fix direction:** Wrap each multi-statement mutation in `db.transaction()` so it's all-or-nothing.
+
+### 10. User search returns full rows incl. email ✅
+- **Where:** `backend/src/controllers/usersController.ts:32` — `SELECT * FROM users WHERE username ILIKE $1 OR email ILIKE $1 LIMIT 50`.
+- **What:** Search returns every column, including email, and matches on email too.
+- **Why it matters:** Email/PII disclosure and user-enumeration via search.
+- **Fix direction:** Select only public columns; don't match on email (or only allow exact-email lookups behind a separate, rate-limited path).
+
+### 11. Auth tokens persisted in plaintext UserDefaults ⚠️
+- **Where:** `app/Mile A Day/Services/TokenStore.swift` writes Keychain **and** mirrors to `UserDefaults`; legacy readers (`FriendService`, `WorkoutService`, `ProfileImageService`, `DailyStepsSyncService`) and the watch bridge in `Models/HealthKitManager.swift` read the plaintext copy.
+- **What:** The Keychain migration is half-done; tokens still live unencrypted in `UserDefaults`, and the access token is shipped to the watch via application context.
+- **Why it matters:** Plaintext tokens land in device/iCloud backups; a compromised backup or watch yields working credentials.
+- **Fix direction:** Finish the migration — make Keychain the single source of truth, delete the UserDefaults mirror, and stop sending the access token to the watch (send a device-scoped hint or refresh on the watch separately).
+
+### 12. Widget refresh-budget exhaustion + no midnight rollover ✅
+- **Where:** `app/Mile A Day/Widgets/TodayProgressWidget.swift:48` (60s refresh request); `app/Mile A Day/Shared/WidgetDataStore.swift` (double reload, immediate + 0.5s).
+- **What:** The timeline asks WidgetKit to refresh every 60 seconds. WidgetKit caps the number of refreshes per day, so the budget is spent quickly and the widget then freezes unpredictably. There's no timeline entry scheduled at local midnight, so the widget shows yesterday's miles after midnight. `WidgetDataStore` also triggers two timeline reloads per save.
+- **Why it matters:** Widgets look broken/stale — a visible, everyday UX failure.
+- **Fix direction:** Use a realistic refresh cadence, add an explicit timeline entry at the next local midnight (reset to 0), and de-dup the reload calls.
+
+### 13. Duplicate refresh storms on launch/foreground ✅
+- **Where:** `app/Mile A Day/Views/MainTabView.swift` — `.task` and `.onChange(of: scenePhase == .active)` both call `competitionService.refreshAllData()` + `friendService.refreshAllData()` + unread count.
+- **What:** Cold launch runs the `.task`; the first `.active` transition then runs the identical set again. No de-duplication.
+- **Why it matters:** Doubles network/battery on every foreground and can delay the first paint behind redundant requests.
+- **Fix direction:** Add a minimum-interval / in-flight guard per service so overlapping triggers coalesce.
+
+### 14. Main-thread O(n) stat recomputation on launch ⚠️
+- **Where:** `app/Mile A Day/Models/HealthKitManager+DataFetching.swift` calls `recalculateStatsWithAllWorkouts()` on the main queue after updating cached workouts.
+- **What:** A linear pass over the full cached-workout array runs on the main thread.
+- **Why it matters:** With large histories this blocks UI for 100-500ms during cold launch and stutters animations.
+- **Fix direction:** Move the computation off-main and publish results back; consider incremental updates instead of full recompute.
+
+### 15. Unbounded cron fan-outs ✅ (logic) / ⚠️ (scale)
+- **Where:** `backend/src/cron/silentSyncCron.ts` iterates `SELECT DISTINCT user_id` and awaits each push serially; `backend/src/services/notificationService.ts` `checkCompetitionsEndingSoon` / `checkStreaksBroken` scan unbounded sets and re-query per row.
+- **What:** Cron jobs iterate the entire user/competition base one row at a time with no pagination or bounded concurrency.
+- **Why it matters:** Fine today, but a single slow push blocks the rest, and runtime grows linearly with users — these will choke as the base grows.
+- **Fix direction:** Page through users and fan out in bounded-concurrency batches; pre-aggregate where possible.
+
+---
+
+## P2 — Medium
+
+### 16. Fire-and-forget error swallowing in the upload path ✅
+- **Where:** `backend/src/controllers/workoutController.ts:95-103` — an un-awaited async IIFE runs `checkLeadChanges` / `checkCompetitionMilestones`; rejections escape the surrounding try.
+- **Why it matters:** Notification/competition side effects can fail invisibly while the upload returns 200, so users silently miss lead-change/milestone alerts.
+- **Fix direction:** Await and handle, or hand off to a job queue with its own error handling.
+
+### 17. Invalid push-token cleanup silently ignored ⚠️
+- **Where:** `backend/src/services/pushNotificationService.ts:162,377` — `removeInvalidToken(...).catch(() => {})`.
+- **Why it matters:** Dead device tokens accumulate forever; APNs/FCM failures get masked.
+- **Fix direction:** Log failures; let them surface to the cron error handler.
+
+### 18. Sensitive data in `print()` logs ⚠️
+- **Where:** `app/Mile A Day/Services/APIClient.swift` (~203, raw response bodies up to 2000 chars); `TokenRefreshService`, `FriendService` ("auth token present"), `AppDelegate` (APNs token prefix).
+- **Why it matters:** Tokens/PII can end up in device console and crash logs.
+- **Fix direction:** Gate verbose logs behind `#if DEBUG`; never log token material or full response bodies.
+
+### 19. Hard-coded backend user id in dev settings ⚠️
+- **Where:** `app/Mile A Day/Views/Settings/DeveloperSettingsView.swift` (~480).
+- **Why it matters:** Ships a real user id in the binary; the whole Developer Settings screen is reachable in release builds.
+- **Fix direction:** Remove the hard-coded id; wrap Developer Settings in `#if DEBUG`.
+
+### 20. Concurrent UserDefaults writes can drop synced-workout ids ⚠️
+- **Where:** `app/Mile A Day/Services/WorkoutSyncService.swift` — `markWorkoutsAsSynced` does read-union-write with no mutual exclusion across concurrent batches; the `uploadedWorkoutIds` set also grows unbounded.
+- **Why it matters:** Two batches finishing together can clobber each other's additions → duplicate uploads; the ever-growing set eventually strains UserDefaults.
+- **Fix direction:** Serialize updates (actor/queue); store sync state in a database keyed by workout id rather than one growing array.
+
+### 21. `updateFriendSettings` doesn't verify the relationship ⚠️
+- **Where:** `backend/src/controllers/notificationSettingsController.ts` — takes `:friendId` and writes settings without confirming a friendship exists.
+- **Why it matters:** Lets a user write per-friend notification settings for arbitrary ids.
+- **Fix direction:** Validate the friendship before writing.
+
+### 22. Nudge/flex logging has no idempotency ⚠️
+- **Where:** `backend/src/services/pushNotificationService.ts:544,584` — inserts without a unique constraint.
+- **Why it matters:** Rapid double-taps double-log and can double-count against rate limits.
+- **Fix direction:** Add a unique constraint (e.g. per sender/target/day) with `ON CONFLICT DO NOTHING`.
+
+### 23. Workout tracking view stops timer but not location on disappear ⚠️
+- **Where:** `app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift` `onDisappear`.
+- **Why it matters:** Dismissing without ending a workout can leave GPS running — battery drain.
+- **Fix direction:** Stop location tracking on disappear unless an explicit "keep running in background" state is intended.
+
+### 24. Deprecated `UserDefaults.synchronize()` ⚠️
+- **Where:** multiple call sites (`InProgressWorkoutStore`, `WorkoutSyncService`, …).
+- **Why it matters:** Unnecessary since iOS 13; adds main-thread stalls.
+- **Fix direction:** Remove the calls; rely on automatic persistence.
+
+### 25. N+1 in `checkCompetitionMilestones` ⚠️
+- **Where:** `backend/src/services/notificationService.ts:286-291` — full `getCompetition()` per competition in a loop.
+- **Why it matters:** One full aggregation round-trip per competition; slow for users in many competitions.
+- **Fix direction:** Batch the needed data in a single query or parallelize with a bound.
+
+### 26. Stale celebrations on foreground ⚠️
+- **Where:** `app/Mile A Day/Managers/CelebrationManager.swift`.
+- **Why it matters:** Celebrations queued while backgrounded replay on return even when no longer relevant.
+- **Fix direction:** Timestamp queued celebrations and drop stale ones on foreground.
+
+### 27. Push-token registration auth is order-fragile ✅ (not currently exploitable)
+- **Where:** `backend/src/routes/deviceRoutes.ts` + `server.ts` mount order.
+- **Why it matters:** It's protected only because it's mounted after `authenticateToken`; a future reorder silently opens unauthenticated token registration.
+- **Fix direction:** Add an explicit auth guard on the route so safety doesn't depend on mount order.
+
+---
+
+## P3 — Low / cleanup
+
+- **28. Wildcard CORS + no rate limit on `/public/profile-image/:username`** ✅ — `backend/src/server.ts:49-67`. Enumeration surface. Restrict origins; add rate limiting.
+- **29. No rate limiting on `/auth/*`** ✅ — mitigated by Sign in with Apple, but still worth a limiter.
+- **30. Dead code: empty `getWorkoutRange()`** ✅ — `backend/src/controllers/workoutController.ts:182`, still wired to a route. Remove or implement.
+- **31. `refreshData()` clears `isRefreshing` before async work finishes** ⚠️ — `app/Mile A Day/Views/Dashboard/DashboardView.swift`. Spinner dismisses early. Tie the flag to the async completion.
+- **32. Location accuracy gate uses strict `>0 && <50`** ⚠️ — `WorkoutLocationManager.swift`. Drops exactly-0/50m readings and doesn't special-case negative sentinels. Use `<=` bounds and handle invalid accuracy explicitly.
+- **33. APIClient 15s timeout hardcoded for all endpoints** ⚠️ — no per-call override for legitimately slow operations.
+- **34. Mass-assignment surface in `updateUser`** ✅ — whitelisted but unvalidated (no length/format checks). Add per-field validation.
+- **35. Refresh-token reuse detection has a small pre-revocation race window** ⚠️ — `backend/src/services/refreshTokenService.ts`. Low risk given short token lifetimes (see #5).
+
+---
+
+## Confirmed false positives — do **not** ticket these
+
+These were raised by automated passes and disproven during verification:
+
+- **"Daily challenge endpoint is an unprotected IDOR."** False — `backend/src/controllers/dailyChallengeController.ts:23-26` gates non-self access with `areFriends`.
+- **"`checkStreakLifeLoss` is undefined → cron crashes."** False — defined at `backend/src/services/notificationService.ts:775`.
+- **"`/dev/*` mints tokens / sends pushes unauthenticated."** False — every dev controller self-gates on `NODE_ENV === 'production'`. (Residual: this relies on `NODE_ENV` actually being `production` in prod — worth a boot-time assertion, but the endpoints are not open.)
+- **"Device registration auth bypass."** False — it's mounted behind `authenticateToken`.
+- **SQL injection / committed secrets.** None found — queries are parameterized throughout, and no hardcoded secrets/keys were found in source. (Good.)
+
+---
+
+## Suggested sequencing
+
+1. **P0 #1** (disk thrashing) and **P0 #2** (workout IDOR) — biggest reliability/security wins for the least code.
+2. **Auth-hardening cluster** (#5, #7, #8, #10) — small, mechanical, high value; batch into one backend PR.
+3. **iOS lifecycle cluster** (#4, #13, #20, #23, #24) — naturally one PR.
+4. Then work down P1 → P3 by area.
+
+---
+
+_Generated from a read-only audit. Line numbers reflect the state of the code at
+audit time and may have shifted since._

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,769 @@
+# Mile A Day — Audit Issues (copy-paste ready)
+
+One block per finding. Copy the **Title** into the issue title and everything under **Body** into the description. Suggested labels are included. Source: `AUDIT.md`.
+
+Confidence: ✅ verified in code · ⚠️ reported, confirm when scoping.
+
+---
+
+## P0 — Critical
+
+### Issue 1
+**Title:** `[P0] Active workout writes full state to UserDefaults every second (disk thrashing / jank)`
+
+**Body:**
+> **Labels:** bug, performance, ios, P0
+> **Confidence:** ✅ verified
+>
+> **Summary**
+> During an active workout, the entire in-progress state — including up to 5,000 route points (hundreds of KB once JSON-encoded) — is re-encoded and written to `UserDefaults` on every GPS/timer tick, followed by a forced `synchronize()`.
+>
+> **Why it matters**
+> `UserDefaults` is a plist store, not a database. Re-serializing a large blob ~1×/sec and force-flushing it blocks the main thread (jank), drains battery on long outdoor runs, wears flash storage, and risks silent write failures / state corruption as the blob grows. Highest-impact reliability issue in the app.
+>
+> **Where**
+> - `app/Mile A Day/Core/State/InProgressWorkoutStore.swift` (`save` + `synchronize()`)
+> - `app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift` (1 Hz timer / `flushRoutePoints`)
+>
+> **Fix direction**
+> Persist only a small "resume header" (start time, elapsed, cumulative distance) frequently; append route points to a separate append-only store (file/SQLite) on a throttled cadence. Remove `synchronize()`.
+>
+> **Acceptance criteria**
+> - [ ] No full-state encode+write on every tick.
+> - [ ] Route persistence throttled and/or moved off `UserDefaults`.
+> - [ ] Workout still fully recoverable after force-quit mid-run.
+> - [ ] No measurable main-thread stalls during a 60-min GPS run.
+
+---
+
+### Issue 2
+**Title:** `[P0] IDOR: workout endpoints (streak/recent/stats) have no self/friend authorization`
+
+**Body:**
+> **Labels:** security, backend, P0
+> **Confidence:** ✅ verified
+>
+> **Summary**
+> `getStreak`, `getRecentWorkouts`, and `getUserStats` are mounted after `authenticateToken` but only check the target user *exists* — not that the requester is that user or a friend. Any authenticated user can read anyone's workout history, distances, dates, and streak by supplying another `userId`.
+>
+> **Why it matters**
+> Private fitness data is exposed to any logged-in account. Internally inconsistent: the daily-challenge endpoint already gates non-self access via `areFriends` (`dailyChallengeController.ts:23-26`).
+>
+> **Where**
+> - `backend/src/routes/workoutRoutes.ts:9-12`
+> - `backend/src/controllers/workoutController.ts` (`getStreak`, `getRecentWorkouts`, `getUserStats`)
+>
+> **Fix direction**
+> Add `requireSelfAccess('userId')` where only the owner should read, or a "self-or-friend" check mirroring `dailyChallengeController` where friends are meant to see the data.
+>
+> **Acceptance criteria**
+> - [ ] Requesting another user's workout data without the required relationship returns 403.
+> - [ ] Self and (where intended) friends still succeed.
+> - [ ] Consistent policy documented for all `/workouts/:userId/*` reads.
+
+---
+
+### Issue 3
+**Title:** `[P0] Manual workout entry allows fabricated distance/pace/date (cheating vector)`
+
+**Body:**
+> **Labels:** security, bug, backend, ios, P0
+> **Confidence:** ✅ backend gap verified · ⚠️ client specifics
+>
+> **Summary**
+> Client validation only requires `0 < distance < 100` and `duration > 0`, and allows back-dating up to 30 days ("99 miles in 1 second" passes). The backend upload path performs no plausibility validation.
+>
+> **Why it matters**
+> Streaks, total miles, leaderboards, and pace PRs can be arbitrarily inflated — corrupting the core competitive loop and all social comparisons.
+>
+> **Where**
+> - `app/Mile A Day/Views/Dashboard/ManualWorkoutEntryView.swift` (~86-90)
+> - `app/Mile A Day/Services/WorkoutService.swift` (upload)
+> - backend `uploadWorkouts`
+>
+> **Fix direction**
+> Enforce server-side plausibility bounds (max distance/workout, minimum pace floor, date window, per-day caps). Treat client validation as UX only.
+>
+> **Acceptance criteria**
+> - [ ] Backend rejects implausible distance/pace/date with a clear error.
+> - [ ] Bounds documented and shared with the client for matching UX validation.
+> - [ ] Existing legitimate manual entries unaffected.
+
+---
+
+### Issue 4
+**Title:** `[P0] Stacked NotificationCenter observers & un-invalidated timers on Dashboard`
+
+**Body:**
+> **Labels:** bug, performance, ios, P0
+> **Confidence:** ⚠️ reported
+>
+> **Summary**
+> Observers (`WorkoutIndexReady`, `MAD_OpenWorkoutFromLiveActivity`) are added in `onAppear` with no removal; a 1 Hz banner `Timer` is started in `onAppear` with no `onDisappear` invalidate. Each appear (tab switch / nav pop) adds another.
+>
+> **Why it matters**
+> Handlers fire N times for one event — duplicate celebrations, repeated expensive index rebuilds, the workout view flipping open unexpectedly. The banner timer keeps reloading state from disk every second after dismissal (battery + retain cycle).
+>
+> **Where**
+> - `app/Mile A Day/Views/Dashboard/DashboardView.swift` (~351-398)
+> - `app/Mile A Day/Views/Dashboard/WorkoutLocationManager.swift` (~234)
+>
+> **Fix direction**
+> Pair every `addObserver`/`scheduledTimer` with cleanup in `onDisappear` (or use auto-cancelling `.onReceive`/structured concurrency). Store and remove observer tokens.
+>
+> **Acceptance criteria**
+> - [ ] Re-appearing the dashboard does not multiply observer callbacks.
+> - [ ] Banner timer stops when the banner disappears.
+> - [ ] No duplicate celebrations after repeated tab switches.
+
+---
+
+## P1 — High
+
+### Issue 5
+**Title:** `[P1] Access tokens live 30 days and are effectively unrevocable`
+
+**Body:**
+> **Labels:** security, backend, P1
+> **Confidence:** ✅ verified
+>
+> **Summary**
+> `ACCESS_TOKEN_EXPIRY = '30d'` and access tokens aren't checked against the DB on each request (stateless verify only).
+>
+> **Why it matters**
+> A leaked access token works for a month and can't be revoked via the refresh-token rotation system, which never consults server state for access tokens.
+>
+> **Where**
+> - `backend/src/services/tokenService.ts:5`
+>
+> **Fix direction**
+> Shorten access-token lifetime to minutes/hours; rely on the existing refresh flow for renewal.
+>
+> **Acceptance criteria**
+> - [ ] Access-token TTL reduced to a short window.
+> - [ ] Client refresh flow verified to renew transparently.
+
+---
+
+### Issue 6
+**Title:** `[P1] Global error handler leaks internal error messages to clients`
+
+**Body:**
+> **Labels:** security, backend, P1
+> **Confidence:** ✅ verified
+>
+> **Summary**
+> 500 responses include raw `err.message` (DB errors, file paths, library internals); several controllers also concatenate `error.message` into responses.
+>
+> **Why it matters**
+> Information disclosure that helps map the system and leaks implementation detail to ordinary clients.
+>
+> **Where**
+> - `backend/src/server.ts:86-92` (+ various controllers)
+>
+> **Fix direction**
+> Return a generic message + correlation id to clients; log full detail server-side only.
+>
+> **Acceptance criteria**
+> - [ ] 5xx responses contain no raw internal error text.
+> - [ ] Full errors still logged server-side with a correlatable id.
+
+---
+
+### Issue 7
+**Title:** `[P1] JWT secret used without validation (silent auth failure if unset)`
+
+**Body:**
+> **Labels:** security, backend, P1
+> **Confidence:** ✅ verified
+>
+> **Summary**
+> `process.env.APP_JWT_SECRET!` and the middleware encode the secret unchecked. If unset, `TextEncoder().encode(undefined)` produces the bytes of `"undefined"`, and all tokens are signed/verified with that key.
+>
+> **Why it matters**
+> Catastrophic, silent auth weakness — a known misconfiguration lets anyone forge tokens.
+>
+> **Where**
+> - `backend/src/services/tokenService.ts:4`
+> - `backend/src/middleware/auth.ts`
+>
+> **Fix direction**
+> Validate required secrets at boot; crash fast if absent. Never sign/verify with a fallback.
+>
+> **Acceptance criteria**
+> - [ ] App refuses to start if `APP_JWT_SECRET` is missing/empty.
+> - [ ] No code path encodes an undefined secret.
+
+---
+
+### Issue 8
+**Title:** `[P1] Unbounded query limits enable DoS / huge payloads`
+
+**Body:**
+> **Labels:** security, performance, backend, P1
+> **Confidence:** ✅ verified
+>
+> **Summary**
+> `getRecentWorkouts` passes a `null` limit → unbounded rows; notification inbox uses `parseInt(limit)` with no cap and no negative/NaN handling. `?limit=99999999` is accepted.
+>
+> **Why it matters**
+> Memory pressure / DoS and odd SQL behavior on negative/NaN inputs.
+>
+> **Where**
+> - `backend/src/controllers/workoutController.ts:187-201`
+> - `backend/src/controllers/inAppNotificationController.ts:100-101`
+>
+> **Fix direction**
+> Apply the existing `clampLimit`/`clampOffset` helpers consistently; reject non-numeric/negative input.
+>
+> **Acceptance criteria**
+> - [ ] All list endpoints enforce a max page size.
+> - [ ] Negative/NaN limit/offset rejected or clamped.
+
+---
+
+### Issue 9
+**Title:** `[P1] Multi-write operations are not transactional (createCompetition, accept friend)`
+
+**Body:**
+> **Labels:** bug, data-integrity, backend, P1
+> **Confidence:** ✅ verified
+>
+> **Summary**
+> `createCompetition` inserts the competition then the owner membership as two separate statements; the friend-accept double-write has the same shape. No transaction.
+>
+> **Why it matters**
+> A failure between statements leaves corrupt partial state — a competition with no members, or a one-directional friendship.
+>
+> **Where**
+> - `backend/src/services/competitionService.ts:74-91`
+> - `backend/src/services/friendshipService.ts` (accept-request)
+>
+> **Fix direction**
+> Wrap each multi-statement mutation in `db.transaction()` (all-or-nothing).
+>
+> **Acceptance criteria**
+> - [ ] Competition creation is atomic.
+> - [ ] Friend-accept is atomic.
+> - [ ] Simulated mid-operation failure leaves no partial rows.
+
+---
+
+### Issue 10
+**Title:** `[P1] User search returns full rows including email (PII / enumeration)`
+
+**Body:**
+> **Labels:** security, backend, P1
+> **Confidence:** ✅ verified
+>
+> **Summary**
+> `SELECT * FROM users WHERE username ILIKE $1 OR email ILIKE $1 LIMIT 50` returns all columns and matches on email.
+>
+> **Why it matters**
+> Email/PII disclosure and user enumeration via search.
+>
+> **Where**
+> - `backend/src/controllers/usersController.ts:32`
+>
+> **Fix direction**
+> Select only public columns; stop matching on email (or move exact-email lookup behind a separate, rate-limited path).
+>
+> **Acceptance criteria**
+> - [ ] Search results exclude email and other private fields.
+> - [ ] Username search behavior unchanged for users.
+
+---
+
+### Issue 11
+**Title:** `[P1] Auth tokens persisted in plaintext UserDefaults (and sent to watch)`
+
+**Body:**
+> **Labels:** security, ios, P1
+> **Confidence:** ⚠️ reported
+>
+> **Summary**
+> `TokenStore` writes Keychain **and** mirrors tokens to `UserDefaults`; legacy readers and the watch bridge read the plaintext copy. The access token is shipped to the watch via application context.
+>
+> **Why it matters**
+> Plaintext tokens land in device/iCloud backups; a compromised backup or watch yields working credentials.
+>
+> **Where**
+> - `app/Mile A Day/Services/TokenStore.swift`
+> - `FriendService`, `WorkoutService`, `ProfileImageService`, `DailyStepsSyncService`
+> - `app/Mile A Day/Models/HealthKitManager.swift` (watch bridge)
+>
+> **Fix direction**
+> Make Keychain the single source of truth; delete the `UserDefaults` mirror; stop sending the access token to the watch.
+>
+> **Acceptance criteria**
+> - [ ] No token written to `UserDefaults`.
+> - [ ] All readers use Keychain via `TokenStore`.
+> - [ ] Watch no longer receives the access token.
+
+---
+
+### Issue 12
+**Title:** `[P1] Widget exhausts refresh budget and has no midnight rollover`
+
+**Body:**
+> **Labels:** bug, ux, ios, widgets, P1
+> **Confidence:** ✅ verified
+>
+> **Summary**
+> The timeline requests refreshes every 60s (WidgetKit caps daily refreshes, so it freezes), has no entry at local midnight (shows yesterday's miles after midnight), and `WidgetDataStore` triggers two reloads per save.
+>
+> **Why it matters**
+> Widgets look broken/stale — a visible, everyday UX failure.
+>
+> **Where**
+> - `app/Mile A Day/Widgets/TodayProgressWidget.swift:48`
+> - `app/Mile A Day/Shared/WidgetDataStore.swift`
+>
+> **Fix direction**
+> Use a realistic refresh cadence; add an explicit timeline entry at next local midnight (reset to 0); de-dup reload calls.
+>
+> **Acceptance criteria**
+> - [ ] Widget no longer freezes from budget exhaustion.
+> - [ ] Widget resets to 0 at local midnight.
+> - [ ] Single reload per data change.
+
+---
+
+### Issue 13
+**Title:** `[P1] Duplicate refresh storms on launch/foreground (MainTabView)`
+
+**Body:**
+> **Labels:** performance, ios, P1
+> **Confidence:** ✅ verified
+>
+> **Summary**
+> `.task` and `.onChange(of: scenePhase == .active)` both call `competitionService.refreshAllData()` + `friendService.refreshAllData()` + unread count. Cold launch + first foreground runs each twice.
+>
+> **Why it matters**
+> Doubles network/battery on every foreground; can delay first paint behind redundant requests.
+>
+> **Where**
+> - `app/Mile A Day/Views/MainTabView.swift`
+>
+> **Fix direction**
+> Add a minimum-interval / in-flight guard per service so overlapping triggers coalesce.
+>
+> **Acceptance criteria**
+> - [ ] Each dataset fetched at most once per launch/foreground burst.
+> - [ ] No regression in freshness on tab switch.
+
+---
+
+### Issue 14
+**Title:** `[P1] O(n) stat recomputation runs on the main thread at launch`
+
+**Body:**
+> **Labels:** performance, ios, P1
+> **Confidence:** ⚠️ reported
+>
+> **Summary**
+> `recalculateStatsWithAllWorkouts()` runs on the main queue over the full cached-workout array after updates.
+>
+> **Why it matters**
+> Large histories block UI 100-500ms during cold launch and stutter animations.
+>
+> **Where**
+> - `app/Mile A Day/Models/HealthKitManager+DataFetching.swift`
+>
+> **Fix direction**
+> Move computation off-main and publish results back; consider incremental updates.
+>
+> **Acceptance criteria**
+> - [ ] No main-thread stall attributable to stat recompute on launch.
+> - [ ] Stats values unchanged.
+
+---
+
+### Issue 15
+**Title:** `[P1] Cron jobs fan out serially over unbounded user/competition sets`
+
+**Body:**
+> **Labels:** performance, scalability, backend, P1
+> **Confidence:** ✅ logic · ⚠️ scale
+>
+> **Summary**
+> `silentSyncCron` iterates `SELECT DISTINCT user_id` awaiting each push serially; `checkCompetitionsEndingSoon` / `checkStreaksBroken` scan unbounded sets and re-query per row.
+>
+> **Why it matters**
+> One slow push blocks the rest; runtime grows linearly with users — will choke as the base grows.
+>
+> **Where**
+> - `backend/src/cron/silentSyncCron.ts`
+> - `backend/src/services/notificationService.ts`
+>
+> **Fix direction**
+> Page through users; fan out in bounded-concurrency batches; pre-aggregate where possible.
+>
+> **Acceptance criteria**
+> - [ ] Cron uses pagination + bounded concurrency.
+> - [ ] One slow recipient no longer blocks the batch.
+
+---
+
+## P2 — Medium
+
+### Issue 16
+**Title:** `[P2] Fire-and-forget async IIFE in upload path swallows errors`
+
+**Body:**
+> **Labels:** bug, backend, P2
+> **Confidence:** ✅ verified
+>
+> **Summary**
+> An un-awaited async IIFE runs `checkLeadChanges` / `checkCompetitionMilestones`; rejections escape the surrounding try, so failures are invisible while upload returns 200.
+>
+> **Where**
+> - `backend/src/controllers/workoutController.ts:95-103`
+>
+> **Fix direction**
+> Await and handle, or hand off to a job queue with its own error handling.
+>
+> **Acceptance criteria**
+> - [ ] Lead-change/milestone failures are logged/handled, not silently dropped.
+
+---
+
+### Issue 17
+**Title:** `[P2] Invalid push-token cleanup errors silently ignored`
+
+**Body:**
+> **Labels:** bug, backend, P2
+> **Confidence:** ⚠️ reported
+>
+> **Summary**
+> `removeInvalidToken(...).catch(() => {})` — dead device tokens accumulate forever; APNs/FCM failures are masked.
+>
+> **Where**
+> - `backend/src/services/pushNotificationService.ts:162,377`
+>
+> **Fix direction**
+> Log failures; surface to the cron error handler.
+>
+> **Acceptance criteria**
+> - [ ] Cleanup failures are logged.
+> - [ ] Dead tokens are actually removed.
+
+---
+
+### Issue 18
+**Title:** `[P2] Sensitive data logged via print() (tokens, full responses, APNs token)`
+
+**Body:**
+> **Labels:** security, ios, P2
+> **Confidence:** ⚠️ reported
+>
+> **Summary**
+> Raw API responses (up to 2000 chars), "auth token present", and APNs token prefix are logged.
+>
+> **Where**
+> - `app/Mile A Day/Services/APIClient.swift` (~203)
+> - `TokenRefreshService`, `FriendService`, `AppDelegate`
+>
+> **Fix direction**
+> Gate verbose logs behind `#if DEBUG`; never log token material or full bodies.
+>
+> **Acceptance criteria**
+> - [ ] Release builds emit no token/PII/response-body logs.
+
+---
+
+### Issue 19
+**Title:** `[P2] Hard-coded backend user id + ungated Developer Settings`
+
+**Body:**
+> **Labels:** security, ios, P2
+> **Confidence:** ⚠️ reported
+>
+> **Summary**
+> A real backend user id is hard-coded in dev settings, and the Developer Settings screen is reachable in release builds.
+>
+> **Where**
+> - `app/Mile A Day/Views/Settings/DeveloperSettingsView.swift` (~480)
+>
+> **Fix direction**
+> Remove the hard-coded id; wrap Developer Settings in `#if DEBUG`.
+>
+> **Acceptance criteria**
+> - [ ] No hard-coded user id in source.
+> - [ ] Developer Settings absent from release builds.
+
+---
+
+### Issue 20
+**Title:** `[P2] Concurrent UserDefaults writes can drop synced-workout ids`
+
+**Body:**
+> **Labels:** bug, data-integrity, ios, P2
+> **Confidence:** ⚠️ reported
+>
+> **Summary**
+> `markWorkoutsAsSynced` does read-union-write with no mutual exclusion across concurrent batches; `uploadedWorkoutIds` also grows unbounded.
+>
+> **Where**
+> - `app/Mile A Day/Services/WorkoutSyncService.swift`
+>
+> **Fix direction**
+> Serialize updates (actor/queue); store sync state in a DB keyed by workout id rather than one growing array.
+>
+> **Acceptance criteria**
+> - [ ] Concurrent batch completion can't drop ids.
+> - [ ] Sync-state storage is bounded.
+
+---
+
+### Issue 21
+**Title:** `[P2] updateFriendSettings doesn't verify the friendship`
+
+**Body:**
+> **Labels:** security, backend, P2
+> **Confidence:** ⚠️ reported
+>
+> **Summary**
+> Takes `:friendId` and writes per-friend notification settings without confirming a friendship exists.
+>
+> **Where**
+> - `backend/src/controllers/notificationSettingsController.ts`
+>
+> **Fix direction**
+> Validate the friendship before writing.
+>
+> **Acceptance criteria**
+> - [ ] Writing settings for a non-friend id is rejected.
+
+---
+
+### Issue 22
+**Title:** `[P2] Nudge/flex logging has no idempotency`
+
+**Body:**
+> **Labels:** bug, backend, P2
+> **Confidence:** ⚠️ reported
+>
+> **Summary**
+> Inserts without a unique constraint; rapid double-taps double-log and can double-count against rate limits.
+>
+> **Where**
+> - `backend/src/services/pushNotificationService.ts:544,584`
+>
+> **Fix direction**
+> Add a unique constraint (e.g. per sender/target/day) with `ON CONFLICT DO NOTHING`.
+>
+> **Acceptance criteria**
+> - [ ] Duplicate nudge/flex in the same window is a no-op.
+
+---
+
+### Issue 23
+**Title:** `[P2] Workout tracking view stops timer but not location on disappear`
+
+**Body:**
+> **Labels:** bug, performance, ios, P2
+> **Confidence:** ⚠️ reported
+>
+> **Summary**
+> `onDisappear` invalidates the timer but doesn't stop location tracking; dismissing without ending a workout can leave GPS running.
+>
+> **Where**
+> - `app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift`
+>
+> **Fix direction**
+> Stop location tracking on disappear unless an explicit background-tracking state is intended.
+>
+> **Acceptance criteria**
+> - [ ] GPS stops when the tracking view is dismissed without an active background workout.
+
+---
+
+### Issue 24
+**Title:** `[P2] Remove deprecated UserDefaults.synchronize() calls`
+
+**Body:**
+> **Labels:** cleanup, performance, ios, P2
+> **Confidence:** ⚠️ reported
+>
+> **Summary**
+> Multiple `synchronize()` call sites; unnecessary since iOS 13 and adds main-thread stalls.
+>
+> **Where**
+> - `InProgressWorkoutStore`, `WorkoutSyncService`, others
+>
+> **Fix direction**
+> Remove the calls; rely on automatic persistence.
+>
+> **Acceptance criteria**
+> - [ ] No `synchronize()` calls remain.
+
+---
+
+### Issue 25
+**Title:** `[P2] N+1 in checkCompetitionMilestones`
+
+**Body:**
+> **Labels:** performance, backend, P2
+> **Confidence:** ⚠️ reported
+>
+> **Summary**
+> Full `getCompetition()` per competition in a loop — one aggregation round-trip each; slow for users in many competitions.
+>
+> **Where**
+> - `backend/src/services/notificationService.ts:286-291`
+>
+> **Fix direction**
+> Batch the needed data in a single query or parallelize with a bound.
+>
+> **Acceptance criteria**
+> - [ ] No per-competition full fetch in the loop.
+
+---
+
+### Issue 26
+**Title:** `[P2] Stale celebrations replay on foreground`
+
+**Body:**
+> **Labels:** bug, ux, ios, P2
+> **Confidence:** ⚠️ reported
+>
+> **Summary**
+> Celebrations queued while backgrounded replay on return even when no longer relevant.
+>
+> **Where**
+> - `app/Mile A Day/Managers/CelebrationManager.swift`
+>
+> **Fix direction**
+> Timestamp queued celebrations; drop stale ones on foreground.
+>
+> **Acceptance criteria**
+> - [ ] No outdated celebration shown after returning to foreground.
+
+---
+
+### Issue 27
+**Title:** `[P2] Device-token registration auth depends on route mount order`
+
+**Body:**
+> **Labels:** security, backend, P2
+> **Confidence:** ✅ verified (not currently exploitable)
+>
+> **Summary**
+> The endpoint is protected only because it's mounted after `authenticateToken`; a future reorder silently opens unauthenticated token registration.
+>
+> **Where**
+> - `backend/src/routes/deviceRoutes.ts` + `server.ts` mount order
+>
+> **Fix direction**
+> Add an explicit auth guard on the route so safety doesn't depend on ordering.
+>
+> **Acceptance criteria**
+> - [ ] Route enforces auth independently of mount order.
+
+---
+
+## P3 — Low / cleanup
+
+### Issue 28
+**Title:** `[P3] Wildcard CORS + no rate limit on /public/profile-image/:username`
+
+**Body:**
+> **Labels:** security, backend, P3 · **Confidence:** ✅
+> Public endpoint sets `Access-Control-Allow-Origin: *` with no rate limiting → enumeration surface.
+> **Where:** `backend/src/server.ts:49-67`
+> **Fix:** Restrict origins; add rate limiting.
+> - [ ] Origins restricted and/or endpoint rate-limited.
+
+---
+
+### Issue 29
+**Title:** `[P3] No rate limiting on /auth/* endpoints`
+
+**Body:**
+> **Labels:** security, backend, P3 · **Confidence:** ✅
+> Mitigated by Sign in with Apple, but a limiter is still good practice.
+> **Where:** `backend/src/routes/authRoutes.ts`
+> **Fix:** Add request throttling.
+> - [ ] Auth endpoints rate-limited.
+
+---
+
+### Issue 30
+**Title:** `[P3] Dead code: empty getWorkoutRange() still wired to a route`
+
+**Body:**
+> **Labels:** cleanup, backend, P3 · **Confidence:** ✅
+> **Where:** `backend/src/controllers/workoutController.ts:182` (+ `workoutRoutes.ts:10`)
+> **Fix:** Remove or implement.
+> - [ ] Empty handler/route removed or implemented.
+
+---
+
+### Issue 31
+**Title:** `[P3] refreshData() clears isRefreshing before async work finishes`
+
+**Body:**
+> **Labels:** bug, ux, ios, P3 · **Confidence:** ⚠️
+> Pull-to-refresh spinner dismisses early.
+> **Where:** `app/Mile A Day/Views/Dashboard/DashboardView.swift`
+> **Fix:** Tie the flag to async completion.
+> - [ ] Spinner persists until data actually loads.
+
+---
+
+### Issue 32
+**Title:** `[P3] Location accuracy gate uses strict >0 && <50 bounds`
+
+**Body:**
+> **Labels:** bug, ios, P3 · **Confidence:** ⚠️
+> Drops exactly-0/50m readings; no negative-sentinel handling.
+> **Where:** `app/Mile A Day/Views/Dashboard/WorkoutLocationManager.swift`
+> **Fix:** Use `<=` bounds; handle invalid (negative) accuracy explicitly.
+> - [ ] Valid edge-case readings no longer dropped.
+
+---
+
+### Issue 33
+**Title:** `[P3] APIClient 15s timeout hardcoded for all endpoints`
+
+**Body:**
+> **Labels:** enhancement, ios, P3 · **Confidence:** ⚠️
+> No per-call override for legitimately slow operations.
+> **Where:** `app/Mile A Day/Services/APIClient.swift`
+> **Fix:** Allow per-request timeout override.
+> - [ ] Callers can specify a timeout.
+
+---
+
+### Issue 34
+**Title:** `[P3] updateUser mass-assignment whitelist lacks field validation`
+
+**Body:**
+> **Labels:** security, backend, P3 · **Confidence:** ✅
+> Whitelisted but unvalidated (no length/format checks).
+> **Where:** `backend/src/controllers/usersController.ts` (`updateUser`)
+> **Fix:** Add per-field validation (lengths, formats).
+> - [ ] Invalid field values rejected.
+
+---
+
+### Issue 35
+**Title:** `[P3] Refresh-token reuse detection has a small pre-revocation race window`
+
+**Body:**
+> **Labels:** security, backend, P3 · **Confidence:** ⚠️
+> Low risk given short token lifetimes (see Issue 5).
+> **Where:** `backend/src/services/refreshTokenService.ts`
+> **Fix:** Tighten rotation/revocation ordering.
+> - [ ] Reused token can't be replayed in the race window.
+
+---
+
+## Not issues — confirmed false positives (do not file)
+
+- **Daily challenge IDOR** — gated by `areFriends` (`dailyChallengeController.ts:23-26`).
+- **`checkStreakLifeLoss` undefined** — defined at `notificationService.ts:775`.
+- **`/dev/*` unauthenticated** — every dev controller self-gates on `NODE_ENV === 'production'`. (Optional: add a boot assertion that `NODE_ENV` is set in prod.)
+- **Device registration auth bypass** — mounted behind `authenticateToken`.
+- **SQL injection / committed secrets** — none found; queries parameterized throughout.

--- a/app/Mile A Day/Services/CompetitionService.swift
+++ b/app/Mile A Day/Services/CompetitionService.swift
@@ -9,6 +9,10 @@ class CompetitionService: ObservableObject {
     @Published var competitions: [Competition] = []
     @Published var invites: [Competition] = []
     @Published var isLoading = false
+    /// True once at least one refresh has completed (success or failure, but not
+    /// cancellation). Views use this to show skeletons only on the true cold
+    /// start instead of swapping live content out on every background refresh.
+    @Published private(set) var hasLoadedOnce = false
     @Published var errorMessage: String?
 
     // MARK: - Private Properties
@@ -424,9 +428,14 @@ class CompetitionService: ObservableObject {
                 // Wait for all tasks to complete
                 for try await _ in group {}
             }
+            hasLoadedOnce = true
 
+        } catch is CancellationError {
+            // The hosting view was torn down mid-refresh. Keep existing data and
+            // don't mark loaded — the next refresh trigger completes the job.
         } catch {
             errorMessage = error.localizedDescription
+            hasLoadedOnce = true
         }
 
         isLoading = false

--- a/app/Mile A Day/Services/FriendService.swift
+++ b/app/Mile A Day/Services/FriendService.swift
@@ -9,6 +9,10 @@ class FriendService: ObservableObject {
     @Published var friends: [BackendUser] = []
     @Published var friendRequests: [BackendUser] = []
     @Published var sentRequests: [BackendUser] = []
+    /// Today-status (completed mile, miles, nudged) per friend id. Lives here —
+    /// not in view @State — so every refresh trigger (app foreground, tab switch,
+    /// push, pull-to-refresh) updates the same data all friend rows read.
+    @Published var nudgeStatuses: [String: NudgeStatusResponse] = [:]
     @Published var isLoading = false
     @Published var errorMessage: String?
     
@@ -343,7 +347,7 @@ class FriendService: ObservableObject {
     func refreshAllData() async {
         isLoading = true
         errorMessage = nil
-        
+
         do {
             // Run all operations concurrently
             try await withThrowingTaskGroup(of: Void.self) { group in
@@ -356,16 +360,38 @@ class FriendService: ObservableObject {
                 group.addTask {
                     try await self.loadSentRequests()
                 }
-                
+
                 // Wait for all tasks to complete
                 for try await _ in group {}
             }
-            
+
+            // Nudge statuses need the fresh friend list, so fetch them after
+            // the group. Without this, friend rows showed stale "Nudge"/progress
+            // state until the Friends view's own one-shot task happened to run.
+            await refreshNudgeStatuses()
+
+        } catch is CancellationError {
+            // The hosting view was torn down mid-refresh (e.g. pull-to-refresh
+            // interrupted). Keep existing data; don't surface an error.
         } catch {
             errorMessage = error.localizedDescription
         }
-        
+
         isLoading = false
+    }
+
+    /// Re-fetch today-status for all current friends into `nudgeStatuses`.
+    func refreshNudgeStatuses() async {
+        let friendIds = friends.map { $0.user_id }
+        guard !friendIds.isEmpty else {
+            nudgeStatuses = [:]
+            return
+        }
+        do {
+            nudgeStatuses = try await checkNudgeStatusBatch(friendIds: friendIds)
+        } catch {
+            print("[FriendService] ❌ refreshNudgeStatuses failed: \(error)")
+        }
     }
     
     /// Get current user ID from UserDefaults

--- a/app/Mile A Day/Services/RemoteChallengeService.swift
+++ b/app/Mile A Day/Services/RemoteChallengeService.swift
@@ -25,7 +25,10 @@ final class RemoteChallengeService: ChallengeServiceProtocol {
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        self.todayChallenge = nil
+        // Restore the last server snapshot so the dashboard has a challenge to show
+        // immediately (and offline) instead of a loading placeholder until the
+        // network round-trip completes.
+        loadTodaySnapshot()
     }
 
     // MARK: - ChallengeServiceProtocol (sync)
@@ -78,7 +81,9 @@ final class RemoteChallengeService: ChallengeServiceProtocol {
     // MARK: - Async refreshers
 
     /// Fetch today's challenge + progress + completion status for the given user.
-    func refreshToday(userId: String) async {
+    /// Transient failures (timeouts, flaky connections) are retried twice with
+    /// backoff so a single dropped request doesn't strand the dashboard card.
+    func refreshToday(userId: String, attempt: Int = 0) async {
         do {
             let response: TodayResponseDTO = try await APIClient.fancyFetch(
                 endpoint: "/users/\(userId)/challenges/today",
@@ -97,7 +102,11 @@ final class RemoteChallengeService: ChallengeServiceProtocol {
                 NotificationCenter.default.post(name: ChallengeService.changedNotification, object: nil)
             }
         } catch {
-            print("[RemoteChallengeService] refreshToday failed: \(error)")
+            print("[RemoteChallengeService] refreshToday failed (attempt \(attempt + 1)): \(error)")
+            if attempt < 2 {
+                try? await Task.sleep(nanoseconds: UInt64(attempt + 1) * 2_000_000_000)
+                await refreshToday(userId: userId, attempt: attempt + 1)
+            }
         }
     }
 
@@ -153,6 +162,30 @@ final class RemoteChallengeService: ChallengeServiceProtocol {
         if let data = try? encoder.encode(response) {
             defaults.set(data, forKey: todayKey)
         }
+    }
+
+    /// Restore the last `/challenges/today` response, but only if it's still for
+    /// today's local date — yesterday's challenge must never masquerade as today's.
+    private func loadTodaySnapshot() {
+        guard let data = defaults.data(forKey: todayKey) else { return }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let response = try? decoder.decode(TodayResponseDTO.self, from: data),
+              response.localDate == Self.currentLocalDateString() else { return }
+        todayChallenge = response.challenge.toDailyChallenge()
+        todayProgress = response.progress
+        todayCompleted = response.completed
+        todayLocalDate = response.localDate
+        tomorrowChallenge = response.tomorrowChallenge?.toDailyChallenge()
+        tomorrowLocalDate = response.tomorrowLocalDate
+    }
+
+    private static func currentLocalDateString() -> String {
+        let fmt = DateFormatter()
+        fmt.calendar = Calendar(identifier: .gregorian)
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.dateFormat = "yyyy-MM-dd"
+        return fmt.string(from: Date())
     }
 
     private static func parseYmd(_ s: String) -> Date? {

--- a/app/Mile A Day/Views/Competitions/CompetitionsListView.swift
+++ b/app/Mile A Day/Views/Competitions/CompetitionsListView.swift
@@ -164,7 +164,11 @@ struct CompetitionsListView: View {
     // MARK: - Competitions Tab
     private var competitionsTab: some View {
         Group {
-            if competitionService.isLoading {
+            // Skeletons only while we have nothing to show. Keying on isLoading
+            // alone swapped the live List out on every background refresh — which
+            // also cancelled pull-to-refresh mid-flight (the List hosting
+            // .refreshable was destroyed), leaving stale data until app restart.
+            if competitionService.competitions.isEmpty && !competitionService.hasLoadedOnce {
                 loadingView
             } else if competitionService.competitions.isEmpty {
                 CompetitionEmptyStateView(
@@ -474,7 +478,8 @@ struct CompetitionsListView: View {
     // MARK: - Invites Tab
     private var invitesTab: some View {
         Group {
-            if competitionService.isLoading {
+            // Same cold-start-only skeleton rule as competitionsTab.
+            if competitionService.invites.isEmpty && !competitionService.hasLoadedOnce {
                 loadingView
             } else if competitionService.invites.isEmpty {
                 CompetitionEmptyStateView(

--- a/app/Mile A Day/Views/Components/MADTabHeader.swift
+++ b/app/Mile A Day/Views/Components/MADTabHeader.swift
@@ -47,18 +47,26 @@ struct MADTabHeader: View {
     }
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline) {
+        // Center alignment: baseline-aligning the 38pt icon circles against the
+        // big title pushed the buttons below the title's visual line. Centering
+        // keeps title and buttons level at any text size.
+        HStack(alignment: .center) {
             Text(title)
-                .font(.system(size: 30, weight: .heavy, design: .rounded))
+                .font(.system(size: 26, weight: .heavy, design: .rounded))
                 .foregroundColor(.white)
+                .lineLimit(1)
+                .minimumScaleFactor(0.65)
 
-            Spacer()
+            Spacer(minLength: MADTheme.Spacing.sm)
 
             HStack(spacing: 8) {
                 ForEach(actions) { action in
                     headerButton(action)
                 }
             }
+            // Buttons keep their intrinsic size; the title scales down first,
+            // so the two sides can never compress into each other or overlap.
+            .fixedSize()
         }
         .padding(.horizontal, MADTheme.Spacing.md)
         .padding(.top, MADTheme.Spacing.sm)

--- a/app/Mile A Day/Views/Dashboard/DashboardComponents.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardComponents.swift
@@ -705,7 +705,10 @@ struct DailyChallengeCard: View {
                 placeholderCard
             }
         }
-        .task {
+        // task(id:) re-runs when backendUserId changes. A plain .task fires once on
+        // appear — if the profile hadn't loaded yet at that instant it bailed on the
+        // guard and never fetched, leaving the card on "Loading…" forever.
+        .task(id: userManager.currentUser.backendUserId) {
             guard let userId = userManager.currentUser.backendUserId else { return }
             await ChallengeService.refresh(userId: userId)
             refreshFromService()
@@ -714,6 +717,9 @@ struct DailyChallengeCard: View {
             refreshFromService()
         }
         .onAppear {
+            // Pick up any cached challenge state immediately (the service restores
+            // today's snapshot from UserDefaults) instead of waiting on the network.
+            refreshFromService()
             // Subtle pulse on the icon when not completed — draws the eye without being annoying.
             iconPulse = true
         }

--- a/app/Mile A Day/Views/Dashboard/UnifiedStatsGrid.swift
+++ b/app/Mile A Day/Views/Dashboard/UnifiedStatsGrid.swift
@@ -12,6 +12,7 @@ struct UnifiedStatsGrid: View {
     @State private var statsData: (totalMiles: Double, mostMiles: Double, fastestPace: TimeInterval, streakDays: Int) = (0.0, 0.0, 0.0, 0)
     @State private var hasLoadedOnce = false
     @State private var isCalculating = false
+    @State private var recomputeInFlight = false
     @State private var showFastestPaceDetail = false
     @State private var showMostMilesDetail = false
     @State private var showTotalMilesDetail = false
@@ -336,13 +337,22 @@ struct UnifiedStatsGrid: View {
     }
 
     private func calculateCurrentStreakStats() {
-        // Show cached data immediately to avoid content shift
+        // Show cached data immediately — and treat it as loaded. Previously the
+        // cache was applied but isCalculating stayed true, so the cards hid the
+        // value behind a spinner until the HealthKit recompute (which can take
+        // many seconds) finished. Cached-then-corrected beats spinner-then-value.
         let cached = healthManager.cachedCurrentStreakStats
         if cached.streakDays > 0 && !hasLoadedOnce {
             statsData = cached
+            hasLoadedOnce = true
         }
 
         isCalculating = !hasLoadedOnce
+
+        // One recompute at a time — onAppear / retroactiveStreak / statsType
+        // changes can all fire this, and each recompute is expensive.
+        guard !recomputeInFlight else { return }
+        recomputeInFlight = true
 
         DispatchQueue.global(qos: .userInitiated).async {
             let stats = healthManager.calculateCurrentStreakStats()
@@ -351,6 +361,7 @@ struct UnifiedStatsGrid: View {
                 self.statsData = stats
                 self.isCalculating = false
                 self.hasLoadedOnce = true
+                self.recomputeInFlight = false
             }
         }
     }

--- a/app/Mile A Day/Views/Friends/FriendsListView.swift
+++ b/app/Mile A Day/Views/Friends/FriendsListView.swift
@@ -135,12 +135,16 @@ struct FriendsListView: View {
     // MARK: - Custom header (title + search + requests-with-badge)
 
     private var friendsHeader: some View {
-        HStack(alignment: .firstTextBaseline) {
+        // Matches MADTabHeader: center-aligned with a 26pt title so the icon
+        // buttons sit level with the text on every tab.
+        HStack(alignment: .center) {
             Text("Friends")
-                .font(.system(size: 30, weight: .heavy, design: .rounded))
+                .font(.system(size: 26, weight: .heavy, design: .rounded))
                 .foregroundColor(.white)
+                .lineLimit(1)
+                .minimumScaleFactor(0.65)
 
-            Spacer()
+            Spacer(minLength: MADTheme.Spacing.sm)
 
             HStack(spacing: 8) {
                 headerCircleButton(systemImage: "magnifyingglass") {

--- a/app/Mile A Day/Views/Friends/FriendsListView.swift
+++ b/app/Mile A Day/Views/Friends/FriendsListView.swift
@@ -25,8 +25,10 @@ struct FriendsListView: View {
     @State private var showingUnfriendAlert = false
     @State private var userToUnfriend: BackendUser?
 
-    // Nudge state
-    @State private var nudgeStatuses: [String: NudgeStatusResponse] = [:]
+    // Nudge state. Statuses live on FriendService (published) so every refresh
+    // path — including app-foreground and tab-switch refreshes that don't go
+    // through this view — keeps the rows current.
+    private var nudgeStatuses: [String: NudgeStatusResponse] { friendService.nudgeStatuses }
     @State private var nudgingFriendId: String?
     @State private var nudgeFeedback: NudgeFeedback?
     @State private var bellShakeIds: Set<String> = []
@@ -108,8 +110,8 @@ struct FriendsListView: View {
             await loadMyRank()
         }
         .refreshable {
+            // refreshAllData re-fetches nudge statuses internally.
             await friendService.refreshAllData()
-            await loadNudgeStatuses()
             await loadMyRank()
         }
         .onReceive(NotificationCenter.default.publisher(for: .didTapPushNotification)) { notification in
@@ -819,17 +821,7 @@ struct FriendsListView: View {
 
     // MARK: - Nudge Methods
     private func loadNudgeStatuses() async {
-        let friendIds = friendService.friends.map { $0.user_id }
-        guard !friendIds.isEmpty else { return }
-
-        do {
-            let statuses = try await friendService.checkNudgeStatusBatch(friendIds: friendIds)
-            await MainActor.run {
-                self.nudgeStatuses = statuses
-            }
-        } catch {
-            print("[FriendsList] ❌ loadNudgeStatuses failed: \(error)")
-        }
+        await friendService.refreshNudgeStatuses()
     }
 
     private func handleNudge(_ friend: BackendUser) {
@@ -840,9 +832,9 @@ struct FriendsListView: View {
                 await MainActor.run {
                     nudgingFriendId = nil
                     FlexNudgeTracker.markFriendNudgeSent(friendId: friend.user_id)
-                    // Update local status — preserve existing miles/completion
-                    let existing = nudgeStatuses[friend.user_id]
-                    nudgeStatuses[friend.user_id] = NudgeStatusResponse(
+                    // Optimistic update on the shared service state — preserve existing miles/completion
+                    let existing = friendService.nudgeStatuses[friend.user_id]
+                    friendService.nudgeStatuses[friend.user_id] = NudgeStatusResponse(
                         can_nudge: false,
                         has_completed_mile: existing?.has_completed_mile ?? false,
                         already_nudged_today: true,

--- a/app/Mile A Day/Views/MainTabView.swift
+++ b/app/Mile A Day/Views/MainTabView.swift
@@ -120,6 +120,22 @@ struct MainTabView: View {
                 selectedTab = tab
             }
         }
+        .onChange(of: selectedTab) { _, newTab in
+            // TabView keeps tab views alive, so their onAppear/.task don't re-fire
+            // on tab switches — without this, Compete/Friends showed whatever was
+            // fetched at launch until the app was backgrounded or killed. These
+            // refreshes are silent: views keep content on screen while data swaps in.
+            Task {
+                switch newTab {
+                case 1:
+                    await competitionService.refreshAllData()
+                case 2:
+                    await friendService.refreshAllData()
+                default:
+                    break
+                }
+            }
+        }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active {
                 Task {

--- a/app/Mile A Day/Views/NotificationInboxView.swift
+++ b/app/Mile A Day/Views/NotificationInboxView.swift
@@ -94,18 +94,11 @@ struct NotificationInboxView: View {
                     }
                 }
             }
-            if unreadCount > 0 {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Read All") {
-                        markAllRead()
-                    }
-                    .foregroundColor(MADTheme.Colors.madRed)
-                    .font(.system(size: 14, weight: .semibold, design: .rounded))
-                }
-            }
         }
         .task {
             await loadNotifications()
+            // Opening the inbox counts as reading — no "Read All" button needed.
+            autoMarkAllRead()
         }
         .refreshable {
             await loadNotifications()
@@ -818,24 +811,15 @@ struct NotificationInboxView: View {
         }
     }
 
-    private func markAllRead() {
+    /// Opening the inbox counts as reading everything: clear the server-side
+    /// unread state and the badge immediately, but leave this session's local
+    /// `is_read` flags untouched so freshly-arrived rows keep their "new"
+    /// highlight while the user is actually looking at them.
+    private func autoMarkAllRead() {
+        guard unreadCount > 0 else { return }
+        unreadCount = 0
         Task {
             try? await friendService.markAllNotificationsRead()
-            await MainActor.run {
-                notifications = notifications.map { n in
-                    InAppNotification(
-                        id: n.id, title: n.title, body: n.body,
-                        type: n.type, data: n.data, is_read: true,
-                        created_at: n.created_at,
-                        hype_target_user_id: n.hype_target_user_id,
-                        hype_context_type: n.hype_context_type,
-                        hype_context_id: n.hype_context_id,
-                        hype_context_label: n.hype_context_label,
-                        is_hyped: n.is_hyped
-                    )
-                }
-                unreadCount = 0
-            }
         }
     }
 }

--- a/app/Mile A Day/Views/Root/RootView.swift
+++ b/app/Mile A Day/Views/Root/RootView.swift
@@ -102,10 +102,12 @@ struct RootView: View {
             UINavigationBar.appearance().tintColor = UIColor(MADTheme.Colors.madRed)
             UINavigationBar.appearance().isTranslucent = true
             
-            // Tab bar for older iOS
+            // Tab bar for older iOS. Use the system's standard blurred background —
+            // a fully transparent bar (configureWithTransparentBackground + .clear)
+            // renders the tab icons directly on top of scrolling content with no
+            // backdrop, which looks broken on every pre-26 device.
             let tabBarAppearance = UITabBarAppearance()
-            tabBarAppearance.configureWithTransparentBackground()
-            tabBarAppearance.backgroundColor = .clear
+            tabBarAppearance.configureWithDefaultBackground()
             
             tabBarAppearance.stackedLayoutAppearance.normal.iconColor = UIColor(MADTheme.Colors.secondaryText)
             tabBarAppearance.stackedLayoutAppearance.normal.titleTextAttributes = [


### PR DESCRIPTION
## 1. Tab bar broken on older iOS (`RootView.swift`)
The pre-iOS 26 appearance branch used `configureWithTransparentBackground()` + `.clear`, making the tab bar fully invisible on **every iOS 17–25 device** — icons rendered directly over content. Switched to `configureWithDefaultBackground()` (standard blurred system bar, adapts light/dark, keeps red tint). iOS 26 Liquid Glass branch untouched.

## 2. Daily Challenge card stuck on "Loading…" (3 compounding bugs)
- Plain `.task` ran once on appear; if `backendUserId` hadn't loaded yet it bailed and **never fetched again** → `.task(id: backendUserId)`.
- `refreshToday` swallowed all errors with no retry → transient failures now retry twice with backoff.
- The today-snapshot cache was saved to UserDefaults but **never read** → restored at init (only if still today's local date), card pulls service state on appear. Challenge now renders instantly and offline.

## 3. Data-freshness overhaul (stale Friends nudges, stale Competitions, broken pull-to-refresh, skeletons)

**Friends — stale "Nudge" rows that refresh didn't fix:** nudge/today statuses lived in `FriendsListView` local `@State`, populated only by that view's one-shot `.task`. None of the app-wide refresh triggers ever updated them. They now live on `FriendService` as `@Published` state fetched inside `refreshAllData()`.

**Competitions — stale until app kill + bad skeletons (one root cause):** both tabs swapped to skeletons whenever `isLoading` flipped. That destroyed the `List` hosting `.refreshable` mid-refresh, so SwiftUI **cancelled the in-flight fetch** — pull-to-refresh silently kept old data. Skeletons now show only on true cold start (`empty && !hasLoadedOnce`); background refreshes keep content on screen. Also kills the empty-state flash at launch and skeleton flicker on foregrounding. Services treat `CancellationError` as a no-op.

**Tab switches now refresh:** `TabView` keeps tab views alive, so `onAppear`/`.task` don't re-fire when switching tabs. `MainTabView` now silently refreshes the selected tab's data on every switch.

## 4. Dashboard "Current Streak" loading forever (`UnifiedStatsGrid`)
Cached streak stats were applied but hidden behind a spinner until a multi-second HealthKit recompute finished. Cached stats now display immediately and get corrected in place; concurrent recomputes are coalesced behind an in-flight guard.

## 5. Tab header alignment + auto-read notifications
- **Headers (Dashboard/Compete/Profile via `MADTabHeader`, plus Friends' matching custom header):** the 38pt icon buttons were `firstTextBaseline`-aligned against the 30pt title, pushing them below the title's visual line. Now center-aligned, title reduced to 26pt, and overlap is impossible by construction: the title has `lineLimit(1)` + `minimumScaleFactor(0.65)` so it shrinks first, the button cluster is `.fixedSize()` with a guaranteed minimum gap.
- **Notifications:** removed the "Read All" toolbar button — opening the inbox now auto-marks everything read (badge + server clear immediately), while just-arrived rows keep their "new" highlight for the current viewing session.

## Notes
- iOS builds via Xcode only (project rule), so not compiled here; all changes use iOS 17-safe APIs. Suggested manual pass: iOS 18 simulator for the tab bar, tab-switching + pull-to-refresh on Compete/Friends, Dashboard streak, and the dashboard header at large Dynamic Type sizes.

https://claude.ai/code/session_01AbQCRc7BqCU8EkqyX9d8NV