### PR TITLE
Stories + social Feed: photo posts with run-stats overlay, hype, and moderation

### DIFF
--- a/app/Mile A Day/Services/PostService.swift
+++ b/app/Mile A Day/Services/PostService.swift
@@ -1,0 +1,285 @@
+import Foundation
+import UIKit
+
+// MARK: - Models
+
+/// Denormalized run stats captured on a post at publish time (mirrors the
+/// backend `stats_snapshot` jsonb). All optional — older/edited posts may omit.
+struct PostStats: Codable, Equatable {
+    let distance: Double?
+    let pace: Double?       // seconds per mile
+    let duration: Double?   // seconds
+    let streak: Int?
+    let date: String?
+}
+
+/// A social post — a photo (run-stats overlay already baked in) plus optional
+/// caption and stats. Surfaces in the Feed and/or as a Story. Field names are
+/// snake_case to decode the backend JSON directly, matching FeedWorkoutItem.
+struct PostItem: Codable, Identifiable {
+    let post_id: String
+    let user_id: String
+    let username: String?
+    let first_name: String?
+    let last_name: String?
+    let profile_image_url: String?
+    let media_url: String
+    let caption: String?
+    let workout_id: String?
+    let stats_snapshot: PostStats?
+    let local_date: String?
+    let share_to_feed: Bool?
+    let share_to_story: Bool?
+    let story_expires_at: String?
+    let created_at: String
+    let is_self: Bool
+    var is_hyped: Bool
+    var hype_count: Int?
+    var is_viewed: Bool?
+
+    var id: String { post_id }
+
+    var displayName: String {
+        if let username, !username.isEmpty { return username }
+        if let first_name, !first_name.isEmpty { return first_name }
+        return "Someone"
+    }
+
+    var mediaURL: URL? { ProfileImageService.fullImageURL(for: media_url) }
+
+    /// Short "2h", "5m", "now" relative time from created_at.
+    var relativeTime: String { RelativeTime.short(from: created_at) }
+}
+
+/// One author's worth of active stories in the rail (lazy-loaded on tap).
+struct StoryGroup: Codable, Identifiable {
+    let user_id: String
+    let username: String?
+    let first_name: String?
+    let last_name: String?
+    let profile_image_url: String?
+    let story_count: Int
+    let has_unviewed: Bool
+    let latest_at: String
+
+    var id: String { user_id }
+
+    var displayName: String {
+        if let username, !username.isEmpty { return username }
+        if let first_name, !first_name.isEmpty { return first_name }
+        return "Someone"
+    }
+}
+
+struct FeedResponse: Decodable {
+    let items: [PostItem]
+    let next_before: String?
+}
+
+/// Generic `{ ok: true }` / `{ accepted: ... }` acknowledgements.
+private struct OKResponse: Decodable {
+    let ok: Bool?
+}
+
+struct TermsStatus: Decodable {
+    let accepted: Bool
+    var accepted_at: String?
+}
+
+enum PostError: LocalizedError {
+    case invalidURL
+    case compressionFailed
+    case notAuthenticated
+    case uploadFailed(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL: return "Invalid URL"
+        case .compressionFailed: return "Couldn't prepare that photo"
+        case .notAuthenticated: return "You're signed out"
+        case .uploadFailed(let code): return "Upload failed (\(code))"
+        }
+    }
+}
+
+// MARK: - Service
+
+/// Stateless API surface for stories + the social feed. JSON calls go through
+/// APIClient.fancyFetch (auto token refresh); the photo upload hand-rolls
+/// multipart like ProfileImageService.
+enum PostService {
+    /// Upload a flattened post photo (overlay already composited). Returns the
+    /// server `media_url` to reference when creating the post.
+    static func uploadMedia(_ image: UIImage) async throws -> String {
+        guard let url = URL(string: "\(AppConfig.baseURL)/posts/media") else {
+            throw PostError.invalidURL
+        }
+        guard let imageData = image.jpegData(compressionQuality: 0.85) else {
+            throw PostError.compressionFailed
+        }
+        guard let accessToken = TokenStore.accessToken else {
+            throw PostError.notAuthenticated
+        }
+
+        let boundary = UUID().uuidString
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 30
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"image\"; filename=\"post.jpg\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: image/jpeg\r\n\r\n".data(using: .utf8)!)
+        body.append(imageData)
+        body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+        request.httpBody = body
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw PostError.uploadFailed(0) }
+        guard http.statusCode == 200 else { throw PostError.uploadFailed(http.statusCode) }
+
+        struct MediaResponse: Decodable { let media_url: String }
+        return try JSONDecoder().decode(MediaResponse.self, from: data).media_url
+    }
+
+    /// Create a post from an already-uploaded media_url. Throws APIError.apiError
+    /// with code "mile_not_completed" / "terms_not_accepted" when gated.
+    static func createPost(
+        mediaUrl: String,
+        caption: String?,
+        workoutId: String?,
+        shareToFeed: Bool,
+        shareToStory: Bool,
+        stats: PostStats?
+    ) async throws -> PostItem {
+        struct Body: Encodable {
+            let media_url: String
+            let caption: String?
+            let workout_id: String?
+            let share_to_feed: Bool
+            let share_to_story: Bool
+            let stats_snapshot: PostStats?
+        }
+        let bodyData = try JSONEncoder().encode(
+            Body(
+                media_url: mediaUrl,
+                caption: caption,
+                workout_id: workoutId,
+                share_to_feed: shareToFeed,
+                share_to_story: shareToStory,
+                stats_snapshot: stats
+            )
+        )
+        return try await APIClient.fancyFetch(
+            endpoint: "/posts",
+            method: .POST,
+            body: bodyData,
+            responseType: PostItem.self
+        )
+    }
+
+    static func fetchStoriesRail() async throws -> [StoryGroup] {
+        try await APIClient.fancyFetch(endpoint: "/posts/stories", responseType: [StoryGroup].self)
+    }
+
+    static func fetchUserStories(userId: String) async throws -> [PostItem] {
+        try await APIClient.fancyFetch(endpoint: "/posts/stories/\(userId)", responseType: [PostItem].self)
+    }
+
+    static func markStoryViewed(postId: String) async throws {
+        _ = try await APIClient.fancyFetch(
+            endpoint: "/posts/stories/\(postId)/view",
+            method: .POST,
+            responseType: OKResponse.self
+        )
+    }
+
+    /// One page of the feed. Pass the previous page's `next_before` to paginate.
+    static func fetchFeed(before: String? = nil) async throws -> FeedResponse {
+        var endpoint = "/posts/feed?limit=20"
+        if let before, let encoded = before.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
+            endpoint += "&before=\(encoded)"
+        }
+        return try await APIClient.fancyFetch(endpoint: endpoint, responseType: FeedResponse.self)
+    }
+
+    static func deletePost(postId: String) async throws {
+        _ = try await APIClient.fancyFetch(
+            endpoint: "/posts/\(postId)",
+            method: .DELETE,
+            responseType: OKResponse.self
+        )
+    }
+
+    static func reportPost(postId: String, reason: String, details: String?) async throws {
+        struct Body: Encodable {
+            let reason: String
+            let details: String?
+        }
+        let bodyData = try JSONEncoder().encode(Body(reason: reason, details: details))
+        _ = try await APIClient.fancyFetch(
+            endpoint: "/posts/\(postId)/report",
+            method: .POST,
+            body: bodyData,
+            responseType: OKResponse.self
+        )
+    }
+
+    static func termsStatus() async throws -> TermsStatus {
+        try await APIClient.fancyFetch(endpoint: "/posts/terms", responseType: TermsStatus.self)
+    }
+
+    @discardableResult
+    static func acceptTerms() async throws -> TermsStatus {
+        try await APIClient.fancyFetch(
+            endpoint: "/posts/terms/accept",
+            method: .POST,
+            responseType: TermsStatus.self
+        )
+    }
+}
+
+/// Blocking is broader than posts (it tears down friendship too), so it lives
+/// in its own small service hitting /blocks.
+enum BlockService {
+    private struct OK: Decodable { let ok: Bool? }
+
+    static func block(userId: String) async throws {
+        _ = try await APIClient.fancyFetch(endpoint: "/blocks/\(userId)", method: .POST, responseType: OK.self)
+    }
+
+    static func unblock(userId: String) async throws {
+        _ = try await APIClient.fancyFetch(endpoint: "/blocks/\(userId)", method: .DELETE, responseType: OK.self)
+    }
+}
+
+// MARK: - Relative time helper
+
+enum RelativeTime {
+    private static let parser: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    private static let parserNoFrac: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    static func date(from iso: String) -> Date? {
+        parser.date(from: iso) ?? parserNoFrac.date(from: iso)
+    }
+
+    /// "now", "5m", "2h", "3d" — compact age for feed/story headers.
+    static func short(from iso: String) -> String {
+        guard let date = date(from: iso) else { return "" }
+        let seconds = max(0, Date().timeIntervalSince(date))
+        if seconds < 60 { return "now" }
+        if seconds < 3600 { return "\(Int(seconds / 60))m" }
+        if seconds < 86_400 { return "\(Int(seconds / 3600))h" }
+        return "\(Int(seconds / 86_400))d"
+    }
+}

--- a/app/Mile A Day/Services/PostService.swift
+++ b/app/Mile A Day/Services/PostService.swift
@@ -11,6 +11,8 @@ struct PostStats: Codable, Equatable {
     let duration: Double?   // seconds
     let streak: Int?
     let date: String?
+    var calories: Double?
+    var steps: Int?
 }
 
 /// A social post — a photo (run-stats overlay already baked in) plus optional

--- a/app/Mile A Day/Views/Feed/PostCardView.swift
+++ b/app/Mile A Day/Views/Feed/PostCardView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+/// A single post in the social feed: author header, photo (overlay already
+/// baked in), caption, hype + social-proof tally, and a report/block/delete menu.
+struct PostCardView: View {
+    let post: PostItem
+    var isHyping: Bool = false
+    let onHype: () -> Void
+    let onReport: () -> Void
+    let onBlock: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+            header
+            photo
+            if let caption = post.caption, !caption.isEmpty {
+                Text(caption)
+                    .font(.system(size: 14, weight: .medium, design: .rounded))
+                    .foregroundColor(.white.opacity(0.9))
+                    .padding(.horizontal, 2)
+            }
+            footer
+        }
+        .padding(MADTheme.Spacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
+                .fill(Color.white.opacity(0.04))
+        )
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            AvatarView(name: post.displayName, imageURL: post.profile_image_url, size: 40)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(post.displayName)
+                    .font(.system(size: 15, weight: .bold, design: .rounded))
+                    .foregroundColor(.white)
+                    .lineLimit(1)
+                Text(post.relativeTime)
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundColor(.white.opacity(0.5))
+            }
+            Spacer()
+            Menu {
+                if post.is_self {
+                    Button(role: .destructive, action: onDelete) {
+                        Label("Delete post", systemImage: "trash")
+                    }
+                } else {
+                    Button(action: onReport) { Label("Report", systemImage: "flag") }
+                    Button(role: .destructive, action: onBlock) {
+                        Label("Block \(post.displayName)", systemImage: "hand.raised")
+                    }
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(.white.opacity(0.6))
+                    .padding(6)
+                    .contentShape(Rectangle())
+            }
+        }
+    }
+
+    private var photo: some View {
+        AsyncImage(url: post.mediaURL) { phase in
+            switch phase {
+            case .success(let image):
+                image.resizable().scaledToFill()
+            case .failure:
+                ZStack {
+                    Color.white.opacity(0.05)
+                    Image(systemName: "photo").foregroundColor(.white.opacity(0.3))
+                }
+            default:
+                ZStack { Color.white.opacity(0.05); ProgressView().tint(.white) }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .aspectRatio(4.0 / 5.0, contentMode: .fit)
+        .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
+    }
+
+    private var footer: some View {
+        HStack(spacing: 10) {
+            if let count = post.hype_count, count > 0 {
+                HypeTally(count: count)
+            }
+            Spacer()
+            if !post.is_self {
+                HypeButton(isHyped: post.is_hyped, isBusy: isHyping, action: onHype)
+            }
+        }
+        .padding(.horizontal, 2)
+        .padding(.bottom, 2)
+    }
+}

--- a/app/Mile A Day/Views/Feed/PostCardView.swift
+++ b/app/Mile A Day/Views/Feed/PostCardView.swift
@@ -14,6 +14,9 @@ struct PostCardView: View {
         VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
             header
             photo
+            if let stats = post.stats_snapshot {
+                PostStatStrip(stats: stats).padding(.horizontal, 2)
+            }
             if let caption = post.caption, !caption.isEmpty {
                 Text(caption)
                     .font(.system(size: 14, weight: .medium, design: .rounded))

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -1,11 +1,15 @@
 import SwiftUI
 
-/// Run stats handed to the composer to seed the overlay sticker.
+/// Run stats handed to the composer to seed the overlay sticker. Carries every
+/// stat we can show; `datum(for:)` formats one and returns nil when there's no
+/// data, so unavailable stats simply don't appear (and aren't offered as toggles).
 struct RunStatsInput {
     var distance: Double
     var paceSecondsPerMile: Double?
     var durationSeconds: Double?
     var streak: Int?
+    var calories: Double?
+    var steps: Int?
     var workoutId: String?
     var dateText: String?
 
@@ -15,8 +19,46 @@ struct RunStatsInput {
             pace: paceSecondsPerMile,
             duration: durationSeconds,
             streak: streak,
-            date: dateText
+            date: dateText,
+            calories: calories,
+            steps: steps
         )
+    }
+
+    /// Stats that actually have data, in a stable display order.
+    func availableStats() -> [RunStatKind] {
+        RunStatKind.allCases.filter { datum(for: $0) != nil }
+    }
+
+    func datum(for kind: RunStatKind) -> RunStatDatum? {
+        switch kind {
+        case .distance:
+            return RunStatDatum(kind: .distance, value: "\(String(format: "%.2f", distance)) mi")
+        case .pace:
+            guard let p = paceSecondsPerMile, p > 0 else { return nil }
+            return RunStatDatum(kind: .pace, value: "\(RunStatsStickerView.paceText(p)) /mi")
+        case .duration:
+            guard let d = durationSeconds, d > 0 else { return nil }
+            return RunStatDatum(kind: .duration, value: RunStatsStickerView.durationText(d))
+        case .streak:
+            guard let s = streak, s > 0 else { return nil }
+            return RunStatDatum(kind: .streak, value: "\(s)")
+        case .calories:
+            guard let c = calories, c > 0 else { return nil }
+            return RunStatDatum(kind: .calories, value: "\(Int(c.rounded())) cal")
+        case .steps:
+            guard let st = steps, st > 0 else { return nil }
+            return RunStatDatum(kind: .steps, value: "\(Self.grouped(st))")
+        case .date:
+            guard let d = dateText, !d.isEmpty else { return nil }
+            return RunStatDatum(kind: .date, value: d)
+        }
+    }
+
+    private static func grouped(_ n: Int) -> String {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        return f.string(from: NSNumber(value: n)) ?? "\(n)"
     }
 }
 
@@ -29,6 +71,8 @@ final class PostComposerViewModel: ObservableObject {
     @Published var stickerEnabled: Bool = true
     /// Sticker center in normalized canvas coordinates (0…1).
     @Published var stickerPos: CGPoint = CGPoint(x: 0.5, y: 0.82)
+    @Published var stickerScale: CGFloat = 1.0
+    @Published var config: StickerConfig
     @Published var isPublishing = false
     @Published var errorMessage: String?
 
@@ -38,6 +82,13 @@ final class PostComposerViewModel: ObservableObject {
 
     init(stats: RunStatsInput) {
         self.stats = stats
+        var cfg = StickerConfig.load()
+        // Drop any remembered stats that aren't available today, and make sure
+        // at least one available stat is shown.
+        let available = Set(stats.availableStats())
+        cfg.enabled = cfg.enabled.filter { available.contains($0) }
+        if cfg.enabled.isEmpty { cfg.enabled = Array(available.prefix(1)) }
+        self.config = cfg
     }
 
     var canPublish: Bool {
@@ -52,19 +103,18 @@ final class PostComposerViewModel: ObservableObject {
             image: image,
             showSticker: stickerEnabled,
             stickerPos: stickerPos,
-            stats: stats
+            stickerScale: stickerScale,
+            input: stats,
+            config: config
         )
         .frame(width: canvasSize.width, height: canvasSize.height)
 
         let renderer = ImageRenderer(content: canvas)
-        // Scale the point-sized canvas up to ~1080px wide for crisp output.
         renderer.scale = max(1, 1080 / canvasSize.width)
         renderer.isOpaque = true
         return renderer.uiImage
     }
 
-    /// Flatten → upload → create. Returns true on success. Maps the server's
-    /// gating errors to friendly messages.
     func publish() async -> Bool {
         guard !isPublishing else { return false }
         guard let flat = flatten() else {
@@ -85,6 +135,7 @@ final class PostComposerViewModel: ObservableObject {
                 shareToStory: shareToStory,
                 stats: stats.snapshot
             )
+            if stickerEnabled { config.save() } // remember the user's overlay style
             return true
         } catch let APIError.apiError(message) where message == "mile_not_completed" {
             errorMessage = "Finish today's mile before you post."
@@ -105,7 +156,9 @@ struct PostCanvas: View {
     let image: UIImage
     let showSticker: Bool
     let stickerPos: CGPoint
-    let stats: RunStatsInput
+    let stickerScale: CGFloat
+    let input: RunStatsInput
+    let config: StickerConfig
 
     var body: some View {
         GeometryReader { geo in
@@ -117,14 +170,9 @@ struct PostCanvas: View {
                     .clipped()
 
                 if showSticker {
-                    RunStatsStickerView(
-                        distance: stats.distance,
-                        paceSecondsPerMile: stats.paceSecondsPerMile,
-                        durationSeconds: stats.durationSeconds,
-                        streak: stats.streak,
-                        dateText: stats.dateText
-                    )
-                    .position(x: stickerPos.x * geo.size.width, y: stickerPos.y * geo.size.height)
+                    RunStatsStickerView(input: input, config: config)
+                        .scaleEffect(stickerScale)
+                        .position(x: stickerPos.x * geo.size.width, y: stickerPos.y * geo.size.height)
                 }
             }
             .frame(width: geo.size.width, height: geo.size.height)
@@ -136,7 +184,7 @@ struct PostCanvas: View {
 struct PostComposerView: View {
     @StateObject private var vm: PostComposerViewModel
     @State private var showImagePicker = false
-    /// Called with true once a post is published so the parent can refresh.
+    @State private var gestureBaseScale: CGFloat = 1.0
     let onFinished: (Bool) -> Void
     @Environment(\.dismiss) private var dismiss
 
@@ -153,7 +201,7 @@ struct PostComposerView: View {
                     VStack(spacing: MADTheme.Spacing.lg) {
                         canvasSection
                         if vm.pickedImage != nil {
-                            stickerToggle
+                            overlayEditor
                             captionField
                             destinationToggles
                         }
@@ -198,7 +246,7 @@ struct PostComposerView: View {
         }
     }
 
-    // MARK: - Sections
+    // MARK: - Canvas
 
     private var canvasSection: some View {
         GeometryReader { geo in
@@ -211,11 +259,12 @@ struct PostComposerView: View {
                             image: image,
                             showSticker: vm.stickerEnabled,
                             stickerPos: vm.stickerPos,
-                            stats: vm.stats
+                            stickerScale: vm.stickerScale,
+                            input: vm.stats,
+                            config: vm.config
                         )
-                        // Invisible drag layer to move the sticker.
                         if vm.stickerEnabled {
-                            stickerDragLayer(canvas: CGSize(width: width, height: height))
+                            stickerGestureLayer(canvas: CGSize(width: width, height: height))
                         }
                     }
                     .frame(width: width, height: height)
@@ -231,9 +280,18 @@ struct PostComposerView: View {
                         }
                         .padding(10)
                     }
+                    .overlay(alignment: .bottom) {
+                        if vm.stickerEnabled {
+                            Text("Drag to move · pinch to resize")
+                                .font(.system(size: 10, weight: .semibold, design: .rounded))
+                                .foregroundColor(.white.opacity(0.65))
+                                .padding(.horizontal, 10).padding(.vertical, 4)
+                                .background(Capsule().fill(.black.opacity(0.4)))
+                                .padding(.bottom, 8)
+                        }
+                    }
                 } else {
-                    photoPlaceholder
-                        .frame(width: width, height: height)
+                    photoPlaceholder.frame(width: width, height: height)
                 }
             }
         }
@@ -267,27 +325,115 @@ struct PostComposerView: View {
         .buttonStyle(.plain)
     }
 
-    private func stickerDragLayer(canvas: CGSize) -> some View {
+    private func stickerGestureLayer(canvas: CGSize) -> some View {
         Color.clear
             .contentShape(Rectangle())
             .gesture(
-                DragGesture()
-                    .onChanged { value in
-                        let x = min(max(value.location.x / canvas.width, 0.12), 0.88)
-                        let y = min(max(value.location.y / canvas.height, 0.1), 0.9)
-                        vm.stickerPos = CGPoint(x: x, y: y)
-                    }
+                SimultaneousGesture(
+                    DragGesture()
+                        .onChanged { value in
+                            let x = min(max(value.location.x / canvas.width, 0.12), 0.88)
+                            let y = min(max(value.location.y / canvas.height, 0.1), 0.9)
+                            vm.stickerPos = CGPoint(x: x, y: y)
+                        },
+                    MagnificationGesture()
+                        .onChanged { value in
+                            vm.stickerScale = min(max(gestureBaseScale * value, 0.6), 1.9)
+                        }
+                        .onEnded { _ in gestureBaseScale = vm.stickerScale }
+                )
             )
-            .allowsHitTesting(true)
     }
 
-    private var stickerToggle: some View {
-        Toggle(isOn: $vm.stickerEnabled) {
-            Label("Show run stats", systemImage: "chart.bar.doc.horizontal")
-                .font(.system(size: 14, weight: .semibold, design: .rounded))
-                .foregroundColor(.white)
+    // MARK: - Overlay editor
+
+    private var overlayEditor: some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
+            Toggle(isOn: $vm.stickerEnabled.animation(.easeInOut)) {
+                Label("Show run stats", systemImage: "chart.bar.doc.horizontal")
+                    .font(.system(size: 15, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white)
+            }
+            .tint(MADTheme.Colors.madRed)
+
+            if vm.stickerEnabled {
+                editorLabel("STYLE")
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: MADTheme.Spacing.sm) {
+                        ForEach(StickerStyle.allCases) { style in
+                            chip(
+                                title: style.title, icon: style.icon,
+                                selected: vm.config.style == style
+                            ) { vm.config.style = style }
+                        }
+                    }
+                }
+
+                editorLabel("SHOW")
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: MADTheme.Spacing.sm) {
+                        ForEach(vm.stats.availableStats()) { kind in
+                            chip(
+                                title: kind.label, icon: kind.icon,
+                                selected: vm.config.isOn(kind)
+                            ) { vm.config.toggle(kind) }
+                        }
+                    }
+                }
+
+                editorLabel("COLOR")
+                HStack(spacing: MADTheme.Spacing.md) {
+                    ForEach(StickerAccent.allCases) { accent in
+                        Button { vm.config.accent = accent } label: {
+                            Circle()
+                                .fill(accent.color)
+                                .frame(width: 26, height: 26)
+                                .overlay(
+                                    Circle().strokeBorder(
+                                        Color.white,
+                                        lineWidth: vm.config.accent == accent ? 2.5 : 0
+                                    )
+                                )
+                                .overlay(
+                                    Circle().strokeBorder(Color.white.opacity(0.2), lineWidth: 1)
+                                )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    Spacer()
+                }
+            }
         }
-        .tint(MADTheme.Colors.madRed)
+        .padding(MADTheme.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
+                .fill(Color.white.opacity(0.04))
+        )
+    }
+
+    private func editorLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 10, weight: .heavy, design: .rounded))
+            .tracking(1.2)
+            .foregroundColor(.white.opacity(0.4))
+    }
+
+    private func chip(title: String, icon: String, selected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 5) {
+                Image(systemName: icon).font(.system(size: 11, weight: .bold))
+                Text(title).font(.system(size: 13, weight: .bold, design: .rounded))
+            }
+            .foregroundColor(selected ? .white : .white.opacity(0.6))
+            .padding(.horizontal, 12).padding(.vertical, 7)
+            .background(
+                Capsule().fill(selected ? AnyShapeStyle(MADTheme.Colors.redGradient) : AnyShapeStyle(Color.white.opacity(0.07)))
+            )
+            .overlay(
+                Capsule().strokeBorder(Color.white.opacity(selected ? 0 : 0.12), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
     }
 
     private var captionField: some View {

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -1,0 +1,343 @@
+import SwiftUI
+
+/// Run stats handed to the composer to seed the overlay sticker.
+struct RunStatsInput {
+    var distance: Double
+    var paceSecondsPerMile: Double?
+    var durationSeconds: Double?
+    var streak: Int?
+    var workoutId: String?
+    var dateText: String?
+
+    var snapshot: PostStats {
+        PostStats(
+            distance: distance,
+            pace: paceSecondsPerMile,
+            duration: durationSeconds,
+            streak: streak,
+            date: dateText
+        )
+    }
+}
+
+@MainActor
+final class PostComposerViewModel: ObservableObject {
+    @Published var pickedImage: UIImage?
+    @Published var caption: String = ""
+    @Published var shareToStory: Bool = true
+    @Published var shareToFeed: Bool = true
+    @Published var stickerEnabled: Bool = true
+    /// Sticker center in normalized canvas coordinates (0…1).
+    @Published var stickerPos: CGPoint = CGPoint(x: 0.5, y: 0.82)
+    @Published var isPublishing = false
+    @Published var errorMessage: String?
+
+    let stats: RunStatsInput
+    /// Captured on-screen canvas size (points), reused to render the composite.
+    var canvasSize: CGSize = .zero
+
+    init(stats: RunStatsInput) {
+        self.stats = stats
+    }
+
+    var canPublish: Bool {
+        pickedImage != nil && (shareToStory || shareToFeed) && !isPublishing
+    }
+
+    /// Render the on-screen canvas (photo + sticker) to a flat JPEG-ready image
+    /// at ~1080px wide, baking the overlay in. Returns nil if no photo.
+    func flatten() -> UIImage? {
+        guard let image = pickedImage, canvasSize.width > 0 else { return nil }
+        let canvas = PostCanvas(
+            image: image,
+            showSticker: stickerEnabled,
+            stickerPos: stickerPos,
+            stats: stats
+        )
+        .frame(width: canvasSize.width, height: canvasSize.height)
+
+        let renderer = ImageRenderer(content: canvas)
+        // Scale the point-sized canvas up to ~1080px wide for crisp output.
+        renderer.scale = max(1, 1080 / canvasSize.width)
+        renderer.isOpaque = true
+        return renderer.uiImage
+    }
+
+    /// Flatten → upload → create. Returns true on success. Maps the server's
+    /// gating errors to friendly messages.
+    func publish() async -> Bool {
+        guard !isPublishing else { return false }
+        guard let flat = flatten() else {
+            errorMessage = "Add a photo first."
+            return false
+        }
+        isPublishing = true
+        errorMessage = nil
+        defer { isPublishing = false }
+
+        do {
+            let mediaUrl = try await PostService.uploadMedia(flat)
+            _ = try await PostService.createPost(
+                mediaUrl: mediaUrl,
+                caption: caption.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : caption,
+                workoutId: stats.workoutId,
+                shareToFeed: shareToFeed,
+                shareToStory: shareToStory,
+                stats: stats.snapshot
+            )
+            return true
+        } catch let APIError.apiError(message) where message == "mile_not_completed" {
+            errorMessage = "Finish today's mile before you post."
+            return false
+        } catch let APIError.apiError(message) where message == "terms_not_accepted" {
+            errorMessage = "Please accept the community terms to post."
+            return false
+        } catch {
+            errorMessage = (error as? LocalizedError)?.errorDescription ?? "Couldn't share your post. Try again."
+            return false
+        }
+    }
+}
+
+/// The photo + sticker canvas (4:5). Shared by the live editor preview and the
+/// ImageRenderer flatten so what you see is exactly what's uploaded.
+struct PostCanvas: View {
+    let image: UIImage
+    let showSticker: Bool
+    let stickerPos: CGPoint
+    let stats: RunStatsInput
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: geo.size.width, height: geo.size.height)
+                    .clipped()
+
+                if showSticker {
+                    RunStatsStickerView(
+                        distance: stats.distance,
+                        paceSecondsPerMile: stats.paceSecondsPerMile,
+                        durationSeconds: stats.durationSeconds,
+                        streak: stats.streak,
+                        dateText: stats.dateText
+                    )
+                    .position(x: stickerPos.x * geo.size.width, y: stickerPos.y * geo.size.height)
+                }
+            }
+            .frame(width: geo.size.width, height: geo.size.height)
+            .clipped()
+        }
+    }
+}
+
+struct PostComposerView: View {
+    @StateObject private var vm: PostComposerViewModel
+    @State private var showImagePicker = false
+    /// Called with true once a post is published so the parent can refresh.
+    let onFinished: (Bool) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    init(stats: RunStatsInput, onFinished: @escaping (Bool) -> Void) {
+        _vm = StateObject(wrappedValue: PostComposerViewModel(stats: stats))
+        self.onFinished = onFinished
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.black.ignoresSafeArea()
+                ScrollView {
+                    VStack(spacing: MADTheme.Spacing.lg) {
+                        canvasSection
+                        if vm.pickedImage != nil {
+                            stickerToggle
+                            captionField
+                            destinationToggles
+                        }
+                        if let error = vm.errorMessage {
+                            Text(error)
+                                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                                .foregroundColor(MADTheme.Colors.error)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                    .padding(MADTheme.Spacing.md)
+                }
+            }
+            .navigationTitle("New Post")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { onFinished(false); dismiss() }
+                        .foregroundColor(.white)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if vm.isPublishing {
+                        ProgressView().tint(.white)
+                    } else {
+                        Button("Share") {
+                            Task {
+                                let ok = await vm.publish()
+                                if ok { onFinished(true); dismiss() }
+                            }
+                        }
+                        .fontWeight(.bold)
+                        .foregroundColor(vm.canPublish ? MADTheme.Colors.madRed : .white.opacity(0.3))
+                        .disabled(!vm.canPublish)
+                    }
+                }
+            }
+            .toolbarBackground(.black, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .sheet(isPresented: $showImagePicker) {
+                ImagePicker(selectedImage: $vm.pickedImage)
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var canvasSection: some View {
+        GeometryReader { geo in
+            let width = geo.size.width
+            let height = width * 5 / 4
+            Group {
+                if let image = vm.pickedImage {
+                    ZStack {
+                        PostCanvas(
+                            image: image,
+                            showSticker: vm.stickerEnabled,
+                            stickerPos: vm.stickerPos,
+                            stats: vm.stats
+                        )
+                        // Invisible drag layer to move the sticker.
+                        if vm.stickerEnabled {
+                            stickerDragLayer(canvas: CGSize(width: width, height: height))
+                        }
+                    }
+                    .frame(width: width, height: height)
+                    .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous))
+                    .onAppear { vm.canvasSize = CGSize(width: width, height: height) }
+                    .overlay(alignment: .topTrailing) {
+                        Button { showImagePicker = true } label: {
+                            Image(systemName: "arrow.triangle.2.circlepath")
+                                .font(.system(size: 14, weight: .bold))
+                                .foregroundColor(.white)
+                                .padding(8)
+                                .background(Circle().fill(.black.opacity(0.45)))
+                        }
+                        .padding(10)
+                    }
+                } else {
+                    photoPlaceholder
+                        .frame(width: width, height: height)
+                }
+            }
+        }
+        .aspectRatio(4.0 / 5.0, contentMode: .fit)
+    }
+
+    private var photoPlaceholder: some View {
+        Button { showImagePicker = true } label: {
+            VStack(spacing: MADTheme.Spacing.md) {
+                Image(systemName: "photo.badge.plus")
+                    .font(.system(size: 44, weight: .semibold))
+                    .foregroundStyle(MADTheme.Colors.redGradient)
+                Text("Choose a photo")
+                    .font(.system(size: 16, weight: .bold, design: .rounded))
+                    .foregroundColor(.white)
+                Text("Share today's walk or run")
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundColor(.white.opacity(0.5))
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
+                    .fill(Color.white.opacity(0.05))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
+                            .strokeBorder(style: StrokeStyle(lineWidth: 1.5, dash: [7]))
+                            .foregroundColor(.white.opacity(0.2))
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func stickerDragLayer(canvas: CGSize) -> some View {
+        Color.clear
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture()
+                    .onChanged { value in
+                        let x = min(max(value.location.x / canvas.width, 0.12), 0.88)
+                        let y = min(max(value.location.y / canvas.height, 0.1), 0.9)
+                        vm.stickerPos = CGPoint(x: x, y: y)
+                    }
+            )
+            .allowsHitTesting(true)
+    }
+
+    private var stickerToggle: some View {
+        Toggle(isOn: $vm.stickerEnabled) {
+            Label("Show run stats", systemImage: "chart.bar.doc.horizontal")
+                .font(.system(size: 14, weight: .semibold, design: .rounded))
+                .foregroundColor(.white)
+        }
+        .tint(MADTheme.Colors.madRed)
+    }
+
+    private var captionField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            TextField("", text: $vm.caption, prompt: Text("Add a caption…").foregroundColor(.white.opacity(0.4)), axis: .vertical)
+                .lineLimit(1...4)
+                .font(.system(size: 15, weight: .medium, design: .rounded))
+                .foregroundColor(.white)
+                .padding(MADTheme.Spacing.md)
+                .background(
+                    RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
+                        .fill(Color.white.opacity(0.06))
+                )
+            Text("\(vm.caption.count)/280")
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .foregroundColor(vm.caption.count > 280 ? MADTheme.Colors.error : .white.opacity(0.4))
+                .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+        .onChange(of: vm.caption) { _, newValue in
+            if newValue.count > 280 { vm.caption = String(newValue.prefix(280)) }
+        }
+    }
+
+    private var destinationToggles: some View {
+        VStack(spacing: MADTheme.Spacing.sm) {
+            Toggle(isOn: $vm.shareToStory) {
+                Label("Share to Story", systemImage: "circle.dashed")
+                    .font(.system(size: 14, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white)
+            }
+            .tint(MADTheme.Colors.madRed)
+
+            Toggle(isOn: $vm.shareToFeed) {
+                Label("Share to Feed", systemImage: "square.stack")
+                    .font(.system(size: 14, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white)
+            }
+            .tint(MADTheme.Colors.madRed)
+
+            if !vm.shareToStory && !vm.shareToFeed {
+                Text("Pick at least one place to share.")
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundColor(MADTheme.Colors.warning)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(MADTheme.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
+                .fill(Color.white.opacity(0.04))
+        )
+    }
+}

--- a/app/Mile A Day/Views/Feed/PostTermsGateView.swift
+++ b/app/Mile A Day/Views/Feed/PostTermsGateView.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+/// One-time community-guidelines / EULA acceptance shown before a user's first
+/// post (App Store Guideline 1.2 — zero tolerance for objectionable content and
+/// abusive users). On accept it records server-side and invokes onAccepted.
+struct PostTermsGateView: View {
+    let onAccepted: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var submitting = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                MADTheme.Colors.appBackgroundGradient.ignoresSafeArea()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: MADTheme.Spacing.lg) {
+                        Image(systemName: "hand.raised.fill")
+                            .font(.system(size: 40))
+                            .foregroundStyle(MADTheme.Colors.redGradient)
+                            .padding(.top, MADTheme.Spacing.lg)
+
+                        Text("Community Guidelines")
+                            .font(MADTheme.Typography.title1)
+                            .foregroundColor(.white)
+
+                        Text("Mile A Day has zero tolerance for objectionable content or abusive behavior. By posting, you agree to:")
+                            .font(.system(size: 15, weight: .medium, design: .rounded))
+                            .foregroundColor(.white.opacity(0.85))
+
+                        VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
+                            rule("photo.fill", "Only share content you have the rights to.")
+                            rule("eye.slash.fill", "No nudity, hate, harassment, or violent content.")
+                            rule("flag.fill", "We review reports within 24 hours and remove violations.")
+                            rule("hand.raised.fill", "You can block or report anyone at any time.")
+                        }
+
+                        Text("Posts and stories are visible to your friends. Accounts that violate these guidelines may be removed.")
+                            .font(.system(size: 13, weight: .medium, design: .rounded))
+                            .foregroundColor(.white.opacity(0.6))
+
+                        if let errorMessage {
+                            Text(errorMessage)
+                                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                                .foregroundColor(MADTheme.Colors.error)
+                        }
+                    }
+                    .padding(MADTheme.Spacing.lg)
+                }
+            }
+            .safeAreaInset(edge: .bottom) {
+                VStack(spacing: MADTheme.Spacing.sm) {
+                    Button {
+                        Task { await accept() }
+                    } label: {
+                        if submitting {
+                            ProgressView().tint(.white).frame(maxWidth: .infinity)
+                        } else {
+                            Text("I Agree").frame(maxWidth: .infinity)
+                        }
+                    }
+                    .madPrimaryButton(fullWidth: true)
+                    .disabled(submitting)
+
+                    Button("Not now") { dismiss() }
+                        .madTertiaryButton()
+                }
+                .padding(MADTheme.Spacing.md)
+                .background(.ultraThinMaterial)
+            }
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    private func rule(_ icon: String, _ text: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 15, weight: .bold))
+                .foregroundColor(MADTheme.Colors.madRed)
+                .frame(width: 22)
+            Text(text)
+                .font(.system(size: 14, weight: .medium, design: .rounded))
+                .foregroundColor(.white.opacity(0.9))
+        }
+    }
+
+    private func accept() async {
+        submitting = true
+        errorMessage = nil
+        defer { submitting = false }
+        do {
+            _ = try await PostService.acceptTerms()
+            onAccepted()
+            dismiss()
+        } catch {
+            errorMessage = (error as? LocalizedError)?.errorDescription ?? "Couldn't save. Try again."
+        }
+    }
+}

--- a/app/Mile A Day/Views/Feed/ReportPostSheet.swift
+++ b/app/Mile A Day/Views/Feed/ReportPostSheet.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+/// Report-a-post sheet (App Store Guideline 1.2). Reasons mirror the backend
+/// `post_reports.reason` check constraint.
+struct ReportPostSheet: View {
+    let postId: String
+    let onDone: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var reason: String = "spam"
+    @State private var details: String = ""
+    @State private var submitting = false
+    @State private var submitted = false
+    @State private var errorMessage: String?
+
+    private let reasons: [(key: String, label: String, icon: String)] = [
+        ("spam", "Spam or misleading", "exclamationmark.bubble"),
+        ("nudity", "Nudity or sexual content", "eye.slash"),
+        ("harassment", "Harassment or bullying", "person.fill.xmark"),
+        ("violence", "Violence or threats", "exclamationmark.triangle"),
+        ("other", "Something else", "ellipsis.circle")
+    ]
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                if submitted {
+                    Section {
+                        Label("Thanks — our team will review this within 24 hours.", systemImage: "checkmark.seal.fill")
+                            .foregroundColor(MADTheme.Colors.success)
+                    }
+                } else {
+                    Section("Why are you reporting this?") {
+                        ForEach(reasons, id: \.key) { item in
+                            Button { reason = item.key } label: {
+                                HStack {
+                                    Label(item.label, systemImage: item.icon)
+                                        .foregroundColor(.primary)
+                                    Spacer()
+                                    if reason == item.key {
+                                        Image(systemName: "checkmark")
+                                            .foregroundColor(MADTheme.Colors.madRed)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Section("Add details (optional)") {
+                        TextField("What's going on?", text: $details, axis: .vertical)
+                            .lineLimit(2...5)
+                    }
+                    if let errorMessage {
+                        Section { Text(errorMessage).foregroundColor(MADTheme.Colors.error) }
+                    }
+                }
+            }
+            .navigationTitle("Report Post")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { onDone(); dismiss() }
+                }
+                if !submitted {
+                    ToolbarItem(placement: .confirmationAction) {
+                        if submitting {
+                            ProgressView()
+                        } else {
+                            Button("Submit") { Task { await submit() } }
+                                .fontWeight(.bold)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func submit() async {
+        submitting = true
+        errorMessage = nil
+        defer { submitting = false }
+        do {
+            try await PostService.reportPost(
+                postId: postId,
+                reason: reason,
+                details: details.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : details
+            )
+            submitted = true
+            try? await Task.sleep(nanoseconds: 1_200_000_000)
+            onDone()
+            dismiss()
+        } catch {
+            errorMessage = (error as? LocalizedError)?.errorDescription ?? "Couldn't submit report."
+        }
+    }
+}

--- a/app/Mile A Day/Views/Feed/RunStatsStickerView.swift
+++ b/app/Mile A Day/Views/Feed/RunStatsStickerView.swift
@@ -1,90 +1,321 @@
 import SwiftUI
 
-/// The run-stats "sticker" overlaid on a post photo (distance / pace / time /
-/// streak), styled to match the celebration + share-card visual language. Used
-/// two ways:
-///   1. Draggable in the composer, then composited onto the photo via ImageRenderer.
-///   2. (Future) re-rendered server-side from `stats_snapshot`.
-/// `displayDate` lets the caller stamp the run's day; pace/duration are optional
-/// and simply omitted when unavailable.
+// MARK: - Stat kinds, styles, accents
+
+/// A single run statistic the user can choose to show on their post.
+enum RunStatKind: String, CaseIterable, Identifiable, Codable {
+    case distance, pace, duration, streak, calories, steps, date
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .distance: return "Distance"
+        case .pace: return "Pace"
+        case .duration: return "Time"
+        case .streak: return "Streak"
+        case .calories: return "Calories"
+        case .steps: return "Steps"
+        case .date: return "Date"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .distance: return "figure.run"
+        case .pace: return "speedometer"
+        case .duration: return "clock.fill"
+        case .streak: return "flame.fill"
+        case .calories: return "bolt.fill"
+        case .steps: return "shoeprints.fill"
+        case .date: return "calendar"
+        }
+    }
+}
+
+/// Visual templates for the overlay. The user can flip between them live.
+enum StickerStyle: String, CaseIterable, Identifiable, Codable {
+    case card, minimal, stacked, streak
+    var id: String { rawValue }
+    var title: String {
+        switch self {
+        case .card: return "Card"
+        case .minimal: return "Minimal"
+        case .stacked: return "Stacked"
+        case .streak: return "Streak"
+        }
+    }
+    var icon: String {
+        switch self {
+        case .card: return "rectangle.fill"
+        case .minimal: return "minus.rectangle.fill"
+        case .stacked: return "list.bullet.rectangle.fill"
+        case .streak: return "flame.fill"
+        }
+    }
+}
+
+/// Accent color applied to icons / highlights on the sticker.
+enum StickerAccent: String, CaseIterable, Identifiable, Codable {
+    case orange, red, blue, green, mono
+    var id: String { rawValue }
+    var color: Color {
+        switch self {
+        case .orange: return .orange
+        case .red: return MADTheme.Colors.madRed
+        case .blue: return Color(red: 0.25, green: 0.6, blue: 0.95)
+        case .green: return MADTheme.Colors.success
+        case .mono: return .white
+        }
+    }
+}
+
+/// User-controlled overlay configuration. Persisted between sessions so the
+/// composer remembers how someone likes to show their run.
+struct StickerConfig: Equatable, Codable {
+    var style: StickerStyle = .card
+    var accent: StickerAccent = .orange
+    var enabled: [RunStatKind] = [.distance, .streak]
+
+    func isOn(_ kind: RunStatKind) -> Bool { enabled.contains(kind) }
+
+    mutating func toggle(_ kind: RunStatKind) {
+        if let idx = enabled.firstIndex(of: kind) {
+            // Keep at least one stat visible.
+            if enabled.count > 1 { enabled.remove(at: idx) }
+        } else {
+            enabled.append(kind)
+        }
+    }
+
+    private static let key = "post.sticker.config.v1"
+    static func load() -> StickerConfig {
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let cfg = try? JSONDecoder().decode(StickerConfig.self, from: data) else {
+            return StickerConfig()
+        }
+        return cfg
+    }
+    func save() {
+        if let data = try? JSONEncoder().encode(self) {
+            UserDefaults.standard.set(data, forKey: StickerConfig.key)
+        }
+    }
+}
+
+/// A formatted stat ready to render.
+struct RunStatDatum: Identifiable {
+    let kind: RunStatKind
+    let value: String
+    var id: String { kind.rawValue }
+    var icon: String { kind.icon }
+    var label: String { kind.label }
+}
+
+// MARK: - Sticker view
+
+/// Config-driven run-stats overlay. Renders only the stats the user enabled, in
+/// the chosen style + accent. Used live in the composer (draggable/scalable) and
+/// baked into the photo via ImageRenderer.
 struct RunStatsStickerView: View {
-    var distance: Double
-    var paceSecondsPerMile: Double?
-    var durationSeconds: Double?
-    var streak: Int?
-    var dateText: String?
+    let input: RunStatsInput
+    let config: StickerConfig
+
+    private var data: [RunStatDatum] {
+        config.enabled.compactMap { input.datum(for: $0) }
+    }
+    private var accent: Color { config.accent.color }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 5) {
-                Image(systemName: "flame.fill")
-                    .font(.system(size: 11, weight: .black))
-                    .foregroundStyle(MADTheme.Colors.redGradient)
-                Text("MILE A DAY")
-                    .font(.system(size: 11, weight: .black, design: .rounded))
-                    .tracking(1.5)
-                    .foregroundColor(.white.opacity(0.85))
-                if let dateText {
-                    Text("· \(dateText)")
-                        .font(.system(size: 11, weight: .semibold, design: .rounded))
-                        .foregroundColor(.white.opacity(0.5))
-                }
+        Group {
+            switch config.style {
+            case .card: cardStyle
+            case .minimal: minimalStyle
+            case .stacked: stackedStyle
+            case .streak: streakStyle
             }
+        }
+        .fixedSize()
+    }
 
-            HStack(alignment: .firstTextBaseline, spacing: 4) {
-                Text(String(format: "%.2f", distance))
-                    .font(.system(size: 40, weight: .black, design: .rounded))
-                    .foregroundColor(.white)
-                    .monospacedDigit()
-                Text("mi")
-                    .font(.system(size: 18, weight: .heavy, design: .rounded))
-                    .foregroundColor(.white.opacity(0.7))
-            }
+    // MARK: Card — brand line, big hero, chip row
 
-            HStack(spacing: 14) {
-                if let paceSecondsPerMile, paceSecondsPerMile > 0 {
-                    stat(icon: "speedometer", value: Self.paceText(paceSecondsPerMile), label: "pace")
-                }
-                if let durationSeconds, durationSeconds > 0 {
-                    stat(icon: "clock.fill", value: Self.durationText(durationSeconds), label: "time")
-                }
-                if let streak, streak > 0 {
-                    stat(icon: "flame.fill", value: "\(streak)", label: streak == 1 ? "day" : "days")
+    private var cardStyle: some View {
+        let hero = data.first
+        let rest = Array(data.dropFirst())
+        return VStack(alignment: .leading, spacing: 8) {
+            brandLine
+            if let hero { heroValue(hero) }
+            if !rest.isEmpty {
+                HStack(spacing: 14) {
+                    ForEach(rest) { chip($0) }
                 }
             }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
-        .background(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .fill(.ultraThinMaterial)
-                .environment(\.colorScheme, .dark)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .strokeBorder(Color.white.opacity(0.18), lineWidth: 1)
-        )
-        .shadow(color: .black.opacity(0.35), radius: 12, x: 0, y: 6)
-        .fixedSize()
+        .background(stickerBackground)
     }
 
-    private func stat(icon: String, value: String, label: String) -> some View {
+    // MARK: Minimal — single inline pill
+
+    private var minimalStyle: some View {
+        HStack(spacing: 8) {
+            ForEach(Array(data.enumerated()), id: \.element.id) { idx, datum in
+                if idx > 0 {
+                    Circle().fill(Color.white.opacity(0.4)).frame(width: 3, height: 3)
+                }
+                HStack(spacing: 4) {
+                    Image(systemName: datum.icon)
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundColor(accent)
+                    Text(datum.value)
+                        .font(.system(size: 14, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+                        .monospacedDigit()
+                }
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
+        .background(Capsule().fill(Color.black.opacity(0.45)))
+        .overlay(Capsule().strokeBorder(Color.white.opacity(0.15), lineWidth: 1))
+    }
+
+    // MARK: Stacked — vertical label/value list
+
+    private var stackedStyle: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            brandLine
+            ForEach(data) { datum in
+                HStack(spacing: 10) {
+                    Image(systemName: datum.icon)
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundColor(accent)
+                        .frame(width: 20)
+                    Text(datum.value)
+                        .font(.system(size: 17, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+                        .monospacedDigit()
+                    Spacer(minLength: 8)
+                    Text(datum.label.uppercased())
+                        .font(.system(size: 9, weight: .heavy, design: .rounded))
+                        .tracking(0.8)
+                        .foregroundColor(.white.opacity(0.5))
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .frame(minWidth: 180)
+        .background(stickerBackground)
+    }
+
+    // MARK: Streak — big flame focus
+
+    private var streakStyle: some View {
+        let streakDatum = input.datum(for: .streak)
+        let others = data.filter { $0.kind != .streak }
+        return VStack(spacing: 6) {
+            Image(systemName: "flame.fill")
+                .font(.system(size: 34, weight: .black))
+                .foregroundStyle(
+                    LinearGradient(colors: [accent, accent.opacity(0.6)], startPoint: .top, endPoint: .bottom)
+                )
+            Text(streakDatum?.value ?? input.datum(for: .distance)?.value ?? "")
+                .font(.system(size: 38, weight: .black, design: .rounded))
+                .foregroundColor(.white)
+                .monospacedDigit()
+            Text(streakDatum != nil ? "DAY STREAK" : "TODAY")
+                .font(.system(size: 10, weight: .heavy, design: .rounded))
+                .tracking(1.6)
+                .foregroundColor(.white.opacity(0.6))
+            if !others.isEmpty {
+                HStack(spacing: 12) {
+                    ForEach(others.prefix(3)) { datum in
+                        HStack(spacing: 4) {
+                            Image(systemName: datum.icon)
+                                .font(.system(size: 10, weight: .bold))
+                                .foregroundColor(accent)
+                            Text(datum.value)
+                                .font(.system(size: 12, weight: .heavy, design: .rounded))
+                                .foregroundColor(.white)
+                                .monospacedDigit()
+                        }
+                    }
+                }
+                .padding(.top, 2)
+            }
+        }
+        .padding(.horizontal, 22)
+        .padding(.vertical, 18)
+        .background(stickerBackground)
+    }
+
+    // MARK: Shared pieces
+
+    private var brandLine: some View {
         HStack(spacing: 5) {
-            Image(systemName: icon)
+            Image(systemName: "flame.fill")
+                .font(.system(size: 11, weight: .black))
+                .foregroundColor(accent)
+            Text("MILE A DAY")
+                .font(.system(size: 11, weight: .black, design: .rounded))
+                .tracking(1.5)
+                .foregroundColor(.white.opacity(0.85))
+        }
+    }
+
+    private func heroValue(_ datum: RunStatDatum) -> some View {
+        // The first enabled stat is rendered large. Distance splits the unit out.
+        Group {
+            if datum.kind == .distance {
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text(String(format: "%.2f", input.distance))
+                        .font(.system(size: 40, weight: .black, design: .rounded))
+                        .foregroundColor(.white)
+                        .monospacedDigit()
+                    Text("mi")
+                        .font(.system(size: 18, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white.opacity(0.7))
+                }
+            } else {
+                Text(datum.value)
+                    .font(.system(size: 36, weight: .black, design: .rounded))
+                    .foregroundColor(.white)
+                    .monospacedDigit()
+            }
+        }
+    }
+
+    private func chip(_ datum: RunStatDatum) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: datum.icon)
                 .font(.system(size: 12, weight: .bold))
-                .foregroundColor(.orange)
+                .foregroundColor(accent)
             VStack(alignment: .leading, spacing: 0) {
-                Text(value)
+                Text(datum.value)
                     .font(.system(size: 15, weight: .heavy, design: .rounded))
                     .foregroundColor(.white)
                     .monospacedDigit()
-                Text(label.uppercased())
+                Text(datum.label.uppercased())
                     .font(.system(size: 8, weight: .heavy, design: .rounded))
                     .tracking(0.8)
                     .foregroundColor(.white.opacity(0.5))
             }
         }
     }
+
+    private var stickerBackground: some View {
+        RoundedRectangle(cornerRadius: 20, style: .continuous)
+            .fill(Color.black.opacity(0.42))
+            .overlay(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .strokeBorder(Color.white.opacity(0.16), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.35), radius: 12, x: 0, y: 6)
+    }
+
+    // MARK: Formatters
 
     static func paceText(_ secPerMile: Double) -> String {
         let m = Int(secPerMile) / 60
@@ -99,5 +330,44 @@ struct RunStatsStickerView: View {
         let s = total % 60
         if h > 0 { return String(format: "%d:%02d:%02d", h, m, s) }
         return String(format: "%d:%02d", m, s)
+    }
+}
+
+/// Compact, glanceable stat chips rendered from a post's `stats_snapshot` —
+/// shown on feed cards so a friend's streak and run read clearly even when the
+/// photo overlay is small or turned off. Renders nothing when there's no data.
+struct PostStatStrip: View {
+    let stats: PostStats
+
+    private struct Item: Identifiable { let id = UUID(); let icon: String; let text: String; let tint: Color }
+
+    private var items: [Item] {
+        var out: [Item] = []
+        if let s = stats.streak, s > 0 {
+            out.append(Item(icon: "flame.fill", text: "\(s) day streak", tint: .orange))
+        }
+        if let d = stats.distance, d > 0 {
+            out.append(Item(icon: "figure.run", text: "\(String(format: "%.2f", d)) mi", tint: .white.opacity(0.85)))
+        }
+        if let p = stats.pace, p > 0 {
+            out.append(Item(icon: "speedometer", text: "\(RunStatsStickerView.paceText(p)) /mi", tint: .white.opacity(0.85)))
+        }
+        return out
+    }
+
+    var body: some View {
+        if !items.isEmpty {
+            HStack(spacing: 8) {
+                ForEach(items) { item in
+                    HStack(spacing: 4) {
+                        Image(systemName: item.icon).font(.system(size: 10, weight: .bold))
+                        Text(item.text).font(.system(size: 11, weight: .heavy, design: .rounded)).monospacedDigit()
+                    }
+                    .foregroundColor(item.tint)
+                    .padding(.horizontal, 8).padding(.vertical, 4)
+                    .background(Capsule().fill(Color.white.opacity(0.06)))
+                }
+            }
+        }
     }
 }

--- a/app/Mile A Day/Views/Feed/RunStatsStickerView.swift
+++ b/app/Mile A Day/Views/Feed/RunStatsStickerView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+/// The run-stats "sticker" overlaid on a post photo (distance / pace / time /
+/// streak), styled to match the celebration + share-card visual language. Used
+/// two ways:
+///   1. Draggable in the composer, then composited onto the photo via ImageRenderer.
+///   2. (Future) re-rendered server-side from `stats_snapshot`.
+/// `displayDate` lets the caller stamp the run's day; pace/duration are optional
+/// and simply omitted when unavailable.
+struct RunStatsStickerView: View {
+    var distance: Double
+    var paceSecondsPerMile: Double?
+    var durationSeconds: Double?
+    var streak: Int?
+    var dateText: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 5) {
+                Image(systemName: "flame.fill")
+                    .font(.system(size: 11, weight: .black))
+                    .foregroundStyle(MADTheme.Colors.redGradient)
+                Text("MILE A DAY")
+                    .font(.system(size: 11, weight: .black, design: .rounded))
+                    .tracking(1.5)
+                    .foregroundColor(.white.opacity(0.85))
+                if let dateText {
+                    Text("· \(dateText)")
+                        .font(.system(size: 11, weight: .semibold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.5))
+                }
+            }
+
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Text(String(format: "%.2f", distance))
+                    .font(.system(size: 40, weight: .black, design: .rounded))
+                    .foregroundColor(.white)
+                    .monospacedDigit()
+                Text("mi")
+                    .font(.system(size: 18, weight: .heavy, design: .rounded))
+                    .foregroundColor(.white.opacity(0.7))
+            }
+
+            HStack(spacing: 14) {
+                if let paceSecondsPerMile, paceSecondsPerMile > 0 {
+                    stat(icon: "speedometer", value: Self.paceText(paceSecondsPerMile), label: "pace")
+                }
+                if let durationSeconds, durationSeconds > 0 {
+                    stat(icon: "clock.fill", value: Self.durationText(durationSeconds), label: "time")
+                }
+                if let streak, streak > 0 {
+                    stat(icon: "flame.fill", value: "\(streak)", label: streak == 1 ? "day" : "days")
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .environment(\.colorScheme, .dark)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.18), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.35), radius: 12, x: 0, y: 6)
+        .fixedSize()
+    }
+
+    private func stat(icon: String, value: String, label: String) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: icon)
+                .font(.system(size: 12, weight: .bold))
+                .foregroundColor(.orange)
+            VStack(alignment: .leading, spacing: 0) {
+                Text(value)
+                    .font(.system(size: 15, weight: .heavy, design: .rounded))
+                    .foregroundColor(.white)
+                    .monospacedDigit()
+                Text(label.uppercased())
+                    .font(.system(size: 8, weight: .heavy, design: .rounded))
+                    .tracking(0.8)
+                    .foregroundColor(.white.opacity(0.5))
+            }
+        }
+    }
+
+    static func paceText(_ secPerMile: Double) -> String {
+        let m = Int(secPerMile) / 60
+        let s = Int(secPerMile) % 60
+        return String(format: "%d:%02d", m, s)
+    }
+
+    static func durationText(_ seconds: Double) -> String {
+        let total = Int(seconds)
+        let h = total / 3600
+        let m = (total % 3600) / 60
+        let s = total % 60
+        if h > 0 { return String(format: "%d:%02d:%02d", h, m, s) }
+        return String(format: "%d:%02d", m, s)
+    }
+}

--- a/app/Mile A Day/Views/Feed/RunStatsStickerView.swift
+++ b/app/Mile A Day/Views/Feed/RunStatsStickerView.swift
@@ -338,6 +338,9 @@ struct RunStatsStickerView: View {
 /// photo overlay is small or turned off. Renders nothing when there's no data.
 struct PostStatStrip: View {
     let stats: PostStats
+    /// When shown over a photo (story viewer), use a darker chip + shadow so the
+    /// text stays legible on any image. Default keeps the feed-card appearance.
+    var onPhoto: Bool = false
 
     private struct Item: Identifiable { let id = UUID(); let icon: String; let text: String; let tint: Color }
 
@@ -365,7 +368,8 @@ struct PostStatStrip: View {
                     }
                     .foregroundColor(item.tint)
                     .padding(.horizontal, 8).padding(.vertical, 4)
-                    .background(Capsule().fill(Color.white.opacity(0.06)))
+                    .background(Capsule().fill(onPhoto ? Color.black.opacity(0.45) : Color.white.opacity(0.06)))
+                    .shadow(color: onPhoto ? .black.opacity(0.5) : .clear, radius: onPhoto ? 4 : 0)
                 }
             }
         }

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -1,0 +1,242 @@
+import SwiftUI
+
+/// The social surface inside the Friends tab: a stories rail on top, a paginated
+/// photo feed below, and a compose button. Posting is gated on completing the
+/// daily mile (cosmetic here — the server re-verifies) and on a one-time terms
+/// acceptance. Reads the shared HealthKit/User singletons for stats + gating.
+struct SocialFeedView: View {
+    @StateObject private var healthManager = HealthKitManager.shared
+    @StateObject private var userManager = UserManager.shared
+
+    @State private var feed: [PostItem] = []
+    @State private var stories: [StoryGroup] = []
+    @State private var nextBefore: String?
+    @State private var isLoading = false
+    @State private var isLoadingMore = false
+    @State private var loadedOnce = false
+
+    @State private var hypingPostIds: Set<String> = []
+    @State private var termsAccepted: Bool?
+
+    // Presentation
+    @State private var presentingComposer = false
+    @State private var viewerGroup: StoryGroup?
+    @State private var reportingPost: PostItem?
+    @State private var showTermsGate = false
+    @State private var showMileHint = false
+
+    private var currentUserId: String? { UserDefaults.standard.string(forKey: "backendUserId") }
+    private var canPost: Bool { healthManager.todaysDistance >= userManager.currentUser.goalMiles }
+
+    private var statsInput: RunStatsInput {
+        let user = userManager.currentUser
+        return RunStatsInput(
+            distance: healthManager.todaysDistance,
+            paceSecondsPerMile: nil,
+            durationSeconds: nil,
+            streak: user.streak,
+            workoutId: nil,
+            dateText: Self.todayText()
+        )
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: MADTheme.Spacing.md) {
+                StoriesRailView(
+                    groups: stories,
+                    currentUserId: currentUserId,
+                    myName: userManager.currentUser.username ?? userManager.currentUser.name,
+                    myImageURL: userManager.currentUser.profileImageUrl,
+                    canPost: canPost,
+                    onTapAdd: handleCompose,
+                    onTapGroup: { viewerGroup = $0 }
+                )
+
+                Divider().overlay(Color.white.opacity(0.08))
+
+                if isLoading && feed.isEmpty {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: MADTheme.Colors.madRed))
+                        .padding(.top, MADTheme.Spacing.xxl)
+                } else if feed.isEmpty {
+                    emptyState
+                } else {
+                    ForEach(feed) { post in
+                        PostCardView(
+                            post: post,
+                            isHyping: hypingPostIds.contains(post.post_id),
+                            onHype: { Task { await hype(post) } },
+                            onReport: { reportingPost = post },
+                            onBlock: { Task { await block(post) } },
+                            onDelete: { Task { await deletePost(post) } }
+                        )
+                        .onAppear { if post.id == feed.last?.id { Task { await loadMore() } } }
+                        .padding(.horizontal, MADTheme.Spacing.md)
+                    }
+                    if isLoadingMore {
+                        ProgressView().tint(.white).padding(.vertical, MADTheme.Spacing.md)
+                    }
+                }
+            }
+            .padding(.vertical, MADTheme.Spacing.sm)
+            .padding(.bottom, MADTheme.Spacing.xxl)
+        }
+        .scrollIndicators(.hidden)
+        .refreshable { await refresh() }
+        .overlay(alignment: .bottomTrailing) { composeButton }
+        .task { if !loadedOnce { await refresh(); await loadTermsStatus() } }
+        .fullScreenCover(item: $viewerGroup) { group in
+            StoryViewerView(group: group, currentUserId: currentUserId) { changed in
+                viewerGroup = nil
+                if changed { Task { await refresh() } }
+            }
+        }
+        .sheet(isPresented: $presentingComposer) {
+            PostComposerView(stats: statsInput) { success in
+                if success { Task { await refresh() } }
+            }
+        }
+        .sheet(item: $reportingPost) { post in
+            ReportPostSheet(postId: post.post_id) { reportingPost = nil }
+        }
+        .sheet(isPresented: $showTermsGate) {
+            PostTermsGateView {
+                termsAccepted = true
+                presentingComposer = true
+            }
+        }
+        .alert("Finish today's mile first", isPresented: $showMileHint) {
+            Button("Got it", role: .cancel) {}
+        } message: {
+            Text("Complete your daily mile to share a post or story today. Keep going — you've got this! 🏃")
+        }
+    }
+
+    private var composeButton: some View {
+        Button(action: handleCompose) {
+            Image(systemName: canPost ? "plus" : "lock.fill")
+                .font(.system(size: 20, weight: .bold))
+                .foregroundColor(.white)
+                .frame(width: 56, height: 56)
+                .background(
+                    Circle().fill(canPost ? AnyShapeStyle(MADTheme.Colors.redGradient) : AnyShapeStyle(Color.gray.opacity(0.6)))
+                )
+                .shadow(color: .black.opacity(0.3), radius: 8, y: 4)
+        }
+        .padding(.trailing, MADTheme.Spacing.lg)
+        .padding(.bottom, MADTheme.Spacing.lg)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: MADTheme.Spacing.md) {
+            Image(systemName: "camera.on.rectangle")
+                .font(.system(size: 40))
+                .foregroundColor(.white.opacity(0.3))
+            Text("No posts yet")
+                .font(.system(size: 17, weight: .bold, design: .rounded))
+                .foregroundColor(.white)
+            Text("Finish your mile, then share a photo of today's walk or run.")
+                .font(.system(size: 13, weight: .medium, design: .rounded))
+                .foregroundColor(.white.opacity(0.5))
+                .multilineTextAlignment(.center)
+        }
+        .padding(.top, MADTheme.Spacing.xxl)
+        .padding(.horizontal, MADTheme.Spacing.xl)
+    }
+
+    // MARK: - Compose flow
+
+    private func handleCompose() {
+        guard canPost else { showMileHint = true; return }
+        if termsAccepted == true {
+            presentingComposer = true
+        } else {
+            showTermsGate = true
+        }
+    }
+
+    private func loadTermsStatus() async {
+        if let status = try? await PostService.termsStatus() {
+            await MainActor.run { termsAccepted = status.accepted }
+        }
+    }
+
+    // MARK: - Data
+
+    private func refresh() async {
+        await MainActor.run { isLoading = feed.isEmpty }
+        let feedResponse = try? await PostService.fetchFeed(before: nil)
+        let storyGroups = try? await PostService.fetchStoriesRail()
+        await MainActor.run {
+            if let feedResponse {
+                feed = feedResponse.items
+                nextBefore = feedResponse.next_before
+            }
+            if let storyGroups { stories = storyGroups }
+            isLoading = false
+            loadedOnce = true
+        }
+    }
+
+    private func loadMore() async {
+        guard let before = nextBefore, !isLoadingMore else { return }
+        await MainActor.run { isLoadingMore = true }
+        let response = try? await PostService.fetchFeed(before: before)
+        await MainActor.run {
+            if let response {
+                let existing = Set(feed.map(\.post_id))
+                feed.append(contentsOf: response.items.filter { !existing.contains($0.post_id) })
+                nextBefore = response.next_before
+            }
+            isLoadingMore = false
+        }
+    }
+
+    // MARK: - Actions
+
+    private func hype(_ post: PostItem) async {
+        guard !post.is_self, !post.is_hyped, !hypingPostIds.contains(post.post_id) else { return }
+        await MainActor.run { _ = hypingPostIds.insert(post.post_id) }
+        defer { Task { @MainActor in hypingPostIds.remove(post.post_id) } }
+        do {
+            _ = try await HypeService.sendHype(
+                targetUserId: post.user_id,
+                context: HypeContext(
+                    contextType: "post",
+                    contextId: post.post_id,
+                    contextLabel: post.caption ?? post.displayName
+                )
+            )
+            await MainActor.run { updatePost(post.post_id) { $0.is_hyped = true; $0.hype_count = ($0.hype_count ?? 0) + 1 } }
+        } catch {
+            // conflict / rate-limited — leave as-is.
+        }
+    }
+
+    private func block(_ post: PostItem) async {
+        do {
+            try await BlockService.block(userId: post.user_id)
+            await MainActor.run { feed.removeAll { $0.user_id == post.user_id } }
+            await refresh()
+        } catch {}
+    }
+
+    private func deletePost(_ post: PostItem) async {
+        do {
+            try await PostService.deletePost(postId: post.post_id)
+            await MainActor.run { feed.removeAll { $0.post_id == post.post_id } }
+        } catch {}
+    }
+
+    private func updatePost(_ id: String, _ mutate: (inout PostItem) -> Void) {
+        guard let idx = feed.firstIndex(where: { $0.post_id == id }) else { return }
+        mutate(&feed[idx])
+    }
+
+    private static func todayText() -> String {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f.string(from: Date())
+    }
+}

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -30,11 +30,22 @@ struct SocialFeedView: View {
 
     private var statsInput: RunStatsInput {
         let user = userManager.currentUser
+        // Pull today's real run data from HealthKit so users can show pace, time,
+        // calories and steps — not just distance. Zero/absent values are dropped
+        // by RunStatsInput.datum(for:), so only meaningful stats are offered.
+        let duration = healthManager.todaysTotalDuration
+        // todaysAveragePace is MINUTES per mile; the sticker + snapshot use
+        // SECONDS per mile, so convert here.
+        let paceSecPerMile = healthManager.todaysAveragePace.map { $0 * 60 }
+        let calories = healthManager.todaysTotalCalories
+        let steps = healthManager.todaysSteps
         return RunStatsInput(
             distance: healthManager.todaysDistance,
-            paceSecondsPerMile: nil,
-            durationSeconds: nil,
+            paceSecondsPerMile: (paceSecPerMile ?? 0) > 0 ? paceSecPerMile : nil,
+            durationSeconds: duration > 0 ? duration : nil,
             streak: user.streak,
+            calories: calories > 0 ? calories : nil,
+            steps: steps > 0 ? steps : nil,
             workoutId: nil,
             dateText: Self.todayText()
         )

--- a/app/Mile A Day/Views/Feed/StoriesRailView.swift
+++ b/app/Mile A Day/Views/Feed/StoriesRailView.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+/// Horizontal rail of story rings at the top of the feed. The first cell is the
+/// viewer's "Your story" / add button (gated on completing the mile); the rest
+/// are friends with active stories, unviewed rings highlighted.
+struct StoriesRailView: View {
+    let groups: [StoryGroup]
+    let currentUserId: String?
+    let myName: String
+    let myImageURL: String?
+    let canPost: Bool
+    let onTapAdd: () -> Void
+    let onTapGroup: (StoryGroup) -> Void
+
+    private var friendGroups: [StoryGroup] {
+        groups.filter { $0.user_id != currentUserId }
+    }
+    private var myGroup: StoryGroup? {
+        groups.first { $0.user_id == currentUserId }
+    }
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(alignment: .top, spacing: MADTheme.Spacing.md) {
+                addCell
+                ForEach(friendGroups) { group in
+                    Button { onTapGroup(group) } label: {
+                        cell(
+                            name: group.displayName,
+                            imageURL: group.profile_image_url,
+                            unviewed: group.has_unviewed,
+                            badge: nil
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, MADTheme.Spacing.md)
+            .padding(.vertical, MADTheme.Spacing.sm)
+        }
+    }
+
+    // The viewer's own cell: tapping the ring opens their story if they have one;
+    // the small "+" always opens the composer (when allowed).
+    private var addCell: some View {
+        Button {
+            // If the viewer already has an active story, open it; otherwise
+            // (or when they can post) open the composer. The compose FAB in the
+            // feed also reaches the composer, so adding-more is always available.
+            if let myGroup {
+                onTapGroup(myGroup)
+            } else {
+                onTapAdd()
+            }
+        } label: {
+            VStack(spacing: 6) {
+                ZStack(alignment: .bottomTrailing) {
+                    ring(unviewed: myGroup?.has_unviewed ?? false, dashed: myGroup == nil) {
+                        AvatarView(name: myName, imageURL: myImageURL, size: 64)
+                    }
+                    Image(systemName: canPost ? "plus.circle.fill" : "lock.circle.fill")
+                        .font(.system(size: 22))
+                        .foregroundStyle(.white, canPost ? MADTheme.Colors.madRed : Color.gray)
+                        .background(Circle().fill(.black))
+                        .offset(x: 2, y: 2)
+                }
+                Text("Your story")
+                    .font(.system(size: 11, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.7))
+                    .lineLimit(1)
+            }
+            .frame(width: 76)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func cell(name: String, imageURL: String?, unviewed: Bool, badge: String?) -> some View {
+        VStack(spacing: 6) {
+            ring(unviewed: unviewed, dashed: false) {
+                AvatarView(name: name, imageURL: imageURL, size: 64)
+            }
+            Text(name)
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .foregroundColor(.white.opacity(0.7))
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .frame(width: 76)
+    }
+
+    @ViewBuilder
+    private func ring<Content: View>(unviewed: Bool, dashed: Bool, @ViewBuilder content: () -> Content) -> some View {
+        content()
+            .padding(3)
+            .background(
+                Circle().fill(MADTheme.Colors.madBlack)
+            )
+            .overlay(
+                Circle()
+                    .strokeBorder(
+                        unviewed
+                            ? AnyShapeStyle(LinearGradient(
+                                colors: [MADTheme.Colors.madRed, .orange],
+                                startPoint: .topLeading, endPoint: .bottomTrailing))
+                            : AnyShapeStyle(Color.white.opacity(0.25)),
+                        style: StrokeStyle(lineWidth: 2.5, dash: dashed ? [4] : [])
+                    )
+            )
+    }
+}

--- a/app/Mile A Day/Views/Feed/StoryViewerView.swift
+++ b/app/Mile A Day/Views/Feed/StoryViewerView.swift
@@ -1,0 +1,275 @@
+import SwiftUI
+
+/// Full-screen story playback for a single author: segmented progress bars,
+/// ~5s auto-advance, tap left/right to step, swipe down to dismiss, inline hype,
+/// and a report/block (or delete-own) overflow.
+struct StoryViewerView: View {
+    let group: StoryGroup
+    let currentUserId: String?
+    /// Called when the viewer dismisses, with whether anything changed (a story
+    /// was deleted) so the parent can refresh the rail.
+    let onClose: (_ changed: Bool) -> Void
+
+    @State private var stories: [PostItem] = []
+    @State private var index: Int = 0
+    @State private var progress: CGFloat = 0
+    @State private var isLoading = true
+    @State private var dragOffset: CGFloat = 0
+    @State private var changed = false
+    @State private var paused = false
+
+    @State private var showReport = false
+    @State private var hyping = false
+
+    private let stepDuration: CGFloat = 5.0
+    private let tick = Timer.publish(every: 0.05, on: .main, in: .common).autoconnect()
+
+    private var current: PostItem? { stories.indices.contains(index) ? stories[index] : nil }
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            if isLoading {
+                ProgressView().tint(.white)
+            } else if let post = current {
+                storyImage(post)
+                tapZones
+                VStack(spacing: 0) {
+                    progressBars
+                    header(post)
+                    Spacer()
+                    footer(post)
+                }
+                .padding(.top, 8)
+            } else {
+                Color.clear.onAppear { close() }
+            }
+        }
+        .offset(y: max(0, dragOffset))
+        .gesture(
+            DragGesture()
+                .onChanged { v in if v.translation.height > 0 { dragOffset = v.translation.height } }
+                .onEnded { v in
+                    if v.translation.height > 120 { close() } else { withAnimation { dragOffset = 0 } }
+                }
+        )
+        .task { await load() }
+        .onReceive(tick) { _ in advanceProgress() }
+        .sheet(isPresented: $showReport) {
+            if let post = current {
+                ReportPostSheet(postId: post.post_id) { showReport = false; paused = false }
+            }
+        }
+        .statusBarHidden(true)
+    }
+
+    // MARK: - Pieces
+
+    private func storyImage(_ post: PostItem) -> some View {
+        AsyncImage(url: post.mediaURL) { phase in
+            switch phase {
+            case .success(let image):
+                image.resizable().scaledToFill()
+            case .failure:
+                Image(systemName: "photo").font(.largeTitle).foregroundColor(.white.opacity(0.3))
+            default:
+                ProgressView().tint(.white)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .clipped()
+        .ignoresSafeArea()
+    }
+
+    private var tapZones: some View {
+        HStack(spacing: 0) {
+            Color.clear.contentShape(Rectangle()).onTapGesture { step(-1) }
+            Color.clear.contentShape(Rectangle()).onTapGesture { step(1) }
+        }
+        .ignoresSafeArea()
+    }
+
+    private var progressBars: some View {
+        HStack(spacing: 4) {
+            ForEach(stories.indices, id: \.self) { i in
+                GeometryReader { geo in
+                    Capsule().fill(Color.white.opacity(0.3))
+                        .overlay(alignment: .leading) {
+                            Capsule().fill(Color.white)
+                                .frame(width: geo.size.width * fill(for: i))
+                        }
+                }
+                .frame(height: 3)
+            }
+        }
+        .padding(.horizontal, 10)
+    }
+
+    private func header(_ post: PostItem) -> some View {
+        HStack(spacing: 10) {
+            AvatarView(name: group.displayName, imageURL: group.profile_image_url, size: 36)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(group.displayName)
+                    .font(.system(size: 14, weight: .bold, design: .rounded))
+                    .foregroundColor(.white)
+                Text(post.relativeTime)
+                    .font(.system(size: 11, weight: .medium, design: .rounded))
+                    .foregroundColor(.white.opacity(0.7))
+            }
+            Spacer()
+            overflowMenu(post)
+            Button { close() } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(.white)
+                    .padding(6)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 8)
+        .shadow(color: .black.opacity(0.4), radius: 6)
+    }
+
+    @ViewBuilder
+    private func footer(_ post: PostItem) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if let caption = post.caption, !caption.isEmpty {
+                Text(caption)
+                    .font(.system(size: 14, weight: .medium, design: .rounded))
+                    .foregroundColor(.white)
+                    .shadow(color: .black.opacity(0.6), radius: 4)
+            }
+            if !post.is_self {
+                HStack {
+                    Spacer()
+                    HypeButton(isHyped: post.is_hyped, isBusy: hyping) {
+                        Task { await hype(post) }
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 28)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            LinearGradient(colors: [.clear, .black.opacity(0.5)], startPoint: .top, endPoint: .bottom)
+                .ignoresSafeArea()
+        )
+    }
+
+    @ViewBuilder
+    private func overflowMenu(_ post: PostItem) -> some View {
+        Menu {
+            if post.is_self {
+                Button(role: .destructive) {
+                    Task { await deleteOwn(post) }
+                } label: { Label("Delete story", systemImage: "trash") }
+            } else {
+                Button { paused = true; showReport = true } label: {
+                    Label("Report", systemImage: "flag")
+                }
+                Button(role: .destructive) {
+                    Task { await block(post) }
+                } label: { Label("Block \(group.displayName)", systemImage: "hand.raised") }
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(.white)
+                .padding(6)
+        }
+    }
+
+    // MARK: - Progress / navigation
+
+    private func fill(for i: Int) -> CGFloat {
+        if i < index { return 1 }
+        if i == index { return progress }
+        return 0
+    }
+
+    private func advanceProgress() {
+        guard !isLoading, !paused, !showReport, current != nil else { return }
+        progress += 0.05 / stepDuration
+        if progress >= 1 { step(1) }
+    }
+
+    private func step(_ dir: Int) {
+        progress = 0
+        let next = index + dir
+        if next < 0 { return }
+        if next >= stories.count { close(); return }
+        index = next
+        markViewed()
+    }
+
+    private func markViewed() {
+        guard let post = current else { return }
+        Task { try? await PostService.markStoryViewed(postId: post.post_id) }
+    }
+
+    private func close() {
+        onClose(changed)
+    }
+
+    // MARK: - Actions
+
+    private func load() async {
+        do {
+            let loaded = try await PostService.fetchUserStories(userId: group.user_id)
+            await MainActor.run {
+                stories = loaded
+                isLoading = false
+                if loaded.isEmpty { close() } else { markViewed() }
+            }
+        } catch {
+            await MainActor.run { isLoading = false; close() }
+        }
+    }
+
+    private func hype(_ post: PostItem) async {
+        guard !hyping, !post.is_hyped else { return }
+        hyping = true
+        defer { hyping = false }
+        do {
+            _ = try await HypeService.sendHype(
+                targetUserId: post.user_id,
+                context: HypeContext(
+                    contextType: "post",
+                    contextId: post.post_id,
+                    contextLabel: post.caption ?? group.displayName
+                )
+            )
+            await MainActor.run {
+                if stories.indices.contains(index) {
+                    stories[index].is_hyped = true
+                    stories[index].hype_count = (stories[index].hype_count ?? 0) + 1
+                }
+            }
+        } catch {
+            // conflict (already hyped) / rate-limited — leave button as-is.
+        }
+    }
+
+    private func deleteOwn(_ post: PostItem) async {
+        do {
+            try await PostService.deletePost(postId: post.post_id)
+            changed = true
+            await MainActor.run {
+                stories.removeAll { $0.post_id == post.post_id }
+                if index >= stories.count { index = max(0, stories.count - 1) }
+                progress = 0
+                if stories.isEmpty { close() }
+            }
+        } catch {}
+    }
+
+    private func block(_ post: PostItem) async {
+        do {
+            try await BlockService.block(userId: post.user_id)
+            changed = true
+            await MainActor.run { close() }
+        } catch {}
+    }
+}

--- a/app/Mile A Day/Views/Feed/StoryViewerView.swift
+++ b/app/Mile A Day/Views/Feed/StoryViewerView.swift
@@ -134,6 +134,9 @@ struct StoryViewerView: View {
     @ViewBuilder
     private func footer(_ post: PostItem) -> some View {
         VStack(alignment: .leading, spacing: 10) {
+            if let stats = post.stats_snapshot {
+                PostStatStrip(stats: stats, onPhoto: true)
+            }
             if let caption = post.caption, !caption.isEmpty {
                 Text(caption)
                     .font(.system(size: 14, weight: .medium, design: .rounded))

--- a/app/Mile A Day/Views/Friends/FriendsListView.swift
+++ b/app/Mile A Day/Views/Friends/FriendsListView.swift
@@ -3,11 +3,12 @@ import SwiftUI
 /// Top-level mode for the Friends tab: either the existing friends/requests
 /// management UI, or the new global/friends leaderboard.
 private enum FriendsTabMode: String, CaseIterable, Identifiable {
-    case friends, today, leaderboard
+    case friends, feed, today, leaderboard
     var id: String { rawValue }
     var displayName: String {
         switch self {
         case .friends: return "Friends"
+        case .feed: return "Feed"
         case .today: return "Today"
         case .leaderboard: return "Leaderboard"
         }
@@ -73,6 +74,8 @@ struct FriendsListView: View {
                     )
                 case .today:
                     feedView
+                case .feed:
+                    SocialFeedView()
                 case .friends:
                     friendsHome
                 }
@@ -249,6 +252,7 @@ struct FriendsListView: View {
             selection: $topMode,
             options: [
                 .init(id: .friends, title: "Friends", systemImage: "person.2.fill"),
+                .init(id: .feed, title: "Feed", systemImage: "photo.stack"),
                 .init(id: .today, title: "Today", systemImage: "flame.fill"),
                 .init(id: .leaderboard, title: "Leaderboard", systemImage: "trophy.fill")
             ]

--- a/backend/src/controllers/blocksController.ts
+++ b/backend/src/controllers/blocksController.ts
@@ -1,0 +1,34 @@
+import { Response } from "express";
+import { AuthenticatedRequest } from "../middleware/auth.js";
+import { blockUser, unblockUser } from "../services/moderationService.js";
+
+export async function blockUserController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  const blockerId = req.userId!;
+  const blockedId = req.params.userId;
+  try {
+    if (blockerId === blockedId) {
+      return res.status(400).json({ error: "You can't block yourself" });
+    }
+    await blockUser(blockerId, blockedId);
+    res.json({ ok: true });
+  } catch (error: any) {
+    console.error("Error blocking user:", error.message);
+    res.status(500).json({ error: "Error blocking user" });
+  }
+}
+
+export async function unblockUserController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  try {
+    await unblockUser(req.userId!, req.params.userId);
+    res.json({ ok: true });
+  } catch (error: any) {
+    console.error("Error unblocking user:", error.message);
+    res.status(500).json({ error: "Error unblocking user" });
+  }
+}

--- a/backend/src/controllers/hypeController.ts
+++ b/backend/src/controllers/hypeController.ts
@@ -1,19 +1,19 @@
-import { Response } from 'express';
-import { AuthenticatedRequest } from '../middleware/auth.js';
-import { PostgresService } from '../services/DbService.js';
-import { getFriendship } from '../services/friendshipService.js';
-import { getUser } from '../services/userService.js';
-import { sendPush } from '../services/pushNotificationService.js';
-import { shouldSendNotification } from '../services/notificationSettingsService.js';
+import { Response } from "express";
+import { AuthenticatedRequest } from "../middleware/auth.js";
+import { PostgresService } from "../services/DbService.js";
+import { getFriendship } from "../services/friendshipService.js";
+import { getUser } from "../services/userService.js";
+import { sendPush } from "../services/pushNotificationService.js";
+import { shouldSendNotification } from "../services/notificationSettingsService.js";
 import {
-	logHypeIfUnderLimit,
-	getDailyHypeCount,
-	getHypeResetsAt,
-	hasHypedContext,
-	HYPE_DAILY_LIMIT,
-	HypeContext,
-	getReceivedHypes
-} from '../services/hypeService.js';
+  logHypeIfUnderLimit,
+  getDailyHypeCount,
+  getHypeResetsAt,
+  hasHypedContext,
+  HYPE_DAILY_LIMIT,
+  HypeContext,
+  getReceivedHypes,
+} from "../services/hypeService.js";
 
 const db = PostgresService.getInstance();
 
@@ -21,9 +21,12 @@ const db = PostgresService.getInstance();
  * True if sender and target are accepted participants in at least one
  * currently-active competition.
  */
-async function shareActiveCompetition(senderId: string, targetId: string): Promise<boolean> {
-	const rows = await db.query<{ exists: boolean }>(
-		`SELECT EXISTS (
+async function shareActiveCompetition(
+  senderId: string,
+  targetId: string,
+): Promise<boolean> {
+  const rows = await db.query<{ exists: boolean }>(
+    `SELECT EXISTS (
 			SELECT 1
 			FROM competition_users cu_sender
 			JOIN competition_users cu_target ON cu_target.competition_id = cu_sender.competition_id
@@ -37,16 +40,22 @@ async function shareActiveCompetition(senderId: string, targetId: string): Promi
 				AND c.winner IS NULL
 				AND (c.end_date IS NULL OR c.end_date > NOW())
 		) AS exists`,
-		[senderId, targetId]
-	);
-	return rows[0]?.exists === true;
+    [senderId, targetId],
+  );
+  return rows[0]?.exists === true;
 }
 
-async function isFriendOrCoParticipant(senderId: string, targetId: string): Promise<boolean> {
-	const friendship = await getFriendship(senderId, targetId);
-	const friendsAccepted = !!friendship && !('error' in friendship) && friendship.status === 'accepted';
-	if (friendsAccepted) return true;
-	return shareActiveCompetition(senderId, targetId);
+async function isFriendOrCoParticipant(
+  senderId: string,
+  targetId: string,
+): Promise<boolean> {
+  const friendship = await getFriendship(senderId, targetId);
+  const friendsAccepted =
+    !!friendship &&
+    !("error" in friendship) &&
+    friendship.status === "accepted";
+  if (friendsAccepted) return true;
+  return shareActiveCompetition(senderId, targetId);
 }
 
 /**
@@ -54,158 +63,183 @@ async function isFriendOrCoParticipant(senderId: string, targetId: string): Prom
  * "in 45 minutes"). Returns null if the timestamp is missing or already past.
  */
 function formatTimeUntil(isoTimestamp: string | null): string | null {
-	if (!isoTimestamp) return null;
-	const target = new Date(isoTimestamp).getTime();
-	if (Number.isNaN(target)) return null;
-	const deltaMs = target - Date.now();
-	if (deltaMs <= 0) return null;
-	const minutes = Math.round(deltaMs / 60_000);
-	if (minutes < 60) return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`;
-	const hours = Math.round(minutes / 60);
-	if (hours < 24) return `${hours} ${hours === 1 ? 'hour' : 'hours'}`;
-	const days = Math.round(hours / 24);
-	return `${days} ${days === 1 ? 'day' : 'days'}`;
+  if (!isoTimestamp) return null;
+  const target = new Date(isoTimestamp).getTime();
+  if (Number.isNaN(target)) return null;
+  const deltaMs = target - Date.now();
+  if (deltaMs <= 0) return null;
+  const minutes = Math.round(deltaMs / 60_000);
+  if (minutes < 60) return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours} ${hours === 1 ? "hour" : "hours"}`;
+  const days = Math.round(hours / 24);
+  return `${days} ${days === 1 ? "day" : "days"}`;
 }
 
-function buildHypeBackBody(senderName: string, context: HypeContext | undefined): string {
-	if (!context) {
-		return `@${senderName} just hyped up your recent workout!`;
-	}
-	switch (context.contextType) {
-		case 'mile':
-			return `${senderName} hyped your daily mile 🔥`;
-		case 'badge':
-			return `${senderName} hyped you earning '${context.contextLabel}' 🔥`;
-		case 'pr':
-			return `${senderName} hyped your new ${context.contextLabel} 🔥`;
-		case 'challenge':
-			return `${senderName} hyped your '${context.contextLabel}' challenge 🔥`;
-	}
+function buildHypeBackBody(
+  senderName: string,
+  context: HypeContext | undefined,
+): string {
+  if (!context) {
+    return `@${senderName} just hyped up your recent workout!`;
+  }
+  switch (context.contextType) {
+    case "mile":
+      return `${senderName} hyped your daily mile 🔥`;
+    case "badge":
+      return `${senderName} hyped you earning '${context.contextLabel}' 🔥`;
+    case "pr":
+      return `${senderName} hyped your new ${context.contextLabel} 🔥`;
+    case "challenge":
+      return `${senderName} hyped your '${context.contextLabel}' challenge 🔥`;
+    case "post":
+      return `${senderName} hyped your post 🔥`;
+  }
 }
 
 export async function sendHype(req: AuthenticatedRequest, res: Response) {
-	const senderId = req.userId!;
-	const targetUserId = req.body?.target_user_id;
-	const rawContextType = req.body?.context_type;
-	const rawContextId = req.body?.context_id;
-	const rawContextLabel = req.body?.context_label;
+  const senderId = req.userId!;
+  const targetUserId = req.body?.target_user_id;
+  const rawContextType = req.body?.context_type;
+  const rawContextId = req.body?.context_id;
+  const rawContextLabel = req.body?.context_label;
 
-	try {
-		if (!targetUserId || typeof targetUserId !== 'string') {
-			return res.status(400).json({ error: 'target_user_id is required' });
-		}
-		if (senderId === targetUserId) {
-			return res.status(400).json({ error: "You can't hype yourself" });
-		}
+  try {
+    if (!targetUserId || typeof targetUserId !== "string") {
+      return res.status(400).json({ error: "target_user_id is required" });
+    }
+    if (senderId === targetUserId) {
+      return res.status(400).json({ error: "You can't hype yourself" });
+    }
 
-		// Parse optional context. All three must be present together, or all absent.
-		let context: HypeContext | undefined;
-		const anyCtx = rawContextType || rawContextId || rawContextLabel;
-		const allCtx = rawContextType && rawContextId && rawContextLabel;
-		if (anyCtx && !allCtx) {
-			return res.status(400).json({
-				error: 'context_type, context_id, and context_label must be provided together'
-			});
-		}
-		if (allCtx) {
-			if (!['mile', 'badge', 'pr', 'challenge'].includes(rawContextType)) {
-				return res.status(400).json({
-					error: "context_type must be one of 'mile' | 'badge' | 'pr' | 'challenge'"
-				});
-			}
-			context = {
-				contextType: rawContextType,
-				contextId: String(rawContextId),
-				contextLabel: String(rawContextLabel)
-			};
-		}
+    // Parse optional context. All three must be present together, or all absent.
+    let context: HypeContext | undefined;
+    const anyCtx = rawContextType || rawContextId || rawContextLabel;
+    const allCtx = rawContextType && rawContextId && rawContextLabel;
+    if (anyCtx && !allCtx) {
+      return res.status(400).json({
+        error:
+          "context_type, context_id, and context_label must be provided together",
+      });
+    }
+    if (allCtx) {
+      if (
+        !["mile", "badge", "pr", "challenge", "post"].includes(rawContextType)
+      ) {
+        return res.status(400).json({
+          error:
+            "context_type must be one of 'mile' | 'badge' | 'pr' | 'challenge' | 'post'",
+        });
+      }
+      context = {
+        contextType: rawContextType,
+        contextId: String(rawContextId),
+        contextLabel: String(rawContextLabel),
+      };
+    }
 
-		const allowed = await isFriendOrCoParticipant(senderId, targetUserId);
-		if (!allowed) {
-			return res.status(403).json({
-				error: 'You can only hype friends or people in your active competitions'
-			});
-		}
+    const allowed = await isFriendOrCoParticipant(senderId, targetUserId);
+    if (!allowed) {
+      return res.status(403).json({
+        error:
+          "You can only hype friends or people in your active competitions",
+      });
+    }
 
-		// No event-occurred validation: the recipient only sees a hype affordance
-		// when a real notification exists, so the notification itself is the proof.
-		// Abuse is bounded by the friend/co-participant gate, per-context dedupe,
-		// and the daily hype limit below.
+    // No event-occurred validation: the recipient only sees a hype affordance
+    // when a real notification exists, so the notification itself is the proof.
+    // Abuse is bounded by the friend/co-participant gate, per-context dedupe,
+    // and the daily hype limit below.
 
-		// Context-aware dedupe pre-check (legacy no-context hypes skip this).
-		if (context) {
-			const alreadyHyped = await hasHypedContext(senderId, targetUserId, context.contextType, context.contextId);
-			if (alreadyHyped) {
-				return res.status(409).json({ error: 'already_hyped' });
-			}
-		}
+    // Context-aware dedupe pre-check (legacy no-context hypes skip this).
+    if (context) {
+      const alreadyHyped = await hasHypedContext(
+        senderId,
+        targetUserId,
+        context.contextType,
+        context.contextId,
+      );
+      if (alreadyHyped) {
+        return res.status(409).json({ error: "already_hyped" });
+      }
+    }
 
-		// Atomic: insert iff still under the limit. Closes the concurrent-sender race.
-		const inserted = await logHypeIfUnderLimit(senderId, targetUserId, context);
-		if (!inserted) {
-			const resetsAt = await getHypeResetsAt(senderId);
-			const resetIn = formatTimeUntil(resetsAt);
-			const error = resetIn
-				? `You're out of hypes — you've used all ${HYPE_DAILY_LIMIT} today. Try again in ${resetIn}.`
-				: `You're out of hypes — you've used all ${HYPE_DAILY_LIMIT} today. Come back tomorrow.`;
-			return res.status(429).json({
-				error,
-				hypes_remaining: 0,
-				resets_at: resetsAt
-			});
-		}
+    // Atomic: insert iff still under the limit. Closes the concurrent-sender race.
+    const inserted = await logHypeIfUnderLimit(senderId, targetUserId, context);
+    if (!inserted) {
+      const resetsAt = await getHypeResetsAt(senderId);
+      const resetIn = formatTimeUntil(resetsAt);
+      const error = resetIn
+        ? `You're out of hypes — you've used all ${HYPE_DAILY_LIMIT} today. Try again in ${resetIn}.`
+        : `You're out of hypes — you've used all ${HYPE_DAILY_LIMIT} today. Come back tomorrow.`;
+      return res.status(429).json({
+        error,
+        hypes_remaining: 0,
+        resets_at: resetsAt,
+      });
+    }
 
-		const countAfter = await getDailyHypeCount(senderId);
+    const countAfter = await getDailyHypeCount(senderId);
 
-		const shouldSend = await shouldSendNotification(targetUserId, senderId, 'hype');
-		if (shouldSend) {
-			const sender = await getUser({ userId: senderId });
-			const senderName = sender?.username ?? 'Someone';
-			const body = buildHypeBackBody(senderName, context);
-			const pushData: Record<string, string> = { user_id: senderId };
-			if (context) {
-				pushData.context_type = context.contextType;
-				pushData.context_label = context.contextLabel;
-			}
-			await sendPush(targetUserId, {
-				title: '🔥 You got hyped!',
-				body,
-				type: 'hype_received',
-				data: pushData
-			});
-		}
+    const shouldSend = await shouldSendNotification(
+      targetUserId,
+      senderId,
+      "hype",
+    );
+    if (shouldSend) {
+      const sender = await getUser({ userId: senderId });
+      const senderName = sender?.username ?? "Someone";
+      const body = buildHypeBackBody(senderName, context);
+      const pushData: Record<string, string> = { user_id: senderId };
+      if (context) {
+        pushData.context_type = context.contextType;
+        pushData.context_label = context.contextLabel;
+      }
+      await sendPush(targetUserId, {
+        title: "🔥 You got hyped!",
+        body,
+        type: "hype_received",
+        data: pushData,
+      });
+    }
 
-		res.status(200).json({
-			message: 'Hype sent',
-			hypes_remaining: Math.max(0, HYPE_DAILY_LIMIT - countAfter)
-		});
-	} catch (error: any) {
-		console.error('Error sending hype:', error.message);
-		res.status(500).json({ error: 'Error sending hype' });
-	}
+    res.status(200).json({
+      message: "Hype sent",
+      hypes_remaining: Math.max(0, HYPE_DAILY_LIMIT - countAfter),
+    });
+  } catch (error: any) {
+    console.error("Error sending hype:", error.message);
+    res.status(500).json({ error: "Error sending hype" });
+  }
 }
 
-export async function getReceivedHypesController(req: AuthenticatedRequest, res: Response) {
-	const userId = req.userId!;
-	try {
-		const hypes = await getReceivedHypes(userId);
-		res.status(200).json(hypes);
-	} catch (error: any) {
-		console.error('Error getting received hypes:', error.message);
-		res.status(500).json({ error: 'Error getting received hypes' });
-	}
+export async function getReceivedHypesController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  const userId = req.userId!;
+  try {
+    const hypes = await getReceivedHypes(userId);
+    res.status(200).json(hypes);
+  } catch (error: any) {
+    console.error("Error getting received hypes:", error.message);
+    res.status(500).json({ error: "Error getting received hypes" });
+  }
 }
 
 export async function getHypeStatus(req: AuthenticatedRequest, res: Response) {
-	const senderId = req.userId!;
-	try {
-		const [count, resetsAt] = await Promise.all([getDailyHypeCount(senderId), getHypeResetsAt(senderId)]);
-		res.status(200).json({
-			hypes_remaining: Math.max(0, HYPE_DAILY_LIMIT - count),
-			resets_at: resetsAt
-		});
-	} catch (error: any) {
-		console.error('Error getting hype status:', error.message);
-		res.status(500).json({ error: 'Error getting hype status' });
-	}
+  const senderId = req.userId!;
+  try {
+    const [count, resetsAt] = await Promise.all([
+      getDailyHypeCount(senderId),
+      getHypeResetsAt(senderId),
+    ]);
+    res.status(200).json({
+      hypes_remaining: Math.max(0, HYPE_DAILY_LIMIT - count),
+      resets_at: resetsAt,
+    });
+  } catch (error: any) {
+    console.error("Error getting hype status:", error.message);
+    res.status(500).json({ error: "Error getting hype status" });
+  }
 }

--- a/backend/src/controllers/postsController.ts
+++ b/backend/src/controllers/postsController.ts
@@ -1,0 +1,286 @@
+import { Response } from "express";
+import fs from "fs";
+import path from "path";
+import sharp from "sharp";
+import { AuthenticatedRequest } from "../middleware/auth.js";
+import {
+  createPost,
+  getStoriesRail,
+  getUserActiveStories,
+  markStoryViewed,
+  getFeed,
+  getPostAuthor,
+  softDeletePost,
+  moderatorDeletePost,
+  hasAcceptedTerms,
+  acceptTerms,
+  PostStatsSnapshot,
+} from "../services/postService.js";
+import {
+  reportPost,
+  REPORT_REASONS,
+  ReportReason,
+} from "../services/moderationService.js";
+import { getDailyGoalStatus } from "../services/workoutService.js";
+import { hasUnlimitedActions } from "../services/privilegedUsers.js";
+
+const POSTS_MEDIA_PREFIX = "/uploads/posts/";
+const MAX_CAPTION = 280;
+const DEFAULT_FEED_LIMIT = 20;
+const MAX_FEED_LIMIT = 50;
+
+/**
+ * Upload a post photo. The image arrives already flattened (run-stats overlay
+ * baked in by the client). Mirrors uploadProfileImage: Multer memory buffer →
+ * Sharp auto-orient + resize + JPEG → /uploads/posts/. Returns the media_url
+ * to reference in a subsequent POST /posts.
+ */
+export async function uploadPostMedia(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  const userId = req.userId!;
+  if (!req.file) {
+    return res.status(400).json({ error: "No image file provided" });
+  }
+  try {
+    const filename = `${userId}-${Date.now()}.jpg`;
+    const outputPath = path.join(process.cwd(), "uploads", "posts", filename);
+    await sharp(req.file.buffer)
+      .rotate() // honor EXIF orientation before resizing (portrait photos)
+      .resize(1080, 1920, { fit: "inside", withoutEnlargement: true })
+      .jpeg({ quality: 82 })
+      .toFile(outputPath);
+
+    res.json({ media_url: `${POSTS_MEDIA_PREFIX}${filename}` });
+  } catch (error) {
+    res.status(500).json({
+      error: "Post media upload failed",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+}
+
+export async function createPostController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  const userId = req.userId!;
+  const {
+    media_url,
+    caption,
+    workout_id,
+    share_to_feed,
+    share_to_story,
+    stats_snapshot,
+  } = req.body ?? {};
+
+  try {
+    // Validate media_url points at our own posts upload dir and exists on disk.
+    if (
+      typeof media_url !== "string" ||
+      !media_url.startsWith(POSTS_MEDIA_PREFIX) ||
+      media_url.includes("..")
+    ) {
+      return res
+        .status(400)
+        .json({ error: "A valid uploaded media_url is required" });
+    }
+    const onDisk = path.join(process.cwd(), media_url.replace(/^\//, ""));
+    if (!fs.existsSync(onDisk)) {
+      return res
+        .status(400)
+        .json({ error: "media_url does not reference an uploaded file" });
+    }
+
+    const shareToFeed = share_to_feed !== false; // default true
+    const shareToStory = share_to_story === true; // default false
+    if (!shareToFeed && !shareToStory) {
+      return res
+        .status(400)
+        .json({ error: "A post must be shared to the feed, a story, or both" });
+    }
+
+    if (
+      caption != null &&
+      (typeof caption !== "string" || caption.length > MAX_CAPTION)
+    ) {
+      return res.status(400).json({
+        error: `caption must be a string of at most ${MAX_CAPTION} characters`,
+      });
+    }
+
+    // EULA / UGC terms gate (App Store Guideline 1.2).
+    if (!(await hasAcceptedTerms(userId))) {
+      return res.status(403).json({ error: "terms_not_accepted" });
+    }
+
+    // Authoritative mile-completion gate — recomputed from DB, never trusts client.
+    const goal = await getDailyGoalStatus(userId);
+    if (!goal.completed) {
+      return res.status(403).json({
+        error: "mile_not_completed",
+        miles: goal.miles,
+        goal_miles: goal.goalMiles,
+      });
+    }
+
+    const post = await createPost({
+      userId,
+      mediaUrl: media_url,
+      caption: typeof caption === "string" ? caption.trim() || null : null,
+      workoutId: typeof workout_id === "string" ? workout_id : null,
+      localDate: goal.localDate,
+      shareToFeed,
+      shareToStory,
+      statsSnapshot: (stats_snapshot ?? null) as PostStatsSnapshot | null,
+    });
+
+    res.status(201).json(post);
+  } catch (error: any) {
+    console.error("Error creating post:", error.message);
+    res.status(500).json({ error: "Error creating post" });
+  }
+}
+
+export async function getStoriesRailController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  try {
+    res.status(200).json(await getStoriesRail(req.userId!));
+  } catch (error: any) {
+    console.error("Error fetching stories rail:", error.message);
+    res.status(500).json({ error: "Error fetching stories" });
+  }
+}
+
+export async function getUserStoriesController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  try {
+    res
+      .status(200)
+      .json(await getUserActiveStories(req.userId!, req.params.userId));
+  } catch (error: any) {
+    console.error("Error fetching user stories:", error.message);
+    res.status(500).json({ error: "Error fetching stories" });
+  }
+}
+
+export async function markStoryViewedController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  try {
+    await markStoryViewed(req.userId!, req.params.postId);
+    res.json({ ok: true });
+  } catch (error: any) {
+    console.error("Error marking story viewed:", error.message);
+    res.status(500).json({ error: "Error marking story viewed" });
+  }
+}
+
+export async function getFeedController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  try {
+    const rawLimit = parseInt(String(req.query.limit ?? ""), 10);
+    const limit = Number.isFinite(rawLimit)
+      ? Math.min(Math.max(rawLimit, 1), MAX_FEED_LIMIT)
+      : DEFAULT_FEED_LIMIT;
+    const before =
+      typeof req.query.before === "string" ? req.query.before : null;
+    const items = await getFeed(req.userId!, limit, before);
+    const nextBefore =
+      items.length === limit ? items[items.length - 1].created_at : null;
+    res.status(200).json({ items, next_before: nextBefore });
+  } catch (error: any) {
+    console.error("Error fetching feed:", error.message);
+    res.status(500).json({ error: "Error fetching feed" });
+  }
+}
+
+export async function deletePostController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  const userId = req.userId!;
+  const postId = req.params.postId;
+  try {
+    const deleted = await softDeletePost(userId, postId);
+    if (deleted) return res.json({ ok: true });
+
+    // Not the author — allow admins to remove objectionable content (1.2).
+    if (await hasUnlimitedActions(userId)) {
+      const modDeleted = await moderatorDeletePost(postId);
+      if (modDeleted) return res.json({ ok: true });
+    }
+    return res
+      .status(403)
+      .json({ error: "You can only delete your own posts" });
+  } catch (error: any) {
+    console.error("Error deleting post:", error.message);
+    res.status(500).json({ error: "Error deleting post" });
+  }
+}
+
+export async function reportPostController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  const reporterId = req.userId!;
+  const postId = req.params.postId;
+  const { reason, details } = req.body ?? {};
+  try {
+    if (!REPORT_REASONS.includes(reason)) {
+      return res
+        .status(400)
+        .json({ error: `reason must be one of ${REPORT_REASONS.join(", ")}` });
+    }
+    const author = await getPostAuthor(postId);
+    if (!author) return res.status(404).json({ error: "Post not found" });
+    if (author === reporterId)
+      return res.status(400).json({ error: "You can't report your own post" });
+
+    await reportPost(
+      reporterId,
+      postId,
+      reason as ReportReason,
+      typeof details === "string" ? details : undefined,
+    );
+    res.status(201).json({ message: "Report received" });
+  } catch (error: any) {
+    console.error("Error reporting post:", error.message);
+    res.status(500).json({ error: "Error reporting post" });
+  }
+}
+
+/** GET /posts/terms — has the user accepted the UGC terms? */
+export async function getTermsStatusController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  try {
+    res.status(200).json({ accepted: await hasAcceptedTerms(req.userId!) });
+  } catch (error: any) {
+    console.error("Error fetching terms status:", error.message);
+    res.status(500).json({ error: "Error fetching terms status" });
+  }
+}
+
+/** POST /posts/terms/accept — record one-time terms acceptance. */
+export async function acceptTermsController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  try {
+    const acceptedAt = await acceptTerms(req.userId!);
+    res.status(200).json({ accepted: true, accepted_at: acceptedAt });
+  } catch (error: any) {
+    console.error("Error accepting terms:", error.message);
+    res.status(500).json({ error: "Error accepting terms" });
+  }
+}

--- a/backend/src/cron/storiesCron.ts
+++ b/backend/src/cron/storiesCron.ts
@@ -1,0 +1,118 @@
+import cron from "node-cron";
+import fs from "fs";
+import path from "path";
+import { PostgresService } from "../services/DbService.js";
+
+const db = PostgresService.getInstance();
+
+/**
+ * Expiry is enforced at query time (story_expires_at > NOW()), so this cron is
+ * pure hygiene: it soft-deletes expired story-only posts and unlinks their
+ * media to bound disk growth. Posts also shared to the feed are KEPT (the feed
+ * is permanent), so their media is never touched here. Also sweeps orphaned
+ * /uploads/posts files older than a day that no live post references.
+ */
+async function cleanupExpiredStories(): Promise<void> {
+  // Story-only posts whose 24h window has passed: collect their media, then
+  // soft-delete. Feed-shared posts are excluded so their photo survives.
+  const expired = await db.query<{ post_id: string; media_url: string }>(
+    `UPDATE posts
+		 SET deleted_at = NOW()
+		 WHERE share_to_story
+			 AND NOT share_to_feed
+			 AND deleted_at IS NULL
+			 AND story_expires_at <= NOW()
+		 RETURNING post_id, media_url`,
+  );
+
+  for (const row of expired) {
+    await unlinkMediaIfUnreferenced(row.media_url);
+  }
+  if (expired.length) {
+    console.log(`[CRON] Expired ${expired.length} story-only post(s).`);
+  }
+}
+
+/**
+ * Remove a media file from disk only if no live (non-deleted) post still points
+ * at it — a single photo can back both a story and a feed post (shared upload),
+ * though the composer currently uploads per-post.
+ */
+async function unlinkMediaIfUnreferenced(mediaUrl: string): Promise<void> {
+  if (!mediaUrl || !mediaUrl.startsWith("/uploads/posts/")) return;
+  const stillUsed = await db.query<{ exists: boolean }>(
+    `SELECT EXISTS (
+			SELECT 1 FROM posts WHERE media_url = $1 AND deleted_at IS NULL
+		) AS exists`,
+    [mediaUrl],
+  );
+  if (stillUsed[0]?.exists) return;
+  const onDisk = path.join(process.cwd(), mediaUrl.replace(/^\//, ""));
+  fs.promises.unlink(onDisk).catch(() => {
+    /* already gone */
+  });
+}
+
+/**
+ * Delete /uploads/posts files older than 24h that no live post references —
+ * catches orphans from uploads that never completed a POST /posts.
+ */
+async function sweepOrphanedMedia(): Promise<void> {
+  const dir = path.join(process.cwd(), "uploads", "posts");
+  let files: string[];
+  try {
+    files = await fs.promises.readdir(dir);
+  } catch {
+    return; // dir not created yet
+  }
+  const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+  let removed = 0;
+  for (const file of files) {
+    const full = path.join(dir, file);
+    let mtimeMs: number;
+    try {
+      mtimeMs = (await fs.promises.stat(full)).mtimeMs;
+    } catch {
+      continue;
+    }
+    if (mtimeMs > cutoff) continue;
+    const mediaUrl = `/uploads/posts/${file}`;
+    const referenced = await db.query<{ exists: boolean }>(
+      `SELECT EXISTS (SELECT 1 FROM posts WHERE media_url = $1 AND deleted_at IS NULL) AS exists`,
+      [mediaUrl],
+    );
+    if (referenced[0]?.exists) continue;
+    await fs.promises.unlink(full).catch(() => {});
+    removed += 1;
+  }
+  if (removed)
+    console.log(`[CRON] Swept ${removed} orphaned post media file(s).`);
+}
+
+export function startStoriesCron(): void {
+  // Hourly: expire stories promptly (so disk/privacy don't lag a full day).
+  cron.schedule("15 * * * *", async () => {
+    try {
+      await cleanupExpiredStories();
+    } catch (error: any) {
+      console.error("[CRON] Error expiring stories:", error.message);
+    }
+  });
+
+  // Daily at 3:30 AM ET: sweep orphaned upload files.
+  cron.schedule(
+    "30 3 * * *",
+    async () => {
+      try {
+        await sweepOrphanedMedia();
+      } catch (error: any) {
+        console.error("[CRON] Error sweeping orphaned media:", error.message);
+      }
+    },
+    { timezone: "America/New_York" },
+  );
+
+  console.log(
+    "Stories cron scheduled (hourly expiry + 3:30 AM ET orphan sweep).",
+  );
+}

--- a/backend/src/db/drizzle/0002_early_screwball.sql
+++ b/backend/src/db/drizzle/0002_early_screwball.sql
@@ -1,0 +1,55 @@
+CREATE TABLE "post_reports" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"post_id" uuid NOT NULL,
+	"reporter_id" text NOT NULL,
+	"reason" text NOT NULL,
+	"details" text,
+	"status" text DEFAULT 'open' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "post_reports_reason_check" CHECK (reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text]))
+);
+--> statement-breakpoint
+CREATE TABLE "posts" (
+	"post_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"media_url" text NOT NULL,
+	"caption" text,
+	"workout_id" varchar(255),
+	"stats_snapshot" jsonb,
+	"local_date" date NOT NULL,
+	"share_to_feed" boolean DEFAULT true NOT NULL,
+	"share_to_story" boolean DEFAULT false NOT NULL,
+	"story_expires_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "story_views" (
+	"post_id" uuid NOT NULL,
+	"viewer_id" text NOT NULL,
+	"viewed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "story_views_pkey" PRIMARY KEY("post_id","viewer_id")
+);
+--> statement-breakpoint
+CREATE TABLE "user_blocks" (
+	"blocker_id" text NOT NULL,
+	"blocked_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_blocks_pkey" PRIMARY KEY("blocker_id","blocked_id")
+);
+--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "terms_accepted_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "post_reports" ADD CONSTRAINT "post_reports_post_id_fkey" FOREIGN KEY ("post_id") REFERENCES "public"."posts"("post_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "post_reports" ADD CONSTRAINT "post_reports_reporter_id_fkey" FOREIGN KEY ("reporter_id") REFERENCES "public"."users"("user_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "posts" ADD CONSTRAINT "posts_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("user_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "posts" ADD CONSTRAINT "posts_workout_id_fkey" FOREIGN KEY ("workout_id") REFERENCES "public"."workouts"("workout_id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "story_views" ADD CONSTRAINT "story_views_post_id_fkey" FOREIGN KEY ("post_id") REFERENCES "public"."posts"("post_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "story_views" ADD CONSTRAINT "story_views_viewer_id_fkey" FOREIGN KEY ("viewer_id") REFERENCES "public"."users"("user_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_blocks" ADD CONSTRAINT "user_blocks_blocker_id_fkey" FOREIGN KEY ("blocker_id") REFERENCES "public"."users"("user_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_blocks" ADD CONSTRAINT "user_blocks_blocked_id_fkey" FOREIGN KEY ("blocked_id") REFERENCES "public"."users"("user_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "post_reports_dedupe_idx" ON "post_reports" USING btree ("post_id","reporter_id");--> statement-breakpoint
+CREATE INDEX "idx_post_reports_status" ON "post_reports" USING btree ("status","created_at" DESC NULLS FIRST);--> statement-breakpoint
+CREATE INDEX "idx_posts_user_created" ON "posts" USING btree ("user_id","created_at" DESC NULLS FIRST);--> statement-breakpoint
+CREATE INDEX "idx_posts_feed" ON "posts" USING btree ("created_at" DESC NULLS FIRST) WHERE (deleted_at IS NULL AND share_to_feed);--> statement-breakpoint
+CREATE INDEX "idx_posts_story_active" ON "posts" USING btree ("user_id","story_expires_at") WHERE (deleted_at IS NULL AND share_to_story);--> statement-breakpoint
+CREATE INDEX "idx_user_blocks_blocked" ON "user_blocks" USING btree ("blocked_id");

--- a/backend/src/db/drizzle/meta/0002_snapshot.json
+++ b/backend/src/db/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,3426 @@
+{
+  "id": "8e80c82c-d663-4b5e-85a3-3fd045ab0985",
+  "prevId": "8794fe66-4692-43da-b1e9-bcc87fd54bae",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_badges_category": {
+          "name": "idx_badges_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "badges_rarity_check": {
+          "name": "badges_rarity_check",
+          "value": "rarity = ANY (ARRAY['common'::text, 'rare'::text, 'legendary'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.close_friends": {
+      "name": "close_friends",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_friend_id": {
+          "name": "close_friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_close_friends_friend": {
+          "name": "idx_close_friends_friend",
+          "columns": [
+            {
+              "expression": "close_friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "close_friends_pkey": {
+          "name": "close_friends_pkey",
+          "columns": [
+            "user_id",
+            "close_friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_users": {
+      "name": "competition_users",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_rank": {
+          "name": "last_known_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_score": {
+          "name": "last_known_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rank_updated_at": {
+          "name": "last_rank_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_competition_users_comp": {
+          "name": "idx_competition_users_comp",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_competition": {
+          "name": "idx_competition_users_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_rank_cache": {
+          "name": "idx_competition_users_rank_cache",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_known_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((invite_status)::text = 'accepted'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user": {
+          "name": "idx_competition_users_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user_status": {
+          "name": "idx_competition_users_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invite_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_users_user_id_fkey": {
+          "name": "competition_users_user_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_users_competition_id_fkey": {
+          "name": "competition_users_competition_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_users_pkey": {
+          "name": "competition_users_pkey",
+          "columns": [
+            "competition_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_users_invite_status_check": {
+          "name": "competition_users_invite_status_check",
+          "value": "(invite_status)::text = ANY ((ARRAY['pending'::character varying, 'accepted'::character varying, 'declined'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workouts": {
+          "name": "workouts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_winner": {
+          "name": "idx_competitions_winner",
+          "columns": [
+            {
+              "expression": "winner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(winner IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_winner_fkey": {
+          "name": "competitions_winner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "competitions_owner_fkey": {
+          "name": "competitions_owner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitions_type_check": {
+          "name": "competitions_type_check",
+          "value": "(type)::text = ANY ((ARRAY['streaks'::character varying, 'apex'::character varying, 'clash'::character varying, 'targets'::character varying, 'race'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_challenges": {
+      "name": "daily_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_template": {
+          "name": "description_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_start": {
+          "name": "gradient_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_end": {
+          "name": "gradient_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rotation_index": {
+          "name": "rotation_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_challenges_rotation_index_key": {
+          "name": "daily_challenges_rotation_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rotation_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daily_challenges_type_check": {
+          "name": "daily_challenges_type_check",
+          "value": "type = ANY (ARRAY['pace'::text, 'distance'::text, 'time'::text, 'activity'::text, 'steps'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_steps": {
+      "name": "daily_steps",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_steps_user_date": {
+          "name": "idx_daily_steps_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_steps_user_id_fkey": {
+          "name": "daily_steps_user_id_fkey",
+          "tableFrom": "daily_steps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_steps_pkey": {
+          "name": "daily_steps_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "daily_steps_steps_check": {
+          "name": "daily_steps_steps_check",
+          "value": "steps >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token": {
+          "name": "device_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_tokens_user_id": {
+          "name": "idx_device_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_user_id_fkey": {
+          "name": "device_tokens_user_id_fkey",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_user_id_device_token_key": {
+          "name": "device_tokens_user_id_device_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flex_log": {
+      "name": "flex_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flex_log_lookup": {
+          "name": "idx_flex_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_notification_settings": {
+      "name": "friend_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted": {
+          "name": "muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nudges_muted": {
+          "name": "nudges_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "activity_muted": {
+          "name": "activity_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "friend_notification_settings_pkey": {
+          "name": "friend_notification_settings_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_nudge_log": {
+      "name": "friend_nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_nudge_log_lookup": {
+          "name": "idx_friend_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_friendships_friend_status": {
+          "name": "idx_friendships_friend_status",
+          "columns": [
+            {
+              "expression": "friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_friendships_user_status": {
+          "name": "idx_friendships_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_user_id_fkey": {
+          "name": "friendships_user_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_friend_id_fkey": {
+          "name": "friendships_friend_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendships_pkey": {
+          "name": "friendships_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_friendship_pair": {
+          "name": "unique_friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hype_log": {
+      "name": "hype_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_label": {
+          "name": "context_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hype_log_context_dedupe_idx": {
+          "name": "hype_log_context_dedupe_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_lookup": {
+          "name": "idx_hype_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_app_notifications": {
+      "name": "in_app_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_in_app_notifications_unread": {
+          "name": "idx_in_app_notifications_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_read = false)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_app_notifications_user": {
+          "name": "idx_in_app_notifications_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_app_notifications_user_id_fkey": {
+          "name": "in_app_notifications_user_id_fkey",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_notifications": {
+      "name": "milestone_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_key": {
+          "name": "milestone_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_notifications_milestone_key_key": {
+          "name": "milestone_notifications_milestone_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_audience_settings": {
+      "name": "notification_audience_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_audience_settings_pkey": {
+          "name": "notification_audience_settings_pkey",
+          "columns": [
+            "user_id",
+            "direction",
+            "event_type",
+            "activity_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_audience_settings_direction_check": {
+          "name": "notification_audience_settings_direction_check",
+          "value": "direction = ANY (ARRAY['outgoing'::text, 'incoming'::text])"
+        },
+        "notification_audience_settings_audience_check": {
+          "name": "notification_audience_settings_audience_check",
+          "value": "audience = ANY (ARRAY['none'::text, 'close'::text, 'all'::text, 'ask'::text, 'match_run'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_user_date": {
+          "name": "idx_notification_log_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nudges_enabled": {
+          "name": "nudges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "flexes_enabled": {
+          "name": "flexes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_activity_enabled": {
+          "name": "friend_activity_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_invites_enabled": {
+          "name": "competition_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_updates_enabled": {
+          "name": "competition_updates_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_milestones_enabled": {
+          "name": "competition_milestones_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "hypes_enabled": {
+          "name": "hypes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "step_goal_enabled": {
+          "name": "step_goal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "friend_personal_best_enabled": {
+          "name": "friend_personal_best_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_enabled": {
+          "name": "daily_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_hour": {
+          "name": "daily_reminder_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 18
+        },
+        "timezone_offset_minutes": {
+          "name": "timezone_offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nudge_log": {
+      "name": "nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_nudge_log_lookup": {
+          "name": "idx_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nudge_log_rate_limit": {
+          "name": "idx_nudge_log_rate_limit",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_friend_notifications": {
+      "name": "pending_friend_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pending_friend_notif_user": {
+          "name": "idx_pending_friend_notif_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_pending_friend_notif_workout": {
+          "name": "uq_pending_friend_notif_workout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((workout_id IS NOT NULL) AND (status = 'pending'::text))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pending_friend_notifications_status_check": {
+          "name": "pending_friend_notifications_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'sent'::text, 'dismissed'::text, 'expired'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_notifications": {
+      "name": "pending_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_notifications_unsent": {
+          "name": "idx_pending_notifications_unsent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(sent_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_notifications_user_id_fkey": {
+          "name": "pending_notifications_user_id_fkey",
+          "tableFrom": "pending_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_reports": {
+      "name": "post_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_reports_dedupe_idx": {
+          "name": "post_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_reports_status": {
+          "name": "idx_post_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_reports_post_id_fkey": {
+          "name": "post_reports_post_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_reports_reporter_id_fkey": {
+          "name": "post_reports_reporter_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_reports_reason_check": {
+          "name": "post_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_snapshot": {
+          "name": "stats_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_to_feed": {
+          "name": "share_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_to_story": {
+          "name": "share_to_story",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "story_expires_at": {
+          "name": "story_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_posts_user_created": {
+          "name": "idx_posts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_feed": {
+          "name": "idx_posts_feed",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_story_active": {
+          "name": "idx_posts_story_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "story_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_story)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_fkey": {
+          "name": "posts_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_workout_id_fkey": {
+          "name": "posts_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_family_id": {
+          "name": "token_family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_hash": {
+          "name": "replaced_by_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "token_family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_revoked_at": {
+          "name": "idx_refresh_tokens_revoked_at",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(revoked_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_token_hash": {
+          "name": "idx_refresh_tokens_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_fkey": {
+          "name": "refresh_tokens_user_id_fkey",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_key": {
+          "name": "refresh_tokens_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_views": {
+      "name": "story_views",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_views_post_id_fkey": {
+          "name": "story_views_post_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_views_viewer_id_fkey": {
+          "name": "story_views_viewer_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_views_pkey": {
+          "name": "story_views_pkey",
+          "columns": [
+            "post_id",
+            "viewer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggering_workout_id": {
+          "name": "triggering_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_snapshot": {
+          "name": "progress_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_slot": {
+          "name": "pin_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_badges_user": {
+          "name": "idx_user_badges_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_new": {
+          "name": "idx_user_badges_user_new",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_new = true)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_pin_slot": {
+          "name": "idx_user_badges_user_pin_slot",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(pin_slot IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_workout": {
+          "name": "idx_user_badges_workout",
+          "columns": [
+            {
+              "expression": "triggering_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_badges_user_id_fkey": {
+          "name": "user_badges_user_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_fkey": {
+          "name": "user_badges_badge_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "badge_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_triggering_workout_id_fkey": {
+          "name": "user_badges_triggering_workout_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "triggering_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_badges_user_id_badge_id_key": {
+          "name": "user_badges_user_id_badge_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "badge_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_badges_pin_slot_range": {
+          "name": "user_badges_pin_slot_range",
+          "value": "(pin_slot IS NULL) OR ((pin_slot >= 0) AND (pin_slot <= 2))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_blocks_blocked": {
+          "name": "idx_user_blocks_blocked",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_fkey": {
+          "name": "user_blocks_blocker_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_blocks_blocked_id_fkey": {
+          "name": "user_blocks_blocked_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_pkey": {
+          "name": "user_blocks_pkey",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenge_completions": {
+      "name": "user_challenge_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completing_workout_id": {
+          "name": "completing_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ucc_user": {
+          "name": "idx_ucc_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ucc_user_date": {
+          "name": "idx_ucc_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenge_completions_user_id_fkey": {
+          "name": "user_challenge_completions_user_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_challenge_key_fkey": {
+          "name": "user_challenge_completions_challenge_key_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "daily_challenges",
+          "columnsFrom": [
+            "challenge_key"
+          ],
+          "columnsTo": [
+            "challenge_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_completing_workout_id_fkey": {
+          "name": "user_challenge_completions_completing_workout_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "completing_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_challenge_completions_user_id_local_date_key": {
+          "name": "user_challenge_completions_user_id_local_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_sub": {
+          "name": "apple_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "goal_miles": {
+          "name": "goal_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_current_streak_desc": {
+          "name": "idx_users_current_streak_desc",
+          "columns": [
+            {
+              "expression": "current_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email_trgm": {
+          "name": "idx_users_email_trgm",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_username_trgm": {
+          "name": "idx_users_username_trgm",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_apple_id_key": {
+          "name": "users_apple_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_apple_sub_key": {
+          "name": "users_apple_sub_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "apple_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_completion_notifications": {
+      "name": "workout_completion_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_date": {
+          "name": "notified_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_completion_notifications_user_id_notified_date_key": {
+          "name": "workout_completion_notifications_user_id_notified_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "notified_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_splits": {
+      "name": "workout_splits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_number": {
+          "name": "split_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_duration": {
+          "name": "split_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_distance": {
+          "name": "split_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_pace": {
+          "name": "split_pace",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_splits_time": {
+          "name": "idx_splits_time",
+          "columns": [
+            {
+              "expression": "split_duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_splits_workout": {
+          "name": "idx_splits_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_splits_workout_id_fkey": {
+          "name": "workout_splits_workout_id_fkey",
+          "tableFrom": "workout_splits",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_splits_workout_id_split_number_key": {
+          "name": "workout_splits_workout_id_split_number_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "split_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workouts": {
+      "name": "workouts",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_end_date": {
+          "name": "device_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthkit'"
+        },
+        "original_distance": {
+          "name": "original_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_duration": {
+          "name": "original_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_workouts_local_date_user_id": {
+          "name": "idx_workouts_local_date_user_id",
+          "columns": [
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_device_end": {
+          "name": "idx_workouts_user_device_end",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_local_date": {
+          "name": "idx_workouts_user_local_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workouts_user_workout_unique": {
+          "name": "workouts_user_workout_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/drizzle/meta/_journal.json
+++ b/backend/src/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1781649109407,
       "tag": "0001_optimal_mercury",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1782788263312,
+      "tag": "0002_early_screwball",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/drizzle/schema.ts
+++ b/backend/src/db/drizzle/schema.ts
@@ -1,475 +1,1081 @@
-import { pgTable, index, uuid, text, timestamp, foreignKey, unique, serial, varchar, integer, doublePrecision, numeric, date, boolean, check, jsonb, inet, uniqueIndex, bigserial, primaryKey } from "drizzle-orm/pg-core"
-import { sql } from "drizzle-orm"
+import {
+  pgTable,
+  index,
+  uuid,
+  text,
+  timestamp,
+  foreignKey,
+  unique,
+  serial,
+  varchar,
+  integer,
+  doublePrecision,
+  numeric,
+  date,
+  boolean,
+  check,
+  jsonb,
+  inet,
+  uniqueIndex,
+  bigserial,
+  primaryKey,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 
+export const friendNudgeLog = pgTable(
+  "friend_nudge_log",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    senderId: text("sender_id").notNull(),
+    targetId: text("target_id").notNull(),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+  },
+  (table) => [
+    index("idx_friend_nudge_log_lookup").using(
+      "btree",
+      table.senderId.asc().nullsLast(),
+      table.targetId.asc().nullsLast(),
+      table.createdAt.desc().nullsFirst(),
+    ),
+  ],
+);
 
+export const workoutSplits = pgTable(
+  "workout_splits",
+  {
+    id: serial().primaryKey().notNull(),
+    workoutId: varchar("workout_id", { length: 255 }).notNull(),
+    splitNumber: integer("split_number").notNull(),
+    splitDuration: doublePrecision("split_duration").notNull(),
+    splitDistance: doublePrecision("split_distance"),
+    splitPace: doublePrecision("split_pace"),
+  },
+  (table) => [
+    index("idx_splits_time").using(
+      "btree",
+      table.splitDuration.asc().nullsLast(),
+    ),
+    index("idx_splits_workout").using(
+      "btree",
+      table.workoutId.asc().nullsLast(),
+    ),
+    foreignKey({
+      columns: [table.workoutId],
+      foreignColumns: [workouts.workoutId],
+      name: "workout_splits_workout_id_fkey",
+    }).onDelete("cascade"),
+    unique("workout_splits_workout_id_split_number_key").on(
+      table.workoutId,
+      table.splitNumber,
+    ),
+  ],
+);
 
-export const friendNudgeLog = pgTable("friend_nudge_log", {
-	id: uuid().defaultRandom().primaryKey().notNull(),
-	senderId: text("sender_id").notNull(),
-	targetId: text("target_id").notNull(),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-}, (table) => [
-	index("idx_friend_nudge_log_lookup").using("btree", table.senderId.asc().nullsLast(), table.targetId.asc().nullsLast(), table.createdAt.desc().nullsFirst()),
-]);
+export const flexLog = pgTable(
+  "flex_log",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    senderId: text("sender_id").notNull(),
+    targetId: text("target_id").notNull(),
+    competitionId: text("competition_id").notNull(),
+    message: text(),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+  },
+  (table) => [
+    index("idx_flex_log_lookup").using(
+      "btree",
+      table.senderId.asc().nullsLast(),
+      table.targetId.asc().nullsLast(),
+      table.createdAt.desc().nullsFirst(),
+    ),
+  ],
+);
 
-export const workoutSplits = pgTable("workout_splits", {
-	id: serial().primaryKey().notNull(),
-	workoutId: varchar("workout_id", { length: 255 }).notNull(),
-	splitNumber: integer("split_number").notNull(),
-	splitDuration: doublePrecision("split_duration").notNull(),
-	splitDistance: doublePrecision("split_distance"),
-	splitPace: doublePrecision("split_pace"),
-}, (table) => [
-	index("idx_splits_time").using("btree", table.splitDuration.asc().nullsLast()),
-	index("idx_splits_workout").using("btree", table.workoutId.asc().nullsLast()),
-	foreignKey({
-			columns: [table.workoutId],
-			foreignColumns: [workouts.workoutId],
-			name: "workout_splits_workout_id_fkey"
-		}).onDelete("cascade"),
-	unique("workout_splits_workout_id_split_number_key").on(table.workoutId, table.splitNumber),
-]);
+export const users = pgTable(
+  "users",
+  {
+    userId: text("user_id").primaryKey().notNull(),
+    username: varchar({ length: 30 }),
+    email: varchar({ length: 255 }),
+    firstName: varchar("first_name", { length: 50 }),
+    lastName: varchar("last_name", { length: 50 }),
+    appleSub: varchar("apple_sub", { length: 255 }).notNull(),
+    profileImageUrl: text("profile_image_url"),
+    bio: text(),
+    role: varchar({ length: 20 }).default("user"),
+    goalMiles: numeric("goal_miles").default("1.0").notNull(),
+    currentStreak: integer("current_streak").default(0).notNull(),
+    // One-time acceptance of the UGC terms / EULA, required before a user can
+    // post photos (App Store Guideline 1.2). Null = not yet accepted.
+    termsAcceptedAt: timestamp("terms_accepted_at", {
+      withTimezone: true,
+      mode: "string",
+    }),
+  },
+  (table) => [
+    index("idx_users_current_streak_desc").using(
+      "btree",
+      table.currentStreak.desc().nullsFirst(),
+    ),
+    index("idx_users_email_trgm").using(
+      "gin",
+      table.email.asc().nullsLast().op("gin_trgm_ops"),
+    ),
+    index("idx_users_username").using(
+      "btree",
+      table.username.asc().nullsLast(),
+    ),
+    index("idx_users_username_trgm").using(
+      "gin",
+      table.username.asc().nullsLast().op("gin_trgm_ops"),
+    ),
+    unique("users_apple_id_key").on(table.email),
+    unique("users_apple_sub_key").on(table.appleSub),
+  ],
+);
 
-export const flexLog = pgTable("flex_log", {
-	id: uuid().defaultRandom().primaryKey().notNull(),
-	senderId: text("sender_id").notNull(),
-	targetId: text("target_id").notNull(),
-	competitionId: text("competition_id").notNull(),
-	message: text(),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-}, (table) => [
-	index("idx_flex_log_lookup").using("btree", table.senderId.asc().nullsLast(), table.targetId.asc().nullsLast(), table.createdAt.desc().nullsFirst()),
-]);
-
-export const users = pgTable("users", {
-	userId: text("user_id").primaryKey().notNull(),
-	username: varchar({ length: 30 }),
-	email: varchar({ length: 255 }),
-	firstName: varchar("first_name", { length: 50 }),
-	lastName: varchar("last_name", { length: 50 }),
-	appleSub: varchar("apple_sub", { length: 255 }).notNull(),
-	profileImageUrl: text("profile_image_url"),
-	bio: text(),
-	role: varchar({ length: 20 }).default('user'),
-	goalMiles: numeric("goal_miles").default('1.0').notNull(),
-	currentStreak: integer("current_streak").default(0).notNull(),
-}, (table) => [
-	index("idx_users_current_streak_desc").using("btree", table.currentStreak.desc().nullsFirst()),
-	index("idx_users_email_trgm").using("gin", table.email.asc().nullsLast().op("gin_trgm_ops")),
-	index("idx_users_username").using("btree", table.username.asc().nullsLast()),
-	index("idx_users_username_trgm").using("gin", table.username.asc().nullsLast().op("gin_trgm_ops")),
-	unique("users_apple_id_key").on(table.email),
-	unique("users_apple_sub_key").on(table.appleSub),
-]);
-
-export const workouts = pgTable("workouts", {
-	workoutId: varchar("workout_id", { length: 255 }).primaryKey().notNull(),
-	userId: varchar("user_id", { length: 255 }).notNull(),
-	distance: doublePrecision().notNull(),
-	localDate: date("local_date").notNull(),
-	date: date().notNull(),
-	timezoneOffset: integer("timezone_offset").notNull(),
-	workoutType: varchar("workout_type", { length: 50 }).notNull(),
-	deviceEndDate: timestamp("device_end_date", { withTimezone: true, mode: 'string' }).notNull(),
-	calories: doublePrecision().notNull(),
-	totalDuration: doublePrecision("total_duration").notNull(),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-	source: varchar({ length: 20 }).default('healthkit').notNull(),
-	originalDistance: doublePrecision("original_distance"),
-	originalDuration: doublePrecision("original_duration"),
-	steps: integer(),
-}, (table) => [
-	index("idx_workouts_local_date_user_id").using("btree", table.localDate.asc().nullsLast(), table.userId.asc().nullsLast()),
-	index("idx_workouts_user_device_end").using("btree", table.userId.asc().nullsLast(), table.deviceEndDate.desc().nullsFirst()),
-	index("idx_workouts_user_local_date").using("btree", table.userId.asc().nullsLast(), table.localDate.desc().nullsFirst()),
-	unique("workouts_user_workout_unique").on(table.workoutId, table.userId),
-]);
+export const workouts = pgTable(
+  "workouts",
+  {
+    workoutId: varchar("workout_id", { length: 255 }).primaryKey().notNull(),
+    userId: varchar("user_id", { length: 255 }).notNull(),
+    distance: doublePrecision().notNull(),
+    localDate: date("local_date").notNull(),
+    date: date().notNull(),
+    timezoneOffset: integer("timezone_offset").notNull(),
+    workoutType: varchar("workout_type", { length: 50 }).notNull(),
+    deviceEndDate: timestamp("device_end_date", {
+      withTimezone: true,
+      mode: "string",
+    }).notNull(),
+    calories: doublePrecision().notNull(),
+    totalDuration: doublePrecision("total_duration").notNull(),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+    source: varchar({ length: 20 }).default("healthkit").notNull(),
+    originalDistance: doublePrecision("original_distance"),
+    originalDuration: doublePrecision("original_duration"),
+    steps: integer(),
+  },
+  (table) => [
+    index("idx_workouts_local_date_user_id").using(
+      "btree",
+      table.localDate.asc().nullsLast(),
+      table.userId.asc().nullsLast(),
+    ),
+    index("idx_workouts_user_device_end").using(
+      "btree",
+      table.userId.asc().nullsLast(),
+      table.deviceEndDate.desc().nullsFirst(),
+    ),
+    index("idx_workouts_user_local_date").using(
+      "btree",
+      table.userId.asc().nullsLast(),
+      table.localDate.desc().nullsFirst(),
+    ),
+    unique("workouts_user_workout_unique").on(table.workoutId, table.userId),
+  ],
+);
 
 export const notificationSettings = pgTable("notification_settings", {
-	userId: text("user_id").primaryKey().notNull(),
-	nudgesEnabled: boolean("nudges_enabled").default(true),
-	flexesEnabled: boolean("flexes_enabled").default(true),
-	friendActivityEnabled: boolean("friend_activity_enabled").default(true),
-	competitionInvitesEnabled: boolean("competition_invites_enabled").default(true),
-	competitionUpdatesEnabled: boolean("competition_updates_enabled").default(true),
-	competitionMilestonesEnabled: boolean("competition_milestones_enabled").default(true),
-	quietHoursStart: integer("quiet_hours_start"),
-	quietHoursEnd: integer("quiet_hours_end"),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-	hypesEnabled: boolean("hypes_enabled").default(true).notNull(),
-	stepGoalEnabled: boolean("step_goal_enabled").default(true).notNull(),
-	friendPersonalBestEnabled: boolean("friend_personal_best_enabled").default(true),
-	dailyReminderEnabled: boolean("daily_reminder_enabled").default(true),
-	dailyReminderHour: integer("daily_reminder_hour").default(18),
-	timezoneOffsetMinutes: integer("timezone_offset_minutes"),
+  userId: text("user_id").primaryKey().notNull(),
+  nudgesEnabled: boolean("nudges_enabled").default(true),
+  flexesEnabled: boolean("flexes_enabled").default(true),
+  friendActivityEnabled: boolean("friend_activity_enabled").default(true),
+  competitionInvitesEnabled: boolean("competition_invites_enabled").default(
+    true,
+  ),
+  competitionUpdatesEnabled: boolean("competition_updates_enabled").default(
+    true,
+  ),
+  competitionMilestonesEnabled: boolean(
+    "competition_milestones_enabled",
+  ).default(true),
+  quietHoursStart: integer("quiet_hours_start"),
+  quietHoursEnd: integer("quiet_hours_end"),
+  createdAt: timestamp("created_at", {
+    withTimezone: true,
+    mode: "string",
+  }).defaultNow(),
+  updatedAt: timestamp("updated_at", {
+    withTimezone: true,
+    mode: "string",
+  }).defaultNow(),
+  hypesEnabled: boolean("hypes_enabled").default(true).notNull(),
+  stepGoalEnabled: boolean("step_goal_enabled").default(true).notNull(),
+  friendPersonalBestEnabled: boolean("friend_personal_best_enabled").default(
+    true,
+  ),
+  dailyReminderEnabled: boolean("daily_reminder_enabled").default(true),
+  dailyReminderHour: integer("daily_reminder_hour").default(18),
+  timezoneOffsetMinutes: integer("timezone_offset_minutes"),
 });
 
-export const competitions = pgTable("competitions", {
-	id: varchar({ length: 32 }).default(sql`replace((gen_random_uuid())::text, '-'::text, ''::text)`).primaryKey().notNull(),
-	competitionName: varchar("competition_name", { length: 100 }),
-	startDate: date("start_date"),
-	endDate: date("end_date"),
-	workouts: jsonb().notNull(),
-	type: varchar({ length: 20 }).notNull(),
-	options: jsonb().notNull(),
-	ended: boolean().default(false),
-	winner: text(),
-	owner: text(),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-}, (table) => [
-	index("idx_competitions_winner").using("btree", table.winner.asc().nullsLast()).where(sql`(winner IS NOT NULL)`),
-	foreignKey({
-			columns: [table.winner],
-			foreignColumns: [users.userId],
-			name: "competitions_winner_fkey"
-		}).onDelete("set null"),
-	foreignKey({
-			columns: [table.owner],
-			foreignColumns: [users.userId],
-			name: "competitions_owner_fkey"
-		}).onDelete("set null"),
-	check("competitions_type_check", sql`(type)::text = ANY ((ARRAY['streaks'::character varying, 'apex'::character varying, 'clash'::character varying, 'targets'::character varying, 'race'::character varying])::text[])`),
-]);
+export const competitions = pgTable(
+  "competitions",
+  {
+    id: varchar({ length: 32 })
+      .default(sql`replace((gen_random_uuid())::text, '-'::text, ''::text)`)
+      .primaryKey()
+      .notNull(),
+    competitionName: varchar("competition_name", { length: 100 }),
+    startDate: date("start_date"),
+    endDate: date("end_date"),
+    workouts: jsonb().notNull(),
+    type: varchar({ length: 20 }).notNull(),
+    options: jsonb().notNull(),
+    ended: boolean().default(false),
+    winner: text(),
+    owner: text(),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+    updatedAt: timestamp("updated_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+  },
+  (table) => [
+    index("idx_competitions_winner")
+      .using("btree", table.winner.asc().nullsLast())
+      .where(sql`(winner IS NOT NULL)`),
+    foreignKey({
+      columns: [table.winner],
+      foreignColumns: [users.userId],
+      name: "competitions_winner_fkey",
+    }).onDelete("set null"),
+    foreignKey({
+      columns: [table.owner],
+      foreignColumns: [users.userId],
+      name: "competitions_owner_fkey",
+    }).onDelete("set null"),
+    check(
+      "competitions_type_check",
+      sql`(type)::text = ANY ((ARRAY['streaks'::character varying, 'apex'::character varying, 'clash'::character varying, 'targets'::character varying, 'race'::character varying])::text[])`,
+    ),
+  ],
+);
 
-export const refreshTokens = pgTable("refresh_tokens", {
-	tokenId: uuid("token_id").defaultRandom().primaryKey().notNull(),
-	userId: varchar("user_id", { length: 32 }).notNull(),
-	tokenHash: varchar("token_hash", { length: 64 }).notNull(),
-	tokenFamilyId: uuid("token_family_id").notNull(),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	lastUsedAt: timestamp("last_used_at", { mode: 'string' }).defaultNow().notNull(),
-	expiresAt: timestamp("expires_at", { mode: 'string' }),
-	revokedAt: timestamp("revoked_at", { mode: 'string' }),
-	revokedReason: varchar("revoked_reason", { length: 50 }),
-	replacedByHash: varchar("replaced_by_hash", { length: 64 }),
-	userAgent: text("user_agent"),
-	ipAddress: inet("ip_address"),
-	deviceInfo: jsonb("device_info"),
-}, (table) => [
-	index("idx_refresh_tokens_family_id").using("btree", table.tokenFamilyId.asc().nullsLast()),
-	index("idx_refresh_tokens_revoked_at").using("btree", table.revokedAt.asc().nullsLast()).where(sql`(revoked_at IS NULL)`),
-	index("idx_refresh_tokens_token_hash").using("btree", table.tokenHash.asc().nullsLast()),
-	index("idx_refresh_tokens_user_id").using("btree", table.userId.asc().nullsLast()),
-	foreignKey({
-			columns: [table.userId],
-			foreignColumns: [users.userId],
-			name: "refresh_tokens_user_id_fkey"
-		}).onDelete("cascade"),
-	unique("refresh_tokens_token_hash_key").on(table.tokenHash),
-]);
+export const refreshTokens = pgTable(
+  "refresh_tokens",
+  {
+    tokenId: uuid("token_id").defaultRandom().primaryKey().notNull(),
+    userId: varchar("user_id", { length: 32 }).notNull(),
+    tokenHash: varchar("token_hash", { length: 64 }).notNull(),
+    tokenFamilyId: uuid("token_family_id").notNull(),
+    createdAt: timestamp("created_at", { mode: "string" })
+      .defaultNow()
+      .notNull(),
+    lastUsedAt: timestamp("last_used_at", { mode: "string" })
+      .defaultNow()
+      .notNull(),
+    expiresAt: timestamp("expires_at", { mode: "string" }),
+    revokedAt: timestamp("revoked_at", { mode: "string" }),
+    revokedReason: varchar("revoked_reason", { length: 50 }),
+    replacedByHash: varchar("replaced_by_hash", { length: 64 }),
+    userAgent: text("user_agent"),
+    ipAddress: inet("ip_address"),
+    deviceInfo: jsonb("device_info"),
+  },
+  (table) => [
+    index("idx_refresh_tokens_family_id").using(
+      "btree",
+      table.tokenFamilyId.asc().nullsLast(),
+    ),
+    index("idx_refresh_tokens_revoked_at")
+      .using("btree", table.revokedAt.asc().nullsLast())
+      .where(sql`(revoked_at IS NULL)`),
+    index("idx_refresh_tokens_token_hash").using(
+      "btree",
+      table.tokenHash.asc().nullsLast(),
+    ),
+    index("idx_refresh_tokens_user_id").using(
+      "btree",
+      table.userId.asc().nullsLast(),
+    ),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.userId],
+      name: "refresh_tokens_user_id_fkey",
+    }).onDelete("cascade"),
+    unique("refresh_tokens_token_hash_key").on(table.tokenHash),
+  ],
+);
 
-export const deviceTokens = pgTable("device_tokens", {
-	id: uuid().defaultRandom().primaryKey().notNull(),
-	userId: text("user_id").notNull(),
-	deviceToken: text("device_token").notNull(),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-}, (table) => [
-	index("idx_device_tokens_user_id").using("btree", table.userId.asc().nullsLast()),
-	foreignKey({
-			columns: [table.userId],
-			foreignColumns: [users.userId],
-			name: "device_tokens_user_id_fkey"
-		}).onDelete("cascade"),
-	unique("device_tokens_user_id_device_token_key").on(table.userId, table.deviceToken),
-]);
+export const deviceTokens = pgTable(
+  "device_tokens",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    userId: text("user_id").notNull(),
+    deviceToken: text("device_token").notNull(),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+    updatedAt: timestamp("updated_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+  },
+  (table) => [
+    index("idx_device_tokens_user_id").using(
+      "btree",
+      table.userId.asc().nullsLast(),
+    ),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.userId],
+      name: "device_tokens_user_id_fkey",
+    }).onDelete("cascade"),
+    unique("device_tokens_user_id_device_token_key").on(
+      table.userId,
+      table.deviceToken,
+    ),
+  ],
+);
 
-export const pendingNotifications = pgTable("pending_notifications", {
-	id: uuid().defaultRandom().primaryKey().notNull(),
-	userId: text("user_id").notNull(),
-	type: text().notNull(),
-	competitionId: text("competition_id"),
-	competitionName: text("competition_name"),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-	sentAt: timestamp("sent_at", { withTimezone: true, mode: 'string' }),
-}, (table) => [
-	index("idx_pending_notifications_unsent").using("btree", table.userId.asc().nullsLast()).where(sql`(sent_at IS NULL)`),
-	foreignKey({
-			columns: [table.userId],
-			foreignColumns: [users.userId],
-			name: "pending_notifications_user_id_fkey"
-		}).onDelete("cascade"),
-]);
+export const pendingNotifications = pgTable(
+  "pending_notifications",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    userId: text("user_id").notNull(),
+    type: text().notNull(),
+    competitionId: text("competition_id"),
+    competitionName: text("competition_name"),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+    sentAt: timestamp("sent_at", { withTimezone: true, mode: "string" }),
+  },
+  (table) => [
+    index("idx_pending_notifications_unsent")
+      .using("btree", table.userId.asc().nullsLast())
+      .where(sql`(sent_at IS NULL)`),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.userId],
+      name: "pending_notifications_user_id_fkey",
+    }).onDelete("cascade"),
+  ],
+);
 
-export const nudgeLog = pgTable("nudge_log", {
-	id: uuid().defaultRandom().primaryKey().notNull(),
-	competitionId: text("competition_id").notNull(),
-	senderId: text("sender_id").notNull(),
-	targetId: text("target_id").notNull(),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-}, (table) => [
-	index("idx_nudge_log_lookup").using("btree", table.competitionId.asc().nullsLast(), table.senderId.asc().nullsLast(), table.targetId.asc().nullsLast(), table.createdAt.asc().nullsLast()),
-	index("idx_nudge_log_rate_limit").using("btree", table.competitionId.asc().nullsLast(), table.senderId.asc().nullsLast(), table.targetId.asc().nullsLast(), table.createdAt.asc().nullsLast()),
-]);
+export const nudgeLog = pgTable(
+  "nudge_log",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    competitionId: text("competition_id").notNull(),
+    senderId: text("sender_id").notNull(),
+    targetId: text("target_id").notNull(),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+  },
+  (table) => [
+    index("idx_nudge_log_lookup").using(
+      "btree",
+      table.competitionId.asc().nullsLast(),
+      table.senderId.asc().nullsLast(),
+      table.targetId.asc().nullsLast(),
+      table.createdAt.asc().nullsLast(),
+    ),
+    index("idx_nudge_log_rate_limit").using(
+      "btree",
+      table.competitionId.asc().nullsLast(),
+      table.senderId.asc().nullsLast(),
+      table.targetId.asc().nullsLast(),
+      table.createdAt.asc().nullsLast(),
+    ),
+  ],
+);
 
-export const workoutCompletionNotifications = pgTable("workout_completion_notifications", {
-	id: uuid().defaultRandom().primaryKey().notNull(),
-	userId: text("user_id").notNull(),
-	notifiedDate: date("notified_date").notNull(),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-}, (table) => [
-	unique("workout_completion_notifications_user_id_notified_date_key").on(table.userId, table.notifiedDate),
-]);
+export const workoutCompletionNotifications = pgTable(
+  "workout_completion_notifications",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    userId: text("user_id").notNull(),
+    notifiedDate: date("notified_date").notNull(),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+  },
+  (table) => [
+    unique("workout_completion_notifications_user_id_notified_date_key").on(
+      table.userId,
+      table.notifiedDate,
+    ),
+  ],
+);
 
-export const milestoneNotifications = pgTable("milestone_notifications", {
-	id: uuid().defaultRandom().primaryKey().notNull(),
-	milestoneKey: text("milestone_key").notNull(),
-	competitionId: text("competition_id"),
-	userId: text("user_id"),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-}, (table) => [
-	unique("milestone_notifications_milestone_key_key").on(table.milestoneKey),
-]);
+export const milestoneNotifications = pgTable(
+  "milestone_notifications",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    milestoneKey: text("milestone_key").notNull(),
+    competitionId: text("competition_id"),
+    userId: text("user_id"),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+  },
+  (table) => [
+    unique("milestone_notifications_milestone_key_key").on(table.milestoneKey),
+  ],
+);
 
-export const badges = pgTable("badges", {
-	badgeId: text("badge_id").primaryKey().notNull(),
-	category: text().notNull(),
-	name: text().notNull(),
-	description: text().notNull(),
-	icon: text().notNull(),
-	rarity: text().notNull(),
-	requirement: numeric(),
-	isHidden: boolean("is_hidden").default(false).notNull(),
-	sortOrder: integer("sort_order").default(0).notNull(),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-}, (table) => [
-	index("idx_badges_category").using("btree", table.category.asc().nullsLast()),
-	check("badges_rarity_check", sql`rarity = ANY (ARRAY['common'::text, 'rare'::text, 'legendary'::text])`),
-]);
+export const badges = pgTable(
+  "badges",
+  {
+    badgeId: text("badge_id").primaryKey().notNull(),
+    category: text().notNull(),
+    name: text().notNull(),
+    description: text().notNull(),
+    icon: text().notNull(),
+    rarity: text().notNull(),
+    requirement: numeric(),
+    isHidden: boolean("is_hidden").default(false).notNull(),
+    sortOrder: integer("sort_order").default(0).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("idx_badges_category").using(
+      "btree",
+      table.category.asc().nullsLast(),
+    ),
+    check(
+      "badges_rarity_check",
+      sql`rarity = ANY (ARRAY['common'::text, 'rare'::text, 'legendary'::text])`,
+    ),
+  ],
+);
 
-export const userBadges = pgTable("user_badges", {
-	id: bigserial({ mode: "bigint" }).primaryKey().notNull(),
-	userId: text("user_id").notNull(),
-	badgeId: text("badge_id").notNull(),
-	earnedAt: timestamp("earned_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-	isNew: boolean("is_new").default(true).notNull(),
-	triggeringWorkoutId: varchar("triggering_workout_id", { length: 255 }),
-	progressSnapshot: jsonb("progress_snapshot"),
-	pinSlot: integer("pin_slot"),
-}, (table) => [
-	index("idx_user_badges_user").using("btree", table.userId.asc().nullsLast()),
-	index("idx_user_badges_user_new").using("btree", table.userId.asc().nullsLast()).where(sql`(is_new = true)`),
-	uniqueIndex("idx_user_badges_user_pin_slot").using("btree", table.userId.asc().nullsLast(), table.pinSlot.asc().nullsLast()).where(sql`(pin_slot IS NOT NULL)`),
-	index("idx_user_badges_workout").using("btree", table.triggeringWorkoutId.asc().nullsLast()),
-	foreignKey({
-			columns: [table.userId],
-			foreignColumns: [users.userId],
-			name: "user_badges_user_id_fkey"
-		}).onDelete("cascade"),
-	foreignKey({
-			columns: [table.badgeId],
-			foreignColumns: [badges.badgeId],
-			name: "user_badges_badge_id_fkey"
-		}).onDelete("cascade"),
-	foreignKey({
-			columns: [table.triggeringWorkoutId],
-			foreignColumns: [workouts.workoutId],
-			name: "user_badges_triggering_workout_id_fkey"
-		}).onDelete("set null"),
-	unique("user_badges_user_id_badge_id_key").on(table.userId, table.badgeId),
-	check("user_badges_pin_slot_range", sql`(pin_slot IS NULL) OR ((pin_slot >= 0) AND (pin_slot <= 2))`),
-]);
+export const userBadges = pgTable(
+  "user_badges",
+  {
+    id: bigserial({ mode: "bigint" }).primaryKey().notNull(),
+    userId: text("user_id").notNull(),
+    badgeId: text("badge_id").notNull(),
+    earnedAt: timestamp("earned_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+    isNew: boolean("is_new").default(true).notNull(),
+    triggeringWorkoutId: varchar("triggering_workout_id", { length: 255 }),
+    progressSnapshot: jsonb("progress_snapshot"),
+    pinSlot: integer("pin_slot"),
+  },
+  (table) => [
+    index("idx_user_badges_user").using(
+      "btree",
+      table.userId.asc().nullsLast(),
+    ),
+    index("idx_user_badges_user_new")
+      .using("btree", table.userId.asc().nullsLast())
+      .where(sql`(is_new = true)`),
+    uniqueIndex("idx_user_badges_user_pin_slot")
+      .using(
+        "btree",
+        table.userId.asc().nullsLast(),
+        table.pinSlot.asc().nullsLast(),
+      )
+      .where(sql`(pin_slot IS NOT NULL)`),
+    index("idx_user_badges_workout").using(
+      "btree",
+      table.triggeringWorkoutId.asc().nullsLast(),
+    ),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.userId],
+      name: "user_badges_user_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.badgeId],
+      foreignColumns: [badges.badgeId],
+      name: "user_badges_badge_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.triggeringWorkoutId],
+      foreignColumns: [workouts.workoutId],
+      name: "user_badges_triggering_workout_id_fkey",
+    }).onDelete("set null"),
+    unique("user_badges_user_id_badge_id_key").on(table.userId, table.badgeId),
+    check(
+      "user_badges_pin_slot_range",
+      sql`(pin_slot IS NULL) OR ((pin_slot >= 0) AND (pin_slot <= 2))`,
+    ),
+  ],
+);
 
-export const inAppNotifications = pgTable("in_app_notifications", {
-	id: uuid().defaultRandom().primaryKey().notNull(),
-	userId: text("user_id").notNull(),
-	title: text().notNull(),
-	body: text().notNull(),
-	type: text().notNull(),
-	data: jsonb().default({}),
-	isRead: boolean("is_read").default(false),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-}, (table) => [
-	index("idx_in_app_notifications_unread").using("btree", table.userId.asc().nullsLast(), table.isRead.asc().nullsLast()).where(sql`(is_read = false)`),
-	index("idx_in_app_notifications_user").using("btree", table.userId.asc().nullsLast(), table.createdAt.desc().nullsFirst()),
-	foreignKey({
-			columns: [table.userId],
-			foreignColumns: [users.userId],
-			name: "in_app_notifications_user_id_fkey"
-		}),
-]);
+export const inAppNotifications = pgTable(
+  "in_app_notifications",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    userId: text("user_id").notNull(),
+    title: text().notNull(),
+    body: text().notNull(),
+    type: text().notNull(),
+    data: jsonb().default({}),
+    isRead: boolean("is_read").default(false),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+  },
+  (table) => [
+    index("idx_in_app_notifications_unread")
+      .using(
+        "btree",
+        table.userId.asc().nullsLast(),
+        table.isRead.asc().nullsLast(),
+      )
+      .where(sql`(is_read = false)`),
+    index("idx_in_app_notifications_user").using(
+      "btree",
+      table.userId.asc().nullsLast(),
+      table.createdAt.desc().nullsFirst(),
+    ),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.userId],
+      name: "in_app_notifications_user_id_fkey",
+    }),
+  ],
+);
 
-export const notificationLog = pgTable("notification_log", {
-	id: uuid().defaultRandom().primaryKey().notNull(),
-	userId: text("user_id").notNull(),
-	type: text().notNull(),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-}, (table) => [
-	index("idx_notification_log_user_date").using("btree", table.userId.asc().nullsLast(), table.createdAt.asc().nullsLast()),
-]);
+export const notificationLog = pgTable(
+  "notification_log",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    userId: text("user_id").notNull(),
+    type: text().notNull(),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+  },
+  (table) => [
+    index("idx_notification_log_user_date").using(
+      "btree",
+      table.userId.asc().nullsLast(),
+      table.createdAt.asc().nullsLast(),
+    ),
+  ],
+);
 
-export const userChallengeCompletions = pgTable("user_challenge_completions", {
-	id: bigserial({ mode: "bigint" }).primaryKey().notNull(),
-	userId: text("user_id").notNull(),
-	localDate: date("local_date").notNull(),
-	challengeKey: text("challenge_key").notNull(),
-	completedAt: timestamp("completed_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-	completingWorkoutId: varchar("completing_workout_id", { length: 255 }),
-}, (table) => [
-	index("idx_ucc_user").using("btree", table.userId.asc().nullsLast()),
-	index("idx_ucc_user_date").using("btree", table.userId.asc().nullsLast(), table.localDate.desc().nullsFirst()),
-	foreignKey({
-			columns: [table.userId],
-			foreignColumns: [users.userId],
-			name: "user_challenge_completions_user_id_fkey"
-		}).onDelete("cascade"),
-	foreignKey({
-			columns: [table.challengeKey],
-			foreignColumns: [dailyChallenges.challengeKey],
-			name: "user_challenge_completions_challenge_key_fkey"
-		}),
-	foreignKey({
-			columns: [table.completingWorkoutId],
-			foreignColumns: [workouts.workoutId],
-			name: "user_challenge_completions_completing_workout_id_fkey"
-		}).onDelete("set null"),
-	unique("user_challenge_completions_user_id_local_date_key").on(table.userId, table.localDate),
-]);
+export const userChallengeCompletions = pgTable(
+  "user_challenge_completions",
+  {
+    id: bigserial({ mode: "bigint" }).primaryKey().notNull(),
+    userId: text("user_id").notNull(),
+    localDate: date("local_date").notNull(),
+    challengeKey: text("challenge_key").notNull(),
+    completedAt: timestamp("completed_at", {
+      withTimezone: true,
+      mode: "string",
+    })
+      .defaultNow()
+      .notNull(),
+    completingWorkoutId: varchar("completing_workout_id", { length: 255 }),
+  },
+  (table) => [
+    index("idx_ucc_user").using("btree", table.userId.asc().nullsLast()),
+    index("idx_ucc_user_date").using(
+      "btree",
+      table.userId.asc().nullsLast(),
+      table.localDate.desc().nullsFirst(),
+    ),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.userId],
+      name: "user_challenge_completions_user_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.challengeKey],
+      foreignColumns: [dailyChallenges.challengeKey],
+      name: "user_challenge_completions_challenge_key_fkey",
+    }),
+    foreignKey({
+      columns: [table.completingWorkoutId],
+      foreignColumns: [workouts.workoutId],
+      name: "user_challenge_completions_completing_workout_id_fkey",
+    }).onDelete("set null"),
+    unique("user_challenge_completions_user_id_local_date_key").on(
+      table.userId,
+      table.localDate,
+    ),
+  ],
+);
 
-export const dailyChallenges = pgTable("daily_challenges", {
-	challengeKey: text("challenge_key").primaryKey().notNull(),
-	title: text().notNull(),
-	descriptionTemplate: text("description_template").notNull(),
-	icon: text().notNull(),
-	gradientStart: text("gradient_start").notNull(),
-	gradientEnd: text("gradient_end").notNull(),
-	type: text().notNull(),
-	active: boolean().default(true).notNull(),
-	rotationIndex: integer("rotation_index").notNull(),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-}, (table) => [
-	unique("daily_challenges_rotation_index_key").on(table.rotationIndex),
-	check("daily_challenges_type_check", sql`type = ANY (ARRAY['pace'::text, 'distance'::text, 'time'::text, 'activity'::text, 'steps'::text])`),
-]);
+export const dailyChallenges = pgTable(
+  "daily_challenges",
+  {
+    challengeKey: text("challenge_key").primaryKey().notNull(),
+    title: text().notNull(),
+    descriptionTemplate: text("description_template").notNull(),
+    icon: text().notNull(),
+    gradientStart: text("gradient_start").notNull(),
+    gradientEnd: text("gradient_end").notNull(),
+    type: text().notNull(),
+    active: boolean().default(true).notNull(),
+    rotationIndex: integer("rotation_index").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    unique("daily_challenges_rotation_index_key").on(table.rotationIndex),
+    check(
+      "daily_challenges_type_check",
+      sql`type = ANY (ARRAY['pace'::text, 'distance'::text, 'time'::text, 'activity'::text, 'steps'::text])`,
+    ),
+  ],
+);
 
-export const hypeLog = pgTable("hype_log", {
-	id: uuid().defaultRandom().primaryKey().notNull(),
-	senderId: text("sender_id").notNull(),
-	targetId: text("target_id").notNull(),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-	contextType: text("context_type"),
-	contextId: text("context_id"),
-	contextLabel: text("context_label"),
-}, (table) => [
-	uniqueIndex("hype_log_context_dedupe_idx").using("btree", table.senderId.asc().nullsLast(), table.targetId.asc().nullsLast(), table.contextType.asc().nullsLast(), table.contextId.asc().nullsLast()).where(sql`(context_id IS NOT NULL)`),
-	index("idx_hype_log_lookup").using("btree", table.senderId.asc().nullsLast(), table.createdAt.desc().nullsFirst()),
-]);
+export const hypeLog = pgTable(
+  "hype_log",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    senderId: text("sender_id").notNull(),
+    targetId: text("target_id").notNull(),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+    contextType: text("context_type"),
+    contextId: text("context_id"),
+    contextLabel: text("context_label"),
+  },
+  (table) => [
+    uniqueIndex("hype_log_context_dedupe_idx")
+      .using(
+        "btree",
+        table.senderId.asc().nullsLast(),
+        table.targetId.asc().nullsLast(),
+        table.contextType.asc().nullsLast(),
+        table.contextId.asc().nullsLast(),
+      )
+      .where(sql`(context_id IS NOT NULL)`),
+    index("idx_hype_log_lookup").using(
+      "btree",
+      table.senderId.asc().nullsLast(),
+      table.createdAt.desc().nullsFirst(),
+    ),
+  ],
+);
 
-export const pendingFriendNotifications = pgTable("pending_friend_notifications", {
-	id: bigserial({ mode: "bigint" }).primaryKey().notNull(),
-	userId: text("user_id").notNull(),
-	eventType: text("event_type").notNull(),
-	activityType: text("activity_type").default('').notNull(),
-	workoutId: text("workout_id"),
-	payload: jsonb().notNull(),
-	localDate: date("local_date").notNull(),
-	status: text().default('pending').notNull(),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-}, (table) => [
-	index("idx_pending_friend_notif_user").using("btree", table.userId.asc().nullsLast(), table.status.asc().nullsLast()),
-	uniqueIndex("uq_pending_friend_notif_workout").using("btree", table.userId.asc().nullsLast(), table.eventType.asc().nullsLast(), table.workoutId.asc().nullsLast()).where(sql`((workout_id IS NOT NULL) AND (status = 'pending'::text))`),
-	check("pending_friend_notifications_status_check", sql`status = ANY (ARRAY['pending'::text, 'sent'::text, 'dismissed'::text, 'expired'::text])`),
-]);
+export const pendingFriendNotifications = pgTable(
+  "pending_friend_notifications",
+  {
+    id: bigserial({ mode: "bigint" }).primaryKey().notNull(),
+    userId: text("user_id").notNull(),
+    eventType: text("event_type").notNull(),
+    activityType: text("activity_type").default("").notNull(),
+    workoutId: text("workout_id"),
+    payload: jsonb().notNull(),
+    localDate: date("local_date").notNull(),
+    status: text().default("pending").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("idx_pending_friend_notif_user").using(
+      "btree",
+      table.userId.asc().nullsLast(),
+      table.status.asc().nullsLast(),
+    ),
+    uniqueIndex("uq_pending_friend_notif_workout")
+      .using(
+        "btree",
+        table.userId.asc().nullsLast(),
+        table.eventType.asc().nullsLast(),
+        table.workoutId.asc().nullsLast(),
+      )
+      .where(sql`((workout_id IS NOT NULL) AND (status = 'pending'::text))`),
+    check(
+      "pending_friend_notifications_status_check",
+      sql`status = ANY (ARRAY['pending'::text, 'sent'::text, 'dismissed'::text, 'expired'::text])`,
+    ),
+  ],
+);
 
-export const friendships = pgTable("friendships", {
-	userId: text("user_id").notNull(),
-	friendId: text("friend_id").notNull(),
-	status: text().default('pending').notNull(),
-}, (table) => [
-	index("idx_friendships_friend_status").using("btree", table.friendId.asc().nullsLast(), table.status.asc().nullsLast()),
-	index("idx_friendships_user_status").using("btree", table.userId.asc().nullsLast(), table.status.asc().nullsLast()),
-	foreignKey({
-			columns: [table.userId],
-			foreignColumns: [users.userId],
-			name: "friendships_user_id_fkey"
-		}).onDelete("cascade"),
-	foreignKey({
-			columns: [table.friendId],
-			foreignColumns: [users.userId],
-			name: "friendships_friend_id_fkey"
-		}).onDelete("cascade"),
-	primaryKey({ columns: [table.userId, table.friendId], name: "friendships_pkey"}),
-	unique("unique_friendship_pair").on(table.userId, table.friendId),
-]);
+export const friendships = pgTable(
+  "friendships",
+  {
+    userId: text("user_id").notNull(),
+    friendId: text("friend_id").notNull(),
+    status: text().default("pending").notNull(),
+  },
+  (table) => [
+    index("idx_friendships_friend_status").using(
+      "btree",
+      table.friendId.asc().nullsLast(),
+      table.status.asc().nullsLast(),
+    ),
+    index("idx_friendships_user_status").using(
+      "btree",
+      table.userId.asc().nullsLast(),
+      table.status.asc().nullsLast(),
+    ),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.userId],
+      name: "friendships_user_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.friendId],
+      foreignColumns: [users.userId],
+      name: "friendships_friend_id_fkey",
+    }).onDelete("cascade"),
+    primaryKey({
+      columns: [table.userId, table.friendId],
+      name: "friendships_pkey",
+    }),
+    unique("unique_friendship_pair").on(table.userId, table.friendId),
+  ],
+);
 
-export const closeFriends = pgTable("close_friends", {
-	userId: text("user_id").notNull(),
-	closeFriendId: text("close_friend_id").notNull(),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-}, (table) => [
-	index("idx_close_friends_friend").using("btree", table.closeFriendId.asc().nullsLast()),
-	primaryKey({ columns: [table.userId, table.closeFriendId], name: "close_friends_pkey"}),
-]);
+export const closeFriends = pgTable(
+  "close_friends",
+  {
+    userId: text("user_id").notNull(),
+    closeFriendId: text("close_friend_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("idx_close_friends_friend").using(
+      "btree",
+      table.closeFriendId.asc().nullsLast(),
+    ),
+    primaryKey({
+      columns: [table.userId, table.closeFriendId],
+      name: "close_friends_pkey",
+    }),
+  ],
+);
 
-export const dailySteps = pgTable("daily_steps", {
-	userId: text("user_id").notNull(),
-	localDate: date("local_date").notNull(),
-	steps: integer().notNull(),
-	timezoneOffset: integer("timezone_offset").notNull(),
-	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-}, (table) => [
-	index("idx_daily_steps_user_date").using("btree", table.userId.asc().nullsLast(), table.localDate.desc().nullsFirst()),
-	foreignKey({
-			columns: [table.userId],
-			foreignColumns: [users.userId],
-			name: "daily_steps_user_id_fkey"
-		}).onDelete("cascade"),
-	primaryKey({ columns: [table.userId, table.localDate], name: "daily_steps_pkey"}),
-	check("daily_steps_steps_check", sql`steps >= 0`),
-]);
+export const dailySteps = pgTable(
+  "daily_steps",
+  {
+    userId: text("user_id").notNull(),
+    localDate: date("local_date").notNull(),
+    steps: integer().notNull(),
+    timezoneOffset: integer("timezone_offset").notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("idx_daily_steps_user_date").using(
+      "btree",
+      table.userId.asc().nullsLast(),
+      table.localDate.desc().nullsFirst(),
+    ),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.userId],
+      name: "daily_steps_user_id_fkey",
+    }).onDelete("cascade"),
+    primaryKey({
+      columns: [table.userId, table.localDate],
+      name: "daily_steps_pkey",
+    }),
+    check("daily_steps_steps_check", sql`steps >= 0`),
+  ],
+);
 
-export const notificationAudienceSettings = pgTable("notification_audience_settings", {
-	userId: text("user_id").notNull(),
-	direction: text().notNull(),
-	eventType: text("event_type").notNull(),
-	activityType: text("activity_type").default('').notNull(),
-	audience: text().notNull(),
-	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-}, (table) => [
-	primaryKey({ columns: [table.userId, table.direction, table.eventType, table.activityType], name: "notification_audience_settings_pkey"}),
-	check("notification_audience_settings_direction_check", sql`direction = ANY (ARRAY['outgoing'::text, 'incoming'::text])`),
-	check("notification_audience_settings_audience_check", sql`audience = ANY (ARRAY['none'::text, 'close'::text, 'all'::text, 'ask'::text, 'match_run'::text])`),
-]);
+export const notificationAudienceSettings = pgTable(
+  "notification_audience_settings",
+  {
+    userId: text("user_id").notNull(),
+    direction: text().notNull(),
+    eventType: text("event_type").notNull(),
+    activityType: text("activity_type").default("").notNull(),
+    audience: text().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [
+        table.userId,
+        table.direction,
+        table.eventType,
+        table.activityType,
+      ],
+      name: "notification_audience_settings_pkey",
+    }),
+    check(
+      "notification_audience_settings_direction_check",
+      sql`direction = ANY (ARRAY['outgoing'::text, 'incoming'::text])`,
+    ),
+    check(
+      "notification_audience_settings_audience_check",
+      sql`audience = ANY (ARRAY['none'::text, 'close'::text, 'all'::text, 'ask'::text, 'match_run'::text])`,
+    ),
+  ],
+);
 
-export const friendNotificationSettings = pgTable("friend_notification_settings", {
-	userId: text("user_id").notNull(),
-	friendId: text("friend_id").notNull(),
-	muted: boolean().default(false).notNull(),
-	nudgesMuted: boolean("nudges_muted").default(false).notNull(),
-	activityMuted: boolean("activity_muted").default(false).notNull(),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow(),
-}, (table) => [
-	primaryKey({ columns: [table.userId, table.friendId], name: "friend_notification_settings_pkey"}),
-]);
+export const friendNotificationSettings = pgTable(
+  "friend_notification_settings",
+  {
+    userId: text("user_id").notNull(),
+    friendId: text("friend_id").notNull(),
+    muted: boolean().default(false).notNull(),
+    nudgesMuted: boolean("nudges_muted").default(false).notNull(),
+    activityMuted: boolean("activity_muted").default(false).notNull(),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+    updatedAt: timestamp("updated_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.userId, table.friendId],
+      name: "friend_notification_settings_pkey",
+    }),
+  ],
+);
 
-export const competitionUsers = pgTable("competition_users", {
-	competitionId: text("competition_id").notNull(),
-	userId: text("user_id").notNull(),
-	progress: jsonb(),
-	inviteStatus: varchar("invite_status", { length: 20 }),
-	placement: integer(),
-	lastKnownRank: integer("last_known_rank"),
-	lastKnownScore: doublePrecision("last_known_score"),
-	lastRankUpdatedAt: timestamp("last_rank_updated_at", { withTimezone: true, mode: 'string' }),
-}, (table) => [
-	index("idx_competition_users_comp").using("btree", table.competitionId.asc().nullsLast()),
-	index("idx_competition_users_competition").using("btree", table.competitionId.asc().nullsLast()),
-	index("idx_competition_users_rank_cache").using("btree", table.competitionId.asc().nullsLast(), table.lastKnownRank.asc().nullsLast()).where(sql`((invite_status)::text = 'accepted'::text)`),
-	index("idx_competition_users_user").using("btree", table.userId.asc().nullsLast()),
-	index("idx_competition_users_user_status").using("btree", table.userId.asc().nullsLast(), table.inviteStatus.asc().nullsLast()),
-	foreignKey({
-			columns: [table.userId],
-			foreignColumns: [users.userId],
-			name: "competition_users_user_id_fkey"
-		}).onDelete("cascade"),
-	foreignKey({
-			columns: [table.competitionId],
-			foreignColumns: [competitions.id],
-			name: "competition_users_competition_id_fkey"
-		}).onDelete("cascade"),
-	primaryKey({ columns: [table.competitionId, table.userId], name: "competition_users_pkey"}),
-	check("competition_users_invite_status_check", sql`(invite_status)::text = ANY ((ARRAY['pending'::character varying, 'accepted'::character varying, 'declined'::character varying])::text[])`),
-]);
+export const competitionUsers = pgTable(
+  "competition_users",
+  {
+    competitionId: text("competition_id").notNull(),
+    userId: text("user_id").notNull(),
+    progress: jsonb(),
+    inviteStatus: varchar("invite_status", { length: 20 }),
+    placement: integer(),
+    lastKnownRank: integer("last_known_rank"),
+    lastKnownScore: doublePrecision("last_known_score"),
+    lastRankUpdatedAt: timestamp("last_rank_updated_at", {
+      withTimezone: true,
+      mode: "string",
+    }),
+  },
+  (table) => [
+    index("idx_competition_users_comp").using(
+      "btree",
+      table.competitionId.asc().nullsLast(),
+    ),
+    index("idx_competition_users_competition").using(
+      "btree",
+      table.competitionId.asc().nullsLast(),
+    ),
+    index("idx_competition_users_rank_cache")
+      .using(
+        "btree",
+        table.competitionId.asc().nullsLast(),
+        table.lastKnownRank.asc().nullsLast(),
+      )
+      .where(sql`((invite_status)::text = 'accepted'::text)`),
+    index("idx_competition_users_user").using(
+      "btree",
+      table.userId.asc().nullsLast(),
+    ),
+    index("idx_competition_users_user_status").using(
+      "btree",
+      table.userId.asc().nullsLast(),
+      table.inviteStatus.asc().nullsLast(),
+    ),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.userId],
+      name: "competition_users_user_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.competitionId],
+      foreignColumns: [competitions.id],
+      name: "competition_users_competition_id_fkey",
+    }).onDelete("cascade"),
+    primaryKey({
+      columns: [table.competitionId, table.userId],
+      name: "competition_users_pkey",
+    }),
+    check(
+      "competition_users_invite_status_check",
+      sql`(invite_status)::text = ANY ((ARRAY['pending'::character varying, 'accepted'::character varying, 'declined'::character varying])::text[])`,
+    ),
+  ],
+);
+
+// User-generated social posts. A single row is the unit of content (photo +
+// optional caption + denormalized run stats) and can be surfaced as a Story
+// (24h ephemeral, share_to_story) and/or in the permanent Feed (share_to_feed).
+// The photo is uploaded flattened (overlay baked in) to /uploads/posts/.
+export const posts = pgTable(
+  "posts",
+  {
+    postId: uuid("post_id").defaultRandom().primaryKey().notNull(),
+    userId: text("user_id").notNull(),
+    mediaUrl: text("media_url").notNull(),
+    caption: text(),
+    workoutId: varchar("workout_id", { length: 255 }),
+    // Denormalized {distance, pace, duration, streak, date} captured at post time
+    // so the post survives later edits/deletes of the underlying workout.
+    statsSnapshot: jsonb("stats_snapshot"),
+    localDate: date("local_date").notNull(),
+    shareToFeed: boolean("share_to_feed").default(true).notNull(),
+    shareToStory: boolean("share_to_story").default(false).notNull(),
+    // Absolute expiry (created_at + 24h) set only when shared to story.
+    storyExpiresAt: timestamp("story_expires_at", {
+      withTimezone: true,
+      mode: "string",
+    }),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true, mode: "string" }),
+  },
+  (table) => [
+    index("idx_posts_user_created").using(
+      "btree",
+      table.userId.asc().nullsLast(),
+      table.createdAt.desc().nullsFirst(),
+    ),
+    index("idx_posts_feed")
+      .using("btree", table.createdAt.desc().nullsFirst())
+      .where(sql`(deleted_at IS NULL AND share_to_feed)`),
+    index("idx_posts_story_active")
+      .using(
+        "btree",
+        table.userId.asc().nullsLast(),
+        table.storyExpiresAt.asc().nullsLast(),
+      )
+      .where(sql`(deleted_at IS NULL AND share_to_story)`),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.userId],
+      name: "posts_user_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.workoutId],
+      foreignColumns: [workouts.workoutId],
+      name: "posts_workout_id_fkey",
+    }).onDelete("set null"),
+  ],
+);
+
+// One row per (story, viewer) — powers the "unviewed first" ordering and the
+// seen-ring state in the stories rail.
+export const storyViews = pgTable(
+  "story_views",
+  {
+    postId: uuid("post_id").notNull(),
+    viewerId: text("viewer_id").notNull(),
+    viewedAt: timestamp("viewed_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.postId],
+      foreignColumns: [posts.postId],
+      name: "story_views_post_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.viewerId],
+      foreignColumns: [users.userId],
+      name: "story_views_viewer_id_fkey",
+    }).onDelete("cascade"),
+    primaryKey({
+      columns: [table.postId, table.viewerId],
+      name: "story_views_pkey",
+    }),
+  ],
+);
+
+// Abuse reports on posts (App Store Guideline 1.2). One report per
+// (post, reporter); moderators action the open queue.
+export const postReports = pgTable(
+  "post_reports",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    postId: uuid("post_id").notNull(),
+    reporterId: text("reporter_id").notNull(),
+    reason: text().notNull(),
+    details: text(),
+    status: text().default("open").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("post_reports_dedupe_idx").using(
+      "btree",
+      table.postId.asc().nullsLast(),
+      table.reporterId.asc().nullsLast(),
+    ),
+    index("idx_post_reports_status").using(
+      "btree",
+      table.status.asc().nullsLast(),
+      table.createdAt.desc().nullsFirst(),
+    ),
+    foreignKey({
+      columns: [table.postId],
+      foreignColumns: [posts.postId],
+      name: "post_reports_post_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.reporterId],
+      foreignColumns: [users.userId],
+      name: "post_reports_reporter_id_fkey",
+    }).onDelete("cascade"),
+    check(
+      "post_reports_reason_check",
+      sql`reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])`,
+    ),
+  ],
+);
+
+// Directed user blocks. Filtering applies in BOTH directions so neither party
+// sees the other's posts/stories once a block exists.
+export const userBlocks = pgTable(
+  "user_blocks",
+  {
+    blockerId: text("blocker_id").notNull(),
+    blockedId: text("blocked_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("idx_user_blocks_blocked").using(
+      "btree",
+      table.blockedId.asc().nullsLast(),
+    ),
+    foreignKey({
+      columns: [table.blockerId],
+      foreignColumns: [users.userId],
+      name: "user_blocks_blocker_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.blockedId],
+      foreignColumns: [users.userId],
+      name: "user_blocks_blocked_id_fkey",
+    }).onDelete("cascade"),
+    primaryKey({
+      columns: [table.blockerId, table.blockedId],
+      name: "user_blocks_pkey",
+    }),
+  ],
+);

--- a/backend/src/routes/blocksRoutes.ts
+++ b/backend/src/routes/blocksRoutes.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import {
+  blockUserController,
+  unblockUserController,
+} from "../controllers/blocksController.js";
+
+const router = Router();
+
+router.post("/:userId", blockUserController);
+router.delete("/:userId", unblockUserController);
+
+export default router;

--- a/backend/src/routes/postsRoutes.ts
+++ b/backend/src/routes/postsRoutes.ts
@@ -1,0 +1,51 @@
+import { Router } from "express";
+import multer from "multer";
+import {
+  uploadPostMedia,
+  createPostController,
+  getStoriesRailController,
+  getUserStoriesController,
+  markStoryViewedController,
+  getFeedController,
+  deletePostController,
+  reportPostController,
+  getTermsStatusController,
+  acceptTermsController,
+} from "../controllers/postsController.js";
+
+// Post photos are larger than avatars (full-res portrait stories), so allow 8MB.
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 8 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    if (["image/jpeg", "image/png", "image/webp"].includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error("Only JPEG, PNG, and WebP images are allowed"));
+    }
+  },
+});
+
+const router = Router();
+
+// Terms / EULA gate (App Store Guideline 1.2).
+router.get("/terms", getTermsStatusController);
+router.post("/terms/accept", acceptTermsController);
+
+// Media upload, then JSON create referencing the returned media_url.
+router.post("/media", upload.single("image"), uploadPostMedia);
+router.post("/", createPostController);
+
+// Stories.
+router.get("/stories", getStoriesRailController);
+router.get("/stories/:userId", getUserStoriesController);
+router.post("/stories/:postId/view", markStoryViewedController);
+
+// Persistent feed.
+router.get("/feed", getFeedController);
+
+// Per-post actions.
+router.post("/:postId/report", reportPostController);
+router.delete("/:postId", deletePostController);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,67 +1,74 @@
-import 'dotenv/config';
-import express, { Request, Response, NextFunction } from 'express';
-import compression from 'compression';
-import http from 'http';
-import fs from 'fs';
-import path from 'path';
-import userRoutes from './routes/usersRoutes.js';
-import friendRoutes from './routes/friendshipsRoutes.js';
-import authRoutes from './routes/authRoutes.js';
-import devRoutes from './routes/devRoutes.js';
-import workoutRoutes from './routes/workoutRoutes.js';
-import competitionRoutes from './routes/competitionRoutes.js';
-import deviceRoutes from './routes/deviceRoutes.js';
-import notificationRoutes from './routes/notificationRoutes.js';
-import hypeRoutes from './routes/hypeRoutes.js';
-import badgesRoutes, { publicBadgesRouter } from './routes/badgesRoutes.js';
-import dailyChallengesRoutes from './routes/dailyChallengesRoutes.js';
-import dailyStepsRoutes from './routes/dailyStepsRoutes.js';
-import leaderboardRoutes from './routes/leaderboardRoutes.js';
-import publicRoutes from './routes/publicRoutes.js';
-import { authenticateToken } from './middleware/auth.js';
-import { startCompetitionCron } from './cron/competitionCron.js';
-import { startNotificationCron } from './cron/notificationCron.js';
-import { startSilentSyncCron } from './cron/silentSyncCron.js';
-import { PostgresService } from './services/DbService.js';
-import { webcrypto } from 'node:crypto';
+import "dotenv/config";
+import express, { Request, Response, NextFunction } from "express";
+import compression from "compression";
+import http from "http";
+import fs from "fs";
+import path from "path";
+import userRoutes from "./routes/usersRoutes.js";
+import friendRoutes from "./routes/friendshipsRoutes.js";
+import authRoutes from "./routes/authRoutes.js";
+import devRoutes from "./routes/devRoutes.js";
+import workoutRoutes from "./routes/workoutRoutes.js";
+import competitionRoutes from "./routes/competitionRoutes.js";
+import deviceRoutes from "./routes/deviceRoutes.js";
+import notificationRoutes from "./routes/notificationRoutes.js";
+import hypeRoutes from "./routes/hypeRoutes.js";
+import postsRoutes from "./routes/postsRoutes.js";
+import blocksRoutes from "./routes/blocksRoutes.js";
+import badgesRoutes, { publicBadgesRouter } from "./routes/badgesRoutes.js";
+import dailyChallengesRoutes from "./routes/dailyChallengesRoutes.js";
+import dailyStepsRoutes from "./routes/dailyStepsRoutes.js";
+import leaderboardRoutes from "./routes/leaderboardRoutes.js";
+import publicRoutes from "./routes/publicRoutes.js";
+import { authenticateToken } from "./middleware/auth.js";
+import { startCompetitionCron } from "./cron/competitionCron.js";
+import { startNotificationCron } from "./cron/notificationCron.js";
+import { startSilentSyncCron } from "./cron/silentSyncCron.js";
+import { startStoriesCron } from "./cron/storiesCron.js";
+import { PostgresService } from "./services/DbService.js";
+import { webcrypto } from "node:crypto";
 
 (globalThis as any).crypto ??= webcrypto;
 
 const app = express();
-const PORT = parseInt(process.env.PORT ?? '3000');
+const PORT = parseInt(process.env.PORT ?? "3000");
 
 app.use(compression());
 app.use(express.json());
 
-// Ensure uploads directory exists
-const uploadsDir = path.join(process.cwd(), 'uploads', 'profile-images');
+// Ensure uploads directories exist
+const uploadsDir = path.join(process.cwd(), "uploads", "profile-images");
 fs.mkdirSync(uploadsDir, { recursive: true });
+fs.mkdirSync(path.join(process.cwd(), "uploads", "posts"), { recursive: true });
 
-app.use('/uploads', express.static(path.join(process.cwd(), 'uploads')));
+app.use("/uploads", express.static(path.join(process.cwd(), "uploads")));
 
-app.get('/status', (req, res) => {
-	res.send('healthy');
+app.get("/status", (req, res) => {
+  res.send("healthy");
 });
 
-app.get('/test-signin.html', (req, res) => {
-	res.sendFile(path.join(process.cwd(), 'test-signin.html'));
+app.get("/test-signin.html", (req, res) => {
+  res.sendFile(path.join(process.cwd(), "test-signin.html"));
 });
 
 // Public endpoint: get profile image URL by username
 app.get(
-	'/public/profile-image/:username',
-	(req, res, next) => {
-		res.setHeader('Access-Control-Allow-Origin', '*');
-		next();
-	},
-	async (req, res) => {
-		const db = PostgresService.getInstance();
-		const results = await db.query('SELECT profile_image_url FROM users WHERE username = $1', [req.params.username]);
-		if (!results.length || !results[0].profile_image_url) {
-			return res.status(404).json({ error: 'Not found' });
-		}
-		res.json({ profile_image_url: results[0].profile_image_url });
-	}
+  "/public/profile-image/:username",
+  (req, res, next) => {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    next();
+  },
+  async (req, res) => {
+    const db = PostgresService.getInstance();
+    const results = await db.query(
+      "SELECT profile_image_url FROM users WHERE username = $1",
+      [req.params.username],
+    );
+    if (!results.length || !results[0].profile_image_url) {
+      return res.status(404).json({ error: "Not found" });
+    }
+    res.json({ profile_image_url: results[0].profile_image_url });
+  },
 );
 
 // Public endpoint: minimal profile by username for the marketing site's
@@ -92,34 +99,37 @@ app.get(
 app.use("/auth", authRoutes);
 app.use("/dev", devRoutes);
 app.use("/badges", publicBadgesRouter);
-app.use('/public', publicRoutes);
+app.use("/public", publicRoutes);
 
 app.use(authenticateToken);
-app.use('/users', userRoutes);
-app.use('/users', badgesRoutes);
-app.use('/users', dailyChallengesRoutes);
-app.use('/users', dailyStepsRoutes);
-app.use('/friends', friendRoutes);
-app.use('/workouts', workoutRoutes);
-app.use('/competitions', competitionRoutes);
-app.use('/devices', deviceRoutes);
-app.use('/notifications', notificationRoutes);
-app.use('/hype', hypeRoutes);
-app.use('/leaderboard', leaderboardRoutes);
+app.use("/users", userRoutes);
+app.use("/users", badgesRoutes);
+app.use("/users", dailyChallengesRoutes);
+app.use("/users", dailyStepsRoutes);
+app.use("/friends", friendRoutes);
+app.use("/workouts", workoutRoutes);
+app.use("/competitions", competitionRoutes);
+app.use("/devices", deviceRoutes);
+app.use("/notifications", notificationRoutes);
+app.use("/hype", hypeRoutes);
+app.use("/posts", postsRoutes);
+app.use("/blocks", blocksRoutes);
+app.use("/leaderboard", leaderboardRoutes);
 
 app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
-	console.error('Error:', err.message);
+  console.error("Error:", err.message);
 
-	res.status(500).json({
-		error: 'Internal Server Error',
-		message: err.message
-	});
+  res.status(500).json({
+    error: "Internal Server Error",
+    message: err.message,
+  });
 });
 
 const server = http.createServer(app);
-server.listen(PORT, '0.0.0.0', () => {
-	console.log(`Server running on port ${PORT}`);
-	startCompetitionCron();
-	startNotificationCron();
-	startSilentSyncCron();
+server.listen(PORT, "0.0.0.0", () => {
+  console.log(`Server running on port ${PORT}`);
+  startCompetitionCron();
+  startNotificationCron();
+  startSilentSyncCron();
+  startStoriesCron();
 });

--- a/backend/src/services/hypeService.ts
+++ b/backend/src/services/hypeService.ts
@@ -1,6 +1,9 @@
-import { PostgresService } from './DbService.js';
-import { hasUnlimitedHypes } from './privilegedUsers.js';
-import { START_OF_TODAY_ET_SQL, START_OF_TOMORROW_ET_SQL } from './dailyResetTime.js';
+import { PostgresService } from "./DbService.js";
+import { hasUnlimitedHypes } from "./privilegedUsers.js";
+import {
+  START_OF_TODAY_ET_SQL,
+  START_OF_TOMORROW_ET_SQL,
+} from "./dailyResetTime.js";
 
 const db = PostgresService.getInstance();
 
@@ -11,13 +14,13 @@ export const HYPE_DAILY_LIMIT = 3;
  * The window resets at midnight America/New_York, not rolling 24h.
  */
 export async function getDailyHypeCount(senderId: string): Promise<number> {
-	const rows = await db.query<{ count: string }>(
-		`SELECT COUNT(*)::text AS count FROM hype_log
+  const rows = await db.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM hype_log
 		WHERE sender_id = $1
 			AND created_at >= ${START_OF_TODAY_ET_SQL}`,
-		[senderId]
-	);
-	return parseInt(rows[0]?.count ?? '0', 10);
+    [senderId],
+  );
+  return parseInt(rows[0]?.count ?? "0", 10);
 }
 
 /**
@@ -25,44 +28,47 @@ export async function getDailyHypeCount(senderId: string): Promise<number> {
  * Privileged users bypass the cap.
  */
 export async function canHype(senderId: string): Promise<boolean> {
-	if (await hasUnlimitedHypes(senderId)) return true;
-	const count = await getDailyHypeCount(senderId);
-	return count < HYPE_DAILY_LIMIT;
+  if (await hasUnlimitedHypes(senderId)) return true;
+  const count = await getDailyHypeCount(senderId);
+  return count < HYPE_DAILY_LIMIT;
 }
 
 export interface HypeContext {
-	contextType: 'mile' | 'badge' | 'pr' | 'challenge';
-	contextId: string;
-	contextLabel: string;
+  contextType: "mile" | "badge" | "pr" | "challenge" | "post";
+  contextId: string;
+  contextLabel: string;
 }
 
 export interface ReceivedHype {
-	sender_id: string;
-	username: string | null;
-	first_name: string | null;
-	last_name: string | null;
-	profile_image_url: string | null;
-	context_type: string | null;
-	context_label: string | null;
-	created_at: string;
+  sender_id: string;
+  username: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  profile_image_url: string | null;
+  context_type: string | null;
+  context_label: string | null;
+  created_at: string;
 }
 
 /**
  * Recent hypes the user has RECEIVED, newest first, with sender info — powers
  * the "you got hyped" surface on the profile so it isn't push-only.
  */
-export async function getReceivedHypes(userId: string, limit: number = 30): Promise<ReceivedHype[]> {
-	const rows = await db.query<ReceivedHype>(
-		`SELECT h.sender_id, u.username, u.first_name, u.last_name, u.profile_image_url,
+export async function getReceivedHypes(
+  userId: string,
+  limit: number = 30,
+): Promise<ReceivedHype[]> {
+  const rows = await db.query<ReceivedHype>(
+    `SELECT h.sender_id, u.username, u.first_name, u.last_name, u.profile_image_url,
 			h.context_type, h.context_label, h.created_at
 		FROM hype_log h
 		JOIN users u ON u.user_id = h.sender_id
 		WHERE h.target_id = $1
 		ORDER BY h.created_at DESC
 		LIMIT $2`,
-		[userId, limit]
-	);
-	return rows;
+    [userId, limit],
+  );
+  return rows;
 }
 
 /**
@@ -75,45 +81,45 @@ export async function getReceivedHypes(userId: string, limit: number = 30): Prom
  * function will surface a PG unique violation otherwise.
  */
 export async function logHypeIfUnderLimit(
-	senderId: string,
-	targetId: string,
-	context?: HypeContext
+  senderId: string,
+  targetId: string,
+  context?: HypeContext,
 ): Promise<{ id: string } | null> {
-	const unlimited = await hasUnlimitedHypes(senderId);
+  const unlimited = await hasUnlimitedHypes(senderId);
 
-	if (context) {
-		const sql = unlimited
-			? `INSERT INTO hype_log (sender_id, target_id, context_type, context_id, context_label)
+  if (context) {
+    const sql = unlimited
+      ? `INSERT INTO hype_log (sender_id, target_id, context_type, context_id, context_label)
 				VALUES ($1, $2, $3, $4, $5)
 				RETURNING id`
-			: `INSERT INTO hype_log (sender_id, target_id, context_type, context_id, context_label)
+      : `INSERT INTO hype_log (sender_id, target_id, context_type, context_id, context_label)
 				SELECT $1, $2, $3, $4, $5
 				WHERE (
 					SELECT COUNT(*) FROM hype_log
 					WHERE sender_id = $1 AND created_at >= ${START_OF_TODAY_ET_SQL}
 				) < ${HYPE_DAILY_LIMIT}
 				RETURNING id`;
-		const rows = await db.query<{ id: string }>(sql, [
-			senderId,
-			targetId,
-			context.contextType,
-			context.contextId,
-			context.contextLabel
-		]);
-		return rows[0] ?? null;
-	}
+    const rows = await db.query<{ id: string }>(sql, [
+      senderId,
+      targetId,
+      context.contextType,
+      context.contextId,
+      context.contextLabel,
+    ]);
+    return rows[0] ?? null;
+  }
 
-	const sql = unlimited
-		? `INSERT INTO hype_log (sender_id, target_id) VALUES ($1, $2) RETURNING id`
-		: `INSERT INTO hype_log (sender_id, target_id)
+  const sql = unlimited
+    ? `INSERT INTO hype_log (sender_id, target_id) VALUES ($1, $2) RETURNING id`
+    : `INSERT INTO hype_log (sender_id, target_id)
 			SELECT $1, $2
 			WHERE (
 				SELECT COUNT(*) FROM hype_log
 				WHERE sender_id = $1 AND created_at >= ${START_OF_TODAY_ET_SQL}
 			) < ${HYPE_DAILY_LIMIT}
 			RETURNING id`;
-	const rows = await db.query<{ id: string }>(sql, [senderId, targetId]);
-	return rows[0] ?? null;
+  const rows = await db.query<{ id: string }>(sql, [senderId, targetId]);
+  return rows[0] ?? null;
 }
 
 /**
@@ -121,31 +127,35 @@ export async function logHypeIfUnderLimit(
  * Only meaningful when context is provided; legacy NULL-context hypes are not deduped.
  */
 export async function hasHypedContext(
-	senderId: string,
-	targetId: string,
-	contextType: string,
-	contextId: string
+  senderId: string,
+  targetId: string,
+  contextType: string,
+  contextId: string,
 ): Promise<boolean> {
-	const rows = await db.query<{ exists: boolean }>(
-		`SELECT EXISTS (
+  const rows = await db.query<{ exists: boolean }>(
+    `SELECT EXISTS (
 			SELECT 1 FROM hype_log
 			WHERE sender_id = $1 AND target_id = $2
 				AND context_type = $3 AND context_id = $4
 		) AS exists`,
-		[senderId, targetId, contextType, contextId]
-	);
-	return rows[0]?.exists === true;
+    [senderId, targetId, contextType, contextId],
+  );
+  return rows[0]?.exists === true;
 }
 
 /**
  * ISO timestamp when the sender's daily cap resets — midnight ET tomorrow.
  * Returns null if they have spare capacity right now.
  */
-export async function getHypeResetsAt(senderId: string): Promise<string | null> {
-	if (await hasUnlimitedHypes(senderId)) return null;
-	const count = await getDailyHypeCount(senderId);
-	if (count < HYPE_DAILY_LIMIT) return null;
+export async function getHypeResetsAt(
+  senderId: string,
+): Promise<string | null> {
+  if (await hasUnlimitedHypes(senderId)) return null;
+  const count = await getDailyHypeCount(senderId);
+  if (count < HYPE_DAILY_LIMIT) return null;
 
-	const rows = await db.query<{ resets_at: string }>(`SELECT ${START_OF_TOMORROW_ET_SQL}::text AS resets_at`);
-	return rows[0]?.resets_at ?? null;
+  const rows = await db.query<{ resets_at: string }>(
+    `SELECT ${START_OF_TOMORROW_ET_SQL}::text AS resets_at`,
+  );
+  return rows[0]?.resets_at ?? null;
 }

--- a/backend/src/services/moderationService.ts
+++ b/backend/src/services/moderationService.ts
@@ -1,0 +1,78 @@
+import { PostgresService } from "./DbService.js";
+import { updateFriendship } from "./friendshipService.js";
+
+const db = PostgresService.getInstance();
+
+export const REPORT_REASONS = [
+  "spam",
+  "nudity",
+  "harassment",
+  "violence",
+  "other",
+] as const;
+export type ReportReason = (typeof REPORT_REASONS)[number];
+
+/**
+ * All user ids the viewer should not see content from, in EITHER direction:
+ * people the viewer blocked, plus people who blocked the viewer. Used as a
+ * NOT-IN subquery across every post/story read so blocks are symmetric.
+ */
+export async function getBlockedIds(userId: string): Promise<string[]> {
+  const rows = await db.query<{ uid: string }>(
+    `SELECT blocked_id AS uid FROM user_blocks WHERE blocker_id = $1
+		 UNION
+		 SELECT blocker_id AS uid FROM user_blocks WHERE blocked_id = $1`,
+    [userId],
+  );
+  return rows.map((r) => r.uid);
+}
+
+/**
+ * Record an abuse report on a post. Idempotent per (post, reporter) via the
+ * partial unique index — repeat reports are silently ignored.
+ */
+export async function reportPost(
+  reporterId: string,
+  postId: string,
+  reason: ReportReason,
+  details?: string,
+): Promise<void> {
+  await db.query(
+    `INSERT INTO post_reports (post_id, reporter_id, reason, details)
+		 VALUES ($1, $2, $3, $4)
+		 ON CONFLICT (post_id, reporter_id) DO NOTHING`,
+    [postId, reporterId, reason, details ?? null],
+  );
+}
+
+/**
+ * Block another user. Also tears down any friendship in both directions so the
+ * relationship-gated surfaces (hype, feed circle) drop immediately.
+ */
+export async function blockUser(
+  blockerId: string,
+  blockedId: string,
+): Promise<void> {
+  await db.query(
+    `INSERT INTO user_blocks (blocker_id, blocked_id)
+		 VALUES ($1, $2)
+		 ON CONFLICT (blocker_id, blocked_id) DO NOTHING`,
+    [blockerId, blockedId],
+  );
+  // Best-effort friendship teardown; a missing friendship is not an error.
+  try {
+    await updateFriendship(blockerId, blockedId, "removed");
+  } catch {
+    /* no friendship to remove */
+  }
+}
+
+export async function unblockUser(
+  blockerId: string,
+  blockedId: string,
+): Promise<void> {
+  await db.query(
+    `DELETE FROM user_blocks WHERE blocker_id = $1 AND blocked_id = $2`,
+    [blockerId, blockedId],
+  );
+}

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -1,0 +1,331 @@
+import { PostgresService } from "./DbService.js";
+
+const db = PostgresService.getInstance();
+
+// Shared circle + symmetric-block fragment. `$1` is always the viewer id.
+// `circle` = the viewer's accepted friends plus the viewer themself; blocked
+// ids (either direction) are excluded so neither party sees the other.
+const CIRCLE_CTE = `
+WITH circle AS (
+	SELECT friend_id AS uid FROM friendships WHERE user_id = $1 AND status = 'accepted'
+	UNION
+	SELECT $1 AS uid
+),
+blocked AS (
+	SELECT blocked_id AS uid FROM user_blocks WHERE blocker_id = $1
+	UNION
+	SELECT blocker_id AS uid FROM user_blocks WHERE blocked_id = $1
+)`;
+
+export interface PostStatsSnapshot {
+  distance?: number;
+  pace?: number | null;
+  duration?: number | null;
+  streak?: number | null;
+  date?: string | null;
+}
+
+export interface PostRow {
+  post_id: string;
+  user_id: string;
+  username: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  profile_image_url: string | null;
+  media_url: string;
+  caption: string | null;
+  workout_id: string | null;
+  stats_snapshot: PostStatsSnapshot | null;
+  local_date: string;
+  share_to_feed: boolean;
+  share_to_story: boolean;
+  story_expires_at: string | null;
+  created_at: string;
+  is_self: boolean;
+  is_hyped: boolean;
+  hype_count: number;
+  is_viewed?: boolean;
+}
+
+export interface StoryGroup {
+  user_id: string;
+  username: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  profile_image_url: string | null;
+  story_count: number;
+  has_unviewed: boolean;
+  latest_at: string;
+}
+
+// SELECT list shared by feed + story-detail reads so both shapes match PostRow.
+// `$1` must be the viewer id (drives is_self / is_hyped).
+const POST_SELECT = `
+	p.post_id,
+	p.user_id,
+	u.username,
+	u.first_name,
+	u.last_name,
+	u.profile_image_url,
+	p.media_url,
+	p.caption,
+	p.workout_id,
+	p.stats_snapshot,
+	p.local_date::text AS local_date,
+	p.share_to_feed,
+	p.share_to_story,
+	p.story_expires_at,
+	p.created_at,
+	(p.user_id = $1) AS is_self,
+	EXISTS (
+		SELECT 1 FROM hype_log h
+		WHERE h.sender_id = $1
+			AND h.target_id = p.user_id
+			AND h.context_type = 'post'
+			AND h.context_id = p.post_id::text
+	) AS is_hyped,
+	(
+		SELECT COUNT(*)::int FROM hype_log hc
+		WHERE hc.context_type = 'post' AND hc.context_id = p.post_id::text
+	) AS hype_count`;
+
+export interface CreatePostInput {
+  userId: string;
+  mediaUrl: string;
+  caption?: string | null;
+  workoutId?: string | null;
+  localDate: string;
+  shareToFeed: boolean;
+  shareToStory: boolean;
+  statsSnapshot?: PostStatsSnapshot | null;
+}
+
+/**
+ * Insert a post and return it shaped as a PostRow (is_self=true, no hypes yet).
+ * story_expires_at is set to now()+24h only when the post is shared to a story.
+ */
+export async function createPost(input: CreatePostInput): Promise<PostRow> {
+  const rows = await db.query<PostRow>(
+    `
+		WITH inserted AS (
+			INSERT INTO posts (
+				user_id, media_url, caption, workout_id, stats_snapshot,
+				local_date, share_to_feed, share_to_story, story_expires_at
+			)
+			VALUES (
+				$1, $2, $3, $4, $5::jsonb, $6::date, $7, $8,
+				CASE WHEN $8 THEN NOW() + INTERVAL '24 hours' ELSE NULL END
+			)
+			RETURNING *
+		)
+		SELECT
+			p.post_id, p.user_id, u.username, u.first_name, u.last_name, u.profile_image_url,
+			p.media_url, p.caption, p.workout_id, p.stats_snapshot, p.local_date::text AS local_date,
+			p.share_to_feed, p.share_to_story, p.story_expires_at, p.created_at,
+			true AS is_self, false AS is_hyped, 0 AS hype_count
+		FROM inserted p
+		JOIN users u ON u.user_id = p.user_id
+		`,
+    [
+      input.userId,
+      input.mediaUrl,
+      input.caption ?? null,
+      input.workoutId ?? null,
+      input.statsSnapshot ? JSON.stringify(input.statsSnapshot) : null,
+      input.localDate,
+      input.shareToFeed,
+      input.shareToStory,
+    ],
+  );
+  return rows[0];
+}
+
+/**
+ * Stories rail: one entry per author with an active (unexpired, non-deleted)
+ * story the viewer is allowed to see. Ordered viewer-first, then unviewed
+ * groups, then most-recent. The full per-author stories are fetched lazily via
+ * getUserActiveStories when a ring is tapped.
+ */
+export async function getStoriesRail(viewerId: string): Promise<StoryGroup[]> {
+  const rows = await db.query<{
+    user_id: string;
+    username: string | null;
+    first_name: string | null;
+    last_name: string | null;
+    profile_image_url: string | null;
+    created_at: string;
+    is_viewed: boolean;
+  }>(
+    `
+		${CIRCLE_CTE}
+		SELECT
+			p.user_id, u.username, u.first_name, u.last_name, u.profile_image_url, p.created_at,
+			EXISTS (
+				SELECT 1 FROM story_views sv WHERE sv.post_id = p.post_id AND sv.viewer_id = $1
+			) AS is_viewed
+		FROM posts p
+		JOIN circle c ON c.uid = p.user_id
+		JOIN users u ON u.user_id = p.user_id
+		WHERE p.share_to_story
+			AND p.deleted_at IS NULL
+			AND p.story_expires_at > NOW()
+			AND p.user_id NOT IN (SELECT uid FROM blocked)
+		ORDER BY p.created_at ASC
+		`,
+    [viewerId],
+  );
+
+  const groups = new Map<string, StoryGroup>();
+  for (const r of rows) {
+    const g = groups.get(r.user_id);
+    if (!g) {
+      groups.set(r.user_id, {
+        user_id: r.user_id,
+        username: r.username,
+        first_name: r.first_name,
+        last_name: r.last_name,
+        profile_image_url: r.profile_image_url,
+        story_count: 1,
+        has_unviewed: !r.is_viewed,
+        latest_at: r.created_at,
+      });
+    } else {
+      g.story_count += 1;
+      g.has_unviewed = g.has_unviewed || !r.is_viewed;
+      if (r.created_at > g.latest_at) g.latest_at = r.created_at;
+    }
+  }
+
+  return Array.from(groups.values()).sort((a, b) => {
+    if (a.user_id === viewerId) return -1;
+    if (b.user_id === viewerId) return 1;
+    if (a.has_unviewed !== b.has_unviewed) return a.has_unviewed ? -1 : 1;
+    return a.latest_at < b.latest_at ? 1 : -1;
+  });
+}
+
+/**
+ * One author's active stories, oldest→newest (story playback order), each
+ * tagged with is_viewed/is_hyped/hype_count for the viewer. Returns [] if the
+ * author is outside the viewer's circle or blocked.
+ */
+export async function getUserActiveStories(
+  viewerId: string,
+  authorId: string,
+): Promise<PostRow[]> {
+  const rows = await db.query<PostRow>(
+    `
+		${CIRCLE_CTE}
+		SELECT ${POST_SELECT},
+			EXISTS (
+				SELECT 1 FROM story_views sv WHERE sv.post_id = p.post_id AND sv.viewer_id = $1
+			) AS is_viewed
+		FROM posts p
+		JOIN circle c ON c.uid = p.user_id
+		JOIN users u ON u.user_id = p.user_id
+		WHERE p.user_id = $2
+			AND p.share_to_story
+			AND p.deleted_at IS NULL
+			AND p.story_expires_at > NOW()
+			AND p.user_id NOT IN (SELECT uid FROM blocked)
+		ORDER BY p.created_at ASC
+		`,
+    [viewerId, authorId],
+  );
+  return rows;
+}
+
+/** Record that the viewer saw a story. Idempotent. */
+export async function markStoryViewed(
+  viewerId: string,
+  postId: string,
+): Promise<void> {
+  await db.query(
+    `INSERT INTO story_views (post_id, viewer_id) VALUES ($1, $2)
+		 ON CONFLICT (post_id, viewer_id) DO NOTHING`,
+    [postId, viewerId],
+  );
+}
+
+/**
+ * Persistent feed: photo posts from the viewer's circle, newest first, keyset
+ * paginated on created_at. Pass `before` (an ISO timestamp) to fetch older.
+ */
+export async function getFeed(
+  viewerId: string,
+  limit: number,
+  before?: string | null,
+): Promise<PostRow[]> {
+  const rows = await db.query<PostRow>(
+    `
+		${CIRCLE_CTE}
+		SELECT ${POST_SELECT}
+		FROM posts p
+		JOIN circle c ON c.uid = p.user_id
+		JOIN users u ON u.user_id = p.user_id
+		WHERE p.share_to_feed
+			AND p.deleted_at IS NULL
+			AND p.user_id NOT IN (SELECT uid FROM blocked)
+			AND ($2::timestamptz IS NULL OR p.created_at < $2::timestamptz)
+		ORDER BY p.created_at DESC
+		LIMIT $3
+		`,
+    [viewerId, before ?? null, limit],
+  );
+  return rows;
+}
+
+/** The author of a post (for hype targeting / report validation). */
+export async function getPostAuthor(postId: string): Promise<string | null> {
+  const rows = await db.query<{ user_id: string }>(
+    `SELECT user_id FROM posts WHERE post_id = $1 AND deleted_at IS NULL`,
+    [postId],
+  );
+  return rows[0]?.user_id ?? null;
+}
+
+/**
+ * Soft-delete a post the caller authored. Returns true if a row was deleted,
+ * false if the post doesn't exist or isn't theirs (caller maps to 403/404).
+ */
+export async function softDeletePost(
+  authorId: string,
+  postId: string,
+): Promise<boolean> {
+  const rows = await db.query<{ post_id: string }>(
+    `UPDATE posts SET deleted_at = NOW()
+		 WHERE post_id = $1 AND user_id = $2 AND deleted_at IS NULL
+		 RETURNING post_id`,
+    [postId, authorId],
+  );
+  return rows.length > 0;
+}
+
+/** Moderator override delete (privileged users) — ignores authorship. */
+export async function moderatorDeletePost(postId: string): Promise<boolean> {
+  const rows = await db.query<{ post_id: string }>(
+    `UPDATE posts SET deleted_at = NOW() WHERE post_id = $1 AND deleted_at IS NULL RETURNING post_id`,
+    [postId],
+  );
+  return rows.length > 0;
+}
+
+/** Whether the user has accepted the UGC terms / EULA (gate for first post). */
+export async function hasAcceptedTerms(userId: string): Promise<boolean> {
+  const rows = await db.query<{ terms_accepted_at: string | null }>(
+    `SELECT terms_accepted_at FROM users WHERE user_id = $1`,
+    [userId],
+  );
+  return rows[0]?.terms_accepted_at != null;
+}
+
+/** Stamp the user's one-time terms acceptance (no-op if already accepted). */
+export async function acceptTerms(userId: string): Promise<string> {
+  const rows = await db.query<{ terms_accepted_at: string }>(
+    `UPDATE users SET terms_accepted_at = COALESCE(terms_accepted_at, NOW())
+		 WHERE user_id = $1
+		 RETURNING terms_accepted_at`,
+    [userId],
+  );
+  return rows[0]?.terms_accepted_at;
+}

--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -1,10 +1,13 @@
-import { Workout } from '../types/workouts.js';
-import { PostgresService } from './DbService.js';
+import { Workout } from "../types/workouts.js";
+import { PostgresService } from "./DbService.js";
 
 const db = PostgresService.getInstance();
 
-export async function uploadWorkouts(userId: string, workouts: Workout[]): Promise<string[]> {
-	const workoutQuery = `
+export async function uploadWorkouts(
+  userId: string,
+  workouts: Workout[],
+): Promise<string[]> {
+  const workoutQuery = `
       INSERT INTO workouts (
         user_id,
         workout_id,
@@ -36,7 +39,7 @@ export async function uploadWorkouts(userId: string, workouts: Workout[]): Promi
       RETURNING workout_id, (xmax = 0) AS inserted
     `;
 
-	const splitQuery = `
+  const splitQuery = `
         INSERT INTO workout_splits (workout_id, split_number, split_duration, split_distance, split_pace)
         VALUES ($1, $2, $3, $4, $5)
         ON CONFLICT (workout_id, split_number)
@@ -46,41 +49,47 @@ export async function uploadWorkouts(userId: string, workouts: Workout[]): Promi
 			split_pace = EXCLUDED.split_pace
       `;
 
-	await db.transaction(
-		workouts.flatMap((workout: Workout) => {
-			return [
-				{
-					query: workoutQuery,
-					params: [
-						userId,
-						workout.workoutId,
-						workout.distance,
-						workout.localDate,
-						workout.date,
-						workout.timezoneOffset,
-						workout.workoutType,
-						workout.deviceEndDate,
-						workout.calories,
-						workout.totalDuration,
-						workout.source || 'healthkit'
-					]
-				},
-				...workout.splits.map(split => ({
-					query: splitQuery,
-					params: [workout.workoutId, split.splitNumber, split.duration, split.distance, split.pace]
-				}))
-			];
-		})
-	);
+  await db.transaction(
+    workouts.flatMap((workout: Workout) => {
+      return [
+        {
+          query: workoutQuery,
+          params: [
+            userId,
+            workout.workoutId,
+            workout.distance,
+            workout.localDate,
+            workout.date,
+            workout.timezoneOffset,
+            workout.workoutType,
+            workout.deviceEndDate,
+            workout.calories,
+            workout.totalDuration,
+            workout.source || "healthkit",
+          ],
+        },
+        ...workout.splits.map((split) => ({
+          query: splitQuery,
+          params: [
+            workout.workoutId,
+            split.splitNumber,
+            split.duration,
+            split.distance,
+            split.pace,
+          ],
+        })),
+      ];
+    }),
+  );
 
-	return workouts.map(w => w.workoutId);
+  return workouts.map((w) => w.workoutId);
 }
 
 function dateStringMinus(dateStr: string, days: number): string {
-	const [y, m, d] = dateStr.split('-').map(Number);
-	const date = new Date(Date.UTC(y, m - 1, d));
-	date.setUTCDate(date.getUTCDate() - days);
-	return date.toISOString().slice(0, 10);
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const date = new Date(Date.UTC(y, m - 1, d));
+  date.setUTCDate(date.getUTCDate() - days);
+  return date.toISOString().slice(0, 10);
 }
 
 /**
@@ -88,8 +97,8 @@ function dateStringMinus(dateStr: string, days: number): string {
  * timezone_offset of their most recent workout (UTC if they have none).
  */
 export async function getUserLocalToday(userId: string): Promise<string> {
-	const todayResult = await db.query<{ user_today: string }>(
-		`
+  const todayResult = await db.query<{ user_today: string }>(
+    `
     SELECT to_char(
       (NOW() + (COALESCE(
         (SELECT timezone_offset FROM workouts WHERE user_id = $1 ORDER BY device_end_date DESC LIMIT 1),
@@ -98,16 +107,16 @@ export async function getUserLocalToday(userId: string): Promise<string> {
       'YYYY-MM-DD'
     ) AS user_today
   `,
-		[userId]
-	);
-	return todayResult[0].user_today;
+    [userId],
+  );
+  return todayResult[0].user_today;
 }
 
 export async function getActiveStreak(userId: string) {
-	const userToday = await getUserLocalToday(userId);
-	const yesterday = dateStringMinus(userToday, 1);
+  const userToday = await getUserLocalToday(userId);
+  const yesterday = dateStringMinus(userToday, 1);
 
-	const qualifyingDaysQuery = `
+  const qualifyingDaysQuery = `
     SELECT to_char(local_date, 'YYYY-MM-DD') AS local_date
     FROM workouts
     WHERE user_id = $1
@@ -117,81 +126,85 @@ export async function getActiveStreak(userId: string) {
     LIMIT $2 OFFSET $3
   `;
 
-	const LIMIT = 100;
-	let index = 0;
-	let streak = 0;
-	let streakStartDay: string | undefined;
-	let expectedDate: string | undefined;
+  const LIMIT = 100;
+  let index = 0;
+  let streak = 0;
+  let streakStartDay: string | undefined;
+  let expectedDate: string | undefined;
 
-	while (true) {
-		const results = await db.query(qualifyingDaysQuery, [userId, LIMIT, index * LIMIT]);
-		if (results.length === 0) break;
+  while (true) {
+    const results = await db.query(qualifyingDaysQuery, [
+      userId,
+      LIMIT,
+      index * LIMIT,
+    ]);
+    if (results.length === 0) break;
 
-		for (const row of results) {
-			const date: string = row.local_date;
+    for (const row of results) {
+      const date: string = row.local_date;
 
-			if (expectedDate === undefined) {
-				if (date !== userToday && date !== yesterday) {
-					return { streak: 0, start: undefined };
-				}
-				streak = 1;
-				streakStartDay = date;
-				expectedDate = dateStringMinus(date, 1);
-			} else if (date === expectedDate) {
-				streak++;
-				streakStartDay = date;
-				expectedDate = dateStringMinus(date, 1);
-			} else {
-				return { streak, start: streakStartDay };
-			}
-		}
+      if (expectedDate === undefined) {
+        if (date !== userToday && date !== yesterday) {
+          return { streak: 0, start: undefined };
+        }
+        streak = 1;
+        streakStartDay = date;
+        expectedDate = dateStringMinus(date, 1);
+      } else if (date === expectedDate) {
+        streak++;
+        streakStartDay = date;
+        expectedDate = dateStringMinus(date, 1);
+      } else {
+        return { streak, start: streakStartDay };
+      }
+    }
 
-		index++;
-	}
+    index++;
+  }
 
-	return { streak, start: streakStartDay };
+  return { streak, start: streakStartDay };
 }
 
 export async function getTotalMiles(userId: string, startDate?: string) {
-	let distanceQuery = `
+  let distanceQuery = `
     SELECT SUM(distance) FROM workouts
     WHERE user_id = $1
     `;
 
-	const params: (string | number)[] = [userId];
+  const params: (string | number)[] = [userId];
 
-	if (startDate) {
-		distanceQuery += ` AND local_date >= $2`;
-		params.push(startDate);
-	}
+  if (startDate) {
+    distanceQuery += ` AND local_date >= $2`;
+    params.push(startDate);
+  }
 
-	return (await db.query(distanceQuery, params))[0]?.sum;
+  return (await db.query(distanceQuery, params))[0]?.sum;
 }
 
 export async function getBestMilesDay(userId: string, startDate?: string) {
-	let bestDayQuery = `
+  let bestDayQuery = `
     SELECT local_date, SUM(distance) as total_distance FROM workouts
     WHERE user_id = $1
     `;
 
-	const params: (string | number)[] = [userId];
+  const params: (string | number)[] = [userId];
 
-	if (startDate) {
-		bestDayQuery += ` AND local_date >= $2`;
-		params.push(startDate);
-	}
+  if (startDate) {
+    bestDayQuery += ` AND local_date >= $2`;
+    params.push(startDate);
+  }
 
-	bestDayQuery += `
+  bestDayQuery += `
     GROUP BY local_date
     ORDER BY total_distance DESC
     LIMIT 1
     `;
 
-	return (await db.query(bestDayQuery, params))[0];
+  return (await db.query(bestDayQuery, params))[0];
 }
 
 export async function getBestSplit(userId: string, startDate?: string) {
-	let bestSplitQuery = `
+  let bestSplitQuery = `
     SELECT 
       ws.split_pace AS best_split_time,
       w.*
@@ -202,38 +215,41 @@ export async function getBestSplit(userId: string, startDate?: string) {
 	AND ws.split_pace > 0
 	`;
 
-	const params: (string | number)[] = [userId];
+  const params: (string | number)[] = [userId];
 
-	if (startDate) {
-		bestSplitQuery += ` AND w.local_date >= $2`;
-		params.push(startDate);
-	}
+  if (startDate) {
+    bestSplitQuery += ` AND w.local_date >= $2`;
+    params.push(startDate);
+  }
 
-	bestSplitQuery += `
+  bestSplitQuery += `
     ORDER BY ws.split_pace ASC
     LIMIT 1
 	`;
 
-	const result = await db.query(bestSplitQuery, params);
+  const result = await db.query(bestSplitQuery, params);
 
-	if (!result || result.length === 0) {
-		return null;
-	}
+  if (!result || result.length === 0) {
+    return null;
+  }
 
-	const { best_split_time, ...workout } = result[0];
+  const { best_split_time, ...workout } = result[0];
 
-	return { best_split_time, workout };
+  return { best_split_time, workout };
 }
 
-export async function getRecentWorkouts(userId: string, limit: number | null = 10) {
-	const recentWorkoutsQuery = `
+export async function getRecentWorkouts(
+  userId: string,
+  limit: number | null = 10,
+) {
+  const recentWorkoutsQuery = `
 	SELECT * FROM workouts
 	WHERE user_id = $1
 	ORDER BY device_end_date DESC
 	LIMIT $2
 	`;
 
-	return await db.query(recentWorkoutsQuery, [userId, limit]);
+  return await db.query(recentWorkoutsQuery, [userId, limit]);
 }
 
 /**
@@ -242,20 +258,20 @@ export async function getRecentWorkouts(userId: string, limit: number | null = 1
  * Falls back to the server's UTC date if the user has no workouts.
  */
 export async function getUserLocalDate(userId: string): Promise<string> {
-	const rows = await db.query<{ local_date: string }>(
-		`SELECT (NOW() + (COALESCE(
+  const rows = await db.query<{ local_date: string }>(
+    `SELECT (NOW() + (COALESCE(
 			(SELECT timezone_offset FROM workouts WHERE user_id = $1 ORDER BY device_end_date DESC LIMIT 1),
 			0
 		) || ' minutes')::interval)::date::text AS local_date`,
-		[userId]
-	);
-	return rows[0].local_date;
+    [userId],
+  );
+  return rows[0].local_date;
 }
 
 export async function getTodayMiles(userId: string) {
-	// Use the user's timezone offset from their most recent workout to determine
-	// what "today" is in their local time (local_date is stored in user's timezone)
-	const todayMilesQuery = `
+  // Use the user's timezone offset from their most recent workout to determine
+  // what "today" is in their local time (local_date is stored in user's timezone)
+  const todayMilesQuery = `
 	WITH user_tz AS (
 		SELECT COALESCE(
 			(SELECT timezone_offset FROM workouts WHERE user_id = $1 ORDER BY device_end_date DESC LIMIT 1),
@@ -267,8 +283,8 @@ export async function getTodayMiles(userId: string) {
 	AND w.local_date = (NOW() + (user_tz.tz_offset || ' minutes')::interval)::date
 	`;
 
-	const result = await db.query(todayMilesQuery, [userId]);
-	return result[0]?.total_distance || 0;
+  const result = await db.query(todayMilesQuery, [userId]);
+  return result[0]?.total_distance || 0;
 }
 
 /**
@@ -276,21 +292,53 @@ export async function getTodayMiles(userId: string) {
  * Used to validate "did they complete their mile that day?" for historical
  * events like an old mile-completion notification being hyped.
  */
-export async function getMilesOnLocalDate(userId: string, localDate: string): Promise<number> {
-	const result = await db.query<{ total_distance: string | number | null }>(
-		`SELECT COALESCE(SUM(distance), 0) AS total_distance
+export async function getMilesOnLocalDate(
+  userId: string,
+  localDate: string,
+): Promise<number> {
+  const result = await db.query<{ total_distance: string | number | null }>(
+    `SELECT COALESCE(SUM(distance), 0) AS total_distance
 		FROM workouts
 		WHERE user_id = $1 AND local_date = $2::date`,
-		[userId, localDate]
-	);
-	const value = result[0]?.total_distance;
-	return value == null ? 0 : Number(value);
+    [userId, localDate],
+  );
+  const value = result[0]?.total_distance;
+  return value == null ? 0 : Number(value);
+}
+
+export interface DailyGoalStatus {
+  completed: boolean;
+  miles: number;
+  goalMiles: number;
+  localDate: string;
+}
+
+/**
+ * Whether the user has met their personal daily goal (goal_miles) today, in
+ * their local timezone. This is the authoritative server-side gate for posting
+ * a story/feed post — never trust a client-supplied "completed" flag.
+ */
+export async function getDailyGoalStatus(
+  userId: string,
+): Promise<DailyGoalStatus> {
+  const localDate = await getUserLocalDate(userId);
+  const [miles, goalRows] = await Promise.all([
+    getMilesOnLocalDate(userId, localDate),
+    db.query<{ goal_miles: string | number | null }>(
+      `SELECT goal_miles FROM users WHERE user_id = $1`,
+      [userId],
+    ),
+  ]);
+  const goalMiles = Number(goalRows[0]?.goal_miles ?? 1);
+  // Small epsilon so a goal stored as 1.0 isn't missed by 1.0 reading 0.9999.
+  const completed = miles + 1e-9 >= goalMiles;
+  return { completed, miles, goalMiles, localDate };
 }
 
 export interface TodayStats {
-	miles: number;
-	durationSeconds: number;
-	bestSplitPaceSecMi: number | null;
+  miles: number;
+  durationSeconds: number;
+  bestSplitPaceSecMi: number | null;
 }
 
 /**
@@ -302,7 +350,7 @@ export interface TodayStats {
  * today's workouts with distance >= 0.95. NULL if neither is available.
  */
 export async function getTodayStats(userId: string): Promise<TodayStats> {
-	const query = `
+  const query = `
 	WITH user_tz AS (
 		SELECT COALESCE(
 			(SELECT timezone_offset FROM workouts WHERE user_id = $1 ORDER BY device_end_date DESC LIMIT 1),
@@ -341,30 +389,31 @@ export async function getTodayStats(userId: string): Promise<TodayStats> {
 	LEFT JOIN workout_best wb ON TRUE
 	`;
 
-	const rows = await db.query<{
-		miles: number | string;
-		duration_seconds: number | string;
-		best_split_pace_sec_mi: number | string | null;
-	}>(query, [userId]);
+  const rows = await db.query<{
+    miles: number | string;
+    duration_seconds: number | string;
+    best_split_pace_sec_mi: number | string | null;
+  }>(query, [userId]);
 
-	const row = rows[0];
-	const toNum = (v: number | string | null | undefined): number => (v == null ? 0 : typeof v === 'string' ? Number(v) : v);
-	const pace = row?.best_split_pace_sec_mi;
+  const row = rows[0];
+  const toNum = (v: number | string | null | undefined): number =>
+    v == null ? 0 : typeof v === "string" ? Number(v) : v;
+  const pace = row?.best_split_pace_sec_mi;
 
-	return {
-		miles: toNum(row?.miles),
-		durationSeconds: toNum(row?.duration_seconds),
-		bestSplitPaceSecMi: pace == null ? null : Number(pace)
-	};
+  return {
+    miles: toNum(row?.miles),
+    durationSeconds: toNum(row?.duration_seconds),
+    bestSplitPaceSecMi: pace == null ? null : Number(pace),
+  };
 }
 
 export async function getQuantityDateRange(
-	userId: string,
-	startDate: string,
-	endDate?: string,
-	workoutTypes?: ('running' | 'walking')[]
+  userId: string,
+  startDate: string,
+  endDate?: string,
+  workoutTypes?: ("running" | "walking")[],
 ) {
-	let query = `
+  let query = `
 		SELECT
 			TO_CHAR(local_date, 'YYYY-MM-DD') as local_date,
 			SUM(distance) as total_distance
@@ -377,19 +426,23 @@ export async function getQuantityDateRange(
 		ORDER BY local_date ASC
 	`;
 
-	const todaysDate = new Date().toISOString().split('T')[0];
-	const start = new Date(startDate).toISOString().split('T')[0];
-	const end = endDate ? new Date(endDate).toISOString().split('T')[0] : todaysDate;
+  const todaysDate = new Date().toISOString().split("T")[0];
+  const start = new Date(startDate).toISOString().split("T")[0];
+  const end = endDate
+    ? new Date(endDate).toISOString().split("T")[0]
+    : todaysDate;
 
-	const typeMap: Record<string, 'running' | 'walking'> = {
-		run: 'running',
-		walk: 'walking',
-		running: 'running',
-		walking: 'walking'
-	};
-	const normalizedTypes = (workoutTypes ?? ['running', 'walking']).map(t => typeMap[t]).filter(Boolean);
+  const typeMap: Record<string, "running" | "walking"> = {
+    run: "running",
+    walk: "walking",
+    running: "running",
+    walking: "walking",
+  };
+  const normalizedTypes = (workoutTypes ?? ["running", "walking"])
+    .map((t) => typeMap[t])
+    .filter(Boolean);
 
-	return await db.query(query, [userId, start, end, normalizedTypes]);
+  return await db.query(query, [userId, start, end, normalizedTypes]);
 }
 
 /**
@@ -398,14 +451,14 @@ export async function getQuantityDateRange(
  * all participants at once instead of looping per user.
  */
 export async function getQuantityDateRangeBatch(
-	userIds: string[],
-	startDate: string,
-	endDate?: string,
-	workoutTypes?: ('running' | 'walking')[]
+  userIds: string[],
+  startDate: string,
+  endDate?: string,
+  workoutTypes?: ("running" | "walking")[],
 ): Promise<{ user_id: string; local_date: string; total_distance: number }[]> {
-	if (userIds.length === 0) return [];
+  if (userIds.length === 0) return [];
 
-	const query = `
+  const query = `
 		SELECT
 			user_id,
 			TO_CHAR(local_date, 'YYYY-MM-DD') as local_date,
@@ -419,58 +472,66 @@ export async function getQuantityDateRangeBatch(
 		ORDER BY user_id, local_date ASC
 	`;
 
-	const todaysDate = new Date().toISOString().split('T')[0];
-	const start = new Date(startDate).toISOString().split('T')[0];
-	const end = endDate ? new Date(endDate).toISOString().split('T')[0] : todaysDate;
+  const todaysDate = new Date().toISOString().split("T")[0];
+  const start = new Date(startDate).toISOString().split("T")[0];
+  const end = endDate
+    ? new Date(endDate).toISOString().split("T")[0]
+    : todaysDate;
 
-	const typeMap: Record<string, 'running' | 'walking'> = {
-		run: 'running',
-		walk: 'walking',
-		running: 'running',
-		walking: 'walking'
-	};
-	const normalizedTypes = (workoutTypes ?? ['running', 'walking']).map(t => typeMap[t]).filter(Boolean);
+  const typeMap: Record<string, "running" | "walking"> = {
+    run: "running",
+    walk: "walking",
+    running: "running",
+    walking: "walking",
+  };
+  const normalizedTypes = (workoutTypes ?? ["running", "walking"])
+    .map((t) => typeMap[t])
+    .filter(Boolean);
 
-	return await db.query(query, [userIds, start, end, normalizedTypes]);
+  return await db.query(query, [userIds, start, end, normalizedTypes]);
 }
 
 /**
  * Batched manual-workout check for a set of users over a date range.
  * Returns the set of user_ids that have at least one manual/edited workout in range.
  */
-export async function getUsersWithManualWorkouts(userIds: string[], startDate: string, endDate: string): Promise<Set<string>> {
-	if (userIds.length === 0) return new Set();
+export async function getUsersWithManualWorkouts(
+  userIds: string[],
+  startDate: string,
+  endDate: string,
+): Promise<Set<string>> {
+  if (userIds.length === 0) return new Set();
 
-	const result = await db.query<{ user_id: string }>(
-		`SELECT DISTINCT user_id FROM workouts
+  const result = await db.query<{ user_id: string }>(
+    `SELECT DISTINCT user_id FROM workouts
 		 WHERE user_id = ANY($1::text[])
 			AND local_date >= $2
 			AND local_date <= $3
 			AND source IN ('manual', 'edited')`,
-		[userIds, startDate, endDate]
-	);
+    [userIds, startDate, endDate],
+  );
 
-	return new Set(result.map(r => r.user_id));
+  return new Set(result.map((r) => r.user_id));
 }
 
 export async function updateWorkout(
-	userId: string,
-	workoutId: string,
-	updates: { distance?: number; totalDuration?: number; workoutType?: string }
+  userId: string,
+  workoutId: string,
+  updates: { distance?: number; totalDuration?: number; workoutType?: string },
 ) {
-	const current = await db.query(
-		'SELECT distance, total_duration, original_distance FROM workouts WHERE workout_id = $1 AND user_id = $2',
-		[workoutId, userId]
-	);
+  const current = await db.query(
+    "SELECT distance, total_duration, original_distance FROM workouts WHERE workout_id = $1 AND user_id = $2",
+    [workoutId, userId],
+  );
 
-	if (!current || current.length === 0) {
-		return null;
-	}
+  if (!current || current.length === 0) {
+    return null;
+  }
 
-	const row = current[0];
+  const row = current[0];
 
-	const result = await db.query(
-		`UPDATE workouts SET
+  const result = await db.query(
+    `UPDATE workouts SET
 			distance = COALESCE($3, distance),
 			total_duration = COALESCE($4, total_duration),
 			workout_type = COALESCE($5, workout_type),
@@ -479,18 +540,18 @@ export async function updateWorkout(
 			original_duration = COALESCE(original_duration, $7)
 		WHERE workout_id = $1 AND user_id = $2
 		RETURNING *`,
-		[
-			workoutId,
-			userId,
-			updates.distance ?? null,
-			updates.totalDuration ?? null,
-			updates.workoutType ?? null,
-			row.distance,
-			row.total_duration
-		]
-	);
+    [
+      workoutId,
+      userId,
+      updates.distance ?? null,
+      updates.totalDuration ?? null,
+      updates.workoutType ?? null,
+      row.distance,
+      row.total_duration,
+    ],
+  );
 
-	return result[0];
+  return result[0];
 }
 
 /**
@@ -505,18 +566,20 @@ export async function updateWorkout(
  *   null when there is no record. Ties resolve to the most recent date.
  */
 export async function computePersonalRecords(
-	userId: string,
-	excludeWorkoutIds: string[] = []
+  userId: string,
+  excludeWorkoutIds: string[] = [],
 ): Promise<{
-	fastestSplitPaceSecMi: number;
-	mostMilesInOneDay: number;
-	fastestSplitDate: string | null;
-	bestDayDate: string | null;
+  fastestSplitPaceSecMi: number;
+  mostMilesInOneDay: number;
+  fastestSplitDate: string | null;
+  bestDayDate: string | null;
 }> {
-	const exclude = excludeWorkoutIds.length > 0;
-	const excludeClause = exclude ? `AND NOT (w.workout_id = ANY($2::text[]))` : '';
+  const exclude = excludeWorkoutIds.length > 0;
+  const excludeClause = exclude
+    ? `AND NOT (w.workout_id = ANY($2::text[]))`
+    : "";
 
-	const paceQuery = `SELECT s.split_pace::text AS min_pace,
+  const paceQuery = `SELECT s.split_pace::text AS min_pace,
 	       to_char(w.local_date, 'YYYY-MM-DD') AS pace_date
 	   FROM workout_splits s
 	   JOIN workouts w ON w.workout_id = s.workout_id
@@ -527,7 +590,7 @@ export async function computePersonalRecords(
 	   ORDER BY s.split_pace ASC, w.local_date DESC
 	   LIMIT 1`;
 
-	const dayQuery = `SELECT SUM(w.distance)::text AS best_day,
+  const dayQuery = `SELECT SUM(w.distance)::text AS best_day,
 	       to_char(w.local_date, 'YYYY-MM-DD') AS best_day_date
 	   FROM workouts w
 	   WHERE w.user_id = $1 ${excludeClause}
@@ -535,19 +598,27 @@ export async function computePersonalRecords(
 	   ORDER BY SUM(w.distance) DESC, w.local_date DESC
 	   LIMIT 1`;
 
-	const params: any[] = exclude ? [userId, excludeWorkoutIds] : [userId];
+  const params: any[] = exclude ? [userId, excludeWorkoutIds] : [userId];
 
-	const [paceRow, bestDayRow] = await Promise.all([
-		db.query<{ min_pace: string | null; pace_date: string | null }>(paceQuery, params),
-		db.query<{ best_day: string | null; best_day_date: string | null }>(dayQuery, params)
-	]);
+  const [paceRow, bestDayRow] = await Promise.all([
+    db.query<{ min_pace: string | null; pace_date: string | null }>(
+      paceQuery,
+      params,
+    ),
+    db.query<{ best_day: string | null; best_day_date: string | null }>(
+      dayQuery,
+      params,
+    ),
+  ]);
 
-	const fastestSplitPaceSecMi = paceRow[0]?.min_pace ? parseFloat(paceRow[0].min_pace) : 0;
-	const mostMilesInOneDay = parseFloat(bestDayRow[0]?.best_day ?? '0') || 0;
-	return {
-		fastestSplitPaceSecMi,
-		mostMilesInOneDay,
-		fastestSplitDate: paceRow[0]?.pace_date ?? null,
-		bestDayDate: bestDayRow[0]?.best_day_date ?? null
-	};
+  const fastestSplitPaceSecMi = paceRow[0]?.min_pace
+    ? parseFloat(paceRow[0].min_pace)
+    : 0;
+  const mostMilesInOneDay = parseFloat(bestDayRow[0]?.best_day ?? "0") || 0;
+  return {
+    fastestSplitPaceSecMi,
+    mostMilesInOneDay,
+    fastestSplitDate: paceRow[0]?.pace_date ?? null,
+    bestDayDate: bestDayRow[0]?.best_day_date ?? null,
+  };
 }


### PR DESCRIPTION
## What this adds

A user-generated **social layer** on top of the existing friends feed + hype system:

- **Stories** (24h): pick a photo, drag a **run-stats overlay sticker** (distance / pace / time / streak) onto it, publish. Horizontal rail + full-screen viewer (segmented progress bars, tap L/R, ~5s auto-advance, swipe-down dismiss, inline 👏).
- **Persistent Feed**: photo + caption + run stats, hype-able, with a report/block/delete menu. Mounted as a new **"Feed"** mode in the Friends tab.
- **One composer, two destinations**: "Share to Story" and/or "Share to Feed", backed by a single unified `posts` table.
- **"Dave's server" = the existing backend**: photos go through the same **Multer + Sharp → `/uploads/`** pipeline as profile pictures. No S3/new infra.

## Backend (additive; deploy first — tolerant of old clients)

- New tables `posts`, `story_views`, `post_reports`, `user_blocks` + `users.terms_accepted_at`. **Migration `0002` is purely additive** (4 `CREATE TABLE` + one nullable column; no destructive changes to live tables).
- `postService` (create / feed / stories / views / delete) and `moderationService` (report / block with symmetric both-direction filtering).
- New routes under `/posts` and `/blocks`. Photo upload mirrors `uploadProfileImage` → `/uploads/posts/`.
- **Server-authoritative gating**: `POST /posts` re-checks `goal_miles` from the DB (`getDailyGoalStatus`) and rejects with `mile_not_completed` — never trusts a client flag. One-time terms/EULA gate (`terms_not_accepted`) before first post.
- Hyping a post **reuses `/hype`** with `context_type: 'post'` (allowlist widened) — keeps the daily-3 limit, dedupe, friend-gate, and push path.
- Story expiry is enforced at query time; an hourly cron sweeps story-only media + orphaned uploads to bound disk growth.

## iOS

- `PostService` / `BlockService` + models (`PostItem`, `StoryGroup`, `PostStats`); multipart upload mirrors `ProfileImageService`, JSON via `APIClient.fancyFetch`.
- Composer with `ImageRenderer` compositing (overlay baked into a flat JPEG; structured `stats_snapshot` still sent for future re-rendering).
- `StoriesRailView`, `StoryViewerView`, `SocialFeedView`, `PostCardView`, `ReportPostSheet`, `PostTermsGateView`. Reuses `AvatarView`, `HypeButton`/`HypeTally`, `ImagePicker`, and `MADTheme`.
- Compose button + story-add are gated on completing the daily mile (cosmetic; server is authoritative).

## App Store / moderation (Guideline 1.2)

Covers the required floor for photo UGC: **report**, **block** (filters both directions everywhere), **soft-delete** + admin override, and a one-time **EULA/community-guidelines** acceptance. Reports land in `post_reports` for review (queryable via `/db-query`); Apple requires action within 24h.

## Deploy / review notes

- **Apply migration `0002` on the backend before shipping the iOS build.** Backend is additive and safe for old clients; new app calls only the new routes.
- iOS is Xcode-only in this repo — **not compiled in CI here**; please build + eyeball the composer, stories rail/viewer, feed, and report/block flows.
- v1 intentionally defers: video, route-map overlay, "who viewed" analytics UI, push for new posts, comments, close-friends audience, automated image-safety screening.

> Note on branching: this feature is unrelated to the responsive-fix work on PR #176, so it's on its own branch off `main` to keep that PR clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxDWrDAbsnFQ2Jxj1qsgNu)_