### PR TITLE
Suppress upload notifications for full-sync backfill and stale workouts

### DIFF
--- a/app/Mile A Day/Services/WorkoutSyncService.swift
+++ b/app/Mile A Day/Services/WorkoutSyncService.swift
@@ -310,8 +310,9 @@ class WorkoutSyncService: ObservableObject {
                     "[WorkoutSyncService] 📤 Uploading batch \(index + 1)/\(totalBatches) (\(batch.count) workouts)"
                 )
 
-                // Upload batch with retry logic
-                try await uploadBatchWithRetry(batch)
+                // Upload batch with retry logic. This is the initial account-setup
+                // backfill, so flag it full-sync to suppress friend notifications.
+                try await uploadBatchWithRetry(batch, fullSync: true)
 
                 // Mark as synced
                 markWorkoutsAsSynced(batch.map { $0.uuid.uuidString })
@@ -467,13 +468,16 @@ class WorkoutSyncService: ObservableObject {
         }
     }
 
-    /// Upload a single batch with retry logic
-    private func uploadBatchWithRetry(_ workouts: [HKWorkout]) async throws {
+    /// Upload a single batch with retry logic.
+    /// `fullSync` is true only for the one-time HealthKit backfill run at account
+    /// setup / re-login; it tells the backend to skip friend-facing notifications
+    /// so a historical import doesn't spam other users.
+    private func uploadBatchWithRetry(_ workouts: [HKWorkout], fullSync: Bool = false) async throws {
         var lastError: Error?
 
         for attempt in 1...maxRetries {
             do {
-                try await uploadBatch(workouts)
+                try await uploadBatch(workouts, fullSync: fullSync)
                 return  // Success!
             } catch {
                 lastError = error
@@ -493,8 +497,10 @@ class WorkoutSyncService: ObservableObject {
         }
     }
 
-    /// Upload a single batch to the backend
-    private func uploadBatch(_ workouts: [HKWorkout]) async throws {
+    /// Upload a single batch to the backend.
+    /// When `fullSync` is true the request carries ?fullSync=true so the backend
+    /// suppresses friend-facing notifications for this historical backfill.
+    private func uploadBatch(_ workouts: [HKWorkout], fullSync: Bool = false) async throws {
         guard let userId = currentUserId else {
             throw SyncError.notAuthenticated
         }
@@ -503,7 +509,7 @@ class WorkoutSyncService: ObservableObject {
         let workoutData = try await transformWorkoutsForBackend(workouts)
 
         // Make API request using fancyFetch
-        let endpoint = "/workouts/\(userId)/upload"
+        let endpoint = fullSync ? "/workouts/\(userId)/upload?fullSync=true" : "/workouts/\(userId)/upload"
         let requestBody = try JSONSerialization.data(withJSONObject: workoutData)
 
         struct UploadedBadge: Codable {

--- a/backend/src/controllers/workoutController.ts
+++ b/backend/src/controllers/workoutController.ts
@@ -43,6 +43,30 @@ export async function uploadWorkouts(req: Request, res: Response) {
 
 		const userId = req.params.userId;
 
+		// The iOS client sets ?fullSync=true on the bulk HealthKit backfill it runs
+		// once when a user first sets up their account (and on re-login). Those uploads
+		// are historical, so we must NOT spray friend-facing notifications ("got their
+		// mile in", extra-workout, competition lead/milestone, friend badge/challenge,
+		// personal-best) at other users. Absent/any-other value = normal sync (old
+		// clients never send it), so behavior is unchanged for them.
+		const isFullSync = req.query.fullSync === 'true' || req.query.fullSync === '1';
+
+		// A notification only fires for activity from the last 24 hours. An old or
+		// backdated workout (HealthKit can deliver backdated workouts; a manual log
+		// can be for a past day) must NOT notify anyone — not friends, and not the
+		// user for their own badge. We map each achievement back to the workout that
+		// triggered it and suppress its push when that workout is outside the window.
+		const recencyCutoffMs = Date.now() - 24 * 60 * 60 * 1000;
+		const recentWorkoutIds = new Set(
+			(req.body as Workout[])
+				.filter(w => {
+					const ts = Date.parse(w.deviceEndDate ?? w.date);
+					return Number.isFinite(ts) && ts >= recencyCutoffMs;
+				})
+				.map(w => w.workoutId)
+		);
+		const hasRecentWorkout = recentWorkoutIds.size > 0;
+
 		const user = await getUser({ userId });
 		if (!user) {
 			return res.status(400).send({ error: `No user found with ID ${userId}` });
@@ -73,52 +97,76 @@ export async function uploadWorkouts(req: Request, res: Response) {
 			console.error('Error evaluating workout rewards:', rewardError.message);
 		}
 
-		// Check if user has now completed their mile and notify friends
-		try {
-			const todayMiles = await getTodayMiles(userId);
-			if (todayMiles >= 1.0) {
-				const milestoneFired = await notifyFriendsOfMileCompletion(userId).catch(err => {
-					console.error('Error notifying friends:', err.message);
-					return false;
-				});
-				// If the mile was already completed before this upload, any new run/walk
-				// workouts in this batch are "extras" — fan out a per-workout notification.
-				if (!milestoneFired) {
-					for (const w of req.body as Workout[]) {
-						if (w.workoutType === 'running' || w.workoutType === 'walking') {
-							notifyFriendsOfExtraWorkout(userId, w.workoutId).catch(err =>
-								console.error('Error notifying extra workout:', err.message)
-							);
+		// Check if user has now completed their mile and notify friends.
+		// Skipped on the initial account-setup backfill (isFullSync) and when this
+		// upload carried no workout from the last 24h (a pure backfill of old data).
+		if (!isFullSync && hasRecentWorkout) {
+			try {
+				const todayMiles = await getTodayMiles(userId);
+				if (todayMiles >= 1.0) {
+					const milestoneFired = await notifyFriendsOfMileCompletion(userId).catch(err => {
+						console.error('Error notifying friends:', err.message);
+						return false;
+					});
+					// If the mile was already completed before this upload, any new run/walk
+					// workouts in this batch are "extras" — fan out a per-workout notification,
+					// but only for the workouts that are themselves from the last 24h.
+					if (!milestoneFired) {
+						for (const w of req.body as Workout[]) {
+							if (
+								(w.workoutType === 'running' || w.workoutType === 'walking') &&
+								recentWorkoutIds.has(w.workoutId)
+							) {
+								notifyFriendsOfExtraWorkout(userId, w.workoutId).catch(err =>
+									console.error('Error notifying extra workout:', err.message)
+								);
+							}
 						}
 					}
 				}
+				(async () => {
+					const notifiedRecipients = new Map<string, number>();
+					await checkLeadChanges(userId, notifiedRecipients).catch(err =>
+						console.error('Error checking lead changes:', err.message)
+					);
+					await checkCompetitionMilestones(userId, notifiedRecipients).catch(err =>
+						console.error('Error checking milestones:', err.message)
+					);
+				})();
+			} catch (notifError: any) {
+				console.error('Error checking notifications:', notifError.message);
 			}
-			(async () => {
-				const notifiedRecipients = new Map<string, number>();
-				await checkLeadChanges(userId, notifiedRecipients).catch(err =>
-					console.error('Error checking lead changes:', err.message)
-				);
-				await checkCompetitionMilestones(userId, notifiedRecipients).catch(err =>
-					console.error('Error checking milestones:', err.message)
-				);
-			})();
-		} catch (notifError: any) {
-			console.error('Error checking notifications:', notifError.message);
 		}
 
-		// Fire badge + challenge push notifications (non-blocking).
+		// Fire badge + challenge push notifications (non-blocking). Each reward is
+		// attributed to the workout that triggered it: if that workout is outside the
+		// 24h window (e.g. a backfilled or manually-logged past run), NO push fires —
+		// not the user's own badge_earned, not the friend fan-out. Aggregate rewards
+		// with no single triggering workout fall back to "did this batch include any
+		// workout from the last 24h". Friend fan-outs are additionally gated by
+		// isFullSync so the setup backfill never notifies others.
 		for (const badge of rewards.newlyEarnedBadges) {
+			const fromRecentWorkout = badge.triggeringWorkoutId
+				? recentWorkoutIds.has(badge.triggeringWorkoutId)
+				: hasRecentWorkout;
+			if (!fromRecentWorkout) continue;
 			fireBadgeEarnedPush(userId, badge).catch(err => console.error('Error firing badge_earned push:', err.message));
-			if (badge.rarity !== 'common') {
+			if (!isFullSync && badge.rarity !== 'common') {
 				fanOutFriendBadgePush(userId, badge).catch(err =>
 					console.error('Error fanning out friend_badge_earned:', err.message)
 				);
 			}
 		}
-		for (const completion of rewards.newChallengeCompletions) {
-			fanOutFriendChallengePush(userId, completion).catch(err =>
-				console.error('Error fanning out friend_challenge_completed:', err.message)
-			);
+		if (!isFullSync) {
+			for (const completion of rewards.newChallengeCompletions) {
+				const fromRecentWorkout = completion.completingWorkoutId
+					? recentWorkoutIds.has(completion.completingWorkoutId)
+					: hasRecentWorkout;
+				if (!fromRecentWorkout) continue;
+				fanOutFriendChallengePush(userId, completion).catch(err =>
+					console.error('Error fanning out friend_challenge_completed:', err.message)
+				);
+			}
 		}
 
 		// PR detection: compare pre-upload PRs (excluding this batch) to post-upload PRs.
@@ -126,34 +174,36 @@ export async function uploadWorkouts(req: Request, res: Response) {
 		// record was set TODAY (user's local date). Historical imports (e.g. a new
 		// account's initial HealthKit backfill) raise the all-time max too, and
 		// without this guard every backfill batch sprays bogus "new personal best"
-		// pushes at the user's friends. Fire-and-forget.
-		(async () => {
-			try {
-				const [pre, post, userToday] = await Promise.all([
-					computePersonalRecords(userId, uploadedWorkoutIds),
-					computePersonalRecords(userId),
-					getUserLocalToday(userId)
-				]);
-				const lastWorkoutId = uploadedWorkoutIds[uploadedWorkoutIds.length - 1] ?? '';
+		// pushes at the user's friends. The full-sync guard skips this outright;
+		// the today-guard remains the backstop for normal syncs. Fire-and-forget.
+		if (!isFullSync)
+			(async () => {
+				try {
+					const [pre, post, userToday] = await Promise.all([
+						computePersonalRecords(userId, uploadedWorkoutIds),
+						computePersonalRecords(userId),
+						getUserLocalToday(userId)
+					]);
+					const lastWorkoutId = uploadedWorkoutIds[uploadedWorkoutIds.length - 1] ?? '';
 
-				if (
-					post.fastestSplitPaceSecMi > 0 &&
-					(pre.fastestSplitPaceSecMi === 0 || post.fastestSplitPaceSecMi < pre.fastestSplitPaceSecMi) &&
-					post.fastestSplitDate === userToday
-				) {
-					fanOutFriendPersonalBestPush(userId, 'fastest_mile', post.fastestSplitPaceSecMi, lastWorkoutId).catch(err =>
-						console.error('Error fanning out friend_personal_best (fastest_mile):', err.message)
-					);
+					if (
+						post.fastestSplitPaceSecMi > 0 &&
+						(pre.fastestSplitPaceSecMi === 0 || post.fastestSplitPaceSecMi < pre.fastestSplitPaceSecMi) &&
+						post.fastestSplitDate === userToday
+					) {
+						fanOutFriendPersonalBestPush(userId, 'fastest_mile', post.fastestSplitPaceSecMi, lastWorkoutId).catch(
+							err => console.error('Error fanning out friend_personal_best (fastest_mile):', err.message)
+						);
+					}
+					if (post.mostMilesInOneDay > pre.mostMilesInOneDay && post.bestDayDate === userToday) {
+						fanOutFriendPersonalBestPush(userId, 'most_miles_day', post.mostMilesInOneDay, lastWorkoutId).catch(err =>
+							console.error('Error fanning out friend_personal_best (most_miles_day):', err.message)
+						);
+					}
+				} catch (err: any) {
+					console.error('Error detecting personal bests:', err.message);
 				}
-				if (post.mostMilesInOneDay > pre.mostMilesInOneDay && post.bestDayDate === userToday) {
-					fanOutFriendPersonalBestPush(userId, 'most_miles_day', post.mostMilesInOneDay, lastWorkoutId).catch(err =>
-						console.error('Error fanning out friend_personal_best (most_miles_day):', err.message)
-					);
-				}
-			} catch (err: any) {
-				console.error('Error detecting personal bests:', err.message);
-			}
-		})();
+			})();
 
 		res.status(200).json({
 			message: 'Successfully uploaded workouts.',


### PR DESCRIPTION
Two layers so a new account's HealthKit backfill (and any backdated workout) no longer spams notifications:

- iOS sends ?fullSync=true on the initial account-setup backfill; the upload controller skips all friend-facing fan-outs for those requests.
- Server-side 24h recency gate: each achievement is attributed to its triggering workout (badge triggeringWorkoutId, challenge completingWorkoutId, per-workout for extras) and its push is dropped when that workout is older than 24h — covering friend fan-outs and the user's own badge_earned. Mile-completion / lead-change / milestone pushes require a recent workout in the batch. PRs already carry an equivalent same-day guard.