### PR TITLE
Fix celebration "Continue" button hidden by tab bar + large-font/Display-Zoom truncation

### DIFF
--- a/app/Mile A Day/Views/Celebrations/BadgeUnlockCelebrationView.swift
+++ b/app/Mile A Day/Views/Celebrations/BadgeUnlockCelebrationView.swift
@@ -312,7 +312,10 @@ struct BadgeUnlockCelebrationView: View {
                                 }
                             }
 
-                            Spacer(minLength: 120)
+                            // Clear the floating tab bar + home indicator so the
+                            // buttons are reachable when scrolled to the bottom
+                            // (the celebration ignores the safe area).
+                            Spacer(minLength: geo.safeAreaInsets.bottom + 60)
                         }
                         .padding(.horizontal, 32)
                         .padding(.top, 8)

--- a/app/Mile A Day/Views/Celebrations/GoalCompletedCelebrationView.swift
+++ b/app/Mile A Day/Views/Celebrations/GoalCompletedCelebrationView.swift
@@ -139,7 +139,10 @@ struct GoalCompletedCelebrationView: View {
                                     .transition(.move(edge: .bottom).combined(with: .opacity))
                             }
 
-                            Spacer(minLength: 40)
+                            // Clear the floating tab bar + home indicator so the
+                            // Continue button is reachable when scrolled to the
+                            // bottom (the celebration ignores the safe area).
+                            Spacer(minLength: geo.safeAreaInsets.bottom + 40)
                         }
                         .padding(.horizontal, 24)
                         .padding(.top, 8)

--- a/app/Mile A Day/Views/Celebrations/MilestoneCelebrationView.swift
+++ b/app/Mile A Day/Views/Celebrations/MilestoneCelebrationView.swift
@@ -167,9 +167,11 @@ struct MilestoneCelebrationView: View {
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                 }
 
-                // Safe area spacing for bottom (tab bar + home indicator)
+                // Clear the floating tab bar + home indicator (this overlay
+                // ignores the safe area, so the Continue button would otherwise
+                // sit under the tab bar).
                 Spacer()
-                    .frame(height: 56)
+                    .frame(height: 110)
             }
         }
         .ignoresSafeArea()

--- a/app/Mile A Day/Views/Celebrations/PostGoalEncouragementView.swift
+++ b/app/Mile A Day/Views/Celebrations/PostGoalEncouragementView.swift
@@ -177,7 +177,10 @@ struct PostGoalEncouragementView: View {
                                 .transition(.move(edge: .bottom).combined(with: .opacity))
                             }
 
-                            Spacer(minLength: 40)
+                            // Clear the floating tab bar + home indicator so the
+                            // button is reachable when scrolled to the bottom
+                            // (the celebration ignores the safe area).
+                            Spacer(minLength: geo.safeAreaInsets.bottom + 40)
                         }
                         .padding(.horizontal, 24)
                         .padding(.top, 8)

--- a/app/Mile A Day/Views/Components/FriendComponents.swift
+++ b/app/Mile A Day/Views/Components/FriendComponents.swift
@@ -42,11 +42,19 @@ struct UserProfileCard: View {
                             Text(user.username ?? "Unknown")
                                 .font(MADTheme.Typography.headline)
                                 .foregroundColor(MADTheme.Colors.primaryText)
+                                // Truncate long names with an ellipsis instead of
+                                // wrapping char-by-char (e.g. "Char les") when the
+                                // row is narrow next to the action button.
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.8)
+                                .truncationMode(.tail)
 
                             if user.displayName != user.username {
                                 Text(user.displayName)
                                     .font(MADTheme.Typography.caption)
                                     .foregroundColor(MADTheme.Colors.secondaryText)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
                             }
                         }
 
@@ -55,6 +63,8 @@ struct UserProfileCard: View {
                             Text(subtitle)
                                 .font(.system(size: 11, weight: .medium, design: .rounded))
                                 .foregroundColor(subtitle.contains("Done") ? .green.opacity(0.8) : .orange.opacity(0.8))
+                                .lineLimit(1)
+                                .truncationMode(.tail)
                         }
 
                         // Bio
@@ -65,15 +75,19 @@ struct UserProfileCard: View {
                                 .lineLimit(2)
                         }
                     }
+                    // Take the remaining row width so long names truncate here
+                    // instead of squeezing the action button off-screen.
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
             .buttonStyle(PlainButtonStyle())
 
-            Spacer()
-
-            // Action Button - Separate from the profile tap area
+            // Action Button - Separate from the profile tap area. The profile
+            // area above flexes to fill, so the button keeps its intrinsic size
+            // and stays pinned to the trailing edge.
             if let actionButton = actionButton {
                 actionButton
+                    .layoutPriority(1)
             }
         }
         .padding(MADTheme.Spacing.md)

--- a/app/Mile A Day/Views/Components/MADTabHeader.swift
+++ b/app/Mile A Day/Views/Components/MADTabHeader.swift
@@ -240,6 +240,11 @@ struct MADPillPicker<Tag: Hashable>: View {
                 }
                 Text(option.title)
                     .font(.system(size: 13, weight: .bold, design: .rounded))
+                    // Scale the label down rather than wrapping char-by-char
+                    // (e.g. "Leaderboa rd") when many pills share a narrow row
+                    // or the device uses Display Zoom / large text.
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
                 if option.badgeCount > 0 {
                     Text("\(option.badgeCount)")
                         .font(.system(size: 10, weight: .heavy, design: .rounded))

--- a/app/Mile A Day/Views/Friends/FriendsListView.swift
+++ b/app/Mile A Day/Views/Friends/FriendsListView.swift
@@ -671,6 +671,7 @@ struct FriendsListView: View {
                             .font(.system(size: 16, weight: .bold, design: .rounded))
                             .foregroundColor(heroHeadlineColor(isComplete: isComplete))
                             .lineLimit(1)
+                            .minimumScaleFactor(0.8)
                         if streak > 0 {
                             HStack(spacing: 2) {
                                 Image(systemName: "flame.fill")


### PR DESCRIPTION
## Problem

**1. Goal-completed celebration "Continue" button unreachable** (primary report)

The goal-completed celebration renders as an `.overlay()` on the Dashboard, while the TabView's floating tab bar stays on top of it. Because the celebration `.ignoresSafeArea()`, its scrollable content extends *under* the tab bar — so the bottom "Continue" button sat behind the tab bar and couldn't be seen or tapped even when scrolled all the way down.

**2. Layout breaks on large font / Display Zoom** (friend's-mom screenshots)

On a device with Display Zoom / large text, several screens truncated badly:
- Profile & Friends pill tabs wrapped char-by-char: "Activit y", "Setting s", "Leaderboa rd".
- Find Friends rows wrapped names char-by-char: "Aar on", "Cha rles DiL o".

## Fix

**Celebration buttons** — pad the bottom of each celebration's scroll content by the real safe-area bottom inset (which, inside a TabView, includes the tab bar) so the action buttons clear it:
- `GoalCompletedCelebrationView`, `PostGoalEncouragementView`, `BadgeUnlockCelebrationView` — `geo.safeAreaInsets.bottom + N` (these already read `geo` for the top inset).
- `MilestoneCelebrationView` (no `GeometryReader`, static layout) — bumped its fixed bottom spacer from 56 → 110 to clear the bar on all devices.
- `YearlyMilestoneCelebrationView` was left as-is: its content respects the safe area already (only its background ignores it), so its buttons aren't affected.

**Responsive text**
- `MADPillPicker`: `.lineLimit(1)` + `.minimumScaleFactor(0.6)` so labels scale down instead of wrapping. Fixes both the Profile and Friends tab pickers in one place.
- `UserProfileCard`: name/username truncate with an ellipsis (`.lineLimit(1)`, `.truncationMode(.tail)`), the name column flexes (`maxWidth: .infinity`), and the action button keeps its intrinsic size (`.layoutPriority(1)`, removed the now-redundant `Spacer`).
- Friends hero headline: added `.minimumScaleFactor(0.8)` so "Halfway through" shrinks slightly before truncating.

## Testing notes

iOS builds are Xcode-only in this repo, so this hasn't been compiled here — please build and eyeball:
- A goal-completed celebration: confirm "Continue" scrolls clear above the tab bar.
- Profile/Friends tabs and Find Friends rows under Settings → Accessibility → Display & Text / Display Zoom at a large setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxDWrDAbsnFQ2Jxj1qsgNu)_