### PR TITLE
Premium 3D medals, anti-cheat, BeReal-style run posts, post-mile leaderboard, QR/link-sharing fix

### DIFF
--- a/app/Mile A Day/Core/State/DeepLinkRouter.swift
+++ b/app/Mile A Day/Core/State/DeepLinkRouter.swift
@@ -24,7 +24,9 @@ final class DeepLinkRouter: ObservableObject {
         if url.scheme == "mileaday", url.host == "u" {
             let candidate = url.lastPathComponent
             raw = candidate.isEmpty ? nil : candidate
-        } else if url.scheme == "https", url.host?.lowercased() == "mileaday.run" {
+        } else if url.scheme == "https",
+                  let host = url.host?.lowercased(),
+                  host == "mileaday.run" || host == "www.mileaday.run" {
             let parts = url.path.split(separator: "/").map(String.init)
             raw = (parts.count == 2 && parts[0] == "u") ? parts[1] : nil
         } else {

--- a/app/Mile A Day/Managers/CelebrationManager.swift
+++ b/app/Mile A Day/Managers/CelebrationManager.swift
@@ -279,6 +279,8 @@ enum CelebrationType: Identifiable, Equatable {
     case badgeSummary(count: Int, badges: [Badge])
     /// Rewarding moment when the user completes today's daily challenge.
     case challengeCompleted(info: ChallengeCelebrationInfo)
+    /// BeReal-style prompt to add a photo to the just-finished mile.
+    case postRunPhotoPrompt(workoutId: String, workoutType: String)
 
     var id: String {
         switch self {
@@ -298,6 +300,8 @@ enum CelebrationType: Identifiable, Equatable {
             return "badge-summary"
         case .challengeCompleted(let info):
             return "challenge-completed-\(info.key)"
+        case .postRunPhotoPrompt(let workoutId, _):
+            return "post-run-photo-\(workoutId)"
         }
     }
 
@@ -319,6 +323,8 @@ enum CelebrationType: Identifiable, Equatable {
             return true // only one welcome summary
         case (.challengeCompleted(let i1), .challengeCompleted(let i2)):
             return i1.key == i2.key // one celebration per challenge per day
+        case (.postRunPhotoPrompt(let w1, _), .postRunPhotoPrompt(let w2, _)):
+            return w1 == w2 // one prompt per workout
         default:
             return false
         }
@@ -490,6 +496,7 @@ class CelebrationManager: ObservableObject {
         case .badgeUnlocked: return 3
         case .milestone: return 4
         case .challengeCompleted: return 5 // celebrate the daily challenge as a finale
+        case .postRunPhotoPrompt: return 6 // BeReal photo prompt — the very last step
         }
     }
 

--- a/app/Mile A Day/Models/HealthKitManager.swift
+++ b/app/Mile A Day/Models/HealthKitManager.swift
@@ -703,7 +703,8 @@ class HealthKitManager: ObservableObject {
                 return
             }
 
-            let workouts = (samples as? [HKWorkout]) ?? []
+            let workouts = ((samples as? [HKWorkout]) ?? [])
+                .filter { !DeletedWorkoutRegistry.contains($0.uuid.uuidString) }
             guard !workouts.isEmpty else {
                 // Successful query, genuinely no workouts in the window — a real 0.
                 DispatchQueue.main.async {

--- a/app/Mile A Day/Models/User.swift
+++ b/app/Mile A Day/Models/User.swift
@@ -722,6 +722,11 @@ struct Badge: Identifiable, Codable {
             if n >= 100 { return .rare }
             return .common
         }
+        if id.starts(with: "nudge_") {
+            if n >= 500 { return .legendary }
+            if n >= 100 { return .rare }
+            return .common
+        }
         if id.starts(with: "comp_won_") {
             return n >= 5 ? .legendary : .rare
         }

--- a/app/Mile A Day/Models/WorkoutIndex.swift
+++ b/app/Mile A Day/Models/WorkoutIndex.swift
@@ -63,6 +63,29 @@ struct ManualWorkoutRegistry {
     }
 }
 
+/// Workouts the user deleted in Mile A Day. Apple Health is read-only to us, so a
+/// deleted HealthKit workout still exists on device and would otherwise re-appear
+/// on every index rebuild (and re-upload on the next sync). We tombstone its id
+/// locally so it's excluded from all app-side aggregates; the backend keeps its
+/// own tombstone so it never counts there either.
+struct DeletedWorkoutRegistry {
+    private static let key = "com.mileaday.deletedWorkoutIds"
+
+    static func markDeleted(_ workoutId: String) {
+        var ids = all
+        ids.insert(workoutId)
+        UserDefaults.standard.set(Array(ids), forKey: key)
+    }
+
+    static func contains(_ workoutId: String) -> Bool {
+        all.contains(workoutId)
+    }
+
+    static var all: Set<String> {
+        Set(UserDefaults.standard.stringArray(forKey: key) ?? [])
+    }
+}
+
 /// ARCHITECTURAL IMPROVEMENT: Single Source of Truth for Workout Data
 /// This index pre-computes and caches workout data to eliminate:
 /// - Race conditions and data inconsistencies

--- a/app/Mile A Day/Models/WorkoutProcessor.swift
+++ b/app/Mile A Day/Models/WorkoutProcessor.swift
@@ -33,12 +33,16 @@ class WorkoutProcessor {
         var correctionCount = 0
         
         for workout in workouts {
+            // Skip workouts the user deleted in-app — Health still has them, but
+            // they must not count toward streaks, totals, or the calendar.
+            if DeletedWorkoutRegistry.contains(workout.uuid.uuidString) { continue }
+
             let (localDate, offset) = determineLocalDateWithOffset(for: workout)
-            
+
             if offset != 0 {
                 correctionCount += 1
             }
-            
+
             records.append(WorkoutRecord(from: workout, timezoneCorrectedDate: localDate, timezoneOffset: offset))
         }
         

--- a/app/Mile A Day/Services/RunPostService.swift
+++ b/app/Mile A Day/Services/RunPostService.swift
@@ -30,6 +30,25 @@ enum RunPostService {
         )
     }
 
+    /// The workout that pushed today's total past the daily goal — the same one
+    /// the post-run prompt auto-posts. Recomputed deterministically (today's
+    /// workouts in start order, first to cross the goal) so a photo shared later
+    /// from the feed composer carries the same workout id and upserts into the
+    /// SAME feed post instead of creating a duplicate.
+    @MainActor
+    static func dailyMileWorkoutId() -> String? {
+        let workouts = HealthKitManager.shared.todaysWorkouts
+            .sorted { $0.startDate < $1.startDate }
+        let goal = UserManager.shared.currentUser.goalMiles
+        var total = 0.0
+        for workout in workouts {
+            total += workout.totalDistance?.doubleValue(for: HKUnit.mile()) ?? 0
+            if total >= goal { return workout.uuid.uuidString }
+        }
+        // Goal met via non-workout distance — fall back to the latest workout.
+        return workouts.last?.uuid.uuidString
+    }
+
     /// Render the auto image (route map or stats card), upload it, and create the
     /// linked feed post. Called when the user skips the post-run photo prompt.
     @MainActor

--- a/app/Mile A Day/Services/RunPostService.swift
+++ b/app/Mile A Day/Services/RunPostService.swift
@@ -1,0 +1,151 @@
+import SwiftUI
+import UIKit
+import MapKit
+import HealthKit
+import CoreLocation
+
+/// Builds and publishes the "auto" feed post for a completed mile when the user
+/// doesn't add a photo: a rendered GPS route map when the run has one, otherwise
+/// a branded stats card. Linked to the workout so the backend upserts one post
+/// per run (a later photo replaces this image in place).
+enum RunPostService {
+
+    /// Build today's run stats for the composer/auto-post, with the workout id set
+    /// so the resulting post links to the run (enabling the one-post-per-workout
+    /// upsert + feed dedup).
+    @MainActor
+    static func todayStats(workoutId: String) -> RunStatsInput {
+        let hk = HealthKitManager.shared
+        let user = UserManager.shared.currentUser
+        let paceSecPerMile = hk.todaysAveragePace.map { $0 * 60 }
+        return RunStatsInput(
+            distance: hk.todaysDistance,
+            paceSecondsPerMile: (paceSecPerMile ?? 0) > 0 ? paceSecPerMile : nil,
+            durationSeconds: hk.todaysTotalDuration > 0 ? hk.todaysTotalDuration : nil,
+            streak: user.streak,
+            calories: hk.todaysTotalCalories > 0 ? hk.todaysTotalCalories : nil,
+            steps: hk.todaysSteps > 0 ? hk.todaysSteps : nil,
+            workoutId: workoutId,
+            dateText: todayText()
+        )
+    }
+
+    /// Render the auto image (route map or stats card), upload it, and create the
+    /// linked feed post. Called when the user skips the post-run photo prompt.
+    @MainActor
+    static func autoPostMile(workoutId: String, workoutType: String) async {
+        let stats = todayStats(workoutId: workoutId)
+        let workout = HealthKitManager.shared.todaysWorkouts.first { $0.uuid.uuidString == workoutId }
+
+        var image: UIImage?
+        if let workout {
+            let coords = await HealthKitManager.shared.fetchAllRouteLocations(for: workout)
+                .map { $0.coordinate }
+            if coords.count >= 2 {
+                let color: UIColor = workoutType == "walking"
+                    ? .systemBlue : UIColor(MADTheme.Colors.madRed)
+                image = await renderRouteImage(coordinates: coords, color: color)
+            }
+        }
+        if image == nil {
+            image = renderStatsCard(stats: stats, workoutType: workoutType)
+        }
+        guard let finalImage = image else { return }
+
+        do {
+            let mediaUrl = try await PostService.uploadMedia(finalImage)
+            _ = try await PostService.createPost(
+                mediaUrl: mediaUrl,
+                caption: nil,
+                workoutId: workoutId,
+                shareToFeed: true,
+                shareToStory: false,
+                stats: stats.snapshot
+            )
+        } catch {
+            print("[RunPostService] autoPostMile failed: \(error)")
+        }
+    }
+
+    // MARK: - Rendering
+
+    @MainActor
+    static func renderStatsCard(stats: RunStatsInput, workoutType: String) -> UIImage? {
+        let card = RunStatsCardView(stats: stats, workoutType: workoutType)
+            .frame(width: 1080, height: 1350)
+        let renderer = ImageRenderer(content: card)
+        renderer.scale = 1
+        renderer.isOpaque = true
+        return renderer.uiImage
+    }
+
+    /// Snapshot a map covering the route and draw the traced polyline + start/end
+    /// pins. Uses `MKMapSnapshotter` (not `ImageRenderer`) because live map tiles
+    /// don't render through SwiftUI's renderer.
+    static func renderRouteImage(coordinates: [CLLocationCoordinate2D], color: UIColor) async -> UIImage? {
+        guard coordinates.count >= 2 else { return nil }
+
+        var minLat = coordinates[0].latitude, maxLat = coordinates[0].latitude
+        var minLon = coordinates[0].longitude, maxLon = coordinates[0].longitude
+        for c in coordinates {
+            minLat = min(minLat, c.latitude); maxLat = max(maxLat, c.latitude)
+            minLon = min(minLon, c.longitude); maxLon = max(maxLon, c.longitude)
+        }
+        let center = CLLocationCoordinate2D(latitude: (minLat + maxLat) / 2,
+                                            longitude: (minLon + maxLon) / 2)
+        let span = MKCoordinateSpan(
+            latitudeDelta: max((maxLat - minLat) * 1.4, 0.003),
+            longitudeDelta: max((maxLon - minLon) * 1.4, 0.003)
+        )
+
+        let options = MKMapSnapshotter.Options()
+        options.region = MKCoordinateRegion(center: center, span: span)
+        options.size = CGSize(width: 1080, height: 1350)
+        options.scale = 1
+        options.mapType = .standard
+
+        let snapshotter = MKMapSnapshotter(options: options)
+        let snapshot: MKMapSnapshotter.Snapshot? = await withCheckedContinuation { cont in
+            snapshotter.start { snap, _ in cont.resume(returning: snap) }
+        }
+        guard let snapshot else { return nil }
+
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        let renderer = UIGraphicsImageRenderer(size: options.size, format: format)
+        return renderer.image { ctx in
+            snapshot.image.draw(at: .zero)
+            let cg = ctx.cgContext
+
+            // Bottom scrim for legibility if we ever overlay text.
+            cg.setStrokeColor(color.cgColor)
+            cg.setLineWidth(10)
+            cg.setLineJoin(.round)
+            cg.setLineCap(.round)
+            var first = true
+            for coord in coordinates {
+                let pt = snapshot.point(for: coord)
+                if first { cg.move(to: pt); first = false } else { cg.addLine(to: pt) }
+            }
+            cg.strokePath()
+
+            drawDot(cg, at: snapshot.point(for: coordinates.first!), color: .systemGreen)
+            drawDot(cg, at: snapshot.point(for: coordinates.last!), color: color)
+        }
+    }
+
+    private static func drawDot(_ cg: CGContext, at pt: CGPoint, color: UIColor) {
+        let outer: CGFloat = 15
+        cg.setFillColor(UIColor.white.cgColor)
+        cg.fillEllipse(in: CGRect(x: pt.x - outer, y: pt.y - outer, width: outer * 2, height: outer * 2))
+        let inner: CGFloat = 9
+        cg.setFillColor(color.cgColor)
+        cg.fillEllipse(in: CGRect(x: pt.x - inner, y: pt.y - inner, width: inner * 2, height: inner * 2))
+    }
+
+    private static func todayText() -> String {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f.string(from: Date())
+    }
+}

--- a/app/Mile A Day/Services/WorkoutService.swift
+++ b/app/Mile A Day/Services/WorkoutService.swift
@@ -456,6 +456,40 @@ class WorkoutService: ObservableObject {
             responseType: RecentWorkout.self
         )
     }
+
+    /// Delete a workout. The backend soft-deletes it (so a HealthKit re-sync can't
+    /// resurrect it), recomputes the streak, and revokes any badges the user no
+    /// longer qualifies for. On success the id is tombstoned locally so app-side
+    /// aggregates drop it immediately.
+    func deleteWorkout(workoutId: String) async throws -> WorkoutDeleteResponse {
+        guard let currentUserId = getCurrentUserId() else {
+            throw WorkoutServiceError.notAuthenticated
+        }
+
+        let response: WorkoutDeleteResponse = try await makeRequest(
+            endpoint: "/workouts/\(currentUserId)/workout/\(workoutId)",
+            method: .DELETE,
+            body: nil,
+            responseType: WorkoutDeleteResponse.self
+        )
+
+        DeletedWorkoutRegistry.markDeleted(workoutId)
+        return response
+    }
+}
+
+// MARK: - Delete Response
+
+struct WorkoutDeleteResponse: Codable {
+    let message: String?
+    let currentStreak: Int?
+    let revokedBadges: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case message
+        case currentStreak = "current_streak"
+        case revokedBadges = "revoked_badges"
+    }
 }
 
 // MARK: - Response Models

--- a/app/Mile A Day/Views/BadgeDetailView.swift
+++ b/app/Mile A Day/Views/BadgeDetailView.swift
@@ -45,24 +45,26 @@ struct BadgeDetailView: View {
                 ambientGlow
             }
             
-            VStack(spacing: 0) {
-                Spacer()
-                    .frame(height: 16)
-                
-                // Medal display
-                medalSection
-                    .scaleEffect(showMedal ? 1 : 0.5)
-                    .opacity(showMedal ? 1 : 0)
-                
-                Spacer()
-                    .frame(height: 40)
-                
-                // Details section
-                detailsSection
-                    .opacity(showContent ? 1 : 0)
-                    .offset(y: showContent ? 0 : 30)
-                
-                Spacer()
+            // Scrollable so the medal + details always fit on any screen size and
+            // the hero is never clipped under the dynamic island (the ScrollView
+            // respects the top safe area).
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 0) {
+                    Color.clear.frame(height: 12)
+
+                    // Medal display
+                    medalSection
+                        .scaleEffect(showMedal ? 1 : 0.5)
+                        .opacity(showMedal ? 1 : 0)
+
+                    Color.clear.frame(height: 36)
+
+                    // Details section
+                    detailsSection
+                        .opacity(showContent ? 1 : 0)
+                        .offset(y: showContent ? 0 : 30)
+                }
+                .frame(maxWidth: .infinity)
             }
         }
         .onAppear {
@@ -148,91 +150,18 @@ struct BadgeDetailView: View {
                 .opacity(ribbonDrop ? 1 : 0)
                 .offset(y: ribbonDrop ? 0 : -30)
             
-            // Medal
+            // Medal — premium tiltable 3D medal with live shimmer.
             ZStack {
                 // Outer glow rings
                 if !badge.isLocked {
                     ForEach(0..<3, id: \.self) { i in
                         Circle()
                             .stroke(badge.rarity.color.opacity(0.15 - Double(i) * 0.04), lineWidth: 1)
-                            .frame(width: 180 + CGFloat(i * 30), height: 180 + CGFloat(i * 30))
+                            .frame(width: 190 + CGFloat(i * 30), height: 190 + CGFloat(i * 30))
                     }
                 }
-                
-                // Main medal circle
-                Circle()
-                    .fill(
-                        LinearGradient(
-                            colors: badge.isLocked ? [
-                                Color(white: 0.3),
-                                Color(white: 0.18)
-                            ] : medalGradientColors,
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        )
-                    )
-                    .frame(width: 150, height: 150)
-                    .overlay(
-                        Circle()
-                            .stroke(
-                                LinearGradient(
-                                    colors: badge.isLocked ? [
-                                        Color.white.opacity(0.15),
-                                        Color.white.opacity(0.05)
-                                    ] : [
-                                        Color.white.opacity(0.6),
-                                        badge.rarity.color.opacity(0.3)
-                                    ],
-                                    startPoint: .topLeading,
-                                    endPoint: .bottomTrailing
-                                ),
-                                lineWidth: 3
-                            )
-                    )
-                    .shadow(
-                        color: badge.isLocked ? .black.opacity(0.3) : badge.rarity.color.opacity(0.5),
-                        radius: 25,
-                        x: 0,
-                        y: 15
-                    )
-                
-                // Inner decorative ring
-                Circle()
-                    .stroke(Color.white.opacity(badge.isLocked ? 0.1 : 0.25), lineWidth: 2)
-                    .frame(width: 120, height: 120)
-                
-                // Icon
-                if badge.isLocked {
-                    Image(systemName: "lock.fill")
-                        .font(.system(size: 45, weight: .medium))
-                        .foregroundColor(.white.opacity(0.35))
-                } else {
-                    Image(systemName: resolvedIcon)
-                        .font(.system(size: 55, weight: .semibold))
-                        .foregroundStyle(
-                            LinearGradient(
-                                colors: [.white, .white.opacity(0.85)],
-                                startPoint: .top,
-                                endPoint: .bottom
-                            )
-                        )
-                        .shadow(color: .black.opacity(0.3), radius: 3, x: 0, y: 3)
-                }
-                
-                // Shimmer effect
-                if !badge.isLocked {
-                    Circle()
-                        .fill(
-                            LinearGradient(
-                                colors: [.clear, .white.opacity(0.3), .clear],
-                                startPoint: .leading,
-                                endPoint: .trailing
-                            )
-                        )
-                        .frame(width: 150, height: 150)
-                        .offset(x: shimmerOffset)
-                        .clipShape(Circle())
-                }
+
+                TiltableMedal(badge: badge, size: 156)
             }
             .offset(y: -15)
         }

--- a/app/Mile A Day/Views/BadgesView.swift
+++ b/app/Mile A Day/Views/BadgesView.swift
@@ -322,95 +322,15 @@ struct PremiumBadgeCard: View {
     
     var body: some View {
         VStack(spacing: 14) {
-            // Badge medal — fixed 110pt frame so locked cards (which have no glow) match unlocked
+            // Badge medal — premium shared MedalView in a fixed 110pt frame so
+            // locked and unlocked cards line up.
             ZStack {
-                // Outer glow for unlocked
-                if !badge.isLocked {
-                    Circle()
-                        .fill(
-                            RadialGradient(
-                                colors: [badge.rarity.color.opacity(0.4), badge.rarity.color.opacity(0)],
-                                center: .center,
-                                startRadius: 20,
-                                endRadius: 55
-                            )
-                        )
-                        .frame(width: 110, height: 110)
-                }
-                
-                // Medal base
-                Circle()
-                    .fill(
-                        LinearGradient(
-                            colors: badge.isLocked ? [
-                                Color(white: 0.25),
-                                Color(white: 0.15)
-                            ] : medalGradientColors,
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        )
-                    )
-                    .frame(width: 76, height: 76)
-                    .overlay(
-                        Circle()
-                            .stroke(
-                                LinearGradient(
-                                    colors: badge.isLocked ? [
-                                        Color.white.opacity(0.1),
-                                        Color.white.opacity(0.05)
-                                    ] : [
-                                        Color.white.opacity(0.5),
-                                        badge.rarity.color.opacity(0.3)
-                                    ],
-                                    startPoint: .topLeading,
-                                    endPoint: .bottomTrailing
-                                ),
-                                lineWidth: 2
-                            )
-                    )
-                    .shadow(
-                        color: badge.isLocked ? .clear : badge.rarity.color.opacity(0.4),
-                        radius: 12,
-                        x: 0,
-                        y: 6
-                    )
-                
-                // Inner ring
-                if !badge.isLocked {
-                    Circle()
-                        .stroke(Color.white.opacity(0.2), lineWidth: 1)
-                        .frame(width: 60, height: 60)
-                }
-                
-                // Icon
-                if badge.isLocked {
-                    ZStack {
-                        Image(systemName: badgeIcon)
-                            .font(.system(size: 28, weight: .medium))
-                            .foregroundColor(.white.opacity(0.15))
-                        
-                        Image(systemName: "lock.fill")
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundColor(.white.opacity(0.4))
-                            .offset(x: 18, y: -18)
-                    }
-                } else {
-                    Image(systemName: badgeIcon)
-                        .font(.system(size: 30, weight: .semibold))
-                        .foregroundStyle(
-                            LinearGradient(
-                                colors: [.white, .white.opacity(0.85)],
-                                startPoint: .top,
-                                endPoint: .bottom
-                            )
-                        )
-                        .shadow(color: .black.opacity(0.3), radius: 2, x: 0, y: 2)
-                }
-                
-                // Tags
+                MedalView(badge: badge, size: 88)
+
+                // NEW tag
                 if badge.isNew && !badge.isLocked {
                     newTag
-                        .offset(x: 28, y: -28)
+                        .offset(x: 30, y: -34)
                 }
             }
             .frame(width: 110, height: 110)

--- a/app/Mile A Day/Views/Celebrations/BadgeSummaryCelebrationView.swift
+++ b/app/Mile A Day/Views/Celebrations/BadgeSummaryCelebrationView.swift
@@ -97,19 +97,9 @@ struct BadgeSummaryCelebrationView: View {
     }
 
     private func miniMedal(_ badge: Badge) -> some View {
-        ZStack {
-            Circle()
-                .fill(RadialGradient(colors: [badge.rarity.color.opacity(0.4), .clear], center: .center, startRadius: 8, endRadius: 44))
-                .frame(width: 88, height: 88)
-            Circle()
-                .fill(LinearGradient(colors: medalGradientColors(for: badge), startPoint: .topLeading, endPoint: .bottomTrailing))
-                .frame(width: 60, height: 60)
-                .overlay(Circle().stroke(Color.white.opacity(0.5), lineWidth: 2))
-                .shadow(color: badge.rarity.color.opacity(0.5), radius: 8, y: 3)
-            Image(systemName: iconName(for: badge))
-                .font(.system(size: 24, weight: .semibold))
-                .foregroundStyle(LinearGradient(colors: [.white, .white.opacity(0.85)], startPoint: .top, endPoint: .bottom))
-        }
+        // Shared premium medal; shimmer off so the stacked row stays calm.
+        MedalView(badge: badge, size: 72, showShimmer: false)
+            .frame(width: 88, height: 88)
     }
 
     private func runSequence() {

--- a/app/Mile A Day/Views/Celebrations/BadgeUnlockCelebrationView.swift
+++ b/app/Mile A Day/Views/Celebrations/BadgeUnlockCelebrationView.swift
@@ -19,6 +19,8 @@ struct BadgeUnlockCelebrationView: View {
     @State private var iconRotation: Double = -30
     @State private var showRarityBanner = false
     @State private var showConfetti = false
+    @State private var showBurst = false
+    @State private var showRays = false
     @State private var showContent = false
     @State private var showButtons = false
     @State private var hasStartedAnimation: Bool = false
@@ -70,17 +72,19 @@ struct BadgeUnlockCelebrationView: View {
     
     var confettiCount: Int {
         switch badge.rarity {
-        case .common: return 20
-        case .rare: return 30
-        case .legendary: return 40
+        case .common: return 36
+        case .rare: return 55
+        case .legendary: return 80
         }
     }
 
-    var ringCount: Int {
+    // Rotating light rays behind the medal — reserved for rare/legendary so common
+    // unlocks stay clean.
+    var rayCount: Int {
         switch badge.rarity {
-        case .common: return 1
-        case .rare: return 2
-        case .legendary: return 3
+        case .common: return 0
+        case .rare: return 10
+        case .legendary: return 16
         }
     }
     
@@ -121,65 +125,36 @@ struct BadgeUnlockCelebrationView: View {
 
                             // Badge display
                             ZStack {
-                                // Subtle ambient glow
+                                // Rotating light rays (rare/legendary only)
+                                if showRays && rayCount > 0 {
+                                    LightRays(color: rarityColor, rayCount: rayCount)
+                                        .frame(width: 340, height: 340)
+                                        .transition(.opacity)
+                                }
+
+                                // Ambient glow
                                 Circle()
                                     .fill(
                                         RadialGradient(
-                                            colors: [rarityColor.opacity(0.35), rarityColor.opacity(0)],
+                                            colors: [rarityColor.opacity(0.4), rarityColor.opacity(0)],
                                             center: .center,
                                             startRadius: 40,
-                                            endRadius: 110
+                                            endRadius: 130
                                         )
                                     )
-                                    .frame(width: 220, height: 220)
+                                    .frame(width: 240, height: 240)
 
-                                // Medal
-                                ZStack {
-                                    // Main medal
-                                    Circle()
-                                        .fill(
-                                            LinearGradient(
-                                                colors: medalGradient,
-                                                startPoint: .topLeading,
-                                                endPoint: .bottomTrailing
-                                            )
-                                        )
-                                        .frame(width: 160, height: 160)
-                                        .overlay(
-                                            Circle()
-                                                .stroke(
-                                                    LinearGradient(
-                                                        colors: [Color.white.opacity(0.6), rarityColor.opacity(0.3)],
-                                                        startPoint: .topLeading,
-                                                        endPoint: .bottomTrailing
-                                                    ),
-                                                    lineWidth: 3
-                                                )
-                                        )
-                                        .shadow(color: rarityColor.opacity(0.5), radius: 20, x: 0, y: 10)
-
-                                    // Inner ring
-                                    Circle()
-                                        .stroke(Color.white.opacity(0.3), lineWidth: 1.5)
-                                        .frame(width: 130, height: 130)
-
-                                    // Badge icon
-                                    Image(systemName: badgeIcon)
-                                        .font(.system(size: 64, weight: .semibold))
-                                        .foregroundStyle(
-                                            LinearGradient(
-                                                colors: [.white, .white.opacity(0.85)],
-                                                startPoint: .top,
-                                                endPoint: .bottom
-                                            )
-                                        )
-                                        .shadow(color: .black.opacity(0.3), radius: 4, x: 0, y: 3)
-                                        .scaleEffect(iconScale)
-                                        .rotationEffect(.degrees(iconRotation))
-                                        .opacity(showIcon ? 1 : 0)
+                                // Radial burst at the reveal moment
+                                if showBurst {
+                                    BurstEffect(colors: confettiColors, particleCount: 26)
+                                        .frame(width: 280, height: 280)
+                                        .allowsHitTesting(false)
                                 }
-                                .scaleEffect(medalScale)
-                                .opacity(showMedal ? 1 : 0)
+
+                                // Premium tiltable medal
+                                TiltableMedal(badge: badge, size: 172)
+                                    .scaleEffect(medalScale)
+                                    .opacity(showMedal ? 1 : 0)
                             }
 
                             // Badge info content
@@ -409,25 +384,22 @@ struct BadgeUnlockCelebrationView: View {
             }
         }
 
-        // Phase 2: Medal + icon appear together
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
-            withAnimation(.spring(response: 0.5, dampingFraction: 0.55)) {
+        // Phase 2: Light rays fade in behind, then the medal punches in with a burst.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            withAnimation(.easeOut(duration: 0.6)) { showRays = true }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.52)) {
                 showMedal = true
                 medalScale = 1.0
             }
+            showBurst = true
             notificationGenerator.notificationOccurred(.success)
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.55) {
-            withAnimation(.spring(response: 0.4, dampingFraction: 0.5)) {
-                showIcon = true
-                iconScale = 1.0
-                iconRotation = 0
-            }
-            impactGenerator.impactOccurred(intensity: 0.8)
+            impactGenerator.impactOccurred(intensity: 1.0)
         }
 
-        // Phase 3: Confetti
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+        // Phase 3: Confetti rains down
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
             showConfetti = true
         }
 
@@ -524,6 +496,43 @@ struct RarityBannerView: View {
     }
 }
 
+
+// MARK: - Light Rays
+
+/// Slowly rotating volumetric light rays behind the medal. Masked to fade out at
+/// the center (behind the medal) and the edges so it reads as a soft halo of
+/// god-rays rather than a hard pinwheel.
+struct LightRays: View {
+    let color: Color
+    var rayCount: Int = 12
+
+    @State private var angle: Double = 0
+
+    private var rayColors: [Color] {
+        (0..<max(1, rayCount)).flatMap { _ in [color.opacity(0), color.opacity(0.32)] }
+    }
+
+    var body: some View {
+        AngularGradient(gradient: Gradient(colors: rayColors), center: .center)
+            .blur(radius: 5)
+            .mask(
+                RadialGradient(
+                    colors: [.clear, .white, .clear],
+                    center: .center,
+                    startRadius: 50,
+                    endRadius: 170
+                )
+            )
+            .blendMode(.screen)
+            .rotationEffect(.degrees(angle))
+            .onAppear {
+                withAnimation(.linear(duration: 18).repeatForever(autoreverses: false)) {
+                    angle = 360
+                }
+            }
+            .allowsHitTesting(false)
+    }
+}
 
 // MARK: - Confetti Cannon
 

--- a/app/Mile A Day/Views/Celebrations/CelebrationContainerView.swift
+++ b/app/Mile A Day/Views/Celebrations/CelebrationContainerView.swift
@@ -52,6 +52,9 @@ struct CelebrationContainerView: View {
 
         case .challengeCompleted(let info):
             ChallengeCompletedCelebrationView(info: info)
+
+        case .postRunPhotoPrompt(let workoutId, let workoutType):
+            PostRunPhotoPromptView(workoutId: workoutId, workoutType: workoutType)
         }
     }
 }

--- a/app/Mile A Day/Views/Celebrations/ChallengeCompletedCelebrationView.swift
+++ b/app/Mile A Day/Views/Celebrations/ChallengeCompletedCelebrationView.swift
@@ -152,12 +152,14 @@ struct ChallengeCompletedCelebrationView: View {
                                                 startPoint: .top, endPoint: .bottom))
 
             // Completion check badge.
-            Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 40))
-                .foregroundColor(.green)
-                .background(Circle().fill(.white).frame(width: 34, height: 34))
-                .offset(x: 46, y: 46)
-                .scaleEffect(checkScale)
+            ZStack {
+                Circle().fill(.white).frame(width: 32, height: 32)
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 40))
+                    .foregroundColor(.green)
+            }
+            .offset(x: 46, y: 46)
+            .scaleEffect(checkScale)
         }
         .scaleEffect(badgeScale)
     }

--- a/app/Mile A Day/Views/Celebrations/LeaderboardMoveUpView.swift
+++ b/app/Mile A Day/Views/Celebrations/LeaderboardMoveUpView.swift
@@ -19,6 +19,16 @@ struct LeaderboardMoveUpView: View {
     private var myRank: Int { (rows.firstIndex { $0.isMe }.map { $0 + 1 }) ?? 0 }
     private var totalCount: Int { rows.count }
 
+    // Rank movement from this just-finished run/walk: compare where I'd sit with my
+    // pre-workout mileage vs now, so we can show "moved up N spots".
+    private var latestWorkoutMiles: Double { stats.latestWorkout?.distance ?? 0 }
+    private var myMiles: Double { rows.first { $0.isMe }?.miles ?? stats.todaysDistance }
+    private var previousMiles: Double { max(0, myMiles - latestWorkoutMiles) }
+    private var previousRank: Int {
+        rows.filter { !$0.isMe && $0.miles > previousMiles }.count + 1
+    }
+    private var spotsMovedUp: Int { max(0, previousRank - myRank) }
+
     struct LBRow: Identifiable {
         let user_id: String
         let name: String
@@ -46,6 +56,13 @@ struct LeaderboardMoveUpView: View {
                            startPoint: .top, endPoint: .bottom)
                 .ignoresSafeArea()
                 .opacity(showOverlay ? 1 : 0)
+
+            // Gold burst when you land #1.
+            if loaded && myRank == 1 && animateMe {
+                BurstEffect(colors: [.yellow, .orange, .white], particleCount: 30)
+                    .frame(height: 320)
+                    .allowsHitTesting(false)
+            }
 
             VStack(spacing: MADTheme.Spacing.lg) {
                 Spacer(minLength: MADTheme.Spacing.xl)
@@ -88,12 +105,37 @@ struct LeaderboardMoveUpView: View {
                 .font(.system(size: 22, weight: .black, design: .rounded))
                 .foregroundColor(.white)
             if loaded && rows.count > 1 {
-                Text(myRank <= 3 ? "You're in the top 3! 🔥" : "You're #\(myRank) of \(totalCount) today")
-                    .font(.system(size: 14, weight: .semibold, design: .rounded))
-                    .foregroundColor(.white.opacity(0.65))
+                movementBadge
             }
         }
         .opacity(showBoard ? 1 : 0)
+    }
+
+    @ViewBuilder
+    private var movementBadge: some View {
+        if myRank == 1 {
+            badgePill("👑 You took #1 today!", color: Color(red: 1.0, green: 0.84, blue: 0.0))
+        } else if spotsMovedUp > 0 {
+            badgePill("🚀 Moved up \(spotsMovedUp) spot\(spotsMovedUp == 1 ? "" : "s")!", color: .green)
+        } else if myRank <= 3 {
+            badgePill("🔥 You're on the podium!", color: .orange)
+        } else {
+            badgePill("You're #\(myRank) of \(totalCount)", color: MADTheme.Colors.madRed)
+        }
+    }
+
+    private func badgePill(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.system(size: 14, weight: .heavy, design: .rounded))
+            .foregroundColor(.white)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 7)
+            .background(
+                Capsule().fill(color.opacity(0.22))
+                    .overlay(Capsule().strokeBorder(color.opacity(0.6), lineWidth: 1))
+            )
+            .scaleEffect(animateMe ? 1 : 0.7)
+            .opacity(animateMe ? 1 : 0)
     }
 
     private var board: some View {
@@ -254,6 +296,10 @@ struct LeaderboardMoveUpView: View {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
                 withAnimation(.spring(response: 0.6, dampingFraction: 0.7)) { animateMe = true }
                 UINotificationFeedbackGenerator().notificationOccurred(.success)
+                // Extra thump when you land the top spot.
+                if myRank == 1 {
+                    UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
+                }
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.1) {
                 withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) { showButton = true }

--- a/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
+++ b/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+/// BeReal-style prompt shown as the finale after finishing today's mile: snap a
+/// photo of your run, or skip. Either way the run becomes one feed item — taking
+/// a photo publishes it with the photo; skipping publishes the route map (or a
+/// stats card) via `RunPostService`. Friends get one merged notification ~10 min
+/// later (handled server-side), so there's a window to add a photo.
+struct PostRunPhotoPromptView: View {
+    let workoutId: String
+    let workoutType: String
+
+    @ObservedObject private var manager = CelebrationManager.shared
+    @State private var showComposer = false
+    @State private var appeared = false
+    @State private var didAct = false
+
+    private var isWalk: Bool { workoutType == "walking" }
+    private var accent: Color { isWalk ? .blue : MADTheme.Colors.madRed }
+
+    var body: some View {
+        ZStack {
+            LinearGradient(colors: [Color(red: 0.08, green: 0.06, blue: 0.10), .black],
+                           startPoint: .top, endPoint: .bottom)
+                .ignoresSafeArea()
+
+            VStack(spacing: MADTheme.Spacing.lg) {
+                Spacer()
+
+                ZStack {
+                    Circle().fill(accent.opacity(0.18)).frame(width: 150, height: 150)
+                    Circle().strokeBorder(accent.opacity(0.4), lineWidth: 1).frame(width: 150, height: 150)
+                    Image(systemName: "camera.fill")
+                        .font(.system(size: 54, weight: .semibold))
+                        .foregroundStyle(LinearGradient(colors: [.white, accent],
+                                                        startPoint: .top, endPoint: .bottom))
+                        .shadow(color: accent.opacity(0.5), radius: 16)
+                }
+                .scaleEffect(appeared ? 1 : 0.6)
+                .opacity(appeared ? 1 : 0)
+
+                VStack(spacing: 8) {
+                    Text(isWalk ? "Capture your walk" : "Capture your run")
+                        .font(.system(size: 26, weight: .black, design: .rounded))
+                        .foregroundColor(.white)
+                    Text("Add a photo to today's mile — it shares to your feed either way. Snap one before your friends get the heads-up.")
+                        .font(.system(size: 14, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.6))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, MADTheme.Spacing.xl)
+                }
+                .opacity(appeared ? 1 : 0)
+
+                Spacer()
+
+                VStack(spacing: MADTheme.Spacing.sm) {
+                    Button { showComposer = true } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: "camera.fill")
+                            Text("Take a photo")
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                    .madPrimaryButton(fullWidth: true)
+
+                    Button { skip() } label: {
+                        Text("Skip")
+                            .font(MADTheme.Typography.headline)
+                            .foregroundColor(.white.opacity(0.7))
+                    }
+                    .padding(.top, 2)
+                }
+                .padding(.horizontal, MADTheme.Spacing.lg)
+                .padding(.bottom, MADTheme.Spacing.xl)
+            }
+        }
+        .onAppear { withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) { appeared = true } }
+        .fullScreenCover(isPresented: $showComposer) {
+            PostComposerView(stats: RunPostService.todayStats(workoutId: workoutId)) { success in
+                showComposer = false
+                didAct = true
+                // Cancelled the camera? Still publish the auto route/stats post so
+                // the run gets one nice feed item.
+                if !success {
+                    Task { await RunPostService.autoPostMile(workoutId: workoutId, workoutType: workoutType) }
+                }
+                finish()
+            }
+        }
+    }
+
+    private func skip() {
+        guard !didAct else { return }
+        didAct = true
+        Task { await RunPostService.autoPostMile(workoutId: workoutId, workoutType: workoutType) }
+        finish()
+    }
+
+    private func finish() {
+        manager.dismissCurrentCelebration()
+    }
+}

--- a/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
+++ b/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
@@ -75,7 +75,7 @@ struct PostRunPhotoPromptView: View {
         }
         .onAppear { withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) { appeared = true } }
         .fullScreenCover(isPresented: $showComposer) {
-            PostComposerView(stats: RunPostService.todayStats(workoutId: workoutId)) { success in
+            PostComposerView(stats: RunPostService.todayStats(workoutId: workoutId), autoOpenCamera: true) { success in
                 showComposer = false
                 didAct = true
                 // Cancelled the camera? Still publish the auto route/stats post so

--- a/app/Mile A Day/Views/Components/BadgeRowCard.swift
+++ b/app/Mile A Day/Views/Components/BadgeRowCard.swift
@@ -49,44 +49,8 @@ struct BadgeRowCard: View {
             isShowingDetail = true
         } label: {
             HStack(spacing: MADTheme.Spacing.md) {
-                // Mini medal
-                ZStack {
-                    Circle()
-                        .fill(
-                            LinearGradient(
-                                colors: badge.isLocked
-                                    ? [Color(white: 0.25), Color(white: 0.15)]
-                                    : medalGradientColors,
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
-                            )
-                        )
-                        .frame(width: 40, height: 40)
-                        .overlay(
-                            Circle()
-                                .stroke(
-                                    badge.isLocked
-                                        ? Color.white.opacity(0.08)
-                                        : Color.white.opacity(0.3),
-                                    lineWidth: 1
-                                )
-                        )
-                        .shadow(
-                            color: badge.isLocked ? .clear : badge.rarity.color.opacity(0.3),
-                            radius: 6, x: 0, y: 3
-                        )
-
-                    if badge.isLocked {
-                        Image(systemName: "lock.fill")
-                            .font(.system(size: 14, weight: .medium))
-                            .foregroundColor(.white.opacity(0.3))
-                    } else {
-                        Image(systemName: badgeIcon)
-                            .font(.system(size: 17, weight: .semibold))
-                            .foregroundColor(.white)
-                            .shadow(color: .black.opacity(0.3), radius: 1, x: 0, y: 1)
-                    }
-                }
+                // Mini medal — shared premium look (no shimmer at this small size).
+                MedalView(badge: badge, size: 44, showShimmer: false)
 
                 // Name & rarity
                 VStack(alignment: .leading, spacing: 2) {

--- a/app/Mile A Day/Views/Components/FriendBadgeCompareView.swift
+++ b/app/Mile A Day/Views/Components/FriendBadgeCompareView.swift
@@ -331,29 +331,7 @@ private struct FriendBadgeDetailView: View {
                                 .frame(width: 200, height: 200)
                         }
 
-                        Circle()
-                            .fill(
-                                LinearGradient(
-                                    colors: badge.isLocked
-                                        ? [Color(white: 0.25), Color(white: 0.15)]
-                                        : medalGradientColors(for: badge),
-                                    startPoint: .topLeading,
-                                    endPoint: .bottomTrailing
-                                )
-                            )
-                            .frame(width: 140, height: 140)
-                            .overlay(
-                                Circle()
-                                    .stroke(
-                                        badge.isLocked ? Color.white.opacity(0.1) : Color.white.opacity(0.5),
-                                        lineWidth: 3
-                                    )
-                            )
-                            .shadow(color: badge.isLocked ? .clear : badge.rarity.color.opacity(0.4), radius: 18, x: 0, y: 8)
-
-                        Image(systemName: badge.isLocked ? "lock.fill" : iconName(for: badge))
-                            .font(.system(size: 50, weight: .semibold))
-                            .foregroundColor(badge.isLocked ? .white.opacity(0.35) : .white)
+                        TiltableMedal(badge: badge, size: 144)
                     }
                     .padding(.top, MADTheme.Spacing.lg)
 

--- a/app/Mile A Day/Views/Components/ImagePicker.swift
+++ b/app/Mile A Day/Views/Components/ImagePicker.swift
@@ -45,6 +45,56 @@ struct ImagePicker: UIViewControllerRepresentable {
     }
 }
 
+// MARK: - Camera Capture
+
+/// Camera-only capture (no photo library). Used by the post composer so shared
+/// walks/runs are captured in the moment rather than uploaded from the roll.
+struct CameraPicker: UIViewControllerRepresentable {
+    @Binding var image: UIImage?
+    @Environment(\.presentationMode) var presentationMode
+
+    /// Whether the device actually has a camera (false on Simulator).
+    static var isAvailable: Bool {
+        UIImagePickerController.isSourceTypeAvailable(.camera)
+    }
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        // Guard against unavailable cameras (e.g. Simulator) — presenting a
+        // `.camera` source there would crash. Callers gate on `isAvailable`.
+        guard Self.isAvailable else { return UIViewController() }
+
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.cameraCaptureMode = .photo
+        picker.allowsEditing = false
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        let parent: CameraPicker
+        init(_ parent: CameraPicker) { self.parent = parent }
+
+        func imagePickerController(
+            _ picker: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
+            if let img = info[.originalImage] as? UIImage {
+                parent.image = img
+            }
+            parent.presentationMode.wrappedValue.dismiss()
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            parent.presentationMode.wrappedValue.dismiss()
+        }
+    }
+}
+
 // MARK: - Profile Image Cropper
 
 struct ProfileImageCropper: View {

--- a/app/Mile A Day/Views/Components/ManagePinnedBadgesSheet.swift
+++ b/app/Mile A Day/Views/Components/ManagePinnedBadgesSheet.swift
@@ -254,30 +254,7 @@ private struct BadgePickerCard: View {
         Button(action: onTap) {
             VStack(spacing: 10) {
                 ZStack {
-                    Circle()
-                        .fill(
-                            LinearGradient(
-                                colors: medalGradientColors(for: badge),
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
-                            )
-                        )
-                        .frame(width: 64, height: 64)
-                        .overlay(
-                            Circle()
-                                .stroke(Color.white.opacity(0.4), lineWidth: 1.5)
-                        )
-                        .shadow(color: badge.rarity.color.opacity(0.35), radius: 8, x: 0, y: 4)
-
-                    Image(systemName: iconName(for: badge))
-                        .font(.system(size: 24, weight: .semibold))
-                        .foregroundStyle(
-                            LinearGradient(
-                                colors: [.white, .white.opacity(0.85)],
-                                startPoint: .top,
-                                endPoint: .bottom
-                            )
-                        )
+                    MedalView(badge: badge, size: 64, showShimmer: false)
 
                     if let idx = selectionIndex {
                         ZStack {

--- a/app/Mile A Day/Views/Components/MedalView.swift
+++ b/app/Mile A Day/Views/Components/MedalView.swift
@@ -1,0 +1,334 @@
+//
+//  MedalView.swift
+//  Mile A Day
+//
+//  One premium, metallic, embossed medal used EVERYWHERE a medal is shown so the
+//  look is consistent across the grid, detail screen, unlock celebration, profile
+//  showcase, and challenge gallery.
+//
+//  - `MedalView` is the pure disc. It takes `roll`/`pitch` (-1...1) so a parent can
+//    drive a 3D tilt + moving specular highlight, plus an internal shimmer sweep.
+//    It does NOT observe motion itself, so dozens can render in a grid cheaply.
+//  - `TiltableMedal` wraps `MedalView` and feeds it live device tilt from the
+//    shared `MedalMotion` — use it for the single hero medal on detail / unlock.
+//
+
+import SwiftUI
+import CoreMotion
+
+// MARK: - Shared device-motion source
+
+/// One `CMMotionManager` for the whole app, ref-counted so the sensor only runs
+/// while a tiltable medal is on screen. Publishes normalized roll/pitch in -1...1,
+/// relative to however the phone is held when the first medal appears (so the
+/// medal reads "flat" at rest and reacts to tilt from there).
+final class MedalMotion: ObservableObject {
+    static let shared = MedalMotion()
+
+    @Published var roll: Double = 0
+    @Published var pitch: Double = 0
+
+    private let manager = CMMotionManager()
+    private var refCount = 0
+    private var refRoll: Double?
+    private var refPitch: Double?
+
+    private init() {}
+
+    func start() {
+        refCount += 1
+        guard manager.isDeviceMotionAvailable, !manager.isDeviceMotionActive else { return }
+        manager.deviceMotionUpdateInterval = 1.0 / 30.0
+        manager.startDeviceMotionUpdates(to: .main) { [weak self] motion, _ in
+            guard let self, let m = motion else { return }
+            if self.refRoll == nil { self.refRoll = m.attitude.roll }
+            if self.refPitch == nil { self.refPitch = m.attitude.pitch }
+            let span = 0.6 // radians of tilt that maps to the full -1...1 range
+            let r = (m.attitude.roll - (self.refRoll ?? 0)) / span
+            let p = (m.attitude.pitch - (self.refPitch ?? 0)) / span
+            self.roll = min(1, max(-1, r))
+            self.pitch = min(1, max(-1, p))
+        }
+    }
+
+    func stop() {
+        refCount = max(0, refCount - 1)
+        if refCount == 0 {
+            manager.stopDeviceMotionUpdates()
+            refRoll = nil
+            refPitch = nil
+            roll = 0
+            pitch = 0
+        }
+    }
+}
+
+// MARK: - Metallic palette
+
+struct MedalPalette {
+    let rimHi: Color, rimMid: Color, rimLo: Color
+    let faceHi: Color, faceMid: Color, faceLo: Color
+    let iconHi: Color, iconLo: Color
+    let glow: Color
+
+    static func forRarity(_ rarity: BadgeRarity, locked: Bool) -> MedalPalette {
+        if locked {
+            return MedalPalette(
+                rimHi: Color(red: 0.46, green: 0.47, blue: 0.51),
+                rimMid: Color(red: 0.30, green: 0.31, blue: 0.35),
+                rimLo: Color(red: 0.16, green: 0.17, blue: 0.20),
+                faceHi: Color(red: 0.34, green: 0.35, blue: 0.39),
+                faceMid: Color(red: 0.24, green: 0.25, blue: 0.29),
+                faceLo: Color(red: 0.13, green: 0.14, blue: 0.17),
+                iconHi: Color(red: 0.55, green: 0.56, blue: 0.60),
+                iconLo: Color(red: 0.30, green: 0.31, blue: 0.35),
+                glow: .clear
+            )
+        }
+        switch rarity {
+        case .legendary:
+            return MedalPalette(
+                rimHi: Color(red: 1.00, green: 0.95, blue: 0.66),
+                rimMid: Color(red: 1.00, green: 0.80, blue: 0.26),
+                rimLo: Color(red: 0.62, green: 0.40, blue: 0.04),
+                faceHi: Color(red: 1.00, green: 0.89, blue: 0.52),
+                faceMid: Color(red: 0.95, green: 0.71, blue: 0.22),
+                faceLo: Color(red: 0.52, green: 0.32, blue: 0.02),
+                iconHi: Color(red: 1.00, green: 0.98, blue: 0.84),
+                iconLo: Color(red: 0.80, green: 0.54, blue: 0.12),
+                glow: Color(red: 1.00, green: 0.76, blue: 0.20)
+            )
+        case .rare:
+            return MedalPalette(
+                rimHi: Color(red: 0.93, green: 0.87, blue: 1.00),
+                rimMid: Color(red: 0.66, green: 0.45, blue: 0.96),
+                rimLo: Color(red: 0.30, green: 0.13, blue: 0.52),
+                faceHi: Color(red: 0.82, green: 0.64, blue: 1.00),
+                faceMid: Color(red: 0.58, green: 0.36, blue: 0.86),
+                faceLo: Color(red: 0.28, green: 0.12, blue: 0.48),
+                iconHi: Color(red: 0.97, green: 0.93, blue: 1.00),
+                iconLo: Color(red: 0.62, green: 0.42, blue: 0.92),
+                glow: Color(red: 0.62, green: 0.36, blue: 0.96)
+            )
+        case .common:
+            return MedalPalette(
+                rimHi: Color(red: 0.86, green: 0.94, blue: 1.00),
+                rimMid: Color(red: 0.42, green: 0.66, blue: 0.97),
+                rimLo: Color(red: 0.12, green: 0.31, blue: 0.60),
+                faceHi: Color(red: 0.64, green: 0.81, blue: 1.00),
+                faceMid: Color(red: 0.34, green: 0.56, blue: 0.89),
+                faceLo: Color(red: 0.13, green: 0.29, blue: 0.56),
+                iconHi: Color(red: 0.93, green: 0.97, blue: 1.00),
+                iconLo: Color(red: 0.42, green: 0.62, blue: 0.92),
+                glow: Color(red: 0.30, green: 0.56, blue: 0.96)
+            )
+        }
+    }
+}
+
+// MARK: - The medal disc
+
+struct MedalView: View {
+    let badge: Badge
+    var size: CGFloat = 120
+    /// Device tilt, -1...1. Drive these for a live 3D effect, or leave 0 for a
+    /// static (but still premium) render in grids.
+    var roll: Double = 0
+    var pitch: Double = 0
+    var showShimmer: Bool = true
+
+    @State private var shimmer: CGFloat = -1.2
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var locked: Bool { badge.isLocked }
+    private var palette: MedalPalette { MedalPalette.forRarity(badge.rarity, locked: locked) }
+    private var rimWidth: CGFloat { size * 0.085 }
+    private var icon: String { iconName(for: badge) }
+
+    // Stagger each medal's shimmer so a grid doesn't sweep in unison.
+    private var shimmerDelay: Double {
+        Double(abs(badge.id.hashValue) % 100) / 100.0 * 2.2
+    }
+
+    var body: some View {
+        ZStack {
+            rim
+            face
+            bevel
+            engravedIcon
+            if !locked { specularHighlight }
+            if showShimmer && !locked { shimmerSweep }
+            if locked { lockGlyph }
+        }
+        .frame(width: size, height: size)
+        .compositingGroup()
+        .rotation3DEffect(.degrees(pitch * 9), axis: (x: -1, y: 0, z: 0), perspective: 0.5)
+        .rotation3DEffect(.degrees(roll * 9), axis: (x: 0, y: 1, z: 0), perspective: 0.5)
+        .shadow(color: locked ? .black.opacity(0.35) : palette.glow.opacity(0.55),
+                radius: size * 0.13, x: 0, y: size * 0.06)
+        .onAppear {
+            guard showShimmer && !locked && !reduceMotion else { return }
+            withAnimation(.linear(duration: 2.8).repeatForever(autoreverses: false).delay(0.5 + shimmerDelay)) {
+                shimmer = 1.4
+            }
+        }
+    }
+
+    // Metallic rim with an angular gradient that rotates slightly with tilt so it
+    // catches "light" like brushed metal, plus a milled-edge knurl on bigger sizes.
+    private var rim: some View {
+        ZStack {
+            Circle().fill(palette.rimLo)
+            Circle()
+                .fill(
+                    AngularGradient(
+                        gradient: Gradient(colors: [
+                            palette.rimHi, palette.rimMid, palette.rimLo, palette.rimMid,
+                            palette.rimHi, palette.rimLo, palette.rimMid, palette.rimHi,
+                        ]),
+                        center: .center,
+                        angle: .degrees(roll * 35 - pitch * 15)
+                    )
+                )
+            // Milled-edge detail is reserved for the large hero medals so grids of
+            // many medals stay light.
+            if size >= 120 { knurling }
+        }
+    }
+
+    private var knurling: some View {
+        ZStack {
+            ForEach(0..<48, id: \.self) { i in
+                Capsule()
+                    .fill(Color.black.opacity(0.18))
+                    .frame(width: size * 0.012, height: rimWidth * 0.9)
+                    .offset(y: -(size / 2 - rimWidth / 2))
+                    .rotationEffect(.degrees(Double(i) / 48.0 * 360.0))
+            }
+        }
+        .mask(Circle())
+    }
+
+    // Domed coin face — radial gradient lit from the upper-left.
+    private var face: some View {
+        Circle()
+            .fill(
+                RadialGradient(
+                    colors: [palette.faceHi, palette.faceMid, palette.faceLo],
+                    center: UnitPoint(x: 0.38, y: 0.32),
+                    startRadius: 1,
+                    endRadius: size * 0.52
+                )
+            )
+            .padding(rimWidth)
+    }
+
+    // Beveled edge between rim and face: bright top-left, dark bottom-right.
+    private var bevel: some View {
+        Circle()
+            .strokeBorder(
+                LinearGradient(
+                    colors: [Color.white.opacity(0.55), Color.clear, Color.black.opacity(0.38)],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                ),
+                lineWidth: max(1.5, size * 0.02)
+            )
+            .padding(rimWidth)
+    }
+
+    private var engravedIcon: some View {
+        ZStack {
+            // Engrave shadow (down-right) and top highlight (up-left) sandwich the
+            // metallic glyph for a stamped-into-metal look.
+            Image(systemName: icon)
+                .foregroundColor(.black.opacity(0.30))
+                .offset(x: size * 0.008, y: size * 0.012)
+            Image(systemName: icon)
+                .foregroundColor(.white.opacity(locked ? 0.10 : 0.30))
+                .offset(x: -size * 0.006, y: -size * 0.01)
+            Image(systemName: icon)
+                .foregroundStyle(
+                    LinearGradient(colors: [palette.iconHi, palette.iconLo],
+                                   startPoint: .top, endPoint: .bottom)
+                )
+        }
+        .font(.system(size: size * 0.34, weight: .black))
+        .opacity(locked ? 0.45 : 1)
+    }
+
+    // Soft white blob that slides with device tilt — the marquee "real medal" cue.
+    private var specularHighlight: some View {
+        Circle()
+            .fill(
+                RadialGradient(
+                    colors: [Color.white.opacity(0.6), Color.white.opacity(0)],
+                    center: .center, startRadius: 0, endRadius: size * 0.32
+                )
+            )
+            .frame(width: size * 0.6, height: size * 0.6)
+            .offset(x: CGFloat(roll) * size * 0.26 + size * 0.06,
+                    y: CGFloat(-pitch) * size * 0.26 - size * 0.12)
+            .blendMode(.screen)
+            .mask(Circle().padding(rimWidth * 0.5))
+    }
+
+    private var shimmerSweep: some View {
+        Rectangle()
+            .fill(
+                LinearGradient(
+                    colors: [.clear, Color.white.opacity(0.55), .clear],
+                    startPoint: .leading, endPoint: .trailing
+                )
+            )
+            .frame(width: size * 0.5, height: size * 1.6)
+            .rotationEffect(.degrees(28))
+            .offset(x: shimmer * size)
+            .blendMode(.screen)
+            .mask(Circle().padding(rimWidth * 0.5))
+            .allowsHitTesting(false)
+    }
+
+    private var lockGlyph: some View {
+        Image(systemName: "lock.fill")
+            .font(.system(size: size * 0.26, weight: .bold))
+            .foregroundColor(.white.opacity(0.5))
+            .shadow(color: .black.opacity(0.4), radius: 2, y: 1)
+    }
+}
+
+// MARK: - Live-tilt hero medal
+
+/// `MedalView` driven by live device motion. Use for the single large medal on
+/// the detail screen and the unlock celebration. Starts/stops the shared sensor
+/// with its lifetime.
+struct TiltableMedal: View {
+    let badge: Badge
+    var size: CGFloat = 160
+    var showShimmer: Bool = true
+
+    @ObservedObject private var motion = MedalMotion.shared
+
+    var body: some View {
+        MedalView(badge: badge, size: size,
+                  roll: badge.isLocked ? 0 : motion.roll,
+                  pitch: badge.isLocked ? 0 : motion.pitch,
+                  showShimmer: showShimmer)
+            .onAppear { if !badge.isLocked { motion.start() } }
+            .onDisappear { if !badge.isLocked { motion.stop() } }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Medals") {
+    ZStack {
+        Color.black.ignoresSafeArea()
+        HStack(spacing: 24) {
+            MedalView(badge: Badge(id: "streak_7", name: "Common", description: ""), size: 110)
+            MedalView(badge: Badge(id: "streak_100", name: "Rare", description: ""), size: 110)
+            MedalView(badge: Badge(id: "streak_365", name: "Legendary", description: ""), size: 110)
+            MedalView(badge: Badge(id: "miles_500", name: "Locked", description: "", isLocked: true), size: 110)
+        }
+    }
+}

--- a/app/Mile A Day/Views/Components/PinnedBadgesShowcase.swift
+++ b/app/Mile A Day/Views/Components/PinnedBadgesShowcase.swift
@@ -163,52 +163,8 @@ private struct PinnedBadgeSlotFilled: View {
 
     var body: some View {
         VStack(spacing: 8) {
-            ZStack {
-                Circle()
-                    .fill(
-                        RadialGradient(
-                            colors: [badge.rarity.color.opacity(0.35), badge.rarity.color.opacity(0)],
-                            center: .center,
-                            startRadius: 15,
-                            endRadius: 45
-                        )
-                    )
-                    .frame(width: 90, height: 90)
-
-                Circle()
-                    .fill(
-                        LinearGradient(
-                            colors: medalGradientColors(for: badge),
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        )
-                    )
-                    .frame(width: 64, height: 64)
-                    .overlay(
-                        Circle()
-                            .stroke(
-                                LinearGradient(
-                                    colors: [Color.white.opacity(0.55), badge.rarity.color.opacity(0.35)],
-                                    startPoint: .topLeading,
-                                    endPoint: .bottomTrailing
-                                ),
-                                lineWidth: 2
-                            )
-                    )
-                    .shadow(color: badge.rarity.color.opacity(0.4), radius: 10, x: 0, y: 4)
-
-                Image(systemName: iconName(for: badge))
-                    .font(.system(size: 26, weight: .semibold))
-                    .foregroundStyle(
-                        LinearGradient(
-                            colors: [.white, .white.opacity(0.85)],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                    )
-                    .shadow(color: .black.opacity(0.3), radius: 2, x: 0, y: 2)
-            }
-            .frame(width: 90, height: 90)
+            MedalView(badge: badge, size: 72)
+                .frame(width: 90, height: 90)
 
             Text(badge.name)
                 .font(.system(size: 11, weight: .bold, design: .rounded))

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -321,6 +321,9 @@ struct DashboardView: View {
 
         celebrationManager.lastPostGoalWorkoutCount = healthManager.todaysWorkoutCount
         let stats = buildGoalCompletionStats()
+        // Every extra run/walk also re-runs the today's-miles leaderboard so you
+        // see yourself climb with the added miles, then the extra-mile hype.
+        celebrationManager.addCelebration(.leaderboardMoveUp(stats: stats))
         celebrationManager.addCelebration(.postGoalWorkout(stats: stats))
     }
 

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -77,6 +77,9 @@ struct DashboardView: View {
     /// tour only auto-plays once; users can replay it any time from the
     /// dashboard welcome banner or Help & Support.
     @AppStorage("hasSeenWelcomeTour") private var hasSeenWelcomeTour = false
+    /// Master switch for the post-run photo prompt + auto-sharing the mile to the
+    /// feed. On by default; users can turn the whole flow off in settings.
+    @AppStorage("autoShareRunsToFeed") private var autoShareRunsToFeed = true
     /// Shared with InstructionsBanner — completing the tour hides the banner.
     @AppStorage("hasSeenInstructions") private var hasSeenInstructions = false
     @State private var showWelcomeTour = false
@@ -293,6 +296,14 @@ struct DashboardView: View {
             // Right after the fire/streak screen: show where you land on today's
             // friends leaderboard, animating your climb (Duolingo-style).
             celebrationManager.addCelebration(.leaderboardMoveUp(stats: completionStats))
+
+            // Finale: BeReal-style "add a photo of your run" prompt for the mile
+            // that just completed. Skipping still shares the run (route/stats).
+            if autoShareRunsToFeed, let uuid = healthManager.workoutIndex?.latestWorkoutUUID {
+                let hk = healthManager.todaysWorkouts.first { $0.uuid.uuidString == uuid }
+                let wtype = hk?.workoutActivityType == .walking ? "walking" : "running"
+                celebrationManager.addCelebration(.postRunPhotoPrompt(workoutId: uuid, workoutType: wtype))
+            }
         }
     }
 

--- a/app/Mile A Day/Views/Dashboard/WorkoutDetailView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutDetailView.swift
@@ -13,7 +13,29 @@ struct WorkoutDetailView: View {
     @State private var showEditSheet = false
     @State private var routeCoordinates: [CLLocationCoordinate2D]?
     @State private var isLoadingRoute = false
+    @State private var showDeleteConfirm = false
+    @State private var isDeleting = false
+    @State private var deleteError: String?
     @EnvironmentObject var healthManager: HealthKitManager
+
+    private let workoutService = WorkoutService()
+
+    /// Average speed in mph for this workout (0 if we can't compute it).
+    private var averageSpeedMph: Double {
+        guard workout.duration > 0, distanceMiles > 0 else { return 0 }
+        return distanceMiles / (workout.duration / 3600.0)
+    }
+
+    /// A human can't run/walk a mile faster than ~15 mph (world record), so high
+    /// average speeds almost always mean the tracker was left running in a vehicle.
+    /// >20 mph is auto-excluded by the server; 13–20 is flagged for the user.
+    private enum VehicleSuspicion { case none, flagged, excluded }
+    private var vehicleSuspicion: VehicleSuspicion {
+        let mph = averageSpeedMph
+        if mph >= 20 { return .excluded }
+        if mph >= 13 { return .flagged }
+        return .none
+    }
 
     // Timezone-corrected times from index
     private var correctedEndTime: Date {
@@ -86,9 +108,23 @@ struct WorkoutDetailView: View {
 
                         // Mile Splits Section
                         mileSplitsSection
+
+                        // Delete — remove an accidental / vehicle workout.
+                        deleteButton
                     }
                     .padding(MADTheme.Spacing.md)
                 }
+            }
+            .alert("Delete this workout?", isPresented: $showDeleteConfirm) {
+                Button("Delete", role: .destructive) { performDelete() }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This removes the workout from Mile A Day and recalculates your streak and medals. Badges you only earned because of it will be removed. This can't be undone.")
+            }
+            .alert("Couldn't delete workout", isPresented: Binding(get: { deleteError != nil }, set: { if !$0 { deleteError = nil } })) {
+                Button("OK", role: .cancel) { deleteError = nil }
+            } message: {
+                Text(deleteError ?? "")
             }
             .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)
@@ -126,6 +162,105 @@ struct WorkoutDetailView: View {
         }
     }
 
+    // MARK: - Vehicle warning
+
+    private var vehicleWarningBanner: some View {
+        let excluded = vehicleSuspicion == .excluded
+        return HStack(spacing: 10) {
+            Image(systemName: "car.fill")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(excluded ? .red : .orange)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(excluded ? "Not counted — vehicle speed" : "This pace looks unusually fast")
+                    .font(.system(size: 13, weight: .heavy, design: .rounded))
+                    .foregroundColor(.primary)
+                Text(excluded
+                    ? "This workout averages \(Int(averageSpeedMph)) mph, so it doesn't count toward your mile. Delete it to clear it out."
+                    : "Averaging \(Int(averageSpeedMph)) mph. If you left tracking on in a car, delete it so it doesn't count.")
+                    .font(.system(size: 11, weight: .medium, design: .rounded))
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill((excluded ? Color.red : Color.orange).opacity(0.12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .strokeBorder((excluded ? Color.red : Color.orange).opacity(0.3), lineWidth: 1)
+                )
+        )
+    }
+
+    // MARK: - Delete
+
+    private var deleteButton: some View {
+        Button(role: .destructive) {
+            showDeleteConfirm = true
+        } label: {
+            HStack(spacing: 8) {
+                if isDeleting {
+                    ProgressView().tint(.red)
+                } else {
+                    Image(systemName: "trash")
+                }
+                Text(isDeleting ? "Deleting…" : "Delete this workout")
+                    .fontWeight(.semibold)
+            }
+            .font(.system(size: 15, design: .rounded))
+            .foregroundColor(.red)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .background(
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(Color.red.opacity(0.12))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 14)
+                            .strokeBorder(Color.red.opacity(0.3), lineWidth: 1)
+                    )
+            )
+        }
+        .disabled(isDeleting)
+        .padding(.top, MADTheme.Spacing.sm)
+    }
+
+    private func performDelete() {
+        guard !isDeleting else { return }
+        isDeleting = true
+        let id = workout.uuid.uuidString
+        Task {
+            do {
+                let resp = try await workoutService.deleteWorkout(workoutId: id)
+                await MainActor.run {
+                    // Rebuild local data excluding the now-tombstoned workout so the
+                    // dashboard/streak/calendar drop it immediately.
+                    WorkoutIndex.clear()
+                    healthManager.workoutIndex = nil
+                    healthManager.fetchAllWorkoutData()
+                    healthManager.fetchTodaysDistance()
+                    if let streak = resp.currentStreak {
+                        healthManager.retroactiveStreak = streak
+                    }
+                    isDeleting = false
+                    dismiss()
+                }
+                // Pull fresh server-authoritative badges + challenge state.
+                await UserManager.shared.refreshBadgesFromServer()
+                if let uid = UserManager.shared.currentUser.backendUserId {
+                    await ChallengeService.refresh(userId: uid)
+                }
+            } catch {
+                await MainActor.run {
+                    isDeleting = false
+                    deleteError = error.localizedDescription
+                }
+            }
+        }
+    }
+
     // MARK: - Hero Card
 
     private var heroCard: some View {
@@ -133,6 +268,11 @@ struct WorkoutDetailView: View {
             // Manual/edited warning banner
             if workoutSource != .healthkit {
                 ManualWorkoutBanner(source: workoutSource)
+            }
+
+            // Vehicle-speed warning — surfaces a likely drive so the user can remove it.
+            if vehicleSuspicion != .none {
+                vehicleWarningBanner
             }
 
             // Workout type badge

--- a/app/Mile A Day/Views/Feed/ActivityCardView.swift
+++ b/app/Mile A Day/Views/Feed/ActivityCardView.swift
@@ -64,21 +64,25 @@ struct ActivityCardView: View {
     private var statStrip: some View {
         let items = statItems
         if !items.isEmpty {
-            HStack(spacing: 8) {
-                ForEach(items, id: \.0) { item in
-                    HStack(spacing: 4) {
-                        Image(systemName: item.1).font(.system(size: 10, weight: .bold))
-                            .foregroundColor(.orange)
-                        Text(item.2)
-                            .font(.system(size: 11, weight: .heavy, design: .rounded))
-                            .monospacedDigit()
-                            .foregroundColor(.white.opacity(0.85))
+            // Scrollable so four chips with long values (1:02:15, 10:30 /mi, …)
+            // can never overflow the card on smaller screens.
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(items, id: \.0) { item in
+                        HStack(spacing: 4) {
+                            Image(systemName: item.1).font(.system(size: 10, weight: .bold))
+                                .foregroundColor(.orange)
+                            Text(item.2)
+                                .font(.system(size: 11, weight: .heavy, design: .rounded))
+                                .monospacedDigit()
+                                .foregroundColor(.white.opacity(0.85))
+                        }
+                        .padding(.horizontal, 8).padding(.vertical, 4)
+                        .background(Capsule().fill(Color.white.opacity(0.06)))
                     }
-                    .padding(.horizontal, 8).padding(.vertical, 4)
-                    .background(Capsule().fill(Color.white.opacity(0.06)))
                 }
+                .padding(.horizontal, 2)
             }
-            .padding(.horizontal, 2)
         }
     }
 
@@ -109,7 +113,7 @@ struct ActivityCardView: View {
             out.append(("cal", "bolt.fill", "\(Int(c.rounded())) cal"))
         }
         if let s = entry.steps, s > 0 {
-            out.append(("steps", "shoeprints.fill", "\(s)"))
+            out.append(("steps", "shoeprints.fill", s.formatted(.number.grouping(.automatic))))
         }
         return out
     }

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -185,11 +185,15 @@ struct PostComposerView: View {
     @StateObject private var vm: PostComposerViewModel
     @State private var showCamera = false
     @State private var gestureBaseScale: CGFloat = 1.0
+    /// Launch straight into the camera on first appear (post-run prompt flow) —
+    /// the user already tapped "Take a photo" once to get here.
+    let autoOpenCamera: Bool
     let onFinished: (Bool) -> Void
     @Environment(\.dismiss) private var dismiss
 
-    init(stats: RunStatsInput, onFinished: @escaping (Bool) -> Void) {
+    init(stats: RunStatsInput, autoOpenCamera: Bool = false, onFinished: @escaping (Bool) -> Void) {
         _vm = StateObject(wrappedValue: PostComposerViewModel(stats: stats))
+        self.autoOpenCamera = autoOpenCamera
         self.onFinished = onFinished
     }
 
@@ -243,6 +247,11 @@ struct PostComposerView: View {
             .fullScreenCover(isPresented: $showCamera) {
                 CameraPicker(image: $vm.pickedImage)
                     .ignoresSafeArea()
+            }
+            .onAppear {
+                if autoOpenCamera, vm.pickedImage == nil, CameraPicker.isAvailable {
+                    showCamera = true
+                }
             }
         }
     }

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -183,7 +183,7 @@ struct PostCanvas: View {
 
 struct PostComposerView: View {
     @StateObject private var vm: PostComposerViewModel
-    @State private var showImagePicker = false
+    @State private var showCamera = false
     @State private var gestureBaseScale: CGFloat = 1.0
     let onFinished: (Bool) -> Void
     @Environment(\.dismiss) private var dismiss
@@ -240,8 +240,9 @@ struct PostComposerView: View {
             }
             .toolbarBackground(.black, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
-            .sheet(isPresented: $showImagePicker) {
-                ImagePicker(selectedImage: $vm.pickedImage)
+            .fullScreenCover(isPresented: $showCamera) {
+                CameraPicker(image: $vm.pickedImage)
+                    .ignoresSafeArea()
             }
         }
     }
@@ -271,12 +272,17 @@ struct PostComposerView: View {
                     .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous))
                     .onAppear { vm.canvasSize = CGSize(width: width, height: height) }
                     .overlay(alignment: .topTrailing) {
-                        Button { showImagePicker = true } label: {
-                            Image(systemName: "arrow.triangle.2.circlepath")
-                                .font(.system(size: 14, weight: .bold))
-                                .foregroundColor(.white)
-                                .padding(8)
-                                .background(Circle().fill(.black.opacity(0.45)))
+                        Button { showCamera = true } label: {
+                            HStack(spacing: 5) {
+                                Image(systemName: "camera.fill")
+                                    .font(.system(size: 12, weight: .bold))
+                                Text("Retake")
+                                    .font(.system(size: 12, weight: .bold, design: .rounded))
+                            }
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 7)
+                            .background(Capsule().fill(.black.opacity(0.5)))
                         }
                         .padding(10)
                     }
@@ -299,17 +305,41 @@ struct PostComposerView: View {
     }
 
     private var photoPlaceholder: some View {
-        Button { showImagePicker = true } label: {
+        Button { if CameraPicker.isAvailable { showCamera = true } } label: {
             VStack(spacing: MADTheme.Spacing.md) {
-                Image(systemName: "photo.badge.plus")
-                    .font(.system(size: 44, weight: .semibold))
-                    .foregroundStyle(MADTheme.Colors.redGradient)
-                Text("Choose a photo")
-                    .font(.system(size: 16, weight: .bold, design: .rounded))
+                ZStack {
+                    Circle()
+                        .fill(MADTheme.Colors.redGradient)
+                        .frame(width: 84, height: 84)
+                        .shadow(color: MADTheme.Colors.madRed.opacity(0.4), radius: 16, y: 6)
+                    Image(systemName: "camera.fill")
+                        .font(.system(size: 34, weight: .semibold))
+                        .foregroundColor(.white)
+                }
+
+                VStack(spacing: 4) {
+                    Text(CameraPicker.isAvailable ? "Take a photo" : "Camera unavailable")
+                        .font(.system(size: 18, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+                    Text(CameraPicker.isAvailable
+                        ? "Snap today's walk or run — camera keeps it real."
+                        : "A camera is required to share a post.")
+                        .font(.system(size: 13, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.55))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, MADTheme.Spacing.lg)
+                }
+
+                if CameraPicker.isAvailable {
+                    HStack(spacing: 6) {
+                        Image(systemName: "camera.fill").font(.system(size: 13, weight: .bold))
+                        Text("Open camera").font(.system(size: 14, weight: .bold, design: .rounded))
+                    }
                     .foregroundColor(.white)
-                Text("Share today's walk or run")
-                    .font(.system(size: 13, weight: .medium, design: .rounded))
-                    .foregroundColor(.white.opacity(0.5))
+                    .padding(.horizontal, 18).padding(.vertical, 10)
+                    .background(Capsule().fill(MADTheme.Colors.redGradient))
+                    .padding(.top, 2)
+                }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(
@@ -323,6 +353,7 @@ struct PostComposerView: View {
             )
         }
         .buttonStyle(.plain)
+        .disabled(!CameraPicker.isAvailable)
     }
 
     private func stickerGestureLayer(canvas: CGSize) -> some View {

--- a/app/Mile A Day/Views/Feed/RunStatsCardView.swift
+++ b/app/Mile A Day/Views/Feed/RunStatsCardView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// Branded 4:5 stats card used as the auto feed image for a run that has no
+/// photo and no GPS route (e.g. a treadmill mile). Rendered to a flat image via
+/// `ImageRenderer` and uploaded as the post media.
+struct RunStatsCardView: View {
+    let stats: RunStatsInput
+    /// "running" / "walking" — drives the icon + accent.
+    let workoutType: String
+
+    private var isWalk: Bool { workoutType == "walking" }
+    private var icon: String { isWalk ? "figure.walk" : "figure.run" }
+    private var accent: Color { isWalk ? .blue : MADTheme.Colors.madRed }
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [Color(red: 0.09, green: 0.09, blue: 0.12), .black],
+                startPoint: .top, endPoint: .bottom
+            )
+            // Accent glow
+            RadialGradient(colors: [accent.opacity(0.35), .clear],
+                           center: .init(x: 0.5, y: 0.22), startRadius: 10, endRadius: 360)
+
+            VStack(spacing: 18) {
+                Spacer()
+
+                Image(systemName: icon)
+                    .font(.system(size: 52, weight: .semibold))
+                    .foregroundStyle(LinearGradient(colors: [.white, accent],
+                                                    startPoint: .top, endPoint: .bottom))
+                    .shadow(color: accent.opacity(0.5), radius: 16)
+
+                Text(String(format: "%.2f", stats.distance))
+                    .font(.system(size: 96, weight: .black, design: .rounded))
+                    .foregroundColor(.white)
+                    .monospacedDigit()
+                    .shadow(color: .black.opacity(0.4), radius: 8, y: 4)
+                Text("MILES")
+                    .font(.system(size: 18, weight: .heavy, design: .rounded))
+                    .tracking(6)
+                    .foregroundColor(.white.opacity(0.65))
+
+                HStack(spacing: 10) {
+                    if let p = stats.paceSecondsPerMile, p > 0 {
+                        chip("speedometer", "\(RunStatsStickerView.paceText(p)) /mi")
+                    }
+                    if let d = stats.durationSeconds, d > 0 {
+                        chip("clock.fill", RunStatsStickerView.durationText(d))
+                    }
+                    if let s = stats.streak, s > 0 {
+                        chip("flame.fill", "\(s) day streak", tint: .orange)
+                    }
+                }
+                .padding(.top, 4)
+
+                Spacer()
+
+                HStack(spacing: 6) {
+                    Image(systemName: "figure.run.circle.fill")
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundColor(accent)
+                    Text("Mile A Day")
+                        .font(.system(size: 15, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white.opacity(0.85))
+                    if let date = stats.dateText, !date.isEmpty {
+                        Text("· \(date)")
+                            .font(.system(size: 13, weight: .semibold, design: .rounded))
+                            .foregroundColor(.white.opacity(0.4))
+                    }
+                }
+                .padding(.bottom, 34)
+            }
+            .padding(.horizontal, 28)
+        }
+    }
+
+    private func chip(_ icon: String, _ text: String, tint: Color = .white) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: icon).font(.system(size: 12, weight: .bold))
+            Text(text).font(.system(size: 14, weight: .heavy, design: .rounded)).monospacedDigit()
+        }
+        .foregroundColor(tint)
+        .padding(.horizontal, 12).padding(.vertical, 8)
+        .background(Capsule().fill(Color.white.opacity(0.1)))
+    }
+}

--- a/app/Mile A Day/Views/Feed/RunStatsStickerView.swift
+++ b/app/Mile A Day/Views/Feed/RunStatsStickerView.swift
@@ -142,12 +142,15 @@ struct RunStatsStickerView: View {
     private var cardStyle: some View {
         let hero = data.first
         let rest = Array(data.dropFirst())
+        // Chips wrap into rows of 3 so enabling every stat can't grow the
+        // sticker wider than the photo canvas.
+        let rows = stride(from: 0, to: rest.count, by: 3).map { Array(rest[$0..<min($0 + 3, rest.count)]) }
         return VStack(alignment: .leading, spacing: 8) {
             brandLine
             if let hero { heroValue(hero) }
-            if !rest.isEmpty {
+            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
                 HStack(spacing: 14) {
-                    ForEach(rest) { chip($0) }
+                    ForEach(row) { chip($0) }
                 }
             }
         }

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -45,7 +45,9 @@ struct SocialFeedView: View {
             streak: user.streak,
             calories: calories > 0 ? calories : nil,
             steps: steps > 0 ? steps : nil,
-            workoutId: nil,
+            // Link to the daily-mile workout so this post upserts into the same
+            // feed item as the auto route/stats post — one post per run.
+            workoutId: mileDone ? RunPostService.dailyMileWorkoutId() : nil,
             dateText: Self.todayText()
         )
     }

--- a/app/Mile A Day/Views/Feed/StoryViewerView.swift
+++ b/app/Mile A Day/Views/Feed/StoryViewerView.swift
@@ -17,6 +17,9 @@ struct StoryViewerView: View {
     @State private var dragOffset: CGFloat = 0
     @State private var changed = false
     @State private var paused = false
+    /// The current photo has rendered (or failed) — the 5s timer holds until
+    /// then so a slow connection can't advance past an image nobody saw.
+    @State private var imageReady = false
 
     @State private var showReport = false
     @State private var hyping = false
@@ -68,9 +71,11 @@ struct StoryViewerView: View {
         )
         .task { await load() }
         .onReceive(tick) { _ in advanceProgress() }
-        .sheet(isPresented: $showReport) {
+        // onDismiss also covers swiping the sheet away, which would otherwise
+        // leave `paused` stuck true and freeze the story.
+        .sheet(isPresented: $showReport, onDismiss: { paused = false }) {
             if let post = current {
-                ReportPostSheet(postId: post.post_id) { showReport = false; paused = false }
+                ReportPostSheet(postId: post.post_id) { showReport = false }
             }
         }
         .statusBarHidden(true)
@@ -83,12 +88,16 @@ struct StoryViewerView: View {
             switch phase {
             case .success(let image):
                 image.resizable().scaledToFill()
+                    .onAppear { imageReady = true }
             case .failure:
                 Image(systemName: "photo").font(.largeTitle).foregroundColor(.white.opacity(0.3))
+                    .onAppear { imageReady = true }
             default:
                 ProgressView().tint(.white)
             }
         }
+        // Re-identify per story so the readiness onAppear refires every step.
+        .id(post.post_id)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .clipped()
         .ignoresSafeArea()
@@ -210,7 +219,7 @@ struct StoryViewerView: View {
     }
 
     private func advanceProgress() {
-        guard !isLoading, !paused, !showReport, current != nil else { return }
+        guard !isLoading, !paused, !showReport, imageReady, current != nil else { return }
         progress += 0.05 / stepDuration
         if progress >= 1 { step(1) }
     }
@@ -220,6 +229,7 @@ struct StoryViewerView: View {
         let next = index + dir
         if next < 0 { return }
         if next >= stories.count { close(); return }
+        imageReady = false
         index = next
         markViewed()
     }
@@ -280,6 +290,7 @@ struct StoryViewerView: View {
                 stories.removeAll { $0.post_id == post.post_id }
                 if index >= stories.count { index = max(0, stories.count - 1) }
                 progress = 0
+                imageReady = false
                 if stories.isEmpty { close() }
             }
         } catch {}

--- a/app/Mile A Day/Views/Feed/StoryViewerView.swift
+++ b/app/Mile A Day/Views/Feed/StoryViewerView.swift
@@ -35,6 +35,18 @@ struct StoryViewerView: View {
             } else if let post = current {
                 storyImage(post)
                 tapZones
+
+                // Top scrim so the white progress bars + author stay legible over
+                // bright photos (e.g. a sky).
+                VStack(spacing: 0) {
+                    LinearGradient(colors: [.black.opacity(0.5), .clear],
+                                   startPoint: .top, endPoint: .bottom)
+                        .frame(height: 150)
+                    Spacer()
+                }
+                .ignoresSafeArea()
+                .allowsHitTesting(false)
+
                 VStack(spacing: 0) {
                     progressBars
                     header(post)
@@ -131,32 +143,37 @@ struct StoryViewerView: View {
         .shadow(color: .black.opacity(0.4), radius: 6)
     }
 
+    // Instagram-style footer: caption bottom-left, hype bottom-right, over a soft
+    // bottom scrim. The run stats already live in the photo's baked-in overlay,
+    // so we don't repeat them here.
     @ViewBuilder
     private func footer(_ post: PostItem) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            if let stats = post.stats_snapshot {
-                PostStatStrip(stats: stats, onPhoto: true)
-            }
+        HStack(alignment: .bottom, spacing: 12) {
             if let caption = post.caption, !caption.isEmpty {
                 Text(caption)
-                    .font(.system(size: 14, weight: .medium, design: .rounded))
+                    .font(.system(size: 15, weight: .semibold, design: .rounded))
                     .foregroundColor(.white)
-                    .shadow(color: .black.opacity(0.6), radius: 4)
+                    .shadow(color: .black.opacity(0.7), radius: 4, y: 1)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                Spacer(minLength: 0)
             }
+
             if !post.is_self {
-                HStack {
-                    Spacer()
-                    HypeButton(isHyped: post.is_hyped, isBusy: hyping) {
-                        Task { await hype(post) }
-                    }
+                HypeButton(isHyped: post.is_hyped, isBusy: hyping) {
+                    Task { await hype(post) }
                 }
             }
         }
         .padding(.horizontal, 16)
-        .padding(.bottom, 28)
+        .padding(.bottom, 20)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
-            LinearGradient(colors: [.clear, .black.opacity(0.5)], startPoint: .top, endPoint: .bottom)
+            LinearGradient(colors: [.clear, .black.opacity(0.55)], startPoint: .top, endPoint: .bottom)
+                .frame(height: 200)
+                .frame(maxHeight: .infinity, alignment: .bottom)
+                .allowsHitTesting(false)
                 .ignoresSafeArea()
         )
     }

--- a/app/Mile A Day/Views/NotificationSettingsView.swift
+++ b/app/Mile A Day/Views/NotificationSettingsView.swift
@@ -3,6 +3,8 @@ import UserNotifications
 
 struct NotificationSettingsView: View {
     @State private var prefs = NotificationPreferences.load()
+    /// Local master switch for the post-run photo prompt + auto-sharing the mile.
+    @AppStorage("autoShareRunsToFeed") private var autoShareRunsToFeed = true
     @ObservedObject private var notificationService = MADNotificationService.shared
     @StateObject private var friendService = FriendService()
 
@@ -143,6 +145,9 @@ struct NotificationSettingsView: View {
                     settingsSection(title: "FEED & STORIES", icon: "square.stack.fill", iconColor: MADTheme.Colors.madRed) {
                         settingsToggle("Share my walks & runs to the feed", isOn: $prefs.shareWorkoutsToFeed,
                             description: "Friends see your activity in the unified feed")
+                        settingsDivider
+                        settingsToggle("Photo prompt after a run", isOn: $autoShareRunsToFeed,
+                            description: "Snap a photo of your mile — skipping shares the route map instead")
                         settingsDivider
                         settingsToggle("New posts from friends", isOn: $prefs.friendPostsEnabled,
                             description: "Get notified when a friend shares a photo")

--- a/app/Mile A Day/Views/Profile/ShareProfileView.swift
+++ b/app/Mile A Day/Views/Profile/ShareProfileView.swift
@@ -96,7 +96,7 @@ struct ShareProfileView: View {
         )
 
         VStack(spacing: MADTheme.Spacing.xs) {
-            Text("Have a friend scan this in Mile A Day → Find Friends → Scan")
+            Text("Friends can scan this with their iPhone Camera or in Mile A Day → Find Friends → Scan")
                 .font(.system(size: 13, weight: .medium, design: .rounded))
                 .foregroundColor(.white.opacity(0.6))
 

--- a/app/Mile-A-Day-Info.plist
+++ b/app/Mile-A-Day-Info.plist
@@ -9,7 +9,7 @@
 		<string>com.mileaday.background-refresh</string>
 	</array>
 	<key>NSCameraUsageDescription</key>
-	<string>Mile A Day uses the camera to scan a friend's profile QR code so you can add each other quickly.</string>
+	<string>Mile A Day uses the camera to take photos for your walk and run posts and stories, and to scan a friend's profile QR code so you can add each other quickly.</string>
 	<key>NSHealthShareUsageDescription</key>
 	<string>Mile A Day reads your workouts, walking and running distance, active energy, step count, and workout routes to track your daily mile, calculate streaks, and show your progress. This data is synced to Mile A Day's servers so you can compete with friends and view your history across devices.</string>
 	<key>NSHealthUpdateUsageDescription</key>

--- a/app/Mile-A-Day-Info.plist
+++ b/app/Mile-A-Day-Info.plist
@@ -4,6 +4,17 @@
 <dict>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>org.robertwiscount.Mile-A-Day</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>mileaday</string>
+			</array>
+		</dict>
+	</array>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.mileaday.background-refresh</string>

--- a/backend/src/controllers/postsController.ts
+++ b/backend/src/controllers/postsController.ts
@@ -28,6 +28,13 @@ import { getDailyGoalStatus } from "../services/workoutService.js";
 import { hasUnlimitedActions } from "../services/privilegedUsers.js";
 import { evaluateSocialBadgesForUser } from "../services/badgeService.js";
 
+// Friend "new post" push notifications stay OFF until the Feed/Stories feature
+// ships in the App Store build. The backend is already live, but the feed UI is
+// dev-only right now — notifying live users about posts they can't open (the
+// image isn't reachable on their build) is just noise. Flip to true when the
+// iOS feed is released to the App Store.
+const FRIEND_POST_NOTIFICATIONS_ENABLED = false;
+
 const POSTS_MEDIA_PREFIX = "/uploads/posts/";
 const MAX_CAPTION = 280;
 const DEFAULT_FEED_LIMIT = 20;
@@ -142,7 +149,7 @@ export async function createPostController(
 
     // Fire-and-forget: tell friends about a new feed post (respects their
     // friend_posts_enabled setting). Never blocks the response.
-    if (shareToFeed) {
+    if (shareToFeed && FRIEND_POST_NOTIFICATIONS_ENABLED) {
       notifyFriendsOfPost(userId, post.caption).catch(() => {});
     }
     // Re-evaluate story badges (first story, X stories) in the background.

--- a/backend/src/controllers/workoutController.ts
+++ b/backend/src/controllers/workoutController.ts
@@ -1,255 +1,289 @@
-import { Request, Response } from 'express';
-import { PostgresService } from '../services/DbService.js';
-import hasRequiredKeys from '../utils/hasRequiredKeys.js';
-import { getUser } from '../services/userService.js';
-import { Workout } from '../types/workouts.js';
+import { Request, Response } from "express";
+import { PostgresService } from "../services/DbService.js";
+import hasRequiredKeys from "../utils/hasRequiredKeys.js";
+import { getUser } from "../services/userService.js";
+import { Workout } from "../types/workouts.js";
 import {
-	getActiveStreak,
-	uploadWorkouts as uploadWorkoutsDb,
-	getRecentWorkouts as getRecentWorkoutsDb,
-	getTotalMiles,
-	getBestMilesDay,
-	getBestSplit,
-	getTodayMiles,
-	updateWorkout as updateWorkoutDb,
-	computePersonalRecords,
-	getUserLocalToday
-} from '../services/workoutService.js';
-import { checkRaceCompletions } from '../services/competitionService.js';
+  getActiveStreak,
+  uploadWorkouts as uploadWorkoutsDb,
+  getRecentWorkouts as getRecentWorkoutsDb,
+  getTotalMiles,
+  getBestMilesDay,
+  getBestSplit,
+  getTodayMiles,
+  updateWorkout as updateWorkoutDb,
+  computePersonalRecords,
+  getUserLocalToday,
+} from "../services/workoutService.js";
+import { checkRaceCompletions } from "../services/competitionService.js";
+import { softDeleteWorkout } from "../services/workoutDeletionService.js";
 import {
-	notifyFriendsOfMileCompletion,
-	notifyFriendsOfExtraWorkout,
-	notifyFriendsOfWorkout,
-	checkCompetitionMilestones,
-	checkLeadChanges
-} from '../services/notificationService.js';
-import { evaluateWorkoutRewards } from '../services/badgeService.js';
+  notifyFriendsOfMileCompletion,
+  notifyFriendsOfExtraWorkout,
+  notifyFriendsOfWorkout,
+  checkCompetitionMilestones,
+  checkLeadChanges,
+} from "../services/notificationService.js";
+import { evaluateWorkoutRewards } from "../services/badgeService.js";
 import {
-	fireBadgeEarnedPush,
-	fanOutFriendBadgePush,
-	fanOutFriendChallengePush,
-	fanOutFriendPersonalBestPush
-} from '../services/pushNotificationService.js';
-import { refreshCurrentStreak } from '../services/leaderboardService.js';
+  fireBadgeEarnedPush,
+  fanOutFriendBadgePush,
+  fanOutFriendChallengePush,
+  fanOutFriendPersonalBestPush,
+} from "../services/pushNotificationService.js";
+import { refreshCurrentStreak } from "../services/leaderboardService.js";
 
 export async function uploadWorkouts(req: Request, res: Response) {
-	if (!hasRequiredKeys(['userId'], req, res)) return;
+  if (!hasRequiredKeys(["userId"], req, res)) return;
 
-	try {
-		if (!Array.isArray(req.body)) {
-			return res.status(400).json({
-				error: 'Request body is not an array'
-			});
-		}
+  try {
+    if (!Array.isArray(req.body)) {
+      return res.status(400).json({
+        error: "Request body is not an array",
+      });
+    }
 
-		const userId = req.params.userId;
+    const userId = req.params.userId;
 
-		// The iOS client sets ?fullSync=true on the bulk HealthKit backfill it runs
-		// once when a user first sets up their account (and on re-login). Those uploads
-		// are historical, so we must NOT spray friend-facing notifications ("got their
-		// mile in", extra-workout, competition lead/milestone, friend badge/challenge,
-		// personal-best) at other users. Absent/any-other value = normal sync (old
-		// clients never send it), so behavior is unchanged for them.
-		const isFullSync = req.query.fullSync === 'true' || req.query.fullSync === '1';
+    // The iOS client sets ?fullSync=true on the bulk HealthKit backfill it runs
+    // once when a user first sets up their account (and on re-login). Those uploads
+    // are historical, so we must NOT spray friend-facing notifications ("got their
+    // mile in", extra-workout, competition lead/milestone, friend badge/challenge,
+    // personal-best) at other users. Absent/any-other value = normal sync (old
+    // clients never send it), so behavior is unchanged for them.
+    const isFullSync =
+      req.query.fullSync === "true" || req.query.fullSync === "1";
 
-		// A notification only fires for activity from the last 24 hours. An old or
-		// backdated workout (HealthKit can deliver backdated workouts; a manual log
-		// can be for a past day) must NOT notify anyone — not friends, and not the
-		// user for their own badge. We map each achievement back to the workout that
-		// triggered it and suppress its push when that workout is outside the window.
-		const recencyCutoffMs = Date.now() - 24 * 60 * 60 * 1000;
-		const recentWorkoutIds = new Set(
-			(req.body as Workout[])
-				.filter(w => {
-					const ts = Date.parse(w.deviceEndDate ?? w.date);
-					return Number.isFinite(ts) && ts >= recencyCutoffMs;
-				})
-				.map(w => w.workoutId)
-		);
-		const hasRecentWorkout = recentWorkoutIds.size > 0;
+    // A notification only fires for activity from the last 24 hours. An old or
+    // backdated workout (HealthKit can deliver backdated workouts; a manual log
+    // can be for a past day) must NOT notify anyone — not friends, and not the
+    // user for their own badge. We map each achievement back to the workout that
+    // triggered it and suppress its push when that workout is outside the window.
+    const recencyCutoffMs = Date.now() - 24 * 60 * 60 * 1000;
+    const recentWorkoutIds = new Set(
+      (req.body as Workout[])
+        .filter((w) => {
+          const ts = Date.parse(w.deviceEndDate ?? w.date);
+          return Number.isFinite(ts) && ts >= recencyCutoffMs;
+        })
+        .map((w) => w.workoutId),
+    );
+    const hasRecentWorkout = recentWorkoutIds.size > 0;
 
-		const user = await getUser({ userId });
-		if (!user) {
-			return res.status(400).send({ error: `No user found with ID ${userId}` });
-		}
+    const user = await getUser({ userId });
+    if (!user) {
+      return res.status(400).send({ error: `No user found with ID ${userId}` });
+    }
 
-		const uploadedWorkoutIds = await uploadWorkoutsDb(userId, req.body);
+    const uploadedWorkoutIds = await uploadWorkoutsDb(userId, req.body);
 
-		// Refresh the precomputed streak so the streak leaderboard stays fresh.
-		// Fire-and-forget — recomputation reads ≤500 qualifying days for one
-		// user, so it's cheap, but blocking the response on it isn't worth it.
-		refreshCurrentStreak(userId).catch(err => console.error('Error refreshing current_streak:', err.message));
+    // Refresh the precomputed streak so the streak leaderboard stays fresh.
+    // Fire-and-forget — recomputation reads ≤500 qualifying days for one
+    // user, so it's cheap, but blocking the response on it isn't worth it.
+    refreshCurrentStreak(userId).catch((err) =>
+      console.error("Error refreshing current_streak:", err.message),
+    );
 
-		try {
-			await checkRaceCompletions(userId);
-		} catch (raceError: any) {
-			console.error('Error checking race completions:', raceError.message);
-		}
+    try {
+      await checkRaceCompletions(userId);
+    } catch (raceError: any) {
+      console.error("Error checking race completions:", raceError.message);
+    }
 
-		// Evaluate badges + daily challenges AFTER the upload transaction committed.
-		// Kept inline (not fire-and-forget) so the response includes newly earned items.
-		let rewards = {
-			newlyEarnedBadges: [] as any[],
-			newChallengeCompletions: [] as any[]
-		};
-		try {
-			rewards = await evaluateWorkoutRewards(userId, uploadedWorkoutIds);
-		} catch (rewardError: any) {
-			console.error('Error evaluating workout rewards:', rewardError.message);
-		}
+    // Evaluate badges + daily challenges AFTER the upload transaction committed.
+    // Kept inline (not fire-and-forget) so the response includes newly earned items.
+    let rewards = {
+      newlyEarnedBadges: [] as any[],
+      newChallengeCompletions: [] as any[],
+    };
+    try {
+      rewards = await evaluateWorkoutRewards(userId, uploadedWorkoutIds);
+    } catch (rewardError: any) {
+      console.error("Error evaluating workout rewards:", rewardError.message);
+    }
 
-		// Check if user has now completed their mile and notify friends.
-		// Skipped on the initial account-setup backfill (isFullSync) and when this
-		// upload carried no workout from the last 24h (a pure backfill of old data).
-		if (!isFullSync && hasRecentWorkout) {
-			try {
-				const todayMiles = await getTodayMiles(userId);
-				if (todayMiles >= 1.0) {
-					const milestoneFired = await notifyFriendsOfMileCompletion(userId).catch(err => {
-						console.error('Error notifying friends:', err.message);
-						return false;
-					});
-					// If the mile was already completed before this upload, any new run/walk
-					// workouts in this batch are "extras" — fan out a per-workout notification,
-					// but only for the workouts that are themselves from the last 24h.
-					if (!milestoneFired) {
-						for (const w of req.body as Workout[]) {
-							if (
-								(w.workoutType === 'running' || w.workoutType === 'walking') &&
-								recentWorkoutIds.has(w.workoutId)
-							) {
-								notifyFriendsOfExtraWorkout(userId, w.workoutId).catch(err =>
-									console.error('Error notifying extra workout:', err.message)
-								);
-							}
-						}
-					}
-				} else {
-					// Daily mile NOT yet met — pre-goal workout notifications. Opt-in:
-					// the default outgoing audience for 'workout' is 'none', so this
-					// sends nothing unless the user enabled it. The workout that later
-					// completes the mile takes the >= 1.0 branch (mile_completed only),
-					// so the two never double-fire for the same workout.
-					for (const w of req.body as Workout[]) {
-						if (w.workoutType === 'running' || w.workoutType === 'walking') {
-							notifyFriendsOfWorkout(userId, w.workoutId).catch(err =>
-								console.error('Error notifying pre-goal workout:', err.message)
-							);
-						}
-					}
-				}
-				// Competition lead changes + milestones run on every upload,
-				// regardless of whether the daily mile was completed.
-				(async () => {
-					const notifiedRecipients = new Map<string, number>();
-					await checkLeadChanges(userId, notifiedRecipients).catch(err =>
-						console.error('Error checking lead changes:', err.message)
-					);
-					await checkCompetitionMilestones(userId, notifiedRecipients).catch(err =>
-						console.error('Error checking milestones:', err.message)
-					);
-				})();
-			} catch (notifError: any) {
-				console.error('Error checking notifications:', notifError.message);
-			}
-		}
+    // Check if user has now completed their mile and notify friends.
+    // Skipped on the initial account-setup backfill (isFullSync) and when this
+    // upload carried no workout from the last 24h (a pure backfill of old data).
+    if (!isFullSync && hasRecentWorkout) {
+      try {
+        const todayMiles = await getTodayMiles(userId);
+        if (todayMiles >= 1.0) {
+          const milestoneFired = await notifyFriendsOfMileCompletion(
+            userId,
+          ).catch((err) => {
+            console.error("Error notifying friends:", err.message);
+            return false;
+          });
+          // If the mile was already completed before this upload, any new run/walk
+          // workouts in this batch are "extras" — fan out a per-workout notification,
+          // but only for the workouts that are themselves from the last 24h.
+          if (!milestoneFired) {
+            for (const w of req.body as Workout[]) {
+              if (
+                (w.workoutType === "running" || w.workoutType === "walking") &&
+                recentWorkoutIds.has(w.workoutId)
+              ) {
+                notifyFriendsOfExtraWorkout(userId, w.workoutId).catch((err) =>
+                  console.error("Error notifying extra workout:", err.message),
+                );
+              }
+            }
+          }
+        } else {
+          // Daily mile NOT yet met — pre-goal workout notifications. Opt-in:
+          // the default outgoing audience for 'workout' is 'none', so this
+          // sends nothing unless the user enabled it. The workout that later
+          // completes the mile takes the >= 1.0 branch (mile_completed only),
+          // so the two never double-fire for the same workout.
+          for (const w of req.body as Workout[]) {
+            if (w.workoutType === "running" || w.workoutType === "walking") {
+              notifyFriendsOfWorkout(userId, w.workoutId).catch((err) =>
+                console.error("Error notifying pre-goal workout:", err.message),
+              );
+            }
+          }
+        }
+        // Competition lead changes + milestones run on every upload,
+        // regardless of whether the daily mile was completed.
+        (async () => {
+          const notifiedRecipients = new Map<string, number>();
+          await checkLeadChanges(userId, notifiedRecipients).catch((err) =>
+            console.error("Error checking lead changes:", err.message),
+          );
+          await checkCompetitionMilestones(userId, notifiedRecipients).catch(
+            (err) => console.error("Error checking milestones:", err.message),
+          );
+        })();
+      } catch (notifError: any) {
+        console.error("Error checking notifications:", notifError.message);
+      }
+    }
 
-		// Fire badge + challenge push notifications (non-blocking). Each reward is
-		// attributed to the workout that triggered it: if that workout is outside the
-		// 24h window (e.g. a backfilled or manually-logged past run), NO push fires —
-		// not the user's own badge_earned, not the friend fan-out. Aggregate rewards
-		// with no single triggering workout fall back to "did this batch include any
-		// workout from the last 24h". Friend fan-outs are additionally gated by
-		// isFullSync so the setup backfill never notifies others.
-		for (const badge of rewards.newlyEarnedBadges) {
-			const fromRecentWorkout = badge.triggeringWorkoutId
-				? recentWorkoutIds.has(badge.triggeringWorkoutId)
-				: hasRecentWorkout;
-			if (!fromRecentWorkout) continue;
-			fireBadgeEarnedPush(userId, badge).catch(err => console.error('Error firing badge_earned push:', err.message));
-			if (!isFullSync && badge.rarity !== 'common') {
-				fanOutFriendBadgePush(userId, badge).catch(err =>
-					console.error('Error fanning out friend_badge_earned:', err.message)
-				);
-			}
-		}
-		if (!isFullSync) {
-			for (const completion of rewards.newChallengeCompletions) {
-				const fromRecentWorkout = completion.completingWorkoutId
-					? recentWorkoutIds.has(completion.completingWorkoutId)
-					: hasRecentWorkout;
-				if (!fromRecentWorkout) continue;
-				fanOutFriendChallengePush(userId, completion).catch(err =>
-					console.error('Error fanning out friend_challenge_completed:', err.message)
-				);
-			}
-		}
+    // Fire badge + challenge push notifications (non-blocking). Each reward is
+    // attributed to the workout that triggered it: if that workout is outside the
+    // 24h window (e.g. a backfilled or manually-logged past run), NO push fires —
+    // not the user's own badge_earned, not the friend fan-out. Aggregate rewards
+    // with no single triggering workout fall back to "did this batch include any
+    // workout from the last 24h". Friend fan-outs are additionally gated by
+    // isFullSync so the setup backfill never notifies others.
+    for (const badge of rewards.newlyEarnedBadges) {
+      const fromRecentWorkout = badge.triggeringWorkoutId
+        ? recentWorkoutIds.has(badge.triggeringWorkoutId)
+        : hasRecentWorkout;
+      if (!fromRecentWorkout) continue;
+      fireBadgeEarnedPush(userId, badge).catch((err) =>
+        console.error("Error firing badge_earned push:", err.message),
+      );
+      if (!isFullSync && badge.rarity !== "common") {
+        fanOutFriendBadgePush(userId, badge).catch((err) =>
+          console.error("Error fanning out friend_badge_earned:", err.message),
+        );
+      }
+    }
+    if (!isFullSync) {
+      for (const completion of rewards.newChallengeCompletions) {
+        const fromRecentWorkout = completion.completingWorkoutId
+          ? recentWorkoutIds.has(completion.completingWorkoutId)
+          : hasRecentWorkout;
+        if (!fromRecentWorkout) continue;
+        fanOutFriendChallengePush(userId, completion).catch((err) =>
+          console.error(
+            "Error fanning out friend_challenge_completed:",
+            err.message,
+          ),
+        );
+      }
+    }
 
-		// PR detection: compare pre-upload PRs (excluding this batch) to post-upload PRs.
-		// Fan out one notification per dimension that improved — but only when the
-		// record was set TODAY (user's local date). Historical imports (e.g. a new
-		// account's initial HealthKit backfill) raise the all-time max too, and
-		// without this guard every backfill batch sprays bogus "new personal best"
-		// pushes at the user's friends. The full-sync guard skips this outright;
-		// the today-guard remains the backstop for normal syncs. Fire-and-forget.
-		if (!isFullSync)
-			(async () => {
-				try {
-					const [pre, post, userToday] = await Promise.all([
-						computePersonalRecords(userId, uploadedWorkoutIds),
-						computePersonalRecords(userId),
-						getUserLocalToday(userId)
-					]);
-					const lastWorkoutId = uploadedWorkoutIds[uploadedWorkoutIds.length - 1] ?? '';
+    // PR detection: compare pre-upload PRs (excluding this batch) to post-upload PRs.
+    // Fan out one notification per dimension that improved — but only when the
+    // record was set TODAY (user's local date). Historical imports (e.g. a new
+    // account's initial HealthKit backfill) raise the all-time max too, and
+    // without this guard every backfill batch sprays bogus "new personal best"
+    // pushes at the user's friends. The full-sync guard skips this outright;
+    // the today-guard remains the backstop for normal syncs. Fire-and-forget.
+    if (!isFullSync)
+      (async () => {
+        try {
+          const [pre, post, userToday] = await Promise.all([
+            computePersonalRecords(userId, uploadedWorkoutIds),
+            computePersonalRecords(userId),
+            getUserLocalToday(userId),
+          ]);
+          const lastWorkoutId =
+            uploadedWorkoutIds[uploadedWorkoutIds.length - 1] ?? "";
 
-					if (
-						post.fastestSplitPaceSecMi > 0 &&
-						(pre.fastestSplitPaceSecMi === 0 || post.fastestSplitPaceSecMi < pre.fastestSplitPaceSecMi) &&
-						post.fastestSplitDate === userToday
-					) {
-						fanOutFriendPersonalBestPush(userId, 'fastest_mile', post.fastestSplitPaceSecMi, lastWorkoutId).catch(
-							err => console.error('Error fanning out friend_personal_best (fastest_mile):', err.message)
-						);
-					}
-					if (post.mostMilesInOneDay > pre.mostMilesInOneDay && post.bestDayDate === userToday) {
-						fanOutFriendPersonalBestPush(userId, 'most_miles_day', post.mostMilesInOneDay, lastWorkoutId).catch(err =>
-							console.error('Error fanning out friend_personal_best (most_miles_day):', err.message)
-						);
-					}
-				} catch (err: any) {
-					console.error('Error detecting personal bests:', err.message);
-				}
-			})();
+          if (
+            post.fastestSplitPaceSecMi > 0 &&
+            (pre.fastestSplitPaceSecMi === 0 ||
+              post.fastestSplitPaceSecMi < pre.fastestSplitPaceSecMi) &&
+            post.fastestSplitDate === userToday
+          ) {
+            fanOutFriendPersonalBestPush(
+              userId,
+              "fastest_mile",
+              post.fastestSplitPaceSecMi,
+              lastWorkoutId,
+            ).catch((err) =>
+              console.error(
+                "Error fanning out friend_personal_best (fastest_mile):",
+                err.message,
+              ),
+            );
+          }
+          if (
+            post.mostMilesInOneDay > pre.mostMilesInOneDay &&
+            post.bestDayDate === userToday
+          ) {
+            fanOutFriendPersonalBestPush(
+              userId,
+              "most_miles_day",
+              post.mostMilesInOneDay,
+              lastWorkoutId,
+            ).catch((err) =>
+              console.error(
+                "Error fanning out friend_personal_best (most_miles_day):",
+                err.message,
+              ),
+            );
+          }
+        } catch (err: any) {
+          console.error("Error detecting personal bests:", err.message);
+        }
+      })();
 
-		res.status(200).json({
-			message: 'Successfully uploaded workouts.',
-			newlyEarnedBadges: rewards.newlyEarnedBadges,
-			newChallengeCompletions: rewards.newChallengeCompletions
-		});
-	} catch (error: any) {
-		console.error('Error uploading workouts:', error.message);
-		res.status(500).json({ error: 'Error uploading workouts: ' + error.message });
-	}
+    res.status(200).json({
+      message: "Successfully uploaded workouts.",
+      newlyEarnedBadges: rewards.newlyEarnedBadges,
+      newChallengeCompletions: rewards.newChallengeCompletions,
+    });
+  } catch (error: any) {
+    console.error("Error uploading workouts:", error.message);
+    res
+      .status(500)
+      .json({ error: "Error uploading workouts: " + error.message });
+  }
 }
 
 export async function getStreak(req: Request, res: Response) {
-	if (!hasRequiredKeys(['userId'], req, res)) return;
+  if (!hasRequiredKeys(["userId"], req, res)) return;
 
-	try {
-		const userId = req.params.userId;
+  try {
+    const userId = req.params.userId;
 
-		const user = await getUser({ userId });
-		if (!user) {
-			return res.status(400).send({ error: `No user found with ID ${userId}` });
-		}
+    const user = await getUser({ userId });
+    if (!user) {
+      return res.status(400).send({ error: `No user found with ID ${userId}` });
+    }
 
-		const { streak } = await getActiveStreak(userId);
+    const { streak } = await getActiveStreak(userId);
 
-		return res.status(200).json({ streak });
-	} catch (error: any) {
-		console.error('Error getting streak:', error.message);
-		res.status(500).json({ error: 'Error getting streak: ' + error.message });
-	}
+    return res.status(200).json({ streak });
+  } catch (error: any) {
+    console.error("Error getting streak:", error.message);
+    res.status(500).json({ error: "Error getting streak: " + error.message });
+  }
 }
 
 /**
@@ -262,138 +296,186 @@ export async function getStreak(req: Request, res: Response) {
  * refresh that the upload pipeline kicks off.
  */
 export async function recalibrateStreak(req: Request, res: Response) {
-	if (!hasRequiredKeys(['userId'], req, res)) return;
+  if (!hasRequiredKeys(["userId"], req, res)) return;
 
-	try {
-		const userId = req.params.userId;
+  try {
+    const userId = req.params.userId;
 
-		const user = await getUser({ userId });
-		if (!user) {
-			return res.status(400).send({ error: `No user found with ID ${userId}` });
-		}
+    const user = await getUser({ userId });
+    if (!user) {
+      return res.status(400).send({ error: `No user found with ID ${userId}` });
+    }
 
-		const streak = await refreshCurrentStreak(userId);
+    const streak = await refreshCurrentStreak(userId);
 
-		return res.status(200).json({ streak });
-	} catch (error: any) {
-		console.error('Error recalibrating streak:', error.message);
-		res.status(500).json({ error: 'Error recalibrating streak: ' + error.message });
-	}
+    return res.status(200).json({ streak });
+  } catch (error: any) {
+    console.error("Error recalibrating streak:", error.message);
+    res
+      .status(500)
+      .json({ error: "Error recalibrating streak: " + error.message });
+  }
+}
+
+export async function deleteWorkout(req: Request, res: Response) {
+  if (!hasRequiredKeys(["userId", "workoutId"], req, res)) return;
+
+  try {
+    const { userId, workoutId } = req.params;
+
+    const result = await softDeleteWorkout(userId, workoutId);
+    if (!result.deleted) {
+      return res.status(404).json({ error: "Workout not found" });
+    }
+
+    return res.status(200).json({
+      message: "Workout deleted",
+      current_streak: result.currentStreak,
+      revoked_badges: result.revokedBadges,
+    });
+  } catch (error: any) {
+    console.error("Error deleting workout:", error.message);
+    res.status(500).json({ error: "Error deleting workout: " + error.message });
+  }
 }
 
 export async function getWorkoutRange() {}
 
 export async function getRecentWorkouts(req: Request, res: Response) {
-	if (!hasRequiredKeys(['userId'], req, res)) return;
+  if (!hasRequiredKeys(["userId"], req, res)) return;
 
-	const limitParam = typeof req.query.limit === 'string' ? req.query.limit : '';
-	let resultLimit: number | null = parseInt(limitParam);
-	if (isNaN(resultLimit)) {
-		resultLimit = null;
-	}
+  const limitParam = typeof req.query.limit === "string" ? req.query.limit : "";
+  let resultLimit: number | null = parseInt(limitParam);
+  if (isNaN(resultLimit)) {
+    resultLimit = null;
+  }
 
-	try {
-		const userId = req.params.userId;
+  try {
+    const userId = req.params.userId;
 
-		const user = await getUser({ userId });
-		if (!user) {
-			return res.status(400).send({ error: `No user found with ID ${userId}` });
-		}
+    const user = await getUser({ userId });
+    if (!user) {
+      return res.status(400).send({ error: `No user found with ID ${userId}` });
+    }
 
-		const results = await getRecentWorkoutsDb(userId, resultLimit);
+    const results = await getRecentWorkoutsDb(userId, resultLimit);
 
-		return res.status(200).json(results);
-	} catch (error: any) {
-		console.error('Error getting recent workouts:', error.message);
-		res.status(500).json({ error: 'Error getting recent workouts: ' + error.message });
-	}
+    return res.status(200).json(results);
+  } catch (error: any) {
+    console.error("Error getting recent workouts:", error.message);
+    res
+      .status(500)
+      .json({ error: "Error getting recent workouts: " + error.message });
+  }
 }
 
 export async function getUserStats(req: Request, res: Response) {
-	if (!hasRequiredKeys(['userId'], req, res)) return;
+  if (!hasRequiredKeys(["userId"], req, res)) return;
 
-	try {
-		const userId = req.params.userId;
-		const currentStreak = req.query.current_streak === 'true';
+  try {
+    const userId = req.params.userId;
+    const currentStreak = req.query.current_streak === "true";
 
-		const user = await getUser({ userId });
-		if (!user) {
-			return res.status(400).send({ error: `No user found with ID ${userId}` });
-		}
+    const user = await getUser({ userId });
+    if (!user) {
+      return res.status(400).send({ error: `No user found with ID ${userId}` });
+    }
 
-		const { streak, start } = await getActiveStreak(userId);
+    const { streak, start } = await getActiveStreak(userId);
 
-		const startDateParam = currentStreak ? start : undefined;
-		const [total_miles, best_miles_day, best_split_time, recent_workouts, today_miles] = await Promise.all([
-			getTotalMiles(userId, startDateParam),
-			getBestMilesDay(userId, startDateParam),
-			getBestSplit(userId, startDateParam),
-			getRecentWorkoutsDb(userId, 10),
-			getTodayMiles(userId)
-		]);
+    const startDateParam = currentStreak ? start : undefined;
+    const [
+      total_miles,
+      best_miles_day,
+      best_split_time,
+      recent_workouts,
+      today_miles,
+    ] = await Promise.all([
+      getTotalMiles(userId, startDateParam),
+      getBestMilesDay(userId, startDateParam),
+      getBestSplit(userId, startDateParam),
+      getRecentWorkoutsDb(userId, 10),
+      getTodayMiles(userId),
+    ]);
 
-		// Default goal miles is 1.0 (can be updated when user preferences are stored)
-		const goal_miles = 1.0;
+    // Default goal miles is 1.0 (can be updated when user preferences are stored)
+    const goal_miles = 1.0;
 
-		return res.status(200).json({
-			streak,
-			start_date: start,
-			total_miles,
-			best_miles_day,
-			best_split_time,
-			recent_workouts,
-			today_miles,
-			goal_miles
-		});
-	} catch (error: any) {
-		console.error('Error getting user stats:', error.message);
-		res.status(500).json({ error: 'Error getting user stats: ' + error.message });
-	}
+    return res.status(200).json({
+      streak,
+      start_date: start,
+      total_miles,
+      best_miles_day,
+      best_split_time,
+      recent_workouts,
+      today_miles,
+      goal_miles,
+    });
+  } catch (error: any) {
+    console.error("Error getting user stats:", error.message);
+    res
+      .status(500)
+      .json({ error: "Error getting user stats: " + error.message });
+  }
 }
 
 export async function updateWorkout(req: Request, res: Response) {
-	if (!hasRequiredKeys(['userId', 'workoutId'], req, res)) return;
+  if (!hasRequiredKeys(["userId", "workoutId"], req, res)) return;
 
-	try {
-		const { userId, workoutId } = req.params;
-		const { distance, totalDuration, workoutType } = req.body;
+  try {
+    const { userId, workoutId } = req.params;
+    const { distance, totalDuration, workoutType } = req.body;
 
-		if (distance === undefined && totalDuration === undefined && workoutType === undefined) {
-			return res.status(400).json({ error: 'No fields to update provided' });
-		}
+    if (
+      distance === undefined &&
+      totalDuration === undefined &&
+      workoutType === undefined
+    ) {
+      return res.status(400).json({ error: "No fields to update provided" });
+    }
 
-		if (distance !== undefined && (typeof distance !== 'number' || distance <= 0)) {
-			return res.status(400).json({ error: 'Distance must be a positive number' });
-		}
+    if (
+      distance !== undefined &&
+      (typeof distance !== "number" || distance <= 0)
+    ) {
+      return res
+        .status(400)
+        .json({ error: "Distance must be a positive number" });
+    }
 
-		if (totalDuration !== undefined && (typeof totalDuration !== 'number' || totalDuration <= 0)) {
-			return res.status(400).json({ error: 'Duration must be a positive number' });
-		}
+    if (
+      totalDuration !== undefined &&
+      (typeof totalDuration !== "number" || totalDuration <= 0)
+    ) {
+      return res
+        .status(400)
+        .json({ error: "Duration must be a positive number" });
+    }
 
-		const user = await getUser({ userId });
-		if (!user) {
-			return res.status(400).json({ error: `No user found with ID ${userId}` });
-		}
+    const user = await getUser({ userId });
+    if (!user) {
+      return res.status(400).json({ error: `No user found with ID ${userId}` });
+    }
 
-		const updated = await updateWorkoutDb(userId, workoutId, {
-			distance,
-			totalDuration,
-			workoutType
-		});
+    const updated = await updateWorkoutDb(userId, workoutId, {
+      distance,
+      totalDuration,
+      workoutType,
+    });
 
-		if (!updated) {
-			return res.status(404).json({ error: 'Workout not found' });
-		}
+    if (!updated) {
+      return res.status(404).json({ error: "Workout not found" });
+    }
 
-		try {
-			await checkRaceCompletions(userId);
-		} catch (raceError: any) {
-			console.error('Error checking race completions:', raceError.message);
-		}
+    try {
+      await checkRaceCompletions(userId);
+    } catch (raceError: any) {
+      console.error("Error checking race completions:", raceError.message);
+    }
 
-		res.status(200).json(updated);
-	} catch (error: any) {
-		console.error('Error updating workout:', error.message);
-		res.status(500).json({ error: 'Error updating workout: ' + error.message });
-	}
+    res.status(200).json(updated);
+  } catch (error: any) {
+    console.error("Error updating workout:", error.message);
+    res.status(500).json({ error: "Error updating workout: " + error.message });
+  }
 }

--- a/backend/src/cron/pendingSendCron.ts
+++ b/backend/src/cron/pendingSendCron.ts
@@ -1,0 +1,22 @@
+import cron from "node-cron";
+import { drainDueScheduled } from "../services/pendingNotificationService.js";
+
+/**
+ * Delivers time-delayed friend notifications once their delay elapses — today
+ * that's the deferred mile-completion push (run time + ~10 min) that merges a
+ * post-run photo into a single notification. Runs about once a minute.
+ */
+export function startPendingSendCron(): void {
+  // Off the :00 second/every-minute default a hair to avoid clustering with
+  // other minute jobs.
+  cron.schedule("* * * * *", async () => {
+    try {
+      await drainDueScheduled();
+    } catch (err: any) {
+      console.error("[PendingSendCron] drain failed:", err?.message ?? err);
+    }
+  });
+  console.log(
+    "[PendingSendCron] Scheduled scheduled-notification drain (every minute).",
+  );
+}

--- a/backend/src/db/drizzle/0005_lame_marvex.sql
+++ b/backend/src/db/drizzle/0005_lame_marvex.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "workouts" ADD COLUMN "deleted_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "workouts" ADD COLUMN "exclusion_reason" text;--> statement-breakpoint
+ALTER TABLE "workouts" ADD COLUMN "speed_flagged" boolean DEFAULT false NOT NULL;

--- a/backend/src/db/drizzle/0006_mean_lizard.sql
+++ b/backend/src/db/drizzle/0006_mean_lizard.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "pending_friend_notifications" ADD COLUMN "send_after_at" timestamp with time zone;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_posts_workout_active" ON "posts" USING btree ("workout_id") WHERE (deleted_at IS NULL AND workout_id IS NOT NULL);

--- a/backend/src/db/drizzle/meta/0005_snapshot.json
+++ b/backend/src/db/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,3459 @@
+{
+  "id": "f8c04f1d-5112-4414-9acf-6b6a14a56b23",
+  "prevId": "9320576f-9f0b-4d91-aa00-c977c1b4a7dd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_badges_category": {
+          "name": "idx_badges_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "badges_rarity_check": {
+          "name": "badges_rarity_check",
+          "value": "rarity = ANY (ARRAY['common'::text, 'rare'::text, 'legendary'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.close_friends": {
+      "name": "close_friends",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_friend_id": {
+          "name": "close_friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_close_friends_friend": {
+          "name": "idx_close_friends_friend",
+          "columns": [
+            {
+              "expression": "close_friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "close_friends_pkey": {
+          "name": "close_friends_pkey",
+          "columns": [
+            "user_id",
+            "close_friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_users": {
+      "name": "competition_users",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_rank": {
+          "name": "last_known_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_score": {
+          "name": "last_known_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rank_updated_at": {
+          "name": "last_rank_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_competition_users_comp": {
+          "name": "idx_competition_users_comp",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_competition": {
+          "name": "idx_competition_users_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_rank_cache": {
+          "name": "idx_competition_users_rank_cache",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_known_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((invite_status)::text = 'accepted'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user": {
+          "name": "idx_competition_users_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user_status": {
+          "name": "idx_competition_users_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invite_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_users_user_id_fkey": {
+          "name": "competition_users_user_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_users_competition_id_fkey": {
+          "name": "competition_users_competition_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_users_pkey": {
+          "name": "competition_users_pkey",
+          "columns": [
+            "competition_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_users_invite_status_check": {
+          "name": "competition_users_invite_status_check",
+          "value": "(invite_status)::text = ANY ((ARRAY['pending'::character varying, 'accepted'::character varying, 'declined'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workouts": {
+          "name": "workouts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_winner": {
+          "name": "idx_competitions_winner",
+          "columns": [
+            {
+              "expression": "winner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(winner IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_winner_fkey": {
+          "name": "competitions_winner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "competitions_owner_fkey": {
+          "name": "competitions_owner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitions_type_check": {
+          "name": "competitions_type_check",
+          "value": "(type)::text = ANY ((ARRAY['streaks'::character varying, 'apex'::character varying, 'clash'::character varying, 'targets'::character varying, 'race'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_challenges": {
+      "name": "daily_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_template": {
+          "name": "description_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_start": {
+          "name": "gradient_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_end": {
+          "name": "gradient_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rotation_index": {
+          "name": "rotation_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_challenges_rotation_index_key": {
+          "name": "daily_challenges_rotation_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rotation_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daily_challenges_type_check": {
+          "name": "daily_challenges_type_check",
+          "value": "type = ANY (ARRAY['pace'::text, 'distance'::text, 'time'::text, 'activity'::text, 'steps'::text, 'social'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_steps": {
+      "name": "daily_steps",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_steps_user_date": {
+          "name": "idx_daily_steps_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_steps_user_id_fkey": {
+          "name": "daily_steps_user_id_fkey",
+          "tableFrom": "daily_steps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_steps_pkey": {
+          "name": "daily_steps_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "daily_steps_steps_check": {
+          "name": "daily_steps_steps_check",
+          "value": "steps >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token": {
+          "name": "device_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_tokens_user_id": {
+          "name": "idx_device_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_user_id_fkey": {
+          "name": "device_tokens_user_id_fkey",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_user_id_device_token_key": {
+          "name": "device_tokens_user_id_device_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flex_log": {
+      "name": "flex_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flex_log_lookup": {
+          "name": "idx_flex_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_notification_settings": {
+      "name": "friend_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted": {
+          "name": "muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nudges_muted": {
+          "name": "nudges_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "activity_muted": {
+          "name": "activity_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "friend_notification_settings_pkey": {
+          "name": "friend_notification_settings_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_nudge_log": {
+      "name": "friend_nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_nudge_log_lookup": {
+          "name": "idx_friend_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_friendships_friend_status": {
+          "name": "idx_friendships_friend_status",
+          "columns": [
+            {
+              "expression": "friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_friendships_user_status": {
+          "name": "idx_friendships_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_user_id_fkey": {
+          "name": "friendships_user_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_friend_id_fkey": {
+          "name": "friendships_friend_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendships_pkey": {
+          "name": "friendships_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_friendship_pair": {
+          "name": "unique_friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hype_log": {
+      "name": "hype_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_label": {
+          "name": "context_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hype_log_context_dedupe_idx": {
+          "name": "hype_log_context_dedupe_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_lookup": {
+          "name": "idx_hype_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_app_notifications": {
+      "name": "in_app_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_in_app_notifications_unread": {
+          "name": "idx_in_app_notifications_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_read = false)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_app_notifications_user": {
+          "name": "idx_in_app_notifications_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_app_notifications_user_id_fkey": {
+          "name": "in_app_notifications_user_id_fkey",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_notifications": {
+      "name": "milestone_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_key": {
+          "name": "milestone_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_notifications_milestone_key_key": {
+          "name": "milestone_notifications_milestone_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_audience_settings": {
+      "name": "notification_audience_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_audience_settings_pkey": {
+          "name": "notification_audience_settings_pkey",
+          "columns": [
+            "user_id",
+            "direction",
+            "event_type",
+            "activity_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_audience_settings_direction_check": {
+          "name": "notification_audience_settings_direction_check",
+          "value": "direction = ANY (ARRAY['outgoing'::text, 'incoming'::text])"
+        },
+        "notification_audience_settings_audience_check": {
+          "name": "notification_audience_settings_audience_check",
+          "value": "audience = ANY (ARRAY['none'::text, 'close'::text, 'all'::text, 'ask'::text, 'match_run'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_user_date": {
+          "name": "idx_notification_log_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nudges_enabled": {
+          "name": "nudges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "flexes_enabled": {
+          "name": "flexes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_activity_enabled": {
+          "name": "friend_activity_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_invites_enabled": {
+          "name": "competition_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_updates_enabled": {
+          "name": "competition_updates_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_milestones_enabled": {
+          "name": "competition_milestones_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "hypes_enabled": {
+          "name": "hypes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "step_goal_enabled": {
+          "name": "step_goal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "friend_personal_best_enabled": {
+          "name": "friend_personal_best_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_enabled": {
+          "name": "daily_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_hour": {
+          "name": "daily_reminder_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 18
+        },
+        "timezone_offset_minutes": {
+          "name": "timezone_offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_workouts_to_feed": {
+          "name": "share_workouts_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_posts_enabled": {
+          "name": "friend_posts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nudge_log": {
+      "name": "nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_nudge_log_lookup": {
+          "name": "idx_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nudge_log_rate_limit": {
+          "name": "idx_nudge_log_rate_limit",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_friend_notifications": {
+      "name": "pending_friend_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pending_friend_notif_user": {
+          "name": "idx_pending_friend_notif_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_pending_friend_notif_workout": {
+          "name": "uq_pending_friend_notif_workout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((workout_id IS NOT NULL) AND (status = 'pending'::text))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pending_friend_notifications_status_check": {
+          "name": "pending_friend_notifications_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'sent'::text, 'dismissed'::text, 'expired'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_notifications": {
+      "name": "pending_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_notifications_unsent": {
+          "name": "idx_pending_notifications_unsent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(sent_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_notifications_user_id_fkey": {
+          "name": "pending_notifications_user_id_fkey",
+          "tableFrom": "pending_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_reports": {
+      "name": "post_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_reports_dedupe_idx": {
+          "name": "post_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_reports_status": {
+          "name": "idx_post_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_reports_post_id_fkey": {
+          "name": "post_reports_post_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_reports_reporter_id_fkey": {
+          "name": "post_reports_reporter_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_reports_reason_check": {
+          "name": "post_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_snapshot": {
+          "name": "stats_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_to_feed": {
+          "name": "share_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_to_story": {
+          "name": "share_to_story",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "story_expires_at": {
+          "name": "story_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_posts_user_created": {
+          "name": "idx_posts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_feed": {
+          "name": "idx_posts_feed",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_story_active": {
+          "name": "idx_posts_story_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "story_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_story)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_fkey": {
+          "name": "posts_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_workout_id_fkey": {
+          "name": "posts_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_family_id": {
+          "name": "token_family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_hash": {
+          "name": "replaced_by_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "token_family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_revoked_at": {
+          "name": "idx_refresh_tokens_revoked_at",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(revoked_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_token_hash": {
+          "name": "idx_refresh_tokens_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_fkey": {
+          "name": "refresh_tokens_user_id_fkey",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_key": {
+          "name": "refresh_tokens_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_views": {
+      "name": "story_views",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_views_post_id_fkey": {
+          "name": "story_views_post_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_views_viewer_id_fkey": {
+          "name": "story_views_viewer_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_views_pkey": {
+          "name": "story_views_pkey",
+          "columns": [
+            "post_id",
+            "viewer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggering_workout_id": {
+          "name": "triggering_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_snapshot": {
+          "name": "progress_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_slot": {
+          "name": "pin_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_badges_user": {
+          "name": "idx_user_badges_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_new": {
+          "name": "idx_user_badges_user_new",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_new = true)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_pin_slot": {
+          "name": "idx_user_badges_user_pin_slot",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(pin_slot IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_workout": {
+          "name": "idx_user_badges_workout",
+          "columns": [
+            {
+              "expression": "triggering_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_badges_user_id_fkey": {
+          "name": "user_badges_user_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_fkey": {
+          "name": "user_badges_badge_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "badge_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_triggering_workout_id_fkey": {
+          "name": "user_badges_triggering_workout_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "triggering_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_badges_user_id_badge_id_key": {
+          "name": "user_badges_user_id_badge_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "badge_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_badges_pin_slot_range": {
+          "name": "user_badges_pin_slot_range",
+          "value": "(pin_slot IS NULL) OR ((pin_slot >= 0) AND (pin_slot <= 2))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_blocks_blocked": {
+          "name": "idx_user_blocks_blocked",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_fkey": {
+          "name": "user_blocks_blocker_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_blocks_blocked_id_fkey": {
+          "name": "user_blocks_blocked_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_pkey": {
+          "name": "user_blocks_pkey",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenge_completions": {
+      "name": "user_challenge_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completing_workout_id": {
+          "name": "completing_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ucc_user": {
+          "name": "idx_ucc_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ucc_user_date": {
+          "name": "idx_ucc_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenge_completions_user_id_fkey": {
+          "name": "user_challenge_completions_user_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_challenge_key_fkey": {
+          "name": "user_challenge_completions_challenge_key_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "daily_challenges",
+          "columnsFrom": [
+            "challenge_key"
+          ],
+          "columnsTo": [
+            "challenge_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_completing_workout_id_fkey": {
+          "name": "user_challenge_completions_completing_workout_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "completing_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_challenge_completions_user_id_local_date_key": {
+          "name": "user_challenge_completions_user_id_local_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_sub": {
+          "name": "apple_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "goal_miles": {
+          "name": "goal_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_current_streak_desc": {
+          "name": "idx_users_current_streak_desc",
+          "columns": [
+            {
+              "expression": "current_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email_trgm": {
+          "name": "idx_users_email_trgm",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_username_trgm": {
+          "name": "idx_users_username_trgm",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_apple_id_key": {
+          "name": "users_apple_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_apple_sub_key": {
+          "name": "users_apple_sub_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "apple_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_completion_notifications": {
+      "name": "workout_completion_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_date": {
+          "name": "notified_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_completion_notifications_user_id_notified_date_key": {
+          "name": "workout_completion_notifications_user_id_notified_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "notified_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_splits": {
+      "name": "workout_splits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_number": {
+          "name": "split_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_duration": {
+          "name": "split_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_distance": {
+          "name": "split_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_pace": {
+          "name": "split_pace",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_splits_time": {
+          "name": "idx_splits_time",
+          "columns": [
+            {
+              "expression": "split_duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_splits_workout": {
+          "name": "idx_splits_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_splits_workout_id_fkey": {
+          "name": "workout_splits_workout_id_fkey",
+          "tableFrom": "workout_splits",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_splits_workout_id_split_number_key": {
+          "name": "workout_splits_workout_id_split_number_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "split_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workouts": {
+      "name": "workouts",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_end_date": {
+          "name": "device_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthkit'"
+        },
+        "original_distance": {
+          "name": "original_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_duration": {
+          "name": "original_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_flagged": {
+          "name": "speed_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_workouts_local_date_user_id": {
+          "name": "idx_workouts_local_date_user_id",
+          "columns": [
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_device_end": {
+          "name": "idx_workouts_user_device_end",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_local_date": {
+          "name": "idx_workouts_user_local_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workouts_user_workout_unique": {
+          "name": "workouts_user_workout_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/drizzle/meta/0006_snapshot.json
+++ b/backend/src/db/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,3481 @@
+{
+  "id": "46bfd06c-e404-4c37-b13b-48364f849bea",
+  "prevId": "f8c04f1d-5112-4414-9acf-6b6a14a56b23",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_badges_category": {
+          "name": "idx_badges_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "badges_rarity_check": {
+          "name": "badges_rarity_check",
+          "value": "rarity = ANY (ARRAY['common'::text, 'rare'::text, 'legendary'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.close_friends": {
+      "name": "close_friends",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_friend_id": {
+          "name": "close_friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_close_friends_friend": {
+          "name": "idx_close_friends_friend",
+          "columns": [
+            {
+              "expression": "close_friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "close_friends_pkey": {
+          "name": "close_friends_pkey",
+          "columns": [
+            "user_id",
+            "close_friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_users": {
+      "name": "competition_users",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_rank": {
+          "name": "last_known_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_score": {
+          "name": "last_known_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rank_updated_at": {
+          "name": "last_rank_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_competition_users_comp": {
+          "name": "idx_competition_users_comp",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_competition": {
+          "name": "idx_competition_users_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_rank_cache": {
+          "name": "idx_competition_users_rank_cache",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_known_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((invite_status)::text = 'accepted'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user": {
+          "name": "idx_competition_users_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user_status": {
+          "name": "idx_competition_users_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invite_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_users_user_id_fkey": {
+          "name": "competition_users_user_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_users_competition_id_fkey": {
+          "name": "competition_users_competition_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_users_pkey": {
+          "name": "competition_users_pkey",
+          "columns": [
+            "competition_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_users_invite_status_check": {
+          "name": "competition_users_invite_status_check",
+          "value": "(invite_status)::text = ANY ((ARRAY['pending'::character varying, 'accepted'::character varying, 'declined'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workouts": {
+          "name": "workouts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_winner": {
+          "name": "idx_competitions_winner",
+          "columns": [
+            {
+              "expression": "winner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(winner IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_winner_fkey": {
+          "name": "competitions_winner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "competitions_owner_fkey": {
+          "name": "competitions_owner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitions_type_check": {
+          "name": "competitions_type_check",
+          "value": "(type)::text = ANY ((ARRAY['streaks'::character varying, 'apex'::character varying, 'clash'::character varying, 'targets'::character varying, 'race'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_challenges": {
+      "name": "daily_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_template": {
+          "name": "description_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_start": {
+          "name": "gradient_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_end": {
+          "name": "gradient_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rotation_index": {
+          "name": "rotation_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_challenges_rotation_index_key": {
+          "name": "daily_challenges_rotation_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rotation_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daily_challenges_type_check": {
+          "name": "daily_challenges_type_check",
+          "value": "type = ANY (ARRAY['pace'::text, 'distance'::text, 'time'::text, 'activity'::text, 'steps'::text, 'social'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_steps": {
+      "name": "daily_steps",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_steps_user_date": {
+          "name": "idx_daily_steps_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_steps_user_id_fkey": {
+          "name": "daily_steps_user_id_fkey",
+          "tableFrom": "daily_steps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_steps_pkey": {
+          "name": "daily_steps_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "daily_steps_steps_check": {
+          "name": "daily_steps_steps_check",
+          "value": "steps >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token": {
+          "name": "device_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_tokens_user_id": {
+          "name": "idx_device_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_user_id_fkey": {
+          "name": "device_tokens_user_id_fkey",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_user_id_device_token_key": {
+          "name": "device_tokens_user_id_device_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flex_log": {
+      "name": "flex_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flex_log_lookup": {
+          "name": "idx_flex_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_notification_settings": {
+      "name": "friend_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted": {
+          "name": "muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nudges_muted": {
+          "name": "nudges_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "activity_muted": {
+          "name": "activity_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "friend_notification_settings_pkey": {
+          "name": "friend_notification_settings_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_nudge_log": {
+      "name": "friend_nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_nudge_log_lookup": {
+          "name": "idx_friend_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_friendships_friend_status": {
+          "name": "idx_friendships_friend_status",
+          "columns": [
+            {
+              "expression": "friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_friendships_user_status": {
+          "name": "idx_friendships_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_user_id_fkey": {
+          "name": "friendships_user_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_friend_id_fkey": {
+          "name": "friendships_friend_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendships_pkey": {
+          "name": "friendships_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_friendship_pair": {
+          "name": "unique_friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hype_log": {
+      "name": "hype_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_label": {
+          "name": "context_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hype_log_context_dedupe_idx": {
+          "name": "hype_log_context_dedupe_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_lookup": {
+          "name": "idx_hype_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_app_notifications": {
+      "name": "in_app_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_in_app_notifications_unread": {
+          "name": "idx_in_app_notifications_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_read = false)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_app_notifications_user": {
+          "name": "idx_in_app_notifications_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_app_notifications_user_id_fkey": {
+          "name": "in_app_notifications_user_id_fkey",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_notifications": {
+      "name": "milestone_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_key": {
+          "name": "milestone_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_notifications_milestone_key_key": {
+          "name": "milestone_notifications_milestone_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_audience_settings": {
+      "name": "notification_audience_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_audience_settings_pkey": {
+          "name": "notification_audience_settings_pkey",
+          "columns": [
+            "user_id",
+            "direction",
+            "event_type",
+            "activity_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_audience_settings_direction_check": {
+          "name": "notification_audience_settings_direction_check",
+          "value": "direction = ANY (ARRAY['outgoing'::text, 'incoming'::text])"
+        },
+        "notification_audience_settings_audience_check": {
+          "name": "notification_audience_settings_audience_check",
+          "value": "audience = ANY (ARRAY['none'::text, 'close'::text, 'all'::text, 'ask'::text, 'match_run'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_user_date": {
+          "name": "idx_notification_log_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nudges_enabled": {
+          "name": "nudges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "flexes_enabled": {
+          "name": "flexes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_activity_enabled": {
+          "name": "friend_activity_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_invites_enabled": {
+          "name": "competition_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_updates_enabled": {
+          "name": "competition_updates_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_milestones_enabled": {
+          "name": "competition_milestones_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "hypes_enabled": {
+          "name": "hypes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "step_goal_enabled": {
+          "name": "step_goal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "friend_personal_best_enabled": {
+          "name": "friend_personal_best_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_enabled": {
+          "name": "daily_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_hour": {
+          "name": "daily_reminder_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 18
+        },
+        "timezone_offset_minutes": {
+          "name": "timezone_offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_workouts_to_feed": {
+          "name": "share_workouts_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_posts_enabled": {
+          "name": "friend_posts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nudge_log": {
+      "name": "nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_nudge_log_lookup": {
+          "name": "idx_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nudge_log_rate_limit": {
+          "name": "idx_nudge_log_rate_limit",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_friend_notifications": {
+      "name": "pending_friend_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "send_after_at": {
+          "name": "send_after_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_friend_notif_user": {
+          "name": "idx_pending_friend_notif_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_pending_friend_notif_workout": {
+          "name": "uq_pending_friend_notif_workout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((workout_id IS NOT NULL) AND (status = 'pending'::text))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pending_friend_notifications_status_check": {
+          "name": "pending_friend_notifications_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'sent'::text, 'dismissed'::text, 'expired'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_notifications": {
+      "name": "pending_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_notifications_unsent": {
+          "name": "idx_pending_notifications_unsent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(sent_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_notifications_user_id_fkey": {
+          "name": "pending_notifications_user_id_fkey",
+          "tableFrom": "pending_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_reports": {
+      "name": "post_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_reports_dedupe_idx": {
+          "name": "post_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_reports_status": {
+          "name": "idx_post_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_reports_post_id_fkey": {
+          "name": "post_reports_post_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_reports_reporter_id_fkey": {
+          "name": "post_reports_reporter_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_reports_reason_check": {
+          "name": "post_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_snapshot": {
+          "name": "stats_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_to_feed": {
+          "name": "share_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_to_story": {
+          "name": "share_to_story",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "story_expires_at": {
+          "name": "story_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_posts_user_created": {
+          "name": "idx_posts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_feed": {
+          "name": "idx_posts_feed",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_story_active": {
+          "name": "idx_posts_story_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "story_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_story)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_active": {
+          "name": "uq_posts_workout_active",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_fkey": {
+          "name": "posts_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_workout_id_fkey": {
+          "name": "posts_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_family_id": {
+          "name": "token_family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_hash": {
+          "name": "replaced_by_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "token_family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_revoked_at": {
+          "name": "idx_refresh_tokens_revoked_at",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(revoked_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_token_hash": {
+          "name": "idx_refresh_tokens_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_fkey": {
+          "name": "refresh_tokens_user_id_fkey",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_key": {
+          "name": "refresh_tokens_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_views": {
+      "name": "story_views",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_views_post_id_fkey": {
+          "name": "story_views_post_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_views_viewer_id_fkey": {
+          "name": "story_views_viewer_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_views_pkey": {
+          "name": "story_views_pkey",
+          "columns": [
+            "post_id",
+            "viewer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggering_workout_id": {
+          "name": "triggering_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_snapshot": {
+          "name": "progress_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_slot": {
+          "name": "pin_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_badges_user": {
+          "name": "idx_user_badges_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_new": {
+          "name": "idx_user_badges_user_new",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_new = true)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_pin_slot": {
+          "name": "idx_user_badges_user_pin_slot",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(pin_slot IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_workout": {
+          "name": "idx_user_badges_workout",
+          "columns": [
+            {
+              "expression": "triggering_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_badges_user_id_fkey": {
+          "name": "user_badges_user_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_fkey": {
+          "name": "user_badges_badge_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "badge_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_triggering_workout_id_fkey": {
+          "name": "user_badges_triggering_workout_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "triggering_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_badges_user_id_badge_id_key": {
+          "name": "user_badges_user_id_badge_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "badge_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_badges_pin_slot_range": {
+          "name": "user_badges_pin_slot_range",
+          "value": "(pin_slot IS NULL) OR ((pin_slot >= 0) AND (pin_slot <= 2))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_blocks_blocked": {
+          "name": "idx_user_blocks_blocked",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_fkey": {
+          "name": "user_blocks_blocker_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_blocks_blocked_id_fkey": {
+          "name": "user_blocks_blocked_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_pkey": {
+          "name": "user_blocks_pkey",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenge_completions": {
+      "name": "user_challenge_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completing_workout_id": {
+          "name": "completing_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ucc_user": {
+          "name": "idx_ucc_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ucc_user_date": {
+          "name": "idx_ucc_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenge_completions_user_id_fkey": {
+          "name": "user_challenge_completions_user_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_challenge_key_fkey": {
+          "name": "user_challenge_completions_challenge_key_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "daily_challenges",
+          "columnsFrom": [
+            "challenge_key"
+          ],
+          "columnsTo": [
+            "challenge_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_completing_workout_id_fkey": {
+          "name": "user_challenge_completions_completing_workout_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "completing_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_challenge_completions_user_id_local_date_key": {
+          "name": "user_challenge_completions_user_id_local_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_sub": {
+          "name": "apple_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "goal_miles": {
+          "name": "goal_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_current_streak_desc": {
+          "name": "idx_users_current_streak_desc",
+          "columns": [
+            {
+              "expression": "current_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email_trgm": {
+          "name": "idx_users_email_trgm",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_username_trgm": {
+          "name": "idx_users_username_trgm",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_apple_id_key": {
+          "name": "users_apple_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_apple_sub_key": {
+          "name": "users_apple_sub_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "apple_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_completion_notifications": {
+      "name": "workout_completion_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_date": {
+          "name": "notified_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_completion_notifications_user_id_notified_date_key": {
+          "name": "workout_completion_notifications_user_id_notified_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "notified_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_splits": {
+      "name": "workout_splits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_number": {
+          "name": "split_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_duration": {
+          "name": "split_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_distance": {
+          "name": "split_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_pace": {
+          "name": "split_pace",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_splits_time": {
+          "name": "idx_splits_time",
+          "columns": [
+            {
+              "expression": "split_duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_splits_workout": {
+          "name": "idx_splits_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_splits_workout_id_fkey": {
+          "name": "workout_splits_workout_id_fkey",
+          "tableFrom": "workout_splits",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_splits_workout_id_split_number_key": {
+          "name": "workout_splits_workout_id_split_number_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "split_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workouts": {
+      "name": "workouts",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_end_date": {
+          "name": "device_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthkit'"
+        },
+        "original_distance": {
+          "name": "original_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_duration": {
+          "name": "original_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_flagged": {
+          "name": "speed_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_workouts_local_date_user_id": {
+          "name": "idx_workouts_local_date_user_id",
+          "columns": [
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_device_end": {
+          "name": "idx_workouts_user_device_end",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_local_date": {
+          "name": "idx_workouts_user_local_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workouts_user_workout_unique": {
+          "name": "workouts_user_workout_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/drizzle/meta/_journal.json
+++ b/backend/src/db/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1782826570266,
       "tag": "0004_fixed_viper",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1782858885571,
+      "tag": "0005_lame_marvex",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/drizzle/meta/_journal.json
+++ b/backend/src/db/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1782858885571,
       "tag": "0005_lame_marvex",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1782871587357,
+      "tag": "0006_mean_lizard",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/drizzle/schema.ts
+++ b/backend/src/db/drizzle/schema.ts
@@ -164,6 +164,17 @@ export const workouts = pgTable(
     originalDistance: doublePrecision("original_distance"),
     originalDuration: doublePrecision("original_duration"),
     steps: integer(),
+    // User soft-delete: a deleted workout stops counting toward streaks/miles/
+    // badges/competitions but is kept (and kept tombstoned) so a HealthKit
+    // re-sync can't resurrect it.
+    deletedAt: timestamp("deleted_at", { withTimezone: true, mode: "string" }),
+    // Auto-exclusion: set to a reason (e.g. 'vehicle_speed') when a workout's
+    // average speed is physically impossible on foot. Excluded workouts don't
+    // count but stay visible so the user can see why.
+    exclusionReason: text("exclusion_reason"),
+    // Soft flag for the suspicious-but-possible speed band — still counts, just
+    // surfaced in the UI for the user to review.
+    speedFlagged: boolean("speed_flagged").default(false).notNull(),
   },
   (table) => [
     index("idx_workouts_local_date_user_id").using(

--- a/backend/src/db/drizzle/schema.ts
+++ b/backend/src/db/drizzle/schema.ts
@@ -706,6 +706,13 @@ export const pendingFriendNotifications = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true, mode: "string" })
       .defaultNow()
       .notNull(),
+    // When set, this row is auto-sent by the pending-send cron once NOW() passes
+    // it (used to defer + merge a mile-completion push ~10 min so a photo can
+    // ride along). NULL = the legacy user-confirmation ("ask") flow.
+    sendAfterAt: timestamp("send_after_at", {
+      withTimezone: true,
+      mode: "string",
+    }),
   },
   (table) => [
     index("idx_pending_friend_notif_user").using(
@@ -978,6 +985,12 @@ export const posts = pgTable(
         table.storyExpiresAt.asc().nullsLast(),
       )
       .where(sql`(deleted_at IS NULL AND share_to_story)`),
+    // One live post per workout — lets a run's auto route/stats post be replaced
+    // in place by a photo (upsert by workout_id) instead of creating a second
+    // feed item. NULL workout_ids (manual composer posts) don't conflict.
+    uniqueIndex("uq_posts_workout_active")
+      .on(table.workoutId)
+      .where(sql`(deleted_at IS NULL AND workout_id IS NOT NULL)`),
     foreignKey({
       columns: [table.userId],
       foreignColumns: [users.userId],

--- a/backend/src/routes/workoutRoutes.ts
+++ b/backend/src/routes/workoutRoutes.ts
@@ -1,15 +1,37 @@
-import { Router } from 'express';
-import { getRecentWorkouts, getStreak, getUserStats, getWorkoutRange, uploadWorkouts, updateWorkout, recalibrateStreak } from '../controllers/workoutController.js';
-import { requireSelfAccess } from '../middleware/auth.js';
+import { Router } from "express";
+import {
+  getRecentWorkouts,
+  getStreak,
+  getUserStats,
+  getWorkoutRange,
+  uploadWorkouts,
+  updateWorkout,
+  recalibrateStreak,
+  deleteWorkout,
+} from "../controllers/workoutController.js";
+import { requireSelfAccess } from "../middleware/auth.js";
 
 const router = Router();
 
-router.post('/:userId/upload', requireSelfAccess('userId'), uploadWorkouts);
-router.post('/:userId/recalibrate-streak', requireSelfAccess('userId'), recalibrateStreak);
-router.patch('/:userId/workout/:workoutId', requireSelfAccess('userId'), updateWorkout);
-router.get('/:userId/streak', getStreak);
-router.get('/:userId/range', getWorkoutRange);
-router.get('/:userId/recent', getRecentWorkouts);
-router.get('/:userId/stats', getUserStats);
+router.post("/:userId/upload", requireSelfAccess("userId"), uploadWorkouts);
+router.post(
+  "/:userId/recalibrate-streak",
+  requireSelfAccess("userId"),
+  recalibrateStreak,
+);
+router.patch(
+  "/:userId/workout/:workoutId",
+  requireSelfAccess("userId"),
+  updateWorkout,
+);
+router.delete(
+  "/:userId/workout/:workoutId",
+  requireSelfAccess("userId"),
+  deleteWorkout,
+);
+router.get("/:userId/streak", getStreak);
+router.get("/:userId/range", getWorkoutRange);
+router.get("/:userId/recent", getRecentWorkouts);
+router.get("/:userId/stats", getUserStats);
 
 export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -25,6 +25,7 @@ import { startCompetitionCron } from "./cron/competitionCron.js";
 import { startNotificationCron } from "./cron/notificationCron.js";
 import { startSilentSyncCron } from "./cron/silentSyncCron.js";
 import { startStoriesCron } from "./cron/storiesCron.js";
+import { startPendingSendCron } from "./cron/pendingSendCron.js";
 import { seedExtraBadges } from "./services/badgeService.js";
 import { seedExtraChallenges } from "./services/dailyChallengeService.js";
 import { PostgresService } from "./services/DbService.js";
@@ -134,6 +135,7 @@ server.listen(PORT, "0.0.0.0", () => {
   startNotificationCron();
   startSilentSyncCron();
   startStoriesCron();
+  startPendingSendCron();
   // Idempotently ensure the v2 social/app-function badges exist in the catalog.
   seedExtraBadges();
   // Idempotently ensure the v2 daily challenges (5K/10K/social) exist.

--- a/backend/src/services/badgeService.ts
+++ b/backend/src/services/badgeService.ts
@@ -97,18 +97,18 @@ export async function computeAggregates(
   const [streakRow, totalsRow, paceRow, bestDayRow, ccRow] = await Promise.all([
     computeCurrentStreak(userId),
     db.query<{ total_miles: string | null }>(
-      `SELECT COALESCE(SUM(distance),0)::text AS total_miles FROM workouts WHERE user_id = $1`,
+      `SELECT COALESCE(SUM(distance),0)::text AS total_miles FROM workouts WHERE user_id = $1 AND deleted_at IS NULL AND exclusion_reason IS NULL`,
       [userId],
     ),
     db.query<{ min_pace: string | null }>(
       `SELECT MIN(s.split_pace)::text AS min_pace
 			FROM workout_splits s JOIN workouts w ON w.workout_id = s.workout_id
-			WHERE w.user_id = $1 AND s.split_pace > 0 AND s.split_distance >= 0.95`,
+			WHERE w.user_id = $1 AND s.split_pace > 0 AND s.split_distance >= 0.95 AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL`,
       [userId],
     ),
     db.query<{ best_day: string | null }>(
       `SELECT COALESCE(MAX(day_total),0)::text AS best_day FROM (
-				SELECT SUM(distance) AS day_total FROM workouts WHERE user_id = $1 GROUP BY local_date
+				SELECT SUM(distance) AS day_total FROM workouts WHERE user_id = $1 AND deleted_at IS NULL AND exclusion_reason IS NULL GROUP BY local_date
 			) t`,
       [userId],
     ),
@@ -229,7 +229,7 @@ async function computeCurrentStreak(userId: string): Promise<number> {
   const rows = await db.query<{ local_date: string; total: string }>(
     `SELECT local_date::text AS local_date, SUM(distance)::text AS total
 		FROM workouts
-		WHERE user_id = $1
+		WHERE user_id = $1 AND deleted_at IS NULL AND exclusion_reason IS NULL
 		GROUP BY local_date
 		ORDER BY local_date DESC`,
     [userId],
@@ -448,6 +448,92 @@ export async function evaluateSocialBadgesForUser(
     console.error("[badges] social evaluation failed:", e?.message ?? e);
     return [];
   }
+}
+
+// ─── Revocation (after a workout is deleted/excluded) ───────────────
+
+/**
+ * Longest run of consecutive qualifying days (SUM(distance) >= 0.95) over the
+ * user's entire ACTIVE history (deleted/excluded workouts already filtered out).
+ * Used for revocation: a streak badge means "you reached N consecutive days at
+ * some point", so we keep it as long as that's still true of the real history —
+ * deleting a bogus drive that bridged a streak correctly drops it, while a real
+ * past streak that simply isn't current is preserved.
+ */
+async function computeMaxEverStreak(userId: string): Promise<number> {
+  const rows = await db.query<{ local_date: string }>(
+    `SELECT to_char(local_date, 'YYYY-MM-DD') AS local_date
+		FROM workouts
+		WHERE user_id = $1 AND deleted_at IS NULL AND exclusion_reason IS NULL
+		GROUP BY local_date
+		HAVING SUM(distance) >= ${STREAK_QUALIFYING_DISTANCE}
+		ORDER BY local_date ASC`,
+    [userId],
+  );
+  let best = 0;
+  let run = 0;
+  let prev: string | undefined;
+  for (const { local_date } of rows) {
+    if (prev !== undefined && isPreviousDay(prev, local_date)) {
+      run++;
+    } else {
+      run = 1;
+    }
+    if (run > best) best = run;
+    prev = local_date;
+  }
+  return best;
+}
+
+/** Social/app-function badges are not workout-derived, so a workout deletion
+ * never revokes them. */
+function isWorkoutDerived(category: BadgeCategory): boolean {
+  return !(
+    category === "story" ||
+    category === "hype" ||
+    category === "nudge" ||
+    category === "competition"
+  );
+}
+
+/**
+ * Remove any earned badges the user no longer qualifies for after their active
+ * workout history changed (a deletion or auto-exclusion). Workout-derived badges
+ * are checked against recomputed aggregates, using the max-ever streak so a real
+ * historical achievement is never stripped. Returns the revoked badge ids.
+ */
+export async function revokeUnearnedBadges(userId: string): Promise<string[]> {
+  const [agg, maxStreak, catalog, earnedRows] = await Promise.all([
+    computeAggregates(userId),
+    computeMaxEverStreak(userId),
+    getCatalog(),
+    db.query<{ badge_id: string }>(
+      `SELECT badge_id FROM user_badges WHERE user_id = $1`,
+      [userId],
+    ),
+  ]);
+  const byId = new Map(catalog.map((b) => [b.badgeId, b]));
+  // For "ever earned" semantics, evaluate streak/special badges against the
+  // best streak the real history can still produce.
+  const aggForEarn: UserAggregates = { ...agg, currentStreak: maxStreak };
+
+  const toRevoke: string[] = [];
+  for (const { badge_id } of earnedRows) {
+    const badge = byId.get(badge_id);
+    if (!badge) continue; // unknown/legacy badge — leave it alone
+    if (!isWorkoutDerived(badge.category)) continue;
+    if (!evaluatePredicate(badge, aggForEarn).earned) {
+      toRevoke.push(badge_id);
+    }
+  }
+
+  if (toRevoke.length > 0) {
+    await db.query(
+      `DELETE FROM user_badges WHERE user_id = $1 AND badge_id = ANY($2::text[])`,
+      [userId, toRevoke],
+    );
+  }
+  return toRevoke;
 }
 
 // ─── Catalog seed for the v2 social / app-function badges ───────────

--- a/backend/src/services/competitionService.ts
+++ b/backend/src/services/competitionService.ts
@@ -865,7 +865,8 @@ export async function checkRaceCompletions(userId: string): Promise<void> {
 			WHERE user_id = $1
 				AND local_date >= $2
 				AND local_date <= $3
-				AND workout_type = ANY($4::text[])`,
+				AND workout_type = ANY($4::text[])
+				AND deleted_at IS NULL AND exclusion_reason IS NULL`,
       [userId, startDate, endDate, workoutTypes],
     );
 

--- a/backend/src/services/dailyChallengeService.ts
+++ b/backend/src/services/dailyChallengeService.ts
@@ -147,7 +147,7 @@ export async function evaluateChallengesForBatch(
   const dateRows = await db.query<{ local_date: string }>(
     `SELECT DISTINCT local_date::text AS local_date
 		FROM workouts
-		WHERE user_id = $1 AND workout_id = ANY($2::text[]) AND local_date = $3::date`,
+		WHERE user_id = $1 AND workout_id = ANY($2::text[]) AND local_date = $3::date AND deleted_at IS NULL AND exclusion_reason IS NULL`,
     [userId, newWorkoutIds, todayLocalDate],
   );
 
@@ -238,7 +238,7 @@ async function computeProgress(
     case "walk_it_out": {
       const rows = await db.query<{ total: string | null }>(
         `SELECT COALESCE(SUM(distance),0)::text AS total
-				FROM workouts WHERE user_id = $1 AND local_date = $2 AND workout_type = 'walking'`,
+				FROM workouts WHERE user_id = $1 AND local_date = $2 AND workout_type = 'walking' AND deleted_at IS NULL AND exclusion_reason IS NULL`,
         [userId, localDate],
       );
       const walked = parseFloat(rows[0]?.total ?? "0") || 0;
@@ -285,7 +285,7 @@ async function computeProgress(
         `SELECT
 					(SELECT MIN(s.split_pace) FROM workout_splits s JOIN workouts w ON w.workout_id = s.workout_id
 					 WHERE w.user_id = $1 AND w.local_date = $2 AND s.split_pace > 0 AND s.split_distance >= 0.95)::text AS min_pace,
-					(SELECT COALESCE(SUM(distance),0) FROM workouts WHERE user_id = $1 AND local_date = $2)::text AS day_total`,
+					(SELECT COALESCE(SUM(distance),0) FROM workouts WHERE user_id = $1 AND local_date = $2 AND deleted_at IS NULL AND exclusion_reason IS NULL)::text AS day_total`,
         [userId, localDate],
       );
       const dayTotal = parseFloat(rows[0]?.day_total ?? "0") || 0;
@@ -307,8 +307,9 @@ async function computeProgress(
 						WHERE user_id = $1 AND local_date = $2
 						  AND distance >= $3 * 0.95
 						  AND EXTRACT(HOUR FROM (device_end_date + timezone_offset * INTERVAL '1 minute')) < 12
+					  AND deleted_at IS NULL AND exclusion_reason IS NULL
 					) AS before_noon,
-					(SELECT COALESCE(SUM(distance),0) FROM workouts WHERE user_id = $1 AND local_date = $2)::text AS day_total`,
+					(SELECT COALESCE(SUM(distance),0) FROM workouts WHERE user_id = $1 AND local_date = $2 AND deleted_at IS NULL AND exclusion_reason IS NULL)::text AS day_total`,
         [userId, localDate, goalMiles],
       );
       if (rows[0]?.before_noon) return 1.0;
@@ -331,8 +332,9 @@ async function computeProgress(
 							EXTRACT(HOUR FROM (device_end_date + timezone_offset * INTERVAL '1 minute')) < 9
 							OR EXTRACT(HOUR FROM (device_end_date + timezone_offset * INTERVAL '1 minute')) >= 20
 						  )
+					  AND deleted_at IS NULL AND exclusion_reason IS NULL
 					) AS in_window,
-					(SELECT COALESCE(SUM(distance),0) FROM workouts WHERE user_id = $1 AND local_date = $2)::text AS day_total`,
+					(SELECT COALESCE(SUM(distance),0) FROM workouts WHERE user_id = $1 AND local_date = $2 AND deleted_at IS NULL AND exclusion_reason IS NULL)::text AS day_total`,
         [userId, localDate, goalMiles],
       );
       if (rows[0]?.in_window) return 1.0;
@@ -413,7 +415,7 @@ async function evaluatePredicate(
       const rows = await db.query<{ total: string | null }>(
         `SELECT COALESCE(SUM(distance),0)::text AS total
 				FROM workouts
-				WHERE user_id = $1 AND local_date = $2 AND workout_type = 'walking'`,
+				WHERE user_id = $1 AND local_date = $2 AND workout_type = 'walking' AND deleted_at IS NULL AND exclusion_reason IS NULL`,
         [userId, localDate],
       );
       return parseFloat(rows[0]?.total ?? "0") >= goalMiles * 0.95;
@@ -447,6 +449,7 @@ async function evaluatePredicate(
 					WHERE user_id = $1 AND local_date = $2
 					  AND distance >= $3 * 0.95
 					  AND EXTRACT(HOUR FROM (device_end_date + timezone_offset * INTERVAL '1 minute')) < 12
+					  AND deleted_at IS NULL AND exclusion_reason IS NULL
 				) AS ok`,
         [userId, localDate, goalMiles],
       );
@@ -463,6 +466,7 @@ async function evaluatePredicate(
 						EXTRACT(HOUR FROM (device_end_date + timezone_offset * INTERVAL '1 minute')) < 9
 						OR EXTRACT(HOUR FROM (device_end_date + timezone_offset * INTERVAL '1 minute')) >= 20
 					  )
+					  AND deleted_at IS NULL AND exclusion_reason IS NULL
 				) AS ok`,
         [userId, localDate, goalMiles],
       );
@@ -482,7 +486,7 @@ async function evaluatePredicate(
 					)
 					AND (
 						SELECT COALESCE(SUM(distance),0) >= 1.0
-						FROM workouts WHERE user_id = $1 AND local_date = $2
+						FROM workouts WHERE user_id = $1 AND local_date = $2 AND deleted_at IS NULL AND exclusion_reason IS NULL
 					)
 				) AS ok`,
         [userId, localDate],
@@ -552,7 +556,7 @@ async function dayTotalDistance(
   localDate: string,
 ): Promise<number> {
   const rows = await db.query<{ total: string | null }>(
-    `SELECT COALESCE(SUM(distance),0)::text AS total FROM workouts WHERE user_id = $1 AND local_date = $2`,
+    `SELECT COALESCE(SUM(distance),0)::text AS total FROM workouts WHERE user_id = $1 AND local_date = $2 AND deleted_at IS NULL AND exclusion_reason IS NULL`,
     [userId, localDate],
   );
   return parseFloat(rows[0]?.total ?? "0") || 0;
@@ -563,7 +567,7 @@ async function workoutCountToday(
   localDate: string,
 ): Promise<number> {
   const rows = await db.query<{ c: string }>(
-    `SELECT COUNT(*)::text AS c FROM workouts WHERE user_id = $1 AND local_date = $2 AND distance > 0`,
+    `SELECT COUNT(*)::text AS c FROM workouts WHERE user_id = $1 AND local_date = $2 AND distance > 0 AND deleted_at IS NULL AND exclusion_reason IS NULL`,
     [userId, localDate],
   );
   return parseInt(rows[0]?.c ?? "0", 10) || 0;
@@ -637,7 +641,7 @@ async function todayRunWalkMix(
   }>(
     `SELECT workout_type, COALESCE(SUM(distance),0)::text AS total
 		FROM workouts
-		WHERE user_id = $1 AND local_date = $2
+		WHERE user_id = $1 AND local_date = $2 AND deleted_at IS NULL AND exclusion_reason IS NULL
 		GROUP BY workout_type`,
     [userId, localDate],
   );
@@ -671,7 +675,8 @@ async function crossTrainVariant(
 		FROM workouts
 		WHERE user_id = $1
 		  AND local_date < $2
-		  AND local_date >= ($2::date - INTERVAL '7 days')::date`,
+		  AND local_date >= ($2::date - INTERVAL '7 days')::date
+		  AND deleted_at IS NULL AND exclusion_reason IS NULL`,
     [userId, localDate],
   );
   const run = parseFloat(rows[0]?.run ?? "0") || 0;
@@ -693,6 +698,7 @@ async function findCompletingWorkout(
   const rows = await db.query<{ workout_id: string }>(
     `SELECT workout_id FROM workouts
 		WHERE user_id = $1 AND local_date = $2 AND workout_id = ANY($3::text[])
+		AND deleted_at IS NULL AND exclusion_reason IS NULL
 		ORDER BY device_end_date DESC
 		LIMIT 1`,
     [userId, localDate, newWorkoutIds],

--- a/backend/src/services/dailyReminderService.ts
+++ b/backend/src/services/dailyReminderService.ts
@@ -1,12 +1,12 @@
-import { PostgresService } from './DbService.js';
-import { sendPush } from './pushNotificationService.js';
+import { PostgresService } from "./DbService.js";
+import { sendPush } from "./pushNotificationService.js";
 
 const db = PostgresService.getInstance();
 
 interface ReminderCandidate {
-	user_id: string;
-	goal_miles: string | number;
-	tz_offset: number;
+  user_id: string;
+  goal_miles: string | number;
+  tz_offset: number;
 }
 
 /**
@@ -27,8 +27,8 @@ interface ReminderCandidate {
  *   time from the authoritative workouts table.
  */
 export async function sendPendingDailyReminders(): Promise<void> {
-	const candidates = await db.query<ReminderCandidate>(
-		`
+  const candidates = await db.query<ReminderCandidate>(
+    `
 		WITH user_tz AS (
 			SELECT
 				u.user_id,
@@ -51,30 +51,35 @@ export async function sendPendingDailyReminders(): Promise<void> {
 		  AND COALESCE(
 				(SELECT SUM(w.distance) FROM workouts w
 				 WHERE w.user_id = t.user_id
-				   AND w.local_date = (NOW() + (t.tz_offset || ' minutes')::interval)::date),
+				   AND w.local_date = (NOW() + (t.tz_offset || ' minutes')::interval)::date
+				   AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL),
 				0
 			  ) < t.goal_miles
-		`
-	);
+		`,
+  );
 
-	if (candidates.length === 0) {
-		console.log('[DailyReminder] No users due for a reminder this hour.');
-		return;
-	}
+  if (candidates.length === 0) {
+    console.log("[DailyReminder] No users due for a reminder this hour.");
+    return;
+  }
 
-	console.log(`[DailyReminder] Sending reminders to ${candidates.length} user(s).`);
+  console.log(
+    `[DailyReminder] Sending reminders to ${candidates.length} user(s).`,
+  );
 
-	await Promise.all(
-		candidates.map(async ({ user_id }) => {
-			try {
-				await sendPush(user_id, {
-					title: 'Mile still waiting…',
-					body: "Don't forget to log your daily mile! Lace up and get moving.",
-					type: 'daily_reminder'
-				});
-			} catch (err: any) {
-				console.error(`[DailyReminder] Failed for user ${user_id}: ${err?.message ?? err}`);
-			}
-		})
-	);
+  await Promise.all(
+    candidates.map(async ({ user_id }) => {
+      try {
+        await sendPush(user_id, {
+          title: "Mile still waiting…",
+          body: "Don't forget to log your daily mile! Lace up and get moving.",
+          type: "daily_reminder",
+        });
+      } catch (err: any) {
+        console.error(
+          `[DailyReminder] Failed for user ${user_id}: ${err?.message ?? err}`,
+        );
+      }
+    }),
+  );
 }

--- a/backend/src/services/friendshipService.ts
+++ b/backend/src/services/friendshipService.ts
@@ -1,51 +1,60 @@
-import { Friendship, User } from '../types/user.js';
-import { PostgresService } from './DbService.js';
+import { Friendship, User } from "../types/user.js";
+import { PostgresService } from "./DbService.js";
 
 const db = PostgresService.getInstance();
 
 type ErrorReturn = {
-	error: string;
+  error: string;
 };
 
 type MessageReturn = {
-	message: string;
+  message: string;
 };
 
-export async function areFriends(user1: string, user2: string): Promise<boolean> {
-	if (user1 === user2) return true;
-	const rows = await db.query<{ status: string }>(
-		`SELECT status FROM friendships
+export async function areFriends(
+  user1: string,
+  user2: string,
+): Promise<boolean> {
+  if (user1 === user2) return true;
+  const rows = await db.query<{ status: string }>(
+    `SELECT status FROM friendships
 		WHERE ((user_id = $1 AND friend_id = $2) OR (user_id = $2 AND friend_id = $1))
 		  AND status = 'accepted'
 		LIMIT 1`,
-		[user1, user2]
-	);
-	return rows.length > 0;
+    [user1, user2],
+  );
+  return rows.length > 0;
 }
 
-export async function getFriendship(user1: string, user2: string): Promise<Friendship | ErrorReturn | null> {
-	try {
-		const existingFriendship = await db.query(
-			'SELECT * FROM friendships WHERE (user_id = $1 AND friend_id = $2) OR (user_id = $2 AND friend_id = $1)',
-			[user1, user2]
-		);
+export async function getFriendship(
+  user1: string,
+  user2: string,
+): Promise<Friendship | ErrorReturn | null> {
+  try {
+    const existingFriendship = await db.query(
+      "SELECT * FROM friendships WHERE (user_id = $1 AND friend_id = $2) OR (user_id = $2 AND friend_id = $1)",
+      [user1, user2],
+    );
 
-		return existingFriendship.find(friendship => friendship.user_id === user1) ?? existingFriendship[0];
-	} catch (err: any) {
-		return { error: err.message };
-	}
+    return (
+      existingFriendship.find((friendship) => friendship.user_id === user1) ??
+      existingFriendship[0]
+    );
+  } catch (err: any) {
+    return { error: err.message };
+  }
 }
 
 export async function getFriends(user: string): Promise<User[]> {
-	// Safe column set only — never expose a real email through friend lists
-	// (these are viewable by other users, not just the owner).
-	// BACKWARDS COMPAT: the shipped App Store app decodes friends into a
-	// BackendUser whose `email` is a NON-optional String, so a missing key
-	// hard-fails Codable and breaks the friends list. Return an empty-string
-	// email — present for the old client, leaks nothing. Drop it once the
-	// email-optional app build has fully rolled out.
-	const friends = await db.query(
-		`
+  // Safe column set only — never expose a real email through friend lists
+  // (these are viewable by other users, not just the owner).
+  // BACKWARDS COMPAT: the shipped App Store app decodes friends into a
+  // BackendUser whose `email` is a NON-optional String, so a missing key
+  // hard-fails Codable and breaks the friends list. Return an empty-string
+  // email — present for the old client, leaks nothing. Drop it once the
+  // email-optional app build has fully rolled out.
+  const friends = await db.query(
+    `
 		SELECT u.user_id, u.username, u.first_name, u.last_name, u.bio,
 			u.profile_image_url, u.current_streak, '' AS email
 		FROM friendships f
@@ -53,87 +62,95 @@ export async function getFriends(user: string): Promise<User[]> {
 		WHERE f.user_id = $1
 			AND f.status = 'accepted'
 		`,
-		[user]
-	);
+    [user],
+  );
 
-	return friends;
+  return friends;
 }
 
 export async function getSentRequests(user: string): Promise<User[]> {
-	const sentRequests = await db.query(
-		`
+  const sentRequests = await db.query(
+    `
 		SELECT u.* FROM friendships f
 		JOIN users u ON u.user_id = f.friend_id
 		WHERE f.user_id = $1
 			AND f.status in ( 'pending', 'ignored' ) 
 		`,
-		[user]
-	);
+    [user],
+  );
 
-	return sentRequests;
+  return sentRequests;
 }
 
 type FriendRequestsReturn = {
-	requests: User[];
-	ignored_requests: User[];
+  requests: User[];
+  ignored_requests: User[];
 };
 
-export async function getFriendRequests(user: string): Promise<FriendRequestsReturn> {
-	const friendRequests = await db.query(
-		`
+export async function getFriendRequests(
+  user: string,
+): Promise<FriendRequestsReturn> {
+  const friendRequests = await db.query(
+    `
 		SELECT u.*, f.status FROM friendships f
 		JOIN users u ON u.user_id = f.user_id
 		WHERE f.friend_id = $1
 			AND f.status in ( 'pending', 'ignored' ) 
 		`,
-		[user]
-	);
+    [user],
+  );
 
-	const requests: User[] = [];
-	const ignored_requests: User[] = [];
+  const requests: User[] = [];
+  const ignored_requests: User[] = [];
 
-	friendRequests.forEach(request => {
-		const { status, ...user }: { status: 'pending' | 'ignored' } & User = request;
-		if (status === 'pending') {
-			requests.push(user);
-		} else if (status === 'ignored') {
-			ignored_requests.push(user);
-		}
-	});
+  friendRequests.forEach((request) => {
+    const { status, ...user }: { status: "pending" | "ignored" } & User =
+      request;
+    if (status === "pending") {
+      requests.push(user);
+    } else if (status === "ignored") {
+      ignored_requests.push(user);
+    }
+  });
 
-	return { requests, ignored_requests };
+  return { requests, ignored_requests };
 }
 
-export async function sendFriendRequest(user1: string, user2: string): Promise<MessageReturn | ErrorReturn> {
-	try {
-		await db.query(
-			`
+export async function sendFriendRequest(
+  user1: string,
+  user2: string,
+): Promise<MessageReturn | ErrorReturn> {
+  try {
+    await db.query(
+      `
 			INSERT INTO friendships (user_id, friend_id, status)
 			VALUES ($1, $2, 'pending')
 			ON CONFLICT (user_id, friend_id) DO NOTHING
 			`,
-			[user1, user2]
-		);
+      [user1, user2],
+    );
 
-		return { message: 'Successfully sent friend request' };
-	} catch (err: any) {
-		return { error: err.message };
-	}
+    return { message: "Successfully sent friend request" };
+  } catch (err: any) {
+    return { error: err.message };
+  }
 }
 
 export interface FriendActivity {
-	user_id: string;
-	username: string | null;
-	first_name: string | null;
-	last_name: string | null;
-	profile_image_url: string | null;
-	today_miles: number;
-	completed_today: boolean;
+  user_id: string;
+  username: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  profile_image_url: string | null;
+  today_miles: number;
+  completed_today: boolean;
 }
 
-export async function getFriendsActivityToday(userId: string): Promise<FriendActivity[]> {
-	const results = await db.query(
-		`
+export async function getFriendsActivityToday(
+  userId: string,
+): Promise<FriendActivity[]> {
+  const results = await db.query(
+    `
 		SELECT
 			u.user_id,
 			u.username,
@@ -152,6 +169,7 @@ export async function getFriendsActivityToday(userId: string): Promise<FriendAct
 						) || ' minutes'
 					)::interval
 				)::date
+				AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL
 			), 0)::float as today_miles
 		FROM friendships f
 		JOIN users u ON u.user_id = f.friend_id
@@ -159,26 +177,26 @@ export async function getFriendsActivityToday(userId: string): Promise<FriendAct
 			AND f.status = 'accepted'
 		ORDER BY today_miles DESC
 		`,
-		[userId]
-	);
+    [userId],
+  );
 
-	return results.map((r: any) => ({
-		...r,
-		today_miles: parseFloat(r.today_miles) || 0,
-		completed_today: parseFloat(r.today_miles) >= 1.0
-	}));
+  return results.map((r: any) => ({
+    ...r,
+    today_miles: parseFloat(r.today_miles) || 0,
+    completed_today: parseFloat(r.today_miles) >= 1.0,
+  }));
 }
 
 export interface FriendSuggestion {
-	user_id: string;
-	username: string | null;
-	first_name: string | null;
-	last_name: string | null;
-	bio: string | null;
-	profile_image_url: string | null;
-	current_streak: number;
-	mutual_friends: number;
-	shared_competitions: number;
+  user_id: string;
+  username: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  bio: string | null;
+  profile_image_url: string | null;
+  current_streak: number;
+  mutual_friends: number;
+  shared_competitions: number;
 }
 
 /**
@@ -190,9 +208,12 @@ export interface FriendSuggestion {
  * one-way from the sender; rejected/removed rows are deleted — so a single
  * either-direction check covers every live relationship state).
  */
-export async function getFriendSuggestions(userId: string, limit: number = 20): Promise<FriendSuggestion[]> {
-	const suggestions = await db.query<FriendSuggestion>(
-		`
+export async function getFriendSuggestions(
+  userId: string,
+  limit: number = 20,
+): Promise<FriendSuggestion[]> {
+  const suggestions = await db.query<FriendSuggestion>(
+    `
 		WITH my_friends AS (
 			-- Accepted friendships are stored bidirectionally, so one
 			-- direction is enough to enumerate the friend set.
@@ -247,19 +268,19 @@ export async function getFriendSuggestions(userId: string, limit: number = 20): 
 			u.username ASC
 		LIMIT $2
 		`,
-		[userId, limit]
-	);
+    [userId, limit],
+  );
 
-	// Cold-start fallback: a sparse social graph (no friends-of-friends, no
-	// shared competitions) yields an empty list, leaving "People You May Know"
-	// blank. Top up with the most active runners the user isn't already
-	// connected to so there's always something to discover.
-	if (suggestions.length >= limit) {
-		return suggestions;
-	}
+  // Cold-start fallback: a sparse social graph (no friends-of-friends, no
+  // shared competitions) yields an empty list, leaving "People You May Know"
+  // blank. Top up with the most active runners the user isn't already
+  // connected to so there's always something to discover.
+  if (suggestions.length >= limit) {
+    return suggestions;
+  }
 
-	const fallback = await db.query<FriendSuggestion>(
-		`
+  const fallback = await db.query<FriendSuggestion>(
+    `
 		SELECT u.user_id, u.username, u.first_name, u.last_name, u.bio,
 			u.profile_image_url, u.current_streak,
 			0 AS mutual_friends, 0 AS shared_competitions
@@ -274,38 +295,38 @@ export async function getFriendSuggestions(userId: string, limit: number = 20): 
 		ORDER BY u.current_streak DESC NULLS LAST, u.username ASC
 		LIMIT $2
 		`,
-		// Over-fetch so we can drop anyone already in the graph-based list.
-		[userId, limit + 25]
-	);
+    // Over-fetch so we can drop anyone already in the graph-based list.
+    [userId, limit + 25],
+  );
 
-	const alreadySuggested = new Set(suggestions.map(s => s.user_id));
-	const extras = fallback
-		.filter(u => !alreadySuggested.has(u.user_id))
-		.slice(0, limit - suggestions.length);
+  const alreadySuggested = new Set(suggestions.map((s) => s.user_id));
+  const extras = fallback
+    .filter((u) => !alreadySuggested.has(u.user_id))
+    .slice(0, limit - suggestions.length);
 
-	return [...suggestions, ...extras];
+  return [...suggestions, ...extras];
 }
 
 export interface FeedWorkout {
-	workout_id: string;
-	user_id: string;
-	username: string | null;
-	first_name: string | null;
-	last_name: string | null;
-	profile_image_url: string | null;
-	workout_type: string;
-	distance: number;
-	completed_at: string;
-	is_self: boolean;
-	is_hyped: boolean;
-	// Detail fields — let the client surface duration/pace/calories/steps
-	// inline without an extra round trip. Additive; older clients ignore them.
-	total_duration: number;
-	calories: number;
-	steps: number | null;
-	// Social-proof tally: total hypes this specific workout has received from
-	// anyone (not just the viewer). Powers the "👏 N" badge on each feed row.
-	hype_count: number;
+  workout_id: string;
+  user_id: string;
+  username: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  profile_image_url: string | null;
+  workout_type: string;
+  distance: number;
+  completed_at: string;
+  is_self: boolean;
+  is_hyped: boolean;
+  // Detail fields — let the client surface duration/pace/calories/steps
+  // inline without an extra round trip. Additive; older clients ignore them.
+  total_duration: number;
+  calories: number;
+  steps: number | null;
+  // Social-proof tally: total hypes this specific workout has received from
+  // anyone (not just the viewer). Powers the "👏 N" badge on each feed row.
+  hype_count: number;
 }
 
 /**
@@ -315,9 +336,11 @@ export interface FeedWorkout {
  * on workout_id) so the UI can show a one-shot hype button, plus the total
  * hype tally for that workout.
  */
-export async function getFriendsWorkoutFeed(userId: string): Promise<FeedWorkout[]> {
-	const rows = await db.query<FeedWorkout>(
-		`
+export async function getFriendsWorkoutFeed(
+  userId: string,
+): Promise<FeedWorkout[]> {
+  const rows = await db.query<FeedWorkout>(
+    `
 		WITH circle AS (
 			SELECT friend_id AS uid FROM friendships
 			WHERE user_id = $1 AND status = 'accepted'
@@ -354,117 +377,127 @@ export async function getFriendsWorkoutFeed(userId: string): Promise<FeedWorkout
 		JOIN circle c ON c.uid = w.user_id
 		JOIN users u ON u.user_id = w.user_id
 		WHERE w.device_end_date >= NOW() - INTERVAL '48 hours'
+		AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL
 		ORDER BY w.device_end_date DESC
 		LIMIT 100
 		`,
-		[userId]
-	);
-	return rows;
+    [userId],
+  );
+  return rows;
 }
 
 /**
  * Number of accepted friends shared between the viewer and another user —
  * the "X mutual friends" line shown on a profile.
  */
-export async function getMutualFriendCount(viewerId: string, otherId: string): Promise<number> {
-	if (viewerId === otherId) return 0;
-	const rows = await db.query<{ count: number }>(
-		`
+export async function getMutualFriendCount(
+  viewerId: string,
+  otherId: string,
+): Promise<number> {
+  if (viewerId === otherId) return 0;
+  const rows = await db.query<{ count: number }>(
+    `
 		SELECT COUNT(*)::int AS count
 		FROM friendships a
 		JOIN friendships b ON a.friend_id = b.friend_id
 		WHERE a.user_id = $1 AND a.status = 'accepted'
 			AND b.user_id = $2 AND b.status = 'accepted'
 		`,
-		[viewerId, otherId]
-	);
-	return rows[0]?.count ?? 0;
+    [viewerId, otherId],
+  );
+  return rows[0]?.count ?? 0;
 }
 
 export async function updateFriendship(
-	user1: string,
-	user2: string,
-	status: 'accepted' | 'rejected' | 'ignored' | 'removed'
+  user1: string,
+  user2: string,
+  status: "accepted" | "rejected" | "ignored" | "removed",
 ): Promise<MessageReturn | ErrorReturn> {
-	try {
-		const existingFriendship = await getFriendship(user1, user2);
+  try {
+    const existingFriendship = await getFriendship(user1, user2);
 
-		if (!existingFriendship) {
-			throw new Error(`No friendship found between ${user1} and ${user2}`);
-		}
+    if (!existingFriendship) {
+      throw new Error(`No friendship found between ${user1} and ${user2}`);
+    }
 
-		if ('error' in existingFriendship) {
-			throw new Error(existingFriendship.error);
-		}
+    if ("error" in existingFriendship) {
+      throw new Error(existingFriendship.error);
+    }
 
-		if (existingFriendship.status === status) {
-			throw new Error(`Friendship already has status ${status}`);
-		} else if (
-			(status === 'removed' && existingFriendship.status === 'accepted') ||
-			(status === 'rejected' && (existingFriendship.status === 'pending' || existingFriendship.status === 'ignored'))
-		) {
-			await db.query(
-				`
+    if (existingFriendship.status === status) {
+      throw new Error(`Friendship already has status ${status}`);
+    } else if (
+      (status === "removed" && existingFriendship.status === "accepted") ||
+      (status === "rejected" &&
+        (existingFriendship.status === "pending" ||
+          existingFriendship.status === "ignored"))
+    ) {
+      await db.query(
+        `
 				DELETE FROM friendships
 				WHERE (user_id = $1 AND friend_id = $2)
 					OR (user_id = $2 AND friend_id = $1)
 				`,
-				[user1, user2]
-			);
+        [user1, user2],
+      );
 
-			await db.query(
-				`
+      await db.query(
+        `
 				DELETE FROM close_friends
 				WHERE (user_id = $1 AND close_friend_id = $2)
 					OR (user_id = $2 AND close_friend_id = $1)
 				`,
-				[user1, user2]
-			);
+        [user1, user2],
+      );
 
-			return {
-				message: status === 'rejected' ? 'Successfully rejected friend request' : 'Successfully deleted friendship'
-			};
-		} else if (existingFriendship.user_id === user1) {
-			throw new Error(`User can't update a request they sent`);
-		} else if (
-			status === 'accepted' &&
-			(existingFriendship.status === 'pending' || existingFriendship.status === 'ignored')
-		) {
-			await db.transaction([
-				{
-					query: `
+      return {
+        message:
+          status === "rejected"
+            ? "Successfully rejected friend request"
+            : "Successfully deleted friendship",
+      };
+    } else if (existingFriendship.user_id === user1) {
+      throw new Error(`User can't update a request they sent`);
+    } else if (
+      status === "accepted" &&
+      (existingFriendship.status === "pending" ||
+        existingFriendship.status === "ignored")
+    ) {
+      await db.transaction([
+        {
+          query: `
 					UPDATE friendships
 					SET status = 'accepted'
 					WHERE user_id = $1 AND friend_id = $2
 					`,
-					params: [user2, user1]
-				},
-				{
-					query: `
+          params: [user2, user1],
+        },
+        {
+          query: `
 					INSERT INTO friendships (user_id, friend_id, status)
   					VALUES ($1, $2, 'accepted')
   					ON CONFLICT (user_id, friend_id) DO NOTHING
 					`,
-					params: [user1, user2]
-				}
-			]);
+          params: [user1, user2],
+        },
+      ]);
 
-			return { message: 'Friend request successfully accepted' };
-		} else if (status === 'ignored') {
-			await db.query(
-				`
+      return { message: "Friend request successfully accepted" };
+    } else if (status === "ignored") {
+      await db.query(
+        `
 				UPDATE friendships
 				SET status = 'ignored'
 				WHERE user_id = $1 AND friend_id = $2
 				`,
-				[user2, user1]
-			);
+        [user2, user1],
+      );
 
-			return { message: 'Friend request successfully ignored' };
-		} else {
-			throw new Error('Invalid status.');
-		}
-	} catch (err: any) {
-		return { error: err.message };
-	}
+      return { message: "Friend request successfully ignored" };
+    } else {
+      throw new Error("Invalid status.");
+    }
+  } catch (err: any) {
+    return { error: err.message };
+  }
 }

--- a/backend/src/services/leaderboardService.ts
+++ b/backend/src/services/leaderboardService.ts
@@ -1,4 +1,4 @@
-import { PostgresService } from './DbService.js';
+import { PostgresService } from "./DbService.js";
 
 const db = PostgresService.getInstance();
 
@@ -8,56 +8,58 @@ const db = PostgresService.getInstance();
  * runs; `pace` ranks users by fastest mile in the period (ascending — lower is
  * better); `streak` reads the precomputed users.current_streak column.
  */
-export type LeaderboardMetric = 'miles_ran' | 'miles_total' | 'pace' | 'streak';
-export type LeaderboardPeriod = 'today' | 'week' | 'month' | 'year' | 'all';
+export type LeaderboardMetric = "miles_ran" | "miles_total" | "pace" | "streak";
+export type LeaderboardPeriod = "today" | "week" | "month" | "year" | "all";
 
 export interface LeaderboardEntry {
-	rank: number;
-	user_id: string;
-	username: string | null;
-	first_name: string | null;
-	last_name: string | null;
-	profile_image_url: string | null;
-	value: number;
-	/** Total miles within the active period (or all-time when metric=streak). */
-	period_miles: number;
-	/** Fastest mile pace (seconds/mi) within the same window; null if none. */
-	period_best_pace: number | null;
-	is_current_user: boolean;
+  rank: number;
+  user_id: string;
+  username: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  profile_image_url: string | null;
+  value: number;
+  /** Total miles within the active period (or all-time when metric=streak). */
+  period_miles: number;
+  /** Fastest mile pace (seconds/mi) within the same window; null if none. */
+  period_best_pace: number | null;
+  is_current_user: boolean;
 }
 
 export interface LeaderboardPage {
-	entries: LeaderboardEntry[];
-	total_count: number;
-	has_more: boolean;
-	current_user_entry: LeaderboardEntry | null;
+  entries: LeaderboardEntry[];
+  total_count: number;
+  has_more: boolean;
+  current_user_entry: LeaderboardEntry | null;
 }
 
 interface LeaderboardArgs {
-	metric: LeaderboardMetric;
-	period: LeaderboardPeriod;
-	userId: string;
-	limit: number;
-	offset: number;
+  metric: LeaderboardMetric;
+  period: LeaderboardPeriod;
+  userId: string;
+  limit: number;
+  offset: number;
 }
 
 const MAX_LIMIT = 50;
 const DEFAULT_LIMIT = 25;
 
 export function clampLimit(raw: number | undefined): number {
-	if (!raw || !Number.isFinite(raw) || raw <= 0) return DEFAULT_LIMIT;
-	return Math.min(Math.floor(raw), MAX_LIMIT);
+  if (!raw || !Number.isFinite(raw) || raw <= 0) return DEFAULT_LIMIT;
+  return Math.min(Math.floor(raw), MAX_LIMIT);
 }
 
 export function clampOffset(raw: number | undefined): number {
-	if (!raw || !Number.isFinite(raw) || raw < 0) return 0;
-	return Math.floor(raw);
+  if (!raw || !Number.isFinite(raw) || raw < 0) return 0;
+  return Math.floor(raw);
 }
 
 // Day boundaries roll over at US Eastern midnight (matching competition
 // resolution), NOT UTC — otherwise 'today'/'week' would reset hours early for
 // every user. en-CA gives a YYYY-MM-DD format.
-const ET_DATE_FORMATTER = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' });
+const ET_DATE_FORMATTER = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "America/New_York",
+});
 
 /**
  * Start date (inclusive, ISO date string) for a period. `all` returns null —
@@ -67,19 +69,19 @@ const ET_DATE_FORMATTER = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/
  * anchored to the current US Eastern calendar date.
  */
 function periodStartDate(period: LeaderboardPeriod): string | null {
-	if (period === 'all') return null;
-	// Anchor on today's ET calendar date, then do pure calendar arithmetic:
-	// a Date built from `YYYY-MM-DDT00:00:00Z` sits at UTC midnight, so the
-	// getUTC*/setUTC* math below is plain date math with no timezone drift.
-	const d = new Date(`${ET_DATE_FORMATTER.format(new Date())}T00:00:00Z`);
-	if (period === 'week') {
-		// getUTCDay(): 0=Sun..6=Sat — back up to most recent Sunday.
-		d.setUTCDate(d.getUTCDate() - d.getUTCDay());
-		return d.toISOString().slice(0, 10);
-	}
-	const days = period === 'today' ? 1 : period === 'month' ? 30 : 365;
-	d.setUTCDate(d.getUTCDate() - (days - 1));
-	return d.toISOString().slice(0, 10);
+  if (period === "all") return null;
+  // Anchor on today's ET calendar date, then do pure calendar arithmetic:
+  // a Date built from `YYYY-MM-DDT00:00:00Z` sits at UTC midnight, so the
+  // getUTC*/setUTC* math below is plain date math with no timezone drift.
+  const d = new Date(`${ET_DATE_FORMATTER.format(new Date())}T00:00:00Z`);
+  if (period === "week") {
+    // getUTCDay(): 0=Sun..6=Sat — back up to most recent Sunday.
+    d.setUTCDate(d.getUTCDate() - d.getUTCDay());
+    return d.toISOString().slice(0, 10);
+  }
+  const days = period === "today" ? 1 : period === "month" ? 30 : 365;
+  d.setUTCDate(d.getUTCDate() - (days - 1));
+  return d.toISOString().slice(0, 10);
 }
 
 /**
@@ -87,36 +89,38 @@ function periodStartDate(period: LeaderboardPeriod): string | null {
  * viewer themselves so they always see their own rank in the list.
  */
 async function rankingUserIds(userId: string): Promise<string[]> {
-	const rows = await db.query(
-		`SELECT friend_id FROM friendships
+  const rows = await db.query(
+    `SELECT friend_id FROM friendships
 		 WHERE user_id = $1 AND status = 'accepted'`,
-		[userId]
-	);
-	const ids = rows.map((r: any) => r.friend_id as string);
-	ids.push(userId);
-	return ids;
+    [userId],
+  );
+  const ids = rows.map((r: any) => r.friend_id as string);
+  ids.push(userId);
+  return ids;
 }
 
 /**
  * Streak leaderboard reads precomputed users.current_streak (maintained by
  * workoutController after each upload). Zero-streak users excluded.
  */
-async function getStreakLeaderboard(args: LeaderboardArgs): Promise<LeaderboardPage> {
-	const { userId, limit, offset } = args;
-	const ids = await rankingUserIds(userId);
+async function getStreakLeaderboard(
+  args: LeaderboardArgs,
+): Promise<LeaderboardPage> {
+  const { userId, limit, offset } = args;
+  const ids = await rankingUserIds(userId);
 
-	const countQuery = `
+  const countQuery = `
 		SELECT COUNT(*)::int AS total
 		FROM users u
 		WHERE u.current_streak > 0
 		  AND u.user_id = ANY($1::text[])
 	`;
-	const totalRow = await db.query(countQuery, [ids]);
-	const total_count: number = totalRow[0]?.total ?? 0;
+  const totalRow = await db.query(countQuery, [ids]);
+  const total_count: number = totalRow[0]?.total ?? 0;
 
-	// Streak path is always all-time (controller forces period to 'all'), so the
-	// attached miles/best-pace stats are also all-time — no date filter.
-	const pageQuery = `
+  // Streak path is always all-time (controller forces period to 'all'), so the
+  // attached miles/best-pace stats are also all-time — no date filter.
+  const pageQuery = `
 		SELECT
 			u.user_id,
 			u.username,
@@ -128,6 +132,7 @@ async function getStreakLeaderboard(args: LeaderboardArgs): Promise<LeaderboardP
 				SELECT SUM(w.distance)::float
 				FROM workouts w
 				WHERE w.user_id = u.user_id
+				  AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL
 			), 0)::float AS period_miles,
 			(
 				SELECT MIN(ws.split_pace)::float
@@ -144,41 +149,46 @@ async function getStreakLeaderboard(args: LeaderboardArgs): Promise<LeaderboardP
 		ORDER BY u.current_streak DESC, u.user_id ASC
 		LIMIT $2 OFFSET $3
 	`;
-	const pageRows = await db.query(pageQuery, [ids, limit, offset]);
+  const pageRows = await db.query(pageQuery, [ids, limit, offset]);
 
-	const entries: LeaderboardEntry[] = pageRows.map((r: any) => ({
-		rank: r.rank,
-		user_id: r.user_id,
-		username: r.username ?? null,
-		first_name: r.first_name ?? null,
-		last_name: r.last_name ?? null,
-		profile_image_url: r.profile_image_url ?? null,
-		value: Number(r.value) || 0,
-		period_miles: Number(r.period_miles) || 0,
-		period_best_pace: r.period_best_pace != null ? Number(r.period_best_pace) : null,
-		is_current_user: r.user_id === userId
-	}));
+  const entries: LeaderboardEntry[] = pageRows.map((r: any) => ({
+    rank: r.rank,
+    user_id: r.user_id,
+    username: r.username ?? null,
+    first_name: r.first_name ?? null,
+    last_name: r.last_name ?? null,
+    profile_image_url: r.profile_image_url ?? null,
+    value: Number(r.value) || 0,
+    period_miles: Number(r.period_miles) || 0,
+    period_best_pace:
+      r.period_best_pace != null ? Number(r.period_best_pace) : null,
+    is_current_user: r.user_id === userId,
+  }));
 
-	const current_user_entry = await getCurrentUserStreakEntry(userId, ids, entries);
+  const current_user_entry = await getCurrentUserStreakEntry(
+    userId,
+    ids,
+    entries,
+  );
 
-	return {
-		entries,
-		total_count,
-		has_more: offset + entries.length < total_count,
-		current_user_entry
-	};
+  return {
+    entries,
+    total_count,
+    has_more: offset + entries.length < total_count,
+    current_user_entry,
+  };
 }
 
 async function getCurrentUserStreakEntry(
-	userId: string,
-	ids: string[],
-	pageEntries: LeaderboardEntry[]
+  userId: string,
+  ids: string[],
+  pageEntries: LeaderboardEntry[],
 ): Promise<LeaderboardEntry | null> {
-	const inPage = pageEntries.find(e => e.is_current_user);
-	if (inPage) return inPage;
+  const inPage = pageEntries.find((e) => e.is_current_user);
+  if (inPage) return inPage;
 
-	const rows = await db.query(
-		`
+  const rows = await db.query(
+    `
 		SELECT
 			u.user_id,
 			u.username,
@@ -190,6 +200,7 @@ async function getCurrentUserStreakEntry(
 				SELECT SUM(w.distance)::float
 				FROM workouts w
 				WHERE w.user_id = u.user_id
+				  AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL
 			), 0)::float AS period_miles,
 			(
 				SELECT MIN(ws.split_pace)::float
@@ -207,23 +218,24 @@ async function getCurrentUserStreakEntry(
 		FROM users u
 		WHERE u.user_id = $1
 		`,
-		[userId, ids]
-	);
+    [userId, ids],
+  );
 
-	const row = rows[0];
-	if (!row || row.value <= 0) return null;
-	return {
-		rank: row.rank,
-		user_id: row.user_id,
-		username: row.username ?? null,
-		first_name: row.first_name ?? null,
-		last_name: row.last_name ?? null,
-		profile_image_url: row.profile_image_url ?? null,
-		value: Number(row.value) || 0,
-		period_miles: Number(row.period_miles) || 0,
-		period_best_pace: row.period_best_pace != null ? Number(row.period_best_pace) : null,
-		is_current_user: true
-	};
+  const row = rows[0];
+  if (!row || row.value <= 0) return null;
+  return {
+    rank: row.rank,
+    user_id: row.user_id,
+    username: row.username ?? null,
+    first_name: row.first_name ?? null,
+    last_name: row.last_name ?? null,
+    profile_image_url: row.profile_image_url ?? null,
+    value: Number(row.value) || 0,
+    period_miles: Number(row.period_miles) || 0,
+    period_best_pace:
+      row.period_best_pace != null ? Number(row.period_best_pace) : null,
+    is_current_user: true,
+  };
 }
 
 /**
@@ -231,31 +243,34 @@ async function getCurrentUserStreakEntry(
  * friend group. Index `idx_workouts_local_date_user_id` keeps period-windowed
  * queries fast.
  */
-async function getMilesLeaderboard(args: LeaderboardArgs): Promise<LeaderboardPage> {
-	const { metric, period, userId, limit, offset } = args;
-	const startDate = periodStartDate(period);
-	const ids = await rankingUserIds(userId);
-	// miles_ran counts running workouts only; miles_total counts runs + walks
-	// (explicit IN list — guards against any future workout_type values being
-	// folded in by accident). The sub-line best-pace stays unfiltered so it
-	// matches the user's fastest-mile PR shown elsewhere.
-	const runOnly = metric === 'miles_ran';
-	const runOrWalk = metric === 'miles_total';
+async function getMilesLeaderboard(
+  args: LeaderboardArgs,
+): Promise<LeaderboardPage> {
+  const { metric, period, userId, limit, offset } = args;
+  const startDate = periodStartDate(period);
+  const ids = await rankingUserIds(userId);
+  // miles_ran counts running workouts only; miles_total counts runs + walks
+  // (explicit IN list — guards against any future workout_type values being
+  // folded in by accident). The sub-line best-pace stays unfiltered so it
+  // matches the user's fastest-mile PR shown elsewhere.
+  const runOnly = metric === "miles_ran";
+  const runOrWalk = metric === "miles_total";
 
-	const params: any[] = [ids];
-	const wheres: string[] = [`w.user_id = ANY($1::text[])`];
-	if (runOnly) wheres.push(`w.workout_type = 'running'`);
-	else if (runOrWalk) wheres.push(`w.workout_type IN ('running', 'walking')`);
-	let dateParamIndex: number | null = null;
-	if (startDate) {
-		params.push(startDate);
-		dateParamIndex = params.length;
-		wheres.push(`w.local_date >= $${dateParamIndex}`);
-	}
-	const whereSql = `WHERE ${wheres.join(' AND ')}`;
-	const bestPaceDateClause = dateParamIndex !== null ? `AND w.local_date >= $${dateParamIndex}` : '';
+  const params: any[] = [ids];
+  const wheres: string[] = [`w.user_id = ANY($1::text[])`];
+  if (runOnly) wheres.push(`w.workout_type = 'running'`);
+  else if (runOrWalk) wheres.push(`w.workout_type IN ('running', 'walking')`);
+  let dateParamIndex: number | null = null;
+  if (startDate) {
+    params.push(startDate);
+    dateParamIndex = params.length;
+    wheres.push(`w.local_date >= $${dateParamIndex}`);
+  }
+  const whereSql = `WHERE ${wheres.join(" AND ")} AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL`;
+  const bestPaceDateClause =
+    dateParamIndex !== null ? `AND w.local_date >= $${dateParamIndex}` : "";
 
-	const countQuery = `
+  const countQuery = `
 		SELECT COUNT(*)::int AS total FROM (
 			SELECT w.user_id FROM workouts w
 			${whereSql}
@@ -263,15 +278,15 @@ async function getMilesLeaderboard(args: LeaderboardArgs): Promise<LeaderboardPa
 			HAVING SUM(w.distance) > 0
 		) t
 	`;
-	const totalRow = await db.query(countQuery, params);
-	const total_count: number = totalRow[0]?.total ?? 0;
+  const totalRow = await db.query(countQuery, params);
+  const total_count: number = totalRow[0]?.total ?? 0;
 
-	params.push(limit);
-	const limitParamIndex = params.length;
-	params.push(offset);
-	const offsetParamIndex = params.length;
+  params.push(limit);
+  const limitParamIndex = params.length;
+  params.push(offset);
+  const offsetParamIndex = params.length;
 
-	const pageQuery = `
+  const pageQuery = `
 		WITH totals AS (
 			SELECT w.user_id, SUM(w.distance)::float AS value
 			FROM workouts w
@@ -302,129 +317,144 @@ async function getMilesLeaderboard(args: LeaderboardArgs): Promise<LeaderboardPa
 		ORDER BY t.value DESC, u.user_id ASC
 		LIMIT $${limitParamIndex} OFFSET $${offsetParamIndex}
 	`;
-	const pageRows = await db.query(pageQuery, params);
+  const pageRows = await db.query(pageQuery, params);
 
-	const entries: LeaderboardEntry[] = pageRows.map((r: any) => ({
-		rank: r.rank,
-		user_id: r.user_id,
-		username: r.username ?? null,
-		first_name: r.first_name ?? null,
-		last_name: r.last_name ?? null,
-		profile_image_url: r.profile_image_url ?? null,
-		value: Number(r.value) || 0,
-		period_miles: Number(r.period_miles) || 0,
-		period_best_pace: r.period_best_pace != null ? Number(r.period_best_pace) : null,
-		is_current_user: r.user_id === userId
-	}));
+  const entries: LeaderboardEntry[] = pageRows.map((r: any) => ({
+    rank: r.rank,
+    user_id: r.user_id,
+    username: r.username ?? null,
+    first_name: r.first_name ?? null,
+    last_name: r.last_name ?? null,
+    profile_image_url: r.profile_image_url ?? null,
+    value: Number(r.value) || 0,
+    period_miles: Number(r.period_miles) || 0,
+    period_best_pace:
+      r.period_best_pace != null ? Number(r.period_best_pace) : null,
+    is_current_user: r.user_id === userId,
+  }));
 
-	const current_user_entry = await getCurrentUserMilesEntry(userId, ids, startDate, runOnly, runOrWalk, entries);
+  const current_user_entry = await getCurrentUserMilesEntry(
+    userId,
+    ids,
+    startDate,
+    runOnly,
+    runOrWalk,
+    entries,
+  );
 
-	return {
-		entries,
-		total_count,
-		has_more: offset + entries.length < total_count,
-		current_user_entry
-	};
+  return {
+    entries,
+    total_count,
+    has_more: offset + entries.length < total_count,
+    current_user_entry,
+  };
 }
 
 async function getCurrentUserMilesEntry(
-	userId: string,
-	ids: string[],
-	startDate: string | null,
-	runOnly: boolean,
-	runOrWalk: boolean,
-	pageEntries: LeaderboardEntry[]
+  userId: string,
+  ids: string[],
+  startDate: string | null,
+  runOnly: boolean,
+  runOrWalk: boolean,
+  pageEntries: LeaderboardEntry[],
 ): Promise<LeaderboardEntry | null> {
-	const inPage = pageEntries.find(e => e.is_current_user);
-	if (inPage) return inPage;
+  const inPage = pageEntries.find((e) => e.is_current_user);
+  if (inPage) return inPage;
 
-	const params: any[] = [userId];
-	const wheres: string[] = [`w.user_id = $1`];
-	if (runOnly) wheres.push(`w.workout_type = 'running'`);
-	else if (runOrWalk) wheres.push(`w.workout_type IN ('running', 'walking')`);
-	if (startDate) {
-		params.push(startDate);
-		wheres.push(`w.local_date >= $${params.length}`);
-	}
-	const myTotalQuery = `
+  const params: any[] = [userId];
+  const wheres: string[] = [`w.user_id = $1`];
+  if (runOnly) wheres.push(`w.workout_type = 'running'`);
+  else if (runOrWalk) wheres.push(`w.workout_type IN ('running', 'walking')`);
+  if (startDate) {
+    params.push(startDate);
+    wheres.push(`w.local_date >= $${params.length}`);
+  }
+  const myTotalQuery = `
 		SELECT COALESCE(SUM(w.distance), 0)::float AS value
 		FROM workouts w
-		WHERE ${wheres.join(' AND ')}
+		WHERE ${wheres.join(" AND ")} AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL
 	`;
-	const myTotalRow = await db.query(myTotalQuery, params);
-	const myValue: number = Number(myTotalRow[0]?.value ?? 0);
-	if (myValue <= 0) return null;
+  const myTotalRow = await db.query(myTotalQuery, params);
+  const myValue: number = Number(myTotalRow[0]?.value ?? 0);
+  if (myValue <= 0) return null;
 
-	// Rank = 1 + count of friends-or-self whose period total exceeds mine.
-	const rankParams: any[] = [myValue, ids];
-	const rankInnerWheres: string[] = [`w.user_id = ANY($2::text[])`];
-	if (runOnly) rankInnerWheres.push(`w.workout_type = 'running'`);
-	else if (runOrWalk) rankInnerWheres.push(`w.workout_type IN ('running', 'walking')`);
-	if (startDate) {
-		rankParams.push(startDate);
-		rankInnerWheres.push(`w.local_date >= $${rankParams.length}`);
-	}
+  // Rank = 1 + count of friends-or-self whose period total exceeds mine.
+  const rankParams: any[] = [myValue, ids];
+  const rankInnerWheres: string[] = [`w.user_id = ANY($2::text[])`];
+  if (runOnly) rankInnerWheres.push(`w.workout_type = 'running'`);
+  else if (runOrWalk)
+    rankInnerWheres.push(`w.workout_type IN ('running', 'walking')`);
+  if (startDate) {
+    rankParams.push(startDate);
+    rankInnerWheres.push(`w.local_date >= $${rankParams.length}`);
+  }
 
-	const rankQuery = `
+  const rankQuery = `
 		SELECT COUNT(*)::int + 1 AS rank FROM (
 			SELECT w.user_id
 			FROM workouts w
-			WHERE ${rankInnerWheres.join(' AND ')}
+			WHERE ${rankInnerWheres.join(" AND ")} AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL
 			GROUP BY w.user_id
 			HAVING SUM(w.distance) > $1
 		) t
 	`;
-	const rankRow = await db.query(rankQuery, rankParams);
-	const rank: number = rankRow[0]?.rank ?? 1;
+  const rankRow = await db.query(rankQuery, rankParams);
+  const rank: number = rankRow[0]?.rank ?? 1;
 
-	const userRow = await db.query(
-		`SELECT user_id, username, first_name, last_name, profile_image_url FROM users WHERE user_id = $1`,
-		[userId]
-	);
-	const u = userRow[0];
-	if (!u) return null;
+  const userRow = await db.query(
+    `SELECT user_id, username, first_name, last_name, profile_image_url FROM users WHERE user_id = $1`,
+    [userId],
+  );
+  const u = userRow[0];
+  if (!u) return null;
 
-	// Best mile pace within the same period (or all-time when startDate is null).
-	const paceParams: any[] = [userId];
-	const paceWheres: string[] = [`w.user_id = $1`, `ws.split_distance >= 0.999`, `ws.split_pace > 0`];
-	if (startDate) {
-		paceParams.push(startDate);
-		paceWheres.push(`w.local_date >= $${paceParams.length}`);
-	}
-	const paceRow = await db.query(
-		`SELECT MIN(ws.split_pace)::float AS best_pace
+  // Best mile pace within the same period (or all-time when startDate is null).
+  const paceParams: any[] = [userId];
+  const paceWheres: string[] = [
+    `w.user_id = $1`,
+    `ws.split_distance >= 0.999`,
+    `ws.split_pace > 0`,
+  ];
+  if (startDate) {
+    paceParams.push(startDate);
+    paceWheres.push(`w.local_date >= $${paceParams.length}`);
+  }
+  const paceRow = await db.query(
+    `SELECT MIN(ws.split_pace)::float AS best_pace
 		 FROM workout_splits ws
 		 JOIN workouts w ON w.workout_id = ws.workout_id
-		 WHERE ${paceWheres.join(' AND ')}`,
-		paceParams
-	);
-	const bestPace = paceRow[0]?.best_pace;
+		 WHERE ${paceWheres.join(" AND ")}`,
+    paceParams,
+  );
+  const bestPace = paceRow[0]?.best_pace;
 
-	return {
-		rank,
-		user_id: u.user_id,
-		username: u.username ?? null,
-		first_name: u.first_name ?? null,
-		last_name: u.last_name ?? null,
-		profile_image_url: u.profile_image_url ?? null,
-		value: myValue,
-		period_miles: myValue,
-		period_best_pace: bestPace != null ? Number(bestPace) : null,
-		is_current_user: true
-	};
+  return {
+    rank,
+    user_id: u.user_id,
+    username: u.username ?? null,
+    first_name: u.first_name ?? null,
+    last_name: u.last_name ?? null,
+    profile_image_url: u.profile_image_url ?? null,
+    value: myValue,
+    period_miles: myValue,
+    period_best_pace: bestPace != null ? Number(bestPace) : null,
+    is_current_user: true,
+  };
 }
 
-export async function getLeaderboard(args: LeaderboardArgs): Promise<LeaderboardPage> {
-	switch (args.metric) {
-		case 'streak':
-			return getStreakLeaderboard(args);
-		case 'pace':
-			return getPaceLeaderboard(args);
-		case 'miles_total':
-		case 'miles_ran':
-		default:
-			return getMilesLeaderboard(args);
-	}
+export async function getLeaderboard(
+  args: LeaderboardArgs,
+): Promise<LeaderboardPage> {
+  switch (args.metric) {
+    case "streak":
+      return getStreakLeaderboard(args);
+    case "pace":
+      return getPaceLeaderboard(args);
+    case "miles_total":
+    case "miles_ran":
+    default:
+      return getMilesLeaderboard(args);
+  }
 }
 
 /**
@@ -434,23 +464,30 @@ export async function getLeaderboard(args: LeaderboardArgs): Promise<Leaderboard
  * SplitCalculator emits with an extrapolated per-mile pace — otherwise
  * someone who only ran half a mile at "7:00/mi pace" would show up.
  */
-async function getPaceLeaderboard(args: LeaderboardArgs): Promise<LeaderboardPage> {
-	const { period, userId, limit, offset } = args;
-	const startDate = periodStartDate(period);
-	const ids = await rankingUserIds(userId);
+async function getPaceLeaderboard(
+  args: LeaderboardArgs,
+): Promise<LeaderboardPage> {
+  const { period, userId, limit, offset } = args;
+  const startDate = periodStartDate(period);
+  const ids = await rankingUserIds(userId);
 
-	const params: any[] = [ids];
-	const wheres: string[] = [`w.user_id = ANY($1::text[])`, `ws.split_distance >= 0.999`, `ws.split_pace > 0`];
-	let dateParamIndex: number | null = null;
-	if (startDate) {
-		params.push(startDate);
-		dateParamIndex = params.length;
-		wheres.push(`w.local_date >= $${dateParamIndex}`);
-	}
-	const whereSql = `WHERE ${wheres.join(' AND ')}`;
-	const milesDateClause = dateParamIndex !== null ? `AND w.local_date >= $${dateParamIndex}` : '';
+  const params: any[] = [ids];
+  const wheres: string[] = [
+    `w.user_id = ANY($1::text[])`,
+    `ws.split_distance >= 0.999`,
+    `ws.split_pace > 0`,
+  ];
+  let dateParamIndex: number | null = null;
+  if (startDate) {
+    params.push(startDate);
+    dateParamIndex = params.length;
+    wheres.push(`w.local_date >= $${dateParamIndex}`);
+  }
+  const whereSql = `WHERE ${wheres.join(" AND ")}`;
+  const milesDateClause =
+    dateParamIndex !== null ? `AND w.local_date >= $${dateParamIndex}` : "";
 
-	const countQuery = `
+  const countQuery = `
 		SELECT COUNT(*)::int AS total FROM (
 			SELECT w.user_id
 			FROM workout_splits ws
@@ -459,15 +496,15 @@ async function getPaceLeaderboard(args: LeaderboardArgs): Promise<LeaderboardPag
 			GROUP BY w.user_id
 		) t
 	`;
-	const totalRow = await db.query(countQuery, params);
-	const total_count: number = totalRow[0]?.total ?? 0;
+  const totalRow = await db.query(countQuery, params);
+  const total_count: number = totalRow[0]?.total ?? 0;
 
-	params.push(limit);
-	const limitParamIndex = params.length;
-	params.push(offset);
-	const offsetParamIndex = params.length;
+  params.push(limit);
+  const limitParamIndex = params.length;
+  params.push(offset);
+  const offsetParamIndex = params.length;
 
-	const pageQuery = `
+  const pageQuery = `
 		WITH bests AS (
 			SELECT w.user_id, MIN(ws.split_pace)::float AS value
 			FROM workout_splits ws
@@ -487,6 +524,7 @@ async function getPaceLeaderboard(args: LeaderboardArgs): Promise<LeaderboardPag
 				FROM workouts w
 				WHERE w.user_id = u.user_id
 				  ${milesDateClause}
+				  AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL
 			), 0)::float AS period_miles,
 			b.value AS period_best_pace,
 			RANK() OVER (ORDER BY b.value ASC)::int AS rank
@@ -495,112 +533,127 @@ async function getPaceLeaderboard(args: LeaderboardArgs): Promise<LeaderboardPag
 		ORDER BY b.value ASC, u.user_id ASC
 		LIMIT $${limitParamIndex} OFFSET $${offsetParamIndex}
 	`;
-	const pageRows = await db.query(pageQuery, params);
+  const pageRows = await db.query(pageQuery, params);
 
-	const entries: LeaderboardEntry[] = pageRows.map((r: any) => ({
-		rank: r.rank,
-		user_id: r.user_id,
-		username: r.username ?? null,
-		first_name: r.first_name ?? null,
-		last_name: r.last_name ?? null,
-		profile_image_url: r.profile_image_url ?? null,
-		value: Number(r.value) || 0,
-		period_miles: Number(r.period_miles) || 0,
-		period_best_pace: r.period_best_pace != null ? Number(r.period_best_pace) : null,
-		is_current_user: r.user_id === userId
-	}));
+  const entries: LeaderboardEntry[] = pageRows.map((r: any) => ({
+    rank: r.rank,
+    user_id: r.user_id,
+    username: r.username ?? null,
+    first_name: r.first_name ?? null,
+    last_name: r.last_name ?? null,
+    profile_image_url: r.profile_image_url ?? null,
+    value: Number(r.value) || 0,
+    period_miles: Number(r.period_miles) || 0,
+    period_best_pace:
+      r.period_best_pace != null ? Number(r.period_best_pace) : null,
+    is_current_user: r.user_id === userId,
+  }));
 
-	const current_user_entry = await getCurrentUserPaceEntry(userId, ids, startDate, entries);
+  const current_user_entry = await getCurrentUserPaceEntry(
+    userId,
+    ids,
+    startDate,
+    entries,
+  );
 
-	return {
-		entries,
-		total_count,
-		has_more: offset + entries.length < total_count,
-		current_user_entry
-	};
+  return {
+    entries,
+    total_count,
+    has_more: offset + entries.length < total_count,
+    current_user_entry,
+  };
 }
 
 async function getCurrentUserPaceEntry(
-	userId: string,
-	ids: string[],
-	startDate: string | null,
-	pageEntries: LeaderboardEntry[]
+  userId: string,
+  ids: string[],
+  startDate: string | null,
+  pageEntries: LeaderboardEntry[],
 ): Promise<LeaderboardEntry | null> {
-	const inPage = pageEntries.find(e => e.is_current_user);
-	if (inPage) return inPage;
+  const inPage = pageEntries.find((e) => e.is_current_user);
+  if (inPage) return inPage;
 
-	// Viewer's best pace in the window.
-	const myParams: any[] = [userId];
-	const myWheres: string[] = [`w.user_id = $1`, `ws.split_distance >= 0.999`, `ws.split_pace > 0`];
-	if (startDate) {
-		myParams.push(startDate);
-		myWheres.push(`w.local_date >= $${myParams.length}`);
-	}
-	const myRow = await db.query(
-		`SELECT MIN(ws.split_pace)::float AS value
+  // Viewer's best pace in the window.
+  const myParams: any[] = [userId];
+  const myWheres: string[] = [
+    `w.user_id = $1`,
+    `ws.split_distance >= 0.999`,
+    `ws.split_pace > 0`,
+  ];
+  if (startDate) {
+    myParams.push(startDate);
+    myWheres.push(`w.local_date >= $${myParams.length}`);
+  }
+  const myRow = await db.query(
+    `SELECT MIN(ws.split_pace)::float AS value
 		 FROM workout_splits ws
 		 JOIN workouts w ON w.workout_id = ws.workout_id
-		 WHERE ${myWheres.join(' AND ')}`,
-		myParams
-	);
-	const myValue: number | null = myRow[0]?.value != null ? Number(myRow[0].value) : null;
-	if (myValue == null || !(myValue > 0)) return null;
+		 WHERE ${myWheres.join(" AND ")}`,
+    myParams,
+  );
+  const myValue: number | null =
+    myRow[0]?.value != null ? Number(myRow[0].value) : null;
+  if (myValue == null || !(myValue > 0)) return null;
 
-	// Rank = 1 + count of friends-or-self whose best pace is strictly lower
-	// (faster). RANK semantics with ties match getPaceLeaderboard.
-	const rankParams: any[] = [myValue, ids];
-	const rankWheres: string[] = [`w.user_id = ANY($2::text[])`, `ws.split_distance >= 0.999`, `ws.split_pace > 0`];
-	if (startDate) {
-		rankParams.push(startDate);
-		rankWheres.push(`w.local_date >= $${rankParams.length}`);
-	}
-	const rankRow = await db.query(
-		`SELECT COUNT(*)::int + 1 AS rank FROM (
+  // Rank = 1 + count of friends-or-self whose best pace is strictly lower
+  // (faster). RANK semantics with ties match getPaceLeaderboard.
+  const rankParams: any[] = [myValue, ids];
+  const rankWheres: string[] = [
+    `w.user_id = ANY($2::text[])`,
+    `ws.split_distance >= 0.999`,
+    `ws.split_pace > 0`,
+  ];
+  if (startDate) {
+    rankParams.push(startDate);
+    rankWheres.push(`w.local_date >= $${rankParams.length}`);
+  }
+  const rankRow = await db.query(
+    `SELECT COUNT(*)::int + 1 AS rank FROM (
 			SELECT w.user_id
 			FROM workout_splits ws
 			JOIN workouts w ON w.workout_id = ws.workout_id
-			WHERE ${rankWheres.join(' AND ')}
+			WHERE ${rankWheres.join(" AND ")}
 			GROUP BY w.user_id
 			HAVING MIN(ws.split_pace) < $1
 		) t`,
-		rankParams
-	);
-	const rank: number = rankRow[0]?.rank ?? 1;
+    rankParams,
+  );
+  const rank: number = rankRow[0]?.rank ?? 1;
 
-	// Period miles for the sub-line.
-	const milesParams: any[] = [userId];
-	const milesWheres: string[] = [`w.user_id = $1`];
-	if (startDate) {
-		milesParams.push(startDate);
-		milesWheres.push(`w.local_date >= $${milesParams.length}`);
-	}
-	const milesRow = await db.query(
-		`SELECT COALESCE(SUM(w.distance), 0)::float AS miles
+  // Period miles for the sub-line.
+  const milesParams: any[] = [userId];
+  const milesWheres: string[] = [`w.user_id = $1`];
+  if (startDate) {
+    milesParams.push(startDate);
+    milesWheres.push(`w.local_date >= $${milesParams.length}`);
+  }
+  const milesRow = await db.query(
+    `SELECT COALESCE(SUM(w.distance), 0)::float AS miles
 		 FROM workouts w
-		 WHERE ${milesWheres.join(' AND ')}`,
-		milesParams
-	);
-	const periodMiles: number = Number(milesRow[0]?.miles ?? 0);
+		 WHERE ${milesWheres.join(" AND ")} AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL`,
+    milesParams,
+  );
+  const periodMiles: number = Number(milesRow[0]?.miles ?? 0);
 
-	const userRow = await db.query(
-		`SELECT user_id, username, first_name, last_name, profile_image_url FROM users WHERE user_id = $1`,
-		[userId]
-	);
-	const u = userRow[0];
-	if (!u) return null;
+  const userRow = await db.query(
+    `SELECT user_id, username, first_name, last_name, profile_image_url FROM users WHERE user_id = $1`,
+    [userId],
+  );
+  const u = userRow[0];
+  if (!u) return null;
 
-	return {
-		rank,
-		user_id: u.user_id,
-		username: u.username ?? null,
-		first_name: u.first_name ?? null,
-		last_name: u.last_name ?? null,
-		profile_image_url: u.profile_image_url ?? null,
-		value: myValue,
-		period_miles: periodMiles,
-		period_best_pace: myValue,
-		is_current_user: true
-	};
+  return {
+    rank,
+    user_id: u.user_id,
+    username: u.username ?? null,
+    first_name: u.first_name ?? null,
+    last_name: u.last_name ?? null,
+    profile_image_url: u.profile_image_url ?? null,
+    value: myValue,
+    period_miles: periodMiles,
+    period_best_pace: myValue,
+    is_current_user: true,
+  };
 }
 
 /**
@@ -611,8 +664,8 @@ async function getCurrentUserPaceEntry(
  * qualifying days back from today (or yesterday if today has no workouts yet).
  */
 export async function refreshCurrentStreak(userId: string): Promise<number> {
-	const todayRow = await db.query(
-		`
+  const todayRow = await db.query(
+    `
 		SELECT to_char(
 		  (NOW() + (COALESCE(
 		    (SELECT timezone_offset FROM workouts WHERE user_id = $1 ORDER BY device_end_date DESC LIMIT 1),
@@ -621,50 +674,56 @@ export async function refreshCurrentStreak(userId: string): Promise<number> {
 		  'YYYY-MM-DD'
 		) AS user_today
 		`,
-		[userId]
-	);
-	const userToday: string = todayRow[0]?.user_today;
-	if (!userToday) {
-		await db.query(`UPDATE users SET current_streak = 0 WHERE user_id = $1`, [userId]);
-		return 0;
-	}
+    [userId],
+  );
+  const userToday: string = todayRow[0]?.user_today;
+  if (!userToday) {
+    await db.query(`UPDATE users SET current_streak = 0 WHERE user_id = $1`, [
+      userId,
+    ]);
+    return 0;
+  }
 
-	const days = await db.query(
-		`
+  const days = await db.query(
+    `
 		SELECT to_char(local_date, 'YYYY-MM-DD') AS local_date
 		FROM workouts
 		WHERE user_id = $1
+		AND deleted_at IS NULL AND exclusion_reason IS NULL
 		GROUP BY local_date
 		HAVING SUM(distance) >= 0.95
 		ORDER BY local_date DESC
 		LIMIT 500
 		`,
-		[userId]
-	);
+    [userId],
+  );
 
-	let streak = 0;
-	let expected: string | undefined;
-	const yesterday = dateStringMinus(userToday, 1);
+  let streak = 0;
+  let expected: string | undefined;
+  const yesterday = dateStringMinus(userToday, 1);
 
-	for (const row of days) {
-		const date: string = row.local_date;
-		if (expected === undefined) {
-			if (date !== userToday && date !== yesterday) {
-				streak = 0;
-				break;
-			}
-			streak = 1;
-			expected = dateStringMinus(date, 1);
-		} else if (date === expected) {
-			streak++;
-			expected = dateStringMinus(date, 1);
-		} else {
-			break;
-		}
-	}
+  for (const row of days) {
+    const date: string = row.local_date;
+    if (expected === undefined) {
+      if (date !== userToday && date !== yesterday) {
+        streak = 0;
+        break;
+      }
+      streak = 1;
+      expected = dateStringMinus(date, 1);
+    } else if (date === expected) {
+      streak++;
+      expected = dateStringMinus(date, 1);
+    } else {
+      break;
+    }
+  }
 
-	await db.query(`UPDATE users SET current_streak = $1 WHERE user_id = $2`, [streak, userId]);
-	return streak;
+  await db.query(`UPDATE users SET current_streak = $1 WHERE user_id = $2`, [
+    streak,
+    userId,
+  ]);
+  return streak;
 }
 
 /**
@@ -681,28 +740,34 @@ export async function refreshCurrentStreak(userId: string): Promise<number> {
  * direction. refreshCurrentStreak derives "today" from each user's own timezone
  * offset, so the result is correct regardless of when this job runs.
  */
-export async function reconcileStaleStreaks(): Promise<{ checked: number; changed: number }> {
-	const rows = await db.query<{ user_id: string; current_streak: number }>(
-		`SELECT user_id, current_streak FROM users WHERE current_streak > 0`
-	);
+export async function reconcileStaleStreaks(): Promise<{
+  checked: number;
+  changed: number;
+}> {
+  const rows = await db.query<{ user_id: string; current_streak: number }>(
+    `SELECT user_id, current_streak FROM users WHERE current_streak > 0`,
+  );
 
-	let changed = 0;
-	for (const { user_id, current_streak } of rows) {
-		try {
-			const after = await refreshCurrentStreak(user_id);
-			if (current_streak !== after) changed++;
-		} catch (err: any) {
-			// Isolate per-user failures so one bad row doesn't abort the sweep.
-			console.error(`[Streaks] Failed to reconcile streak for ${user_id}:`, err.message);
-		}
-	}
+  let changed = 0;
+  for (const { user_id, current_streak } of rows) {
+    try {
+      const after = await refreshCurrentStreak(user_id);
+      if (current_streak !== after) changed++;
+    } catch (err: any) {
+      // Isolate per-user failures so one bad row doesn't abort the sweep.
+      console.error(
+        `[Streaks] Failed to reconcile streak for ${user_id}:`,
+        err.message,
+      );
+    }
+  }
 
-	return { checked: rows.length, changed };
+  return { checked: rows.length, changed };
 }
 
 function dateStringMinus(dateStr: string, days: number): string {
-	const [y, m, d] = dateStr.split('-').map(Number);
-	const date = new Date(Date.UTC(y, m - 1, d));
-	date.setUTCDate(date.getUTCDate() - days);
-	return date.toISOString().slice(0, 10);
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const date = new Date(Date.UTC(y, m - 1, d));
+  date.setUTCDate(date.getUTCDate() - days);
+  return date.toISOString().slice(0, 10);
 }

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -1,42 +1,56 @@
-import { PostgresService } from './DbService.js';
-import { sendPush, sendOrQueueCompetitionNotification } from './pushNotificationService.js';
-import { shouldSendNotification, filterRecipientsForNotification } from './notificationSettingsService.js';
-import { getCompetition, getCurrentInterval, getUserScores } from './competitionService.js';
-import { Competition, CompetitionUser } from '../types/competitions.js';
-import { getTodayMiles, getTodayStats, getUserLocalDate } from './workoutService.js';
+import { PostgresService } from "./DbService.js";
 import {
-	resolveAudience,
-	filterByIncomingAudience,
-	restrictToCloseFriends,
-	queuePendingFriendNotification,
-	AudienceActivity,
-	AudienceEventType
-} from './audienceSettingsService.js';
-import { getCloseFriendIds } from './closeFriendsService.js';
+  sendPush,
+  sendOrQueueCompetitionNotification,
+} from "./pushNotificationService.js";
+import {
+  shouldSendNotification,
+  filterRecipientsForNotification,
+} from "./notificationSettingsService.js";
+import {
+  getCompetition,
+  getCurrentInterval,
+  getUserScores,
+} from "./competitionService.js";
+import { Competition, CompetitionUser } from "../types/competitions.js";
+import {
+  getTodayMiles,
+  getTodayStats,
+  getUserLocalDate,
+} from "./workoutService.js";
+import {
+  resolveAudience,
+  filterByIncomingAudience,
+  restrictToCloseFriends,
+  queuePendingFriendNotification,
+  AudienceActivity,
+  AudienceEventType,
+} from "./audienceSettingsService.js";
+import { getCloseFriendIds } from "./closeFriendsService.js";
 
 const db = PostgresService.getInstance();
 
 // ─── Format helpers (file-local) ───────────────────────────────────
 
 function formatMiles(miles: number): string {
-	return `${miles.toFixed(2)} mi`;
+  return `${miles.toFixed(2)} mi`;
 }
 
 function formatDuration(seconds: number): string {
-	const s = Math.max(0, Math.round(seconds));
-	const h = Math.floor(s / 3600);
-	const m = Math.floor((s % 3600) / 60);
-	const sec = s % 60;
-	const pad = (n: number) => n.toString().padStart(2, '0');
-	if (h > 0) return `${h}:${pad(m)}:${pad(sec)}`;
-	return `${m}:${pad(sec)}`;
+  const s = Math.max(0, Math.round(seconds));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  if (h > 0) return `${h}:${pad(m)}:${pad(sec)}`;
+  return `${m}:${pad(sec)}`;
 }
 
 function formatPace(secondsPerMile: number): string {
-	const s = Math.max(0, Math.round(secondsPerMile));
-	const m = Math.floor(s / 60);
-	const sec = s % 60;
-	return `${m}:${sec.toString().padStart(2, '0')}/mi`;
+  const s = Math.max(0, Math.round(secondsPerMile));
+  const m = Math.floor(s / 60);
+  const sec = s % 60;
+  return `${m}:${sec.toString().padStart(2, "0")}/mi`;
 }
 
 // ─── Shared Recipient Pool Helper ──────────────────────────────────
@@ -55,23 +69,23 @@ function formatPace(secondsPerMile: number): string {
  * rely on filterRecipientsForNotification instead).
  */
 export async function getFriendActivityRecipientPool(
-	userId: string,
-	outgoingAudience: 'close' | 'all',
-	eventType: AudienceEventType,
-	activity: AudienceActivity,
-	includeCompetitionPool = true
+  userId: string,
+  outgoingAudience: "close" | "all",
+  eventType: AudienceEventType,
+  activity: AudienceActivity,
+  includeCompetitionPool = true,
 ): Promise<string[]> {
-	const friendRows = await db.query<{ friend_id: string }>(
-		`SELECT friend_id FROM friendships WHERE user_id = $1 AND status = 'accepted'`,
-		[userId]
-	);
+  const friendRows = await db.query<{ friend_id: string }>(
+    `SELECT friend_id FROM friendships WHERE user_id = $1 AND status = 'accepted'`,
+    [userId],
+  );
 
-	let friendIds = friendRows.map(r => r.friend_id);
-	let coParticipantIds: string[] = [];
+  let friendIds = friendRows.map((r) => r.friend_id);
+  let coParticipantIds: string[] = [];
 
-	if (includeCompetitionPool) {
-		const compRows = await db.query<{ user_id: string }>(
-			`SELECT DISTINCT cu_other.user_id
+  if (includeCompetitionPool) {
+    const compRows = await db.query<{ user_id: string }>(
+      `SELECT DISTINCT cu_other.user_id
 			FROM competition_users cu_self
 			JOIN competition_users cu_other ON cu_other.competition_id = cu_self.competition_id
 			JOIN competitions c ON c.id = cu_self.competition_id
@@ -83,23 +97,32 @@ export async function getFriendActivityRecipientPool(
 				AND c.start_date <= NOW()
 				AND c.winner IS NULL
 				AND (c.end_date IS NULL OR c.end_date > NOW())`,
-			[userId]
-		);
-		const friendSet = new Set(friendIds);
-		coParticipantIds = compRows.map(r => r.user_id).filter(id => !friendSet.has(id));
-	}
+      [userId],
+    );
+    const friendSet = new Set(friendIds);
+    coParticipantIds = compRows
+      .map((r) => r.user_id)
+      .filter((id) => !friendSet.has(id));
+  }
 
-	if (outgoingAudience === 'close') {
-		const closeSet = new Set(await getCloseFriendIds(userId));
-		friendIds = friendIds.filter(id => closeSet.has(id));
-		coParticipantIds = coParticipantIds.filter(id => closeSet.has(id));
-	}
+  if (outgoingAudience === "close") {
+    const closeSet = new Set(await getCloseFriendIds(userId));
+    friendIds = friendIds.filter((id) => closeSet.has(id));
+    coParticipantIds = coParticipantIds.filter((id) => closeSet.has(id));
+  }
 
-	const recipients = [...friendIds.slice(0, 5), ...coParticipantIds.slice(0, 5)];
-	if (recipients.length === 0) return [];
+  const recipients = [
+    ...friendIds.slice(0, 5),
+    ...coParticipantIds.slice(0, 5),
+  ];
+  if (recipients.length === 0) return [];
 
-	const prefAllowed = await filterRecipientsForNotification(recipients, userId, 'friend_activity');
-	return filterByIncomingAudience(prefAllowed, userId, eventType, activity);
+  const prefAllowed = await filterRecipientsForNotification(
+    recipients,
+    userId,
+    "friend_activity",
+  );
+  return filterByIncomingAudience(prefAllowed, userId, eventType, activity);
 }
 
 // ─── Workout Completion Notifications ──────────────────────────────
@@ -109,107 +132,144 @@ export async function getFriendActivityRecipientPool(
  * Only sends once per day per user, and respects friend notification settings.
  * Caps at 5 friend notifications to avoid spam.
  */
-export async function notifyFriendsOfMileCompletion(userId: string): Promise<boolean> {
-	try {
-		// Atomically claim this notification slot (prevents race condition duplicates)
-		const today = new Date().toISOString().split('T')[0];
-		const claimed = await db.query(
-			`INSERT INTO workout_completion_notifications (user_id, notified_date) VALUES ($1, $2)
+export async function notifyFriendsOfMileCompletion(
+  userId: string,
+): Promise<boolean> {
+  try {
+    // Atomically claim this notification slot (prevents race condition duplicates)
+    const today = new Date().toISOString().split("T")[0];
+    const claimed = await db.query(
+      `INSERT INTO workout_completion_notifications (user_id, notified_date) VALUES ($1, $2)
 			ON CONFLICT (user_id, notified_date) DO NOTHING
 			RETURNING id`,
-			[userId, today]
-		);
+      [userId, today],
+    );
 
-		if (claimed.length === 0) return false; // Already sent today
+    if (claimed.length === 0) return false; // Already sent today
 
-		// Get user info
-		const [user] = await db.query('SELECT username FROM users WHERE user_id = $1', [userId]);
-		if (!user) return false;
+    // Get user info
+    const [user] = await db.query(
+      "SELECT username FROM users WHERE user_id = $1",
+      [userId],
+    );
+    if (!user) return false;
 
-		// The runner's local date — clients use it as the hype dedupe key. Without
-		// it they fall back to the notification's UTC date, which is off-by-one for
-		// evening miles (e.g. 11pm ET) and collides with the next day's mile.
-		const localDate = await getUserLocalDate(userId);
+    // The runner's local date — clients use it as the hype dedupe key. Without
+    // it they fall back to the notification's UTC date, which is off-by-one for
+    // evening miles (e.g. 11pm ET) and collides with the next day's mile.
+    const localDate = await getUserLocalDate(userId);
 
-		// Activity for audience resolution: the workout that completed the mile —
-		// approximated as today's most recent running/walking workout. Default 'run'.
-		const [recentWorkout] = await db.query<{ workout_id: string; workout_type: string }>(
-			`SELECT workout_id, workout_type
+    // Activity for audience resolution: the workout that completed the mile —
+    // approximated as today's most recent running/walking workout. Default 'run'.
+    const [recentWorkout] = await db.query<{
+      workout_id: string;
+      workout_type: string;
+    }>(
+      `SELECT workout_id, workout_type
 			FROM workouts
 			WHERE user_id = $1 AND local_date = $2 AND workout_type IN ('running', 'walking')
+			AND deleted_at IS NULL AND exclusion_reason IS NULL
 			ORDER BY device_end_date DESC
 			LIMIT 1`,
-			[userId, localDate]
-		);
-		const audienceActivity: AudienceActivity = recentWorkout?.workout_type === 'walking' ? 'walk' : 'run';
+      [userId, localDate],
+    );
+    const audienceActivity: AudienceActivity =
+      recentWorkout?.workout_type === "walking" ? "walk" : "run";
 
-		// Outgoing audience (dedupe slot is already claimed above, so 'none'/'ask'
-		// won't refire later).
-		const outgoing = await resolveAudience(userId, 'outgoing', 'mile_completed', audienceActivity);
-		if (outgoing === 'none') return true;
+    // Outgoing audience (dedupe slot is already claimed above, so 'none'/'ask'
+    // won't refire later).
+    const outgoing = await resolveAudience(
+      userId,
+      "outgoing",
+      "mile_completed",
+      audienceActivity,
+    );
+    if (outgoing === "none") return true;
 
-		const title = `${user.username} got their mile in!`;
+    const title = `${user.username} got their mile in!`;
 
-		// Build a stat-line body. If stats fail or are degenerate, fall back to
-		// the generic body so the notification still goes out.
-		const FALLBACK_BODY = 'Your friend just completed their daily mile. Time to lace up!';
-		let body = FALLBACK_BODY;
-		try {
-			const stats = await getTodayStats(userId);
-			if (stats.miles > 0) {
-				const parts = [formatMiles(stats.miles), formatDuration(stats.durationSeconds)];
-				if (stats.bestSplitPaceSecMi != null && stats.bestSplitPaceSecMi > 0) {
-					parts.push(`best pace ${formatPace(stats.bestSplitPaceSecMi)}`);
-				}
-				body = parts.join(' · ');
-			}
-		} catch (err: any) {
-			console.error('[Notifications] Error building mile completion stats body, using fallback:', err.message);
-		}
+    // Build a stat-line body. If stats fail or are degenerate, fall back to
+    // the generic body so the notification still goes out.
+    const FALLBACK_BODY =
+      "Your friend just completed their daily mile. Time to lace up!";
+    let body = FALLBACK_BODY;
+    try {
+      const stats = await getTodayStats(userId);
+      if (stats.miles > 0) {
+        const parts = [
+          formatMiles(stats.miles),
+          formatDuration(stats.durationSeconds),
+        ];
+        if (stats.bestSplitPaceSecMi != null && stats.bestSplitPaceSecMi > 0) {
+          parts.push(`best pace ${formatPace(stats.bestSplitPaceSecMi)}`);
+        }
+        body = parts.join(" · ");
+      }
+    } catch (err: any) {
+      console.error(
+        "[Notifications] Error building mile completion stats body, using fallback:",
+        err.message,
+      );
+    }
 
-		const payload = {
-			title,
-			body,
-			type: 'friend_activity' as const,
-			category: 'FRIEND_ACTIVITY',
-			data: { user_id: userId, kind: 'mile_completed', local_date: localDate }
-		};
+    const payload = {
+      title,
+      body,
+      type: "friend_activity" as const,
+      category: "FRIEND_ACTIVITY",
+      data: { user_id: userId, kind: "mile_completed", local_date: localDate },
+    };
 
-		// 'ask' — queue for the sender's explicit confirmation instead of sending.
-		if (outgoing === 'ask') {
-			await queuePendingFriendNotification(
-				userId,
-				'mile_completed',
-				audienceActivity,
-				recentWorkout?.workout_id ?? null,
-				payload
-			);
-			return true;
-		}
+    // 'ask' — queue for the sender's explicit confirmation instead of sending.
+    if (outgoing === "ask") {
+      await queuePendingFriendNotification(
+        userId,
+        "mile_completed",
+        audienceActivity,
+        recentWorkout?.workout_id ?? null,
+        payload,
+      );
+      return true;
+    }
 
-		const allowedRecipients = await getFriendActivityRecipientPool(userId, outgoing, 'mile_completed', audienceActivity);
-		if (allowedRecipients.length === 0) return true;
+    const allowedRecipients = await getFriendActivityRecipientPool(
+      userId,
+      outgoing,
+      "mile_completed",
+      audienceActivity,
+    );
+    if (allowedRecipients.length === 0) return true;
 
-		for (const recipientId of allowedRecipients) {
-			sendPush(recipientId, payload).catch(err => console.error('[Push] Error sending friend activity:', err.message));
-		}
+    for (const recipientId of allowedRecipients) {
+      sendPush(recipientId, payload).catch((err) =>
+        console.error("[Push] Error sending friend activity:", err.message),
+      );
+    }
 
-		if (allowedRecipients.length > 0) {
-			console.log(`[Notifications] Sent mile completion to ${allowedRecipients.length} recipients of ${user.username}`);
-		}
-		return true;
-	} catch (err: any) {
-		console.error('[Notifications] Error notifying friends of mile completion:', err.message);
-		return false;
-	}
+    if (allowedRecipients.length > 0) {
+      console.log(
+        `[Notifications] Sent mile completion to ${allowedRecipients.length} recipients of ${user.username}`,
+      );
+    }
+    return true;
+  } catch (err: any) {
+    console.error(
+      "[Notifications] Error notifying friends of mile completion:",
+      err.message,
+    );
+    return false;
+  }
 }
 
 /**
  * Notify friends when a user logs an additional run/walk after they've already
  * completed their daily mile. Dedup'd per workout via milestone_notifications.
  */
-export async function notifyFriendsOfExtraWorkout(userId: string, workoutId: string): Promise<void> {
-	return notifyFriendsOfWorkoutEvent(userId, workoutId, 'extra_workout');
+export async function notifyFriendsOfExtraWorkout(
+  userId: string,
+  workoutId: string,
+): Promise<void> {
+  return notifyFriendsOfWorkoutEvent(userId, workoutId, "extra_workout");
 }
 
 /**
@@ -217,8 +277,11 @@ export async function notifyFriendsOfExtraWorkout(userId: string, workoutId: str
  * (and that didn't complete it). Opt-in: the system default outgoing audience
  * for 'workout' is 'none', so nothing sends unless the user enables it.
  */
-export async function notifyFriendsOfWorkout(userId: string, workoutId: string): Promise<void> {
-	return notifyFriendsOfWorkoutEvent(userId, workoutId, 'workout');
+export async function notifyFriendsOfWorkout(
+  userId: string,
+  workoutId: string,
+): Promise<void> {
+  return notifyFriendsOfWorkoutEvent(userId, workoutId, "workout");
 }
 
 /**
@@ -227,131 +290,168 @@ export async function notifyFriendsOfWorkout(userId: string, workoutId: string):
  * milestone_notifications key `${eventType}:${workoutId}`.
  */
 async function notifyFriendsOfWorkoutEvent(
-	userId: string,
-	workoutId: string,
-	eventType: 'extra_workout' | 'workout'
+  userId: string,
+  workoutId: string,
+  eventType: "extra_workout" | "workout",
 ): Promise<void> {
-	try {
-		const [workout] = await db.query<{
-			workout_type: string;
-			distance: number | string;
-			total_duration: number | string;
-			local_date: string;
-		}>(
-			`SELECT workout_type, distance, total_duration, local_date::text AS local_date
+  try {
+    const [workout] = await db.query<{
+      workout_type: string;
+      distance: number | string;
+      total_duration: number | string;
+      local_date: string;
+    }>(
+      `SELECT workout_type, distance, total_duration, local_date::text AS local_date
 			FROM workouts
-			WHERE user_id = $1 AND workout_id = $2`,
-			[userId, workoutId]
-		);
-		if (!workout) return;
+			WHERE user_id = $1 AND workout_id = $2 AND deleted_at IS NULL AND exclusion_reason IS NULL`,
+      [userId, workoutId],
+    );
+    if (!workout) return;
 
-		const type = workout.workout_type;
-		if (type !== 'running' && type !== 'walking') return;
+    const type = workout.workout_type;
+    if (type !== "running" && type !== "walking") return;
 
-		const distance = Number(workout.distance);
-		const duration = Number(workout.total_duration);
-		if (!(distance > 0)) return;
+    const distance = Number(workout.distance);
+    const duration = Number(workout.total_duration);
+    if (!(distance > 0)) return;
 
-		// Today-only guard: historical/backfill uploads must not announce old
-		// workouts (and must not claim the milestone slot — a same-day re-upload
-		// of a legitimately-new workout should still be able to fire).
-		const localDate = await getUserLocalDate(userId);
-		if (workout.local_date !== localDate) return;
+    // Today-only guard: historical/backfill uploads must not announce old
+    // workouts (and must not claim the milestone slot — a same-day re-upload
+    // of a legitimately-new workout should still be able to fire).
+    const localDate = await getUserLocalDate(userId);
+    if (workout.local_date !== localDate) return;
 
-		// Cross-type guard: a workout already announced under the sibling event
-		// type must not fire again (e.g. a pre-goal 'workout' getting re-uploaded
-		// after the mile is complete would otherwise also fire as 'extra_workout').
-		const siblingKey = `${eventType === 'workout' ? 'extra_workout' : 'workout'}:${workoutId}`;
-		const [sibling] = await db.query(`SELECT 1 FROM milestone_notifications WHERE milestone_key = $1`, [siblingKey]);
-		if (sibling) return;
+    // Cross-type guard: a workout already announced under the sibling event
+    // type must not fire again (e.g. a pre-goal 'workout' getting re-uploaded
+    // after the mile is complete would otherwise also fire as 'extra_workout').
+    const siblingKey = `${eventType === "workout" ? "extra_workout" : "workout"}:${workoutId}`;
+    const [sibling] = await db.query(
+      `SELECT 1 FROM milestone_notifications WHERE milestone_key = $1`,
+      [siblingKey],
+    );
+    if (sibling) return;
 
-		// Atomically claim per-workout slot to avoid re-firing on re-upload.
-		const milestoneKey = `${eventType}:${workoutId}`;
-		const claimed = await db.query(
-			`INSERT INTO milestone_notifications (milestone_key, user_id) VALUES ($1, $2)
+    // Atomically claim per-workout slot to avoid re-firing on re-upload.
+    const milestoneKey = `${eventType}:${workoutId}`;
+    const claimed = await db.query(
+      `INSERT INTO milestone_notifications (milestone_key, user_id) VALUES ($1, $2)
 			ON CONFLICT (milestone_key) DO NOTHING
 			RETURNING id`,
-			[milestoneKey, userId]
-		);
-		if (claimed.length === 0) return;
+      [milestoneKey, userId],
+    );
+    if (claimed.length === 0) return;
 
-		const activity = type === 'running' ? 'run' : 'walk';
+    const activity = type === "running" ? "run" : "walk";
 
-		// Outgoing audience (dedupe slot is already claimed, so 'none'/'ask' won't refire).
-		const outgoing = await resolveAudience(userId, 'outgoing', eventType, activity);
-		if (outgoing === 'none') return;
+    // Outgoing audience (dedupe slot is already claimed, so 'none'/'ask' won't refire).
+    const outgoing = await resolveAudience(
+      userId,
+      "outgoing",
+      eventType,
+      activity,
+    );
+    if (outgoing === "none") return;
 
-		const [user] = await db.query('SELECT username FROM users WHERE user_id = $1', [userId]);
-		if (!user) return;
+    const [user] = await db.query(
+      "SELECT username FROM users WHERE user_id = $1",
+      [userId],
+    );
+    if (!user) return;
 
-		// Best pace for THIS workout: min split pace where split is ~full mile,
-		// else workout average if the workout itself is ~full mile.
-		let bestPace: number | null = null;
-		const [paceRow] = await db.query<{ pace: number | string | null }>(
-			`SELECT MIN(split_pace) AS pace
+    // Best pace for THIS workout: min split pace where split is ~full mile,
+    // else workout average if the workout itself is ~full mile.
+    let bestPace: number | null = null;
+    const [paceRow] = await db.query<{ pace: number | string | null }>(
+      `SELECT MIN(split_pace) AS pace
 			FROM workout_splits
 			WHERE workout_id = $1 AND split_distance >= 0.95 AND split_pace > 0`,
-			[workoutId]
-		);
-		if (paceRow?.pace != null) bestPace = Number(paceRow.pace);
-		if (bestPace == null && distance >= 0.95 && duration > 0) {
-			bestPace = duration / distance;
-		}
+      [workoutId],
+    );
+    if (paceRow?.pace != null) bestPace = Number(paceRow.pace);
+    if (bestPace == null && distance >= 0.95 && duration > 0) {
+      bestPace = duration / distance;
+    }
 
-		const todayMiles = await getTodayMiles(userId);
+    const todayMiles = await getTodayMiles(userId);
 
-		const title = `${user.username} completed a ${activity}`;
-		const parts = [formatMiles(distance), formatDuration(duration)];
-		if (bestPace != null && bestPace > 0) parts.push(`best pace ${formatPace(bestPace)}`);
-		if (todayMiles > 0) parts.push(`${formatMiles(Number(todayMiles))} today`);
-		const body = parts.join(' · ');
+    const title = `${user.username} completed a ${activity}`;
+    const parts = [formatMiles(distance), formatDuration(duration)];
+    if (bestPace != null && bestPace > 0)
+      parts.push(`best pace ${formatPace(bestPace)}`);
+    if (todayMiles > 0) parts.push(`${formatMiles(Number(todayMiles))} today`);
+    const body = parts.join(" · ");
 
-		// Runner's local date (fetched above for the today-only guard) — hype
-		// dedupe key for clients (see mile-completion note).
-		const payload = {
-			title,
-			body,
-			type: 'friend_activity' as const,
-			category: 'FRIEND_ACTIVITY',
-			data: { user_id: userId, kind: eventType, workout_id: workoutId, local_date: localDate }
-		};
+    // Runner's local date (fetched above for the today-only guard) — hype
+    // dedupe key for clients (see mile-completion note).
+    const payload = {
+      title,
+      body,
+      type: "friend_activity" as const,
+      category: "FRIEND_ACTIVITY",
+      data: {
+        user_id: userId,
+        kind: eventType,
+        workout_id: workoutId,
+        local_date: localDate,
+      },
+    };
 
-		// 'ask' — queue for the sender's explicit confirmation instead of sending.
-		if (outgoing === 'ask') {
-			await queuePendingFriendNotification(userId, eventType, activity, workoutId, payload);
-			return;
-		}
+    // 'ask' — queue for the sender's explicit confirmation instead of sending.
+    if (outgoing === "ask") {
+      await queuePendingFriendNotification(
+        userId,
+        eventType,
+        activity,
+        workoutId,
+        payload,
+      );
+      return;
+    }
 
-		// Same recipient pool as mile-completion: friends + active-competition co-participants.
-		const allowedRecipients = await getFriendActivityRecipientPool(userId, outgoing, eventType, activity);
-		if (allowedRecipients.length === 0) return;
+    // Same recipient pool as mile-completion: friends + active-competition co-participants.
+    const allowedRecipients = await getFriendActivityRecipientPool(
+      userId,
+      outgoing,
+      eventType,
+      activity,
+    );
+    if (allowedRecipients.length === 0) return;
 
-		for (const recipientId of allowedRecipients) {
-			sendPush(recipientId, payload).catch(err =>
-				console.error(`[Push] Error sending ${eventType} notification:`, err.message)
-			);
-		}
+    for (const recipientId of allowedRecipients) {
+      sendPush(recipientId, payload).catch((err) =>
+        console.error(
+          `[Push] Error sending ${eventType} notification:`,
+          err.message,
+        ),
+      );
+    }
 
-		if (allowedRecipients.length > 0) {
-			console.log(
-				`[Notifications] Sent ${eventType} (${activity}) to ${allowedRecipients.length} recipients of ${user.username}`
-			);
-		}
-	} catch (err: any) {
-		console.error(`[Notifications] Error notifying friends of ${eventType}:`, err.message);
-	}
+    if (allowedRecipients.length > 0) {
+      console.log(
+        `[Notifications] Sent ${eventType} (${activity}) to ${allowedRecipients.length} recipients of ${user.username}`,
+      );
+    }
+  } catch (err: any) {
+    console.error(
+      `[Notifications] Error notifying friends of ${eventType}:`,
+      err.message,
+    );
+  }
 }
 
 // ─── Competition Milestone Notifications ────────────────────────────
 
 const MAX_MILESTONE_PUSHES_PER_RECIPIENT_PER_TRIGGER = 2;
 
-function tryReserveRecipientSlot(notifiedRecipients: Map<string, number> | undefined, recipientId: string): boolean {
-	if (!notifiedRecipients) return true;
-	const count = notifiedRecipients.get(recipientId) ?? 0;
-	if (count >= MAX_MILESTONE_PUSHES_PER_RECIPIENT_PER_TRIGGER) return false;
-	notifiedRecipients.set(recipientId, count + 1);
-	return true;
+function tryReserveRecipientSlot(
+  notifiedRecipients: Map<string, number> | undefined,
+  recipientId: string,
+): boolean {
+  if (!notifiedRecipients) return true;
+  const count = notifiedRecipients.get(recipientId) ?? 0;
+  if (count >= MAX_MILESTONE_PUSHES_PER_RECIPIENT_PER_TRIGGER) return false;
+  notifiedRecipients.set(recipientId, count + 1);
+  return true;
 }
 
 /**
@@ -366,11 +466,14 @@ function tryReserveRecipientSlot(notifiedRecipients: Map<string, number> | undef
  * multiple shared competitions. Each recipient is capped at
  * MAX_MILESTONE_PUSHES_PER_RECIPIENT_PER_TRIGGER pushes per trigger.
  */
-export async function checkCompetitionMilestones(userId: string, notifiedRecipients?: Map<string, number>): Promise<void> {
-	try {
-		// Get all active competitions for this user
-		const activeComps = await db.query<Competition & { id: string }>(
-			`SELECT c.*
+export async function checkCompetitionMilestones(
+  userId: string,
+  notifiedRecipients?: Map<string, number>,
+): Promise<void> {
+  try {
+    // Get all active competitions for this user
+    const activeComps = await db.query<Competition & { id: string }>(
+      `SELECT c.*
 			FROM competitions c
 			JOIN competition_users cu ON cu.competition_id = c.id
 			WHERE cu.user_id = $1
@@ -379,99 +482,130 @@ export async function checkCompetitionMilestones(userId: string, notifiedRecipie
 				AND c.start_date <= NOW()
 				AND c.winner IS NULL
 				AND (c.end_date IS NULL OR c.end_date > NOW())`,
-			[userId]
-		);
+      [userId],
+    );
 
-		if (activeComps.length === 0) return;
+    if (activeComps.length === 0) return;
 
-		const [user] = await db.query('SELECT username FROM users WHERE user_id = $1', [userId]);
-		const username = user?.username || 'Someone';
+    const [user] = await db.query(
+      "SELECT username FROM users WHERE user_id = $1",
+      [userId],
+    );
+    const username = user?.username || "Someone";
 
-		for (const comp of activeComps) {
-			try {
-				await checkMilestonesForCompetition(comp, userId, username, notifiedRecipients);
-			} catch (err: any) {
-				console.error(`[Milestones] Error checking comp ${comp.id}:`, err.message);
-			}
-		}
-	} catch (err: any) {
-		console.error('[Milestones] Error checking competition milestones:', err.message);
-	}
+    for (const comp of activeComps) {
+      try {
+        await checkMilestonesForCompetition(
+          comp,
+          userId,
+          username,
+          notifiedRecipients,
+        );
+      } catch (err: any) {
+        console.error(
+          `[Milestones] Error checking comp ${comp.id}:`,
+          err.message,
+        );
+      }
+    }
+  } catch (err: any) {
+    console.error(
+      "[Milestones] Error checking competition milestones:",
+      err.message,
+    );
+  }
 }
 
 async function checkMilestonesForCompetition(
-	comp: Competition & { id: string },
-	userId: string,
-	username: string,
-	notifiedRecipients?: Map<string, number>
+  comp: Competition & { id: string },
+  userId: string,
+  username: string,
+  notifiedRecipients?: Map<string, number>,
 ): Promise<void> {
-	const fullComp = await getCompetition(comp.id);
-	if (!fullComp) return;
+  const fullComp = await getCompetition(comp.id);
+  if (!fullComp) return;
 
-	const scores = await getUserScores(fullComp);
-	const userScore = scores[userId]?.score ?? 0;
-	const acceptedUsers = fullComp.users.filter((u: CompetitionUser) => u.invite_status === 'accepted');
+  const scores = await getUserScores(fullComp);
+  const userScore = scores[userId]?.score ?? 0;
+  const acceptedUsers = fullComp.users.filter(
+    (u: CompetitionUser) => u.invite_status === "accepted",
+  );
 
-	// Race: 50% milestone
-	if (fullComp.type === 'race') {
-		const halfGoal = fullComp.options.goal / 2;
-		const milestoneKey = `milestone_race_50_${fullComp.id}_${userId}`;
+  // Race: 50% milestone
+  if (fullComp.type === "race") {
+    const halfGoal = fullComp.options.goal / 2;
+    const milestoneKey = `milestone_race_50_${fullComp.id}_${userId}`;
 
-		if (userScore >= halfGoal) {
-			const claimed = await db.query(
-				`INSERT INTO milestone_notifications (milestone_key, competition_id, user_id) VALUES ($1, $2, $3)
+    if (userScore >= halfGoal) {
+      const claimed = await db.query(
+        `INSERT INTO milestone_notifications (milestone_key, competition_id, user_id) VALUES ($1, $2, $3)
 				ON CONFLICT (milestone_key) DO NOTHING RETURNING id`,
-				[milestoneKey, fullComp.id, userId]
-			);
+        [milestoneKey, fullComp.id, userId],
+      );
 
-			if (claimed.length > 0) {
-				for (const u of acceptedUsers) {
-					if (u.user_id === userId) continue;
-					const shouldSend = await shouldSendNotification(u.user_id, null, 'competition_milestone');
-					if (!shouldSend) continue;
-					if (!tryReserveRecipientSlot(notifiedRecipients, u.user_id)) continue;
+      if (claimed.length > 0) {
+        for (const u of acceptedUsers) {
+          if (u.user_id === userId) continue;
+          const shouldSend = await shouldSendNotification(
+            u.user_id,
+            null,
+            "competition_milestone",
+          );
+          if (!shouldSend) continue;
+          if (!tryReserveRecipientSlot(notifiedRecipients, u.user_id)) continue;
 
-					sendPush(u.user_id, {
-						title: 'Race update!',
-						body: `${username} is halfway to the finish in ${fullComp.competition_name}!`,
-						type: 'competition_milestone',
-						data: { competition_id: fullComp.id }
-					}).catch(err => console.error('[Push] milestone error:', err.message));
-				}
-			}
-		}
-	}
+          sendPush(u.user_id, {
+            title: "Race update!",
+            body: `${username} is halfway to the finish in ${fullComp.competition_name}!`,
+            type: "competition_milestone",
+            data: { competition_id: fullComp.id },
+          }).catch((err) =>
+            console.error("[Push] milestone error:", err.message),
+          );
+        }
+      }
+    }
+  }
 
-	// Clash/Targets: 1 point from winning
-	if ((fullComp.type === 'clash' || fullComp.type === 'targets') && fullComp.options.first_to) {
-		const threshold = fullComp.options.first_to - 1;
-		const milestoneKey = `milestone_oneaway_${fullComp.id}_${userId}`;
+  // Clash/Targets: 1 point from winning
+  if (
+    (fullComp.type === "clash" || fullComp.type === "targets") &&
+    fullComp.options.first_to
+  ) {
+    const threshold = fullComp.options.first_to - 1;
+    const milestoneKey = `milestone_oneaway_${fullComp.id}_${userId}`;
 
-		if (userScore === threshold) {
-			const claimed = await db.query(
-				`INSERT INTO milestone_notifications (milestone_key, competition_id, user_id) VALUES ($1, $2, $3)
+    if (userScore === threshold) {
+      const claimed = await db.query(
+        `INSERT INTO milestone_notifications (milestone_key, competition_id, user_id) VALUES ($1, $2, $3)
 				ON CONFLICT (milestone_key) DO NOTHING RETURNING id`,
-				[milestoneKey, fullComp.id, userId]
-			);
+        [milestoneKey, fullComp.id, userId],
+      );
 
-			if (claimed.length > 0) {
-				const modeLabel = fullComp.type === 'clash' ? 'win' : 'point';
-				for (const u of acceptedUsers) {
-					if (u.user_id === userId) continue;
-					const shouldSend = await shouldSendNotification(u.user_id, null, 'competition_milestone');
-					if (!shouldSend) continue;
-					if (!tryReserveRecipientSlot(notifiedRecipients, u.user_id)) continue;
+      if (claimed.length > 0) {
+        const modeLabel = fullComp.type === "clash" ? "win" : "point";
+        for (const u of acceptedUsers) {
+          if (u.user_id === userId) continue;
+          const shouldSend = await shouldSendNotification(
+            u.user_id,
+            null,
+            "competition_milestone",
+          );
+          if (!shouldSend) continue;
+          if (!tryReserveRecipientSlot(notifiedRecipients, u.user_id)) continue;
 
-					sendPush(u.user_id, {
-						title: 'Almost there!',
-						body: `${username} is one ${modeLabel} away from winning ${fullComp.competition_name}!`,
-						type: 'competition_milestone',
-						data: { competition_id: fullComp.id }
-					}).catch(err => console.error('[Push] milestone error:', err.message));
-				}
-			}
-		}
-	}
+          sendPush(u.user_id, {
+            title: "Almost there!",
+            body: `${username} is one ${modeLabel} away from winning ${fullComp.competition_name}!`,
+            type: "competition_milestone",
+            data: { competition_id: fullComp.id },
+          }).catch((err) =>
+            console.error("[Push] milestone error:", err.message),
+          );
+        }
+      }
+    }
+  }
 }
 
 /**
@@ -479,14 +613,16 @@ async function checkMilestonesForCompetition(
  * Should be called once daily (e.g., at 6 PM ET).
  */
 export async function checkCompetitionsEndingSoon(): Promise<void> {
-	try {
-		const formatter = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' });
-		const today = new Date();
-		const tomorrow = new Date(today.getTime() + 24 * 60 * 60 * 1000);
-		const tomorrowStr = formatter.format(tomorrow);
+  try {
+    const formatter = new Intl.DateTimeFormat("en-CA", {
+      timeZone: "America/New_York",
+    });
+    const today = new Date();
+    const tomorrow = new Date(today.getTime() + 24 * 60 * 60 * 1000);
+    const tomorrowStr = formatter.format(tomorrow);
 
-		const endingSoon = await db.query<Competition & { id: string }>(
-			`SELECT c.*, COALESCE(
+    const endingSoon = await db.query<Competition & { id: string }>(
+      `SELECT c.*, COALESCE(
 				jsonb_agg(
 					jsonb_build_object(
 						'competition_id', cu.competition_id,
@@ -503,35 +639,43 @@ export async function checkCompetitionsEndingSoon(): Promise<void> {
 				AND c.start_date IS NOT NULL
 				AND c.start_date <= NOW()
 			GROUP BY c.id`,
-			[tomorrowStr]
-		);
+      [tomorrowStr],
+    );
 
-		for (const comp of endingSoon) {
-			const milestoneKey = `milestone_ending_${comp.id}`;
-			const claimed = await db.query(
-				`INSERT INTO milestone_notifications (milestone_key, competition_id) VALUES ($1, $2)
+    for (const comp of endingSoon) {
+      const milestoneKey = `milestone_ending_${comp.id}`;
+      const claimed = await db.query(
+        `INSERT INTO milestone_notifications (milestone_key, competition_id) VALUES ($1, $2)
 				ON CONFLICT (milestone_key) DO NOTHING RETURNING id`,
-				[milestoneKey, comp.id]
-			);
+        [milestoneKey, comp.id],
+      );
 
-			if (claimed.length === 0) continue;
+      if (claimed.length === 0) continue;
 
-			const acceptedUsers = comp.users.filter((u: any) => u.invite_status === 'accepted');
-			for (const u of acceptedUsers) {
-				const shouldSend = await shouldSendNotification(u.user_id, null, 'competition_milestone');
-				if (!shouldSend) continue;
+      const acceptedUsers = comp.users.filter(
+        (u: any) => u.invite_status === "accepted",
+      );
+      for (const u of acceptedUsers) {
+        const shouldSend = await shouldSendNotification(
+          u.user_id,
+          null,
+          "competition_milestone",
+        );
+        if (!shouldSend) continue;
 
-				sendPush(u.user_id, {
-					title: 'Last chance!',
-					body: `${comp.competition_name} ends tomorrow. Give it everything you've got!`,
-					type: 'competition_milestone',
-					data: { competition_id: comp.id }
-				}).catch(err => console.error('[Push] ending soon error:', err.message));
-			}
-		}
-	} catch (err: any) {
-		console.error('[Milestones] Error checking ending soon:', err.message);
-	}
+        sendPush(u.user_id, {
+          title: "Last chance!",
+          body: `${comp.competition_name} ends tomorrow. Give it everything you've got!`,
+          type: "competition_milestone",
+          data: { competition_id: comp.id },
+        }).catch((err) =>
+          console.error("[Push] ending soon error:", err.message),
+        );
+      }
+    }
+  } catch (err: any) {
+    console.error("[Milestones] Error checking ending soon:", err.message);
+  }
 }
 
 // ─── Streak Broken Notifications ──────────────────────────────────
@@ -542,16 +686,18 @@ export async function checkCompetitionsEndingSoon(): Promise<void> {
  * Called from the midnight cron (checking yesterday's state).
  */
 export async function checkStreaksBroken(): Promise<void> {
-	try {
-		const formatter = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' });
-		const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
-		const yesterdayStr = formatter.format(yesterday);
+  try {
+    const formatter = new Intl.DateTimeFormat("en-CA", {
+      timeZone: "America/New_York",
+    });
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const yesterdayStr = formatter.format(yesterday);
 
-		// Find users who had a workout yesterday-1 but NOT yesterday
-		// by checking all users who had an active streak >= 10 that is now broken
-		// We look for users whose last qualifying day (>= 0.95 mi) was 2+ days ago
-		const brokenStreaks = await db.query(
-			`WITH user_streaks AS (
+    // Find users who had a workout yesterday-1 but NOT yesterday
+    // by checking all users who had an active streak >= 10 that is now broken
+    // We look for users whose last qualifying day (>= 0.95 mi) was 2+ days ago
+    const brokenStreaks = await db.query(
+      `WITH user_streaks AS (
 				SELECT
 					w.user_id,
 					MAX(w.local_date) as last_active_date,
@@ -560,6 +706,7 @@ export async function checkStreaksBroken(): Promise<void> {
 					SELECT user_id, local_date, SUM(distance) as day_total
 					FROM workouts
 					WHERE local_date >= (CURRENT_DATE - INTERVAL '60 days')
+					AND deleted_at IS NULL AND exclusion_reason IS NULL
 					GROUP BY user_id, local_date
 					HAVING SUM(distance) >= 0.95
 				) w
@@ -569,18 +716,19 @@ export async function checkStreaksBroken(): Promise<void> {
 			FROM user_streaks us
 			JOIN users u ON u.user_id = us.user_id
 			WHERE us.last_active_date < $1`,
-			[yesterdayStr]
-		);
+      [yesterdayStr],
+    );
 
-		for (const { user_id, username } of brokenStreaks) {
-			try {
-				// Get their actual streak count before it broke
-				// We need to count consecutive days ending at their last_active_date
-				const streakResult = await db.query(
-					`WITH daily AS (
+    for (const { user_id, username } of brokenStreaks) {
+      try {
+        // Get their actual streak count before it broke
+        // We need to count consecutive days ending at their last_active_date
+        const streakResult = await db.query(
+          `WITH daily AS (
 						SELECT local_date, SUM(distance) as total
 						FROM workouts
 						WHERE user_id = $1 AND local_date <= $2
+						AND deleted_at IS NULL AND exclusion_reason IS NULL
 						GROUP BY local_date
 						HAVING SUM(distance) >= 0.95
 						ORDER BY local_date DESC
@@ -593,71 +741,97 @@ export async function checkStreaksBroken(): Promise<void> {
 					SELECT COUNT(*) as streak_length
 					FROM numbered
 					WHERE grp = (SELECT grp FROM numbered LIMIT 1)`,
-					[user_id, yesterdayStr]
-				);
+          [user_id, yesterdayStr],
+        );
 
-				const streakLength = parseInt(streakResult[0]?.streak_length ?? '0');
-				if (streakLength < 10) continue;
+        const streakLength = parseInt(streakResult[0]?.streak_length ?? "0");
+        if (streakLength < 10) continue;
 
-				const milestoneKey = `streak_broken_${user_id}_${yesterdayStr}`;
-				const claimed = await db.query(
-					`INSERT INTO milestone_notifications (milestone_key, user_id) VALUES ($1, $2)
+        const milestoneKey = `streak_broken_${user_id}_${yesterdayStr}`;
+        const claimed = await db.query(
+          `INSERT INTO milestone_notifications (milestone_key, user_id) VALUES ($1, $2)
 					ON CONFLICT (milestone_key) DO NOTHING RETURNING id`,
-					[milestoneKey, user_id]
-				);
-				if (claimed.length === 0) continue;
+          [milestoneKey, user_id],
+        );
+        if (claimed.length === 0) continue;
 
-				// Outgoing audience (milestone slot already claimed, so 'none'/'ask' won't refire).
-				const outgoing = await resolveAudience(user_id, 'outgoing', 'streak_broken', '');
-				if (outgoing === 'none') continue;
+        // Outgoing audience (milestone slot already claimed, so 'none'/'ask' won't refire).
+        const outgoing = await resolveAudience(
+          user_id,
+          "outgoing",
+          "streak_broken",
+          "",
+        );
+        if (outgoing === "none") continue;
 
-				const payload = {
-					title: 'Streak broken!',
-					body: `${username}'s ${streakLength}-day streak just ended. Send them some encouragement!`,
-					type: 'friend_activity' as const,
-					data: { user_id, kind: 'streak_broken' }
-				};
+        const payload = {
+          title: "Streak broken!",
+          body: `${username}'s ${streakLength}-day streak just ended. Send them some encouragement!`,
+          type: "friend_activity" as const,
+          data: { user_id, kind: "streak_broken" },
+        };
 
-				// 'ask' — queue for the user's explicit confirmation instead of sending.
-				if (outgoing === 'ask') {
-					await queuePendingFriendNotification(user_id, 'streak_broken', '', null, payload);
-					continue;
-				}
+        // 'ask' — queue for the user's explicit confirmation instead of sending.
+        if (outgoing === "ask") {
+          await queuePendingFriendNotification(
+            user_id,
+            "streak_broken",
+            "",
+            null,
+            payload,
+          );
+          continue;
+        }
 
-				// Notify their friends
-				const friends = await db.query(`SELECT friend_id FROM friendships WHERE user_id = $1 AND status = 'accepted'`, [
-					user_id
-				]);
+        // Notify their friends
+        const friends = await db.query(
+          `SELECT friend_id FROM friendships WHERE user_id = $1 AND status = 'accepted'`,
+          [user_id],
+        );
 
-				let friendIds = friends.map((r: any) => r.friend_id as string);
-				if (outgoing === 'close') {
-					friendIds = await restrictToCloseFriends(user_id, friendIds);
-				}
-				// Recipient-side audience pass (their incoming setting for this event).
-				friendIds = await filterByIncomingAudience(friendIds, user_id, 'streak_broken', '');
+        let friendIds = friends.map((r: any) => r.friend_id as string);
+        if (outgoing === "close") {
+          friendIds = await restrictToCloseFriends(user_id, friendIds);
+        }
+        // Recipient-side audience pass (their incoming setting for this event).
+        friendIds = await filterByIncomingAudience(
+          friendIds,
+          user_id,
+          "streak_broken",
+          "",
+        );
 
-				let sentCount = 0;
-				for (const friend_id of friendIds) {
-					if (sentCount >= 10) break;
-					const shouldSend = await shouldSendNotification(friend_id, user_id, 'friend_activity');
-					if (!shouldSend) continue;
+        let sentCount = 0;
+        for (const friend_id of friendIds) {
+          if (sentCount >= 10) break;
+          const shouldSend = await shouldSendNotification(
+            friend_id,
+            user_id,
+            "friend_activity",
+          );
+          if (!shouldSend) continue;
 
-					sendPush(friend_id, payload).catch(err => console.error('[Push] streak broken error:', err.message));
-					sentCount++;
-				}
+          sendPush(friend_id, payload).catch((err) =>
+            console.error("[Push] streak broken error:", err.message),
+          );
+          sentCount++;
+        }
 
-				if (sentCount > 0) {
-					console.log(
-						`[Notifications] Sent streak broken (${streakLength} days) for ${username} to ${sentCount} friends`
-					);
-				}
-			} catch (err: any) {
-				console.error(`[Notifications] Error checking streak broken for ${user_id}:`, err.message);
-			}
-		}
-	} catch (err: any) {
-		console.error('[Notifications] Error in checkStreaksBroken:', err.message);
-	}
+        if (sentCount > 0) {
+          console.log(
+            `[Notifications] Sent streak broken (${streakLength} days) for ${username} to ${sentCount} friends`,
+          );
+        }
+      } catch (err: any) {
+        console.error(
+          `[Notifications] Error checking streak broken for ${user_id}:`,
+          err.message,
+        );
+      }
+    }
+  } catch (err: any) {
+    console.error("[Notifications] Error in checkStreaksBroken:", err.message);
+  }
 }
 
 // ─── Lead Change Notifications ─────────────────────────────────────
@@ -681,10 +855,13 @@ export async function checkStreaksBroken(): Promise<void> {
  * for a single workout-upload trigger so the same recipient is not spammed across
  * multiple shared competitions.
  */
-export async function checkLeadChanges(userId: string, notifiedRecipients?: Map<string, number>): Promise<void> {
-	try {
-		const activeComps = await db.query<Competition & { id: string }>(
-			`SELECT c.*
+export async function checkLeadChanges(
+  userId: string,
+  notifiedRecipients?: Map<string, number>,
+): Promise<void> {
+  try {
+    const activeComps = await db.query<Competition & { id: string }>(
+      `SELECT c.*
 			FROM competitions c
 			JOIN competition_users cu ON cu.competition_id = c.id
 			WHERE cu.user_id = $1
@@ -694,178 +871,211 @@ export async function checkLeadChanges(userId: string, notifiedRecipients?: Map<
 				AND c.winner IS NULL
 				AND (c.end_date IS NULL OR c.end_date > NOW())
 				AND c.type IN ('clash', 'apex', 'race', 'targets')`,
-			[userId]
-		);
+      [userId],
+    );
 
-		if (activeComps.length === 0) return;
+    if (activeComps.length === 0) return;
 
-		const [user] = await db.query('SELECT username FROM users WHERE user_id = $1', [userId]);
-		const username = user?.username || 'Someone';
+    const [user] = await db.query(
+      "SELECT username FROM users WHERE user_id = $1",
+      [userId],
+    );
+    const username = user?.username || "Someone";
 
-		for (const comp of activeComps) {
-			try {
-				const fullComp = await getCompetition(comp.id);
-				if (!fullComp) continue;
+    for (const comp of activeComps) {
+      try {
+        const fullComp = await getCompetition(comp.id);
+        if (!fullComp) continue;
 
-				const acceptedUsers = fullComp.users.filter((u: CompetitionUser) => u.invite_status === 'accepted');
-				if (acceptedUsers.length < 2) continue;
+        const acceptedUsers = fullComp.users.filter(
+          (u: CompetitionUser) => u.invite_status === "accepted",
+        );
+        if (acceptedUsers.length < 2) continue;
 
-				// Snapshot previous (cached) ranks BEFORE we recompute. Users
-				// with NULL cache values are treated as "no known prior" — we
-				// won't fire dethrone notifications until they've been
-				// indexed at least once.
-				const cachedRows = await db.query<{
-					user_id: string;
-					last_known_rank: number | null;
-					last_known_score: number | null;
-				}>(
-					`SELECT user_id, last_known_rank, last_known_score
+        // Snapshot previous (cached) ranks BEFORE we recompute. Users
+        // with NULL cache values are treated as "no known prior" — we
+        // won't fire dethrone notifications until they've been
+        // indexed at least once.
+        const cachedRows = await db.query<{
+          user_id: string;
+          last_known_rank: number | null;
+          last_known_score: number | null;
+        }>(
+          `SELECT user_id, last_known_rank, last_known_score
 					FROM competition_users
 					WHERE competition_id = $1 AND invite_status = 'accepted'`,
-					[comp.id]
-				);
-				const previousRank = new Map<string, number | null>();
-				for (const row of cachedRows) {
-					previousRank.set(row.user_id, row.last_known_rank);
-				}
+          [comp.id],
+        );
+        const previousRank = new Map<string, number | null>();
+        for (const row of cachedRows) {
+          previousRank.set(row.user_id, row.last_known_rank);
+        }
 
-				// Compute current scores + ranks.
-				const scores = await getUserScores(fullComp);
-				const ranked = [...acceptedUsers]
-					.map(u => ({
-						user_id: u.user_id,
-						displayName: (u as any).username || u.user_id,
-						score: scores[u.user_id]?.score ?? 0
-					}))
-					.sort((a, b) => b.score - a.score);
+        // Compute current scores + ranks.
+        const scores = await getUserScores(fullComp);
+        const ranked = [...acceptedUsers]
+          .map((u) => ({
+            user_id: u.user_id,
+            displayName: (u as any).username || u.user_id,
+            score: scores[u.user_id]?.score ?? 0,
+          }))
+          .sort((a, b) => b.score - a.score);
 
-				const newRankByUser = new Map<string, number>();
-				const newScoreByUser = new Map<string, number>();
-				ranked.forEach((r, idx) => {
-					newRankByUser.set(r.user_id, idx + 1);
-					newScoreByUser.set(r.user_id, r.score);
-				});
+        const newRankByUser = new Map<string, number>();
+        const newScoreByUser = new Map<string, number>();
+        ranked.forEach((r, idx) => {
+          newRankByUser.set(r.user_id, idx + 1);
+          newScoreByUser.set(r.user_id, r.score);
+        });
 
-				const newLeader = ranked[0];
-				const isTied = ranked.length >= 2 && ranked[0].score === ranked[1].score;
-				const leaderId = isTied ? null : (newLeader?.user_id ?? null);
-				const maxScore = newLeader?.score ?? 0;
+        const newLeader = ranked[0];
+        const isTied =
+          ranked.length >= 2 && ranked[0].score === ranked[1].score;
+        const leaderId = isTied ? null : (newLeader?.user_id ?? null);
+        const maxScore = newLeader?.score ?? 0;
 
-				// Per-interval dedup key. For race/apex (no interval option),
-				// getCurrentInterval falls through to a daily key — fine, since
-				// those comps don't reset and the previousRank guard below
-				// prevents re-firing once you're already leading.
-				const intervalKey = getCurrentInterval(new Date(), fullComp.options.interval, fullComp.start_date);
+        // Per-interval dedup key. For race/apex (no interval option),
+        // getCurrentInterval falls through to a daily key — fine, since
+        // those comps don't reset and the previousRank guard below
+        // prevents re-firing once you're already leading.
+        const intervalKey = getCurrentInterval(
+          new Date(),
+          fullComp.options.interval,
+          fullComp.start_date,
+        );
 
-				// ── Path 1: uploader just took the lead.
-				// Only fire if they weren't already the leader going into this
-				// upload — otherwise "you just took the lead" is a lie. NULL
-				// prior (never indexed) counts as "not previously leader" so
-				// the very first upload can still notify.
-				const uploaderPrevRank = previousRank.get(userId);
-				const uploaderWasAlreadyLeader = uploaderPrevRank === 1;
-				if (leaderId === userId && !isTied && maxScore > 0 && !uploaderWasAlreadyLeader) {
-					const milestoneKey = `lead_change_${comp.id}_${userId}_${intervalKey}`;
-					const claimed = await db.query(
-						`INSERT INTO milestone_notifications (milestone_key, competition_id, user_id) VALUES ($1, $2, $3)
+        // ── Path 1: uploader just took the lead.
+        // Only fire if they weren't already the leader going into this
+        // upload — otherwise "you just took the lead" is a lie. NULL
+        // prior (never indexed) counts as "not previously leader" so
+        // the very first upload can still notify.
+        const uploaderPrevRank = previousRank.get(userId);
+        const uploaderWasAlreadyLeader = uploaderPrevRank === 1;
+        if (
+          leaderId === userId &&
+          !isTied &&
+          maxScore > 0 &&
+          !uploaderWasAlreadyLeader
+        ) {
+          const milestoneKey = `lead_change_${comp.id}_${userId}_${intervalKey}`;
+          const claimed = await db.query(
+            `INSERT INTO milestone_notifications (milestone_key, competition_id, user_id) VALUES ($1, $2, $3)
 						ON CONFLICT (milestone_key) DO NOTHING RETURNING id`,
-						[milestoneKey, comp.id, userId]
-					);
-					if (claimed.length > 0) {
-						for (const u of acceptedUsers) {
-							if (u.user_id === userId) continue;
-							const shouldSend = await shouldSendNotification(u.user_id, null, 'competition_milestone');
-							if (!shouldSend) continue;
-							if (!tryReserveRecipientSlot(notifiedRecipients, u.user_id)) continue;
+            [milestoneKey, comp.id, userId],
+          );
+          if (claimed.length > 0) {
+            for (const u of acceptedUsers) {
+              if (u.user_id === userId) continue;
+              const shouldSend = await shouldSendNotification(
+                u.user_id,
+                null,
+                "competition_milestone",
+              );
+              if (!shouldSend) continue;
+              if (!tryReserveRecipientSlot(notifiedRecipients, u.user_id))
+                continue;
 
-							sendPush(u.user_id, {
-								title: 'Lead change!',
-								body: `${username} just took the lead in ${fullComp.competition_name}!`,
-								type: 'competition_milestone',
-								data: { competition_id: fullComp.id }
-							}).catch(err => console.error('[Push] lead change error:', err.message));
-						}
+              sendPush(u.user_id, {
+                title: "Lead change!",
+                body: `${username} just took the lead in ${fullComp.competition_name}!`,
+                type: "competition_milestone",
+                data: { competition_id: fullComp.id },
+              }).catch((err) =>
+                console.error("[Push] lead change error:", err.message),
+              );
+            }
 
-						sendPush(userId, {
-							title: "You're in first!",
-							body: `You just took the lead in ${fullComp.competition_name}! Keep it up!`,
-							type: 'competition_milestone',
-							data: { competition_id: fullComp.id }
-						}).catch(err => console.error('[Push] lead self error:', err.message));
-					}
-				}
+            sendPush(userId, {
+              title: "You're in first!",
+              body: `You just took the lead in ${fullComp.competition_name}! Keep it up!`,
+              type: "competition_milestone",
+              data: { competition_id: fullComp.id },
+            }).catch((err) =>
+              console.error("[Push] lead self error:", err.message),
+            );
+          }
+        }
 
-				// ── Path 2: someone WAS the leader and isn't anymore.
-				// Find users whose cached rank was 1 and whose new rank > 1.
-				// In most cases this is exactly one user; we still loop to be
-				// safe against odd cached state from a prior tie.
-				for (const u of acceptedUsers) {
-					const prior = previousRank.get(u.user_id);
-					const fresh = newRankByUser.get(u.user_id) ?? acceptedUsers.length;
-					if (prior !== 1 || fresh <= 1) continue;
-					// Don't notify the user who took the lead themselves.
-					if (u.user_id === userId) continue;
+        // ── Path 2: someone WAS the leader and isn't anymore.
+        // Find users whose cached rank was 1 and whose new rank > 1.
+        // In most cases this is exactly one user; we still loop to be
+        // safe against odd cached state from a prior tie.
+        for (const u of acceptedUsers) {
+          const prior = previousRank.get(u.user_id);
+          const fresh = newRankByUser.get(u.user_id) ?? acceptedUsers.length;
+          if (prior !== 1 || fresh <= 1) continue;
+          // Don't notify the user who took the lead themselves.
+          if (u.user_id === userId) continue;
 
-					const dethroneKey = `lead_lost_${comp.id}_${u.user_id}_${intervalKey}`;
-					const claimed = await db.query(
-						`INSERT INTO milestone_notifications (milestone_key, competition_id, user_id) VALUES ($1, $2, $3)
+          const dethroneKey = `lead_lost_${comp.id}_${u.user_id}_${intervalKey}`;
+          const claimed = await db.query(
+            `INSERT INTO milestone_notifications (milestone_key, competition_id, user_id) VALUES ($1, $2, $3)
 						ON CONFLICT (milestone_key) DO NOTHING RETURNING id`,
-						[dethroneKey, comp.id, u.user_id]
-					);
-					if (claimed.length === 0) continue;
+            [dethroneKey, comp.id, u.user_id],
+          );
+          if (claimed.length === 0) continue;
 
-					const shouldSend = await shouldSendNotification(u.user_id, null, 'competition_milestone');
-					if (!shouldSend) continue;
-					if (!tryReserveRecipientSlot(notifiedRecipients, u.user_id)) continue;
+          const shouldSend = await shouldSendNotification(
+            u.user_id,
+            null,
+            "competition_milestone",
+          );
+          if (!shouldSend) continue;
+          if (!tryReserveRecipientSlot(notifiedRecipients, u.user_id)) continue;
 
-					const newLeaderScore = newScoreByUser.get(leaderId ?? '') ?? 0;
-					const myScore = newScoreByUser.get(u.user_id) ?? 0;
-					const gap = newLeaderScore - myScore;
-					const unitText = formatGapForType(fullComp.type, gap);
+          const newLeaderScore = newScoreByUser.get(leaderId ?? "") ?? 0;
+          const myScore = newScoreByUser.get(u.user_id) ?? 0;
+          const gap = newLeaderScore - myScore;
+          const unitText = formatGapForType(fullComp.type, gap);
 
-					sendPush(u.user_id, {
-						title: 'You lost 1st!',
-						body: `${username} passed you in ${fullComp.competition_name}. They're ${unitText} ahead — go take it back!`,
-						type: 'competition_milestone',
-						data: { competition_id: fullComp.id, kind: 'lead_lost' }
-					}).catch(err => console.error('[Push] lead lost error:', err.message));
-				}
+          sendPush(u.user_id, {
+            title: "You lost 1st!",
+            body: `${username} passed you in ${fullComp.competition_name}. They're ${unitText} ahead — go take it back!`,
+            type: "competition_milestone",
+            data: { competition_id: fullComp.id, kind: "lead_lost" },
+          }).catch((err) =>
+            console.error("[Push] lead lost error:", err.message),
+          );
+        }
 
-				// ── Persist the new ranks so the next upload's comparison
-				// has fresh values. One UPDATE per user; could be batched
-				// later if the row count grows.
-				for (const [uid, rank] of newRankByUser.entries()) {
-					const score = newScoreByUser.get(uid) ?? 0;
-					await db.query(
-						`UPDATE competition_users
+        // ── Persist the new ranks so the next upload's comparison
+        // has fresh values. One UPDATE per user; could be batched
+        // later if the row count grows.
+        for (const [uid, rank] of newRankByUser.entries()) {
+          const score = newScoreByUser.get(uid) ?? 0;
+          await db.query(
+            `UPDATE competition_users
 						SET last_known_rank = $1, last_known_score = $2, last_rank_updated_at = NOW()
 						WHERE competition_id = $3 AND user_id = $4`,
-						[rank, score, comp.id, uid]
-					);
-				}
-			} catch (err: any) {
-				console.error(`[Notifications] Lead change error for comp ${comp.id}:`, err.message);
-			}
-		}
-	} catch (err: any) {
-		console.error('[Notifications] Error in checkLeadChanges:', err.message);
-	}
+            [rank, score, comp.id, uid],
+          );
+        }
+      } catch (err: any) {
+        console.error(
+          `[Notifications] Lead change error for comp ${comp.id}:`,
+          err.message,
+        );
+      }
+    }
+  } catch (err: any) {
+    console.error("[Notifications] Error in checkLeadChanges:", err.message);
+  }
 }
 
 /** Format a score gap for user-facing notification text, mode-aware. */
 function formatGapForType(type: string, gap: number): string {
-	if (gap <= 0) return '0';
-	switch (type) {
-		case 'clash':
-		case 'targets': {
-			const pts = Math.max(1, Math.round(gap));
-			return `${pts} ${pts === 1 ? 'pt' : 'pts'}`;
-		}
-		case 'apex':
-		case 'race':
-		default:
-			return `${gap.toFixed(2)} mi`;
-	}
+  if (gap <= 0) return "0";
+  switch (type) {
+    case "clash":
+    case "targets": {
+      const pts = Math.max(1, Math.round(gap));
+      return `${pts} ${pts === 1 ? "pt" : "pts"}`;
+    }
+    case "apex":
+    case "race":
+    default:
+      return `${gap.toFixed(2)} mi`;
+  }
 }
 
 // ─── End-of-Interval Per-User Recap Notifications ─────────────────
@@ -875,15 +1085,19 @@ function formatGapForType(type: string, gap: number): string {
 
 /** ISO date string for yesterday in America/New_York (matches workouts.local_date format). */
 function yesterdayLocalDate(): string {
-	const formatter = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' });
-	const y = new Date(Date.now() - 24 * 60 * 60 * 1000);
-	return formatter.format(y);
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/New_York",
+  });
+  const y = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  return formatter.format(y);
 }
 
 /** ISO date string for today in America/New_York. */
 function todayLocalDate(): string {
-	const formatter = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' });
-	return formatter.format(new Date());
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/New_York",
+  });
+  return formatter.format(new Date());
 }
 
 /**
@@ -896,77 +1110,94 @@ function todayLocalDate(): string {
  * we just look at each accepted user's yesterday miles vs the comp goal.
  */
 export async function checkStreakLifeLoss(): Promise<void> {
-	try {
-		const activeStreaks = await db.query<Competition & { id: string }>(
-			`SELECT c.*
+  try {
+    const activeStreaks = await db.query<Competition & { id: string }>(
+      `SELECT c.*
 			FROM competitions c
 			WHERE c.type = 'streaks'
 				AND c.start_date IS NOT NULL
 				AND c.start_date <= NOW()
 				AND c.winner IS NULL
-				AND (c.end_date IS NULL OR c.end_date > NOW())`
-		);
+				AND (c.end_date IS NULL OR c.end_date > NOW())`,
+    );
 
-		if (activeStreaks.length === 0) return;
-		const yesterday = yesterdayLocalDate();
+    if (activeStreaks.length === 0) return;
+    const yesterday = yesterdayLocalDate();
 
-		for (const comp of activeStreaks) {
-			try {
-				const fullComp = await getCompetition(comp.id);
-				if (!fullComp) continue;
-				const goal = fullComp.options.goal ?? 1.0;
-				const totalLives = fullComp.options.lives ?? (fullComp.options.first_to > 0 ? fullComp.options.first_to : 0);
-				if (totalLives === 0) continue;
+    for (const comp of activeStreaks) {
+      try {
+        const fullComp = await getCompetition(comp.id);
+        if (!fullComp) continue;
+        const goal = fullComp.options.goal ?? 1.0;
+        const totalLives =
+          fullComp.options.lives ??
+          (fullComp.options.first_to > 0 ? fullComp.options.first_to : 0);
+        if (totalLives === 0) continue;
 
-				const accepted = fullComp.users.filter((u: CompetitionUser) => u.invite_status === 'accepted');
-				if (accepted.length === 0) continue;
+        const accepted = fullComp.users.filter(
+          (u: CompetitionUser) => u.invite_status === "accepted",
+        );
+        if (accepted.length === 0) continue;
 
-				// Per-user yesterday miles via the comp's interval window. For
-				// streaks the interval is almost always daily; if not, we map
-				// to yesterday's day key directly since getUserScores already
-				// includes per-interval breakdowns.
-				const scores = await getUserScores(fullComp);
+        // Per-user yesterday miles via the comp's interval window. For
+        // streaks the interval is almost always daily; if not, we map
+        // to yesterday's day key directly since getUserScores already
+        // includes per-interval breakdowns.
+        const scores = await getUserScores(fullComp);
 
-				for (const u of accepted) {
-					const remaining = scores[u.user_id]?.remaining_lives ?? totalLives;
-					// Skip users who were already out — they don't lose another life.
-					if (remaining <= 0) continue;
+        for (const u of accepted) {
+          const remaining = scores[u.user_id]?.remaining_lives ?? totalLives;
+          // Skip users who were already out — they don't lose another life.
+          if (remaining <= 0) continue;
 
-					const yesterdayMiles = scores[u.user_id]?.intervals?.[yesterday] ?? 0;
-					if (yesterdayMiles >= goal) continue; // hit the goal — streak safe
+          const yesterdayMiles = scores[u.user_id]?.intervals?.[yesterday] ?? 0;
+          if (yesterdayMiles >= goal) continue; // hit the goal — streak safe
 
-					const livesAfter = Math.max(0, remaining - 1);
-					const milestoneKey = `streak_life_lost_${comp.id}_${u.user_id}_${yesterday}`;
-					const claimed = await db.query(
-						`INSERT INTO milestone_notifications (milestone_key, competition_id, user_id) VALUES ($1, $2, $3)
+          const livesAfter = Math.max(0, remaining - 1);
+          const milestoneKey = `streak_life_lost_${comp.id}_${u.user_id}_${yesterday}`;
+          const claimed = await db.query(
+            `INSERT INTO milestone_notifications (milestone_key, competition_id, user_id) VALUES ($1, $2, $3)
 						ON CONFLICT (milestone_key) DO NOTHING RETURNING id`,
-						[milestoneKey, comp.id, u.user_id]
-					);
-					if (claimed.length === 0) continue;
+            [milestoneKey, comp.id, u.user_id],
+          );
+          if (claimed.length === 0) continue;
 
-					const shouldSend = await shouldSendNotification(u.user_id, null, 'competition_milestone');
-					if (!shouldSend) continue;
+          const shouldSend = await shouldSendNotification(
+            u.user_id,
+            null,
+            "competition_milestone",
+          );
+          if (!shouldSend) continue;
 
-					const title = livesAfter === 0 ? "You're out!" : 'Life lost';
-					const body =
-						livesAfter === 0
-							? `You missed yesterday's mile in ${fullComp.competition_name} and are out of lives.`
-							: `You missed yesterday's mile in ${fullComp.competition_name} — ${livesAfter} ${livesAfter === 1 ? 'life' : 'lives'} left.`;
+          const title = livesAfter === 0 ? "You're out!" : "Life lost";
+          const body =
+            livesAfter === 0
+              ? `You missed yesterday's mile in ${fullComp.competition_name} and are out of lives.`
+              : `You missed yesterday's mile in ${fullComp.competition_name} — ${livesAfter} ${livesAfter === 1 ? "life" : "lives"} left.`;
 
-					sendPush(u.user_id, {
-						title,
-						body,
-						type: 'competition_milestone',
-						data: { competition_id: comp.id, kind: 'streak_life_lost', lives_remaining: String(livesAfter) }
-					}).catch(err => console.error('[Push] streak life lost error:', err.message));
-				}
-			} catch (err: any) {
-				console.error(`[Notifications] Streak life check error for comp ${comp.id}:`, err.message);
-			}
-		}
-	} catch (err: any) {
-		console.error('[Notifications] Error in checkStreakLifeLoss:', err.message);
-	}
+          sendPush(u.user_id, {
+            title,
+            body,
+            type: "competition_milestone",
+            data: {
+              competition_id: comp.id,
+              kind: "streak_life_lost",
+              lives_remaining: String(livesAfter),
+            },
+          }).catch((err) =>
+            console.error("[Push] streak life lost error:", err.message),
+          );
+        }
+      } catch (err: any) {
+        console.error(
+          `[Notifications] Streak life check error for comp ${comp.id}:`,
+          err.message,
+        );
+      }
+    }
+  } catch (err: any) {
+    console.error("[Notifications] Error in checkStreakLifeLoss:", err.message);
+  }
 }
 
 /**
@@ -976,76 +1207,91 @@ export async function checkStreakLifeLoss(): Promise<void> {
  * rollover days (detected in `intervalJustEnded`).
  */
 export async function checkTargetMissed(): Promise<void> {
-	try {
-		const activeTargets = await db.query<Competition & { id: string }>(
-			`SELECT c.*
+  try {
+    const activeTargets = await db.query<Competition & { id: string }>(
+      `SELECT c.*
 			FROM competitions c
 			WHERE c.type = 'targets'
 				AND c.start_date IS NOT NULL
 				AND c.start_date <= NOW()
 				AND c.winner IS NULL
-				AND (c.end_date IS NULL OR c.end_date > NOW())`
-		);
+				AND (c.end_date IS NULL OR c.end_date > NOW())`,
+    );
 
-		if (activeTargets.length === 0) return;
+    if (activeTargets.length === 0) return;
 
-		for (const comp of activeTargets) {
-			try {
-				const fullComp = await getCompetition(comp.id);
-				if (!fullComp) continue;
-				const intervalSetting = fullComp.options.interval ?? 'day';
-				if (!intervalJustEnded(intervalSetting, fullComp.start_date)) continue;
+    for (const comp of activeTargets) {
+      try {
+        const fullComp = await getCompetition(comp.id);
+        if (!fullComp) continue;
+        const intervalSetting = fullComp.options.interval ?? "day";
+        if (!intervalJustEnded(intervalSetting, fullComp.start_date)) continue;
 
-				const goal = fullComp.options.goal ?? 1.0;
-				const accepted = fullComp.users.filter((u: CompetitionUser) => u.invite_status === 'accepted');
-				if (accepted.length === 0) continue;
+        const goal = fullComp.options.goal ?? 1.0;
+        const accepted = fullComp.users.filter(
+          (u: CompetitionUser) => u.invite_status === "accepted",
+        );
+        if (accepted.length === 0) continue;
 
-				const scores = await getUserScores(fullComp);
-				const recentKey = lastIntervalKey(intervalSetting, fullComp.start_date);
+        const scores = await getUserScores(fullComp);
+        const recentKey = lastIntervalKey(intervalSetting, fullComp.start_date);
 
-				// Build the "who hit" list for inclusion in the notification body.
-				const hitNames: string[] = [];
-				const userMiles: Record<string, number> = {};
-				for (const u of accepted) {
-					const m = scores[u.user_id]?.intervals?.[recentKey] ?? 0;
-					userMiles[u.user_id] = m;
-					if (m >= goal) hitNames.push((u as any).username || 'Someone');
-				}
+        // Build the "who hit" list for inclusion in the notification body.
+        const hitNames: string[] = [];
+        const userMiles: Record<string, number> = {};
+        for (const u of accepted) {
+          const m = scores[u.user_id]?.intervals?.[recentKey] ?? 0;
+          userMiles[u.user_id] = m;
+          if (m >= goal) hitNames.push((u as any).username || "Someone");
+        }
 
-				for (const u of accepted) {
-					if (userMiles[u.user_id] >= goal) continue;
-					const milestoneKey = `target_missed_${comp.id}_${u.user_id}_${recentKey}`;
-					const claimed = await db.query(
-						`INSERT INTO milestone_notifications (milestone_key, competition_id, user_id) VALUES ($1, $2, $3)
+        for (const u of accepted) {
+          if (userMiles[u.user_id] >= goal) continue;
+          const milestoneKey = `target_missed_${comp.id}_${u.user_id}_${recentKey}`;
+          const claimed = await db.query(
+            `INSERT INTO milestone_notifications (milestone_key, competition_id, user_id) VALUES ($1, $2, $3)
 						ON CONFLICT (milestone_key) DO NOTHING RETURNING id`,
-						[milestoneKey, comp.id, u.user_id]
-					);
-					if (claimed.length === 0) continue;
+            [milestoneKey, comp.id, u.user_id],
+          );
+          if (claimed.length === 0) continue;
 
-					const shouldSend = await shouldSendNotification(u.user_id, null, 'competition_milestone');
-					if (!shouldSend) continue;
+          const shouldSend = await shouldSendNotification(
+            u.user_id,
+            null,
+            "competition_milestone",
+          );
+          if (!shouldSend) continue;
 
-					const periodLabel =
-						intervalSetting === 'day' ? "yesterday's" : intervalSetting === 'week' ? "last week's" : "last month's";
-					const hitBody =
-						hitNames.length > 0
-							? `${hitNames.slice(0, 3).join(', ')}${hitNames.length > 3 ? ` and ${hitNames.length - 3} more` : ''} hit the target.`
-							: 'No one hit the target.';
+          const periodLabel =
+            intervalSetting === "day"
+              ? "yesterday's"
+              : intervalSetting === "week"
+                ? "last week's"
+                : "last month's";
+          const hitBody =
+            hitNames.length > 0
+              ? `${hitNames.slice(0, 3).join(", ")}${hitNames.length > 3 ? ` and ${hitNames.length - 3} more` : ""} hit the target.`
+              : "No one hit the target.";
 
-					sendPush(u.user_id, {
-						title: `🎯 Missed ${periodLabel} target`,
-						body: `You didn't hit the goal in ${fullComp.competition_name}. ${hitBody}`,
-						type: 'competition_milestone',
-						data: { competition_id: comp.id, kind: 'target_missed' }
-					}).catch(err => console.error('[Push] target missed error:', err.message));
-				}
-			} catch (err: any) {
-				console.error(`[Notifications] Target missed check error for comp ${comp.id}:`, err.message);
-			}
-		}
-	} catch (err: any) {
-		console.error('[Notifications] Error in checkTargetMissed:', err.message);
-	}
+          sendPush(u.user_id, {
+            title: `🎯 Missed ${periodLabel} target`,
+            body: `You didn't hit the goal in ${fullComp.competition_name}. ${hitBody}`,
+            type: "competition_milestone",
+            data: { competition_id: comp.id, kind: "target_missed" },
+          }).catch((err) =>
+            console.error("[Push] target missed error:", err.message),
+          );
+        }
+      } catch (err: any) {
+        console.error(
+          `[Notifications] Target missed check error for comp ${comp.id}:`,
+          err.message,
+        );
+      }
+    }
+  } catch (err: any) {
+    console.error("[Notifications] Error in checkTargetMissed:", err.message);
+  }
 }
 
 /**
@@ -1063,73 +1309,83 @@ export async function checkTargetMissed(): Promise<void> {
  * a single recap rather than a stream of individual updates.
  */
 export async function notifyIntervalResults(): Promise<void> {
-	try {
-		const activeComps = await db.query<Competition & { id: string }>(
-			`SELECT c.*
+  try {
+    const activeComps = await db.query<Competition & { id: string }>(
+      `SELECT c.*
 			FROM competitions c
 			WHERE c.start_date IS NOT NULL
 				AND c.start_date <= NOW()
 				AND c.winner IS NULL
-				AND (c.end_date IS NULL OR c.end_date > NOW())`
-		);
-		if (activeComps.length === 0) return;
+				AND (c.end_date IS NULL OR c.end_date > NOW())`,
+    );
+    if (activeComps.length === 0) return;
 
-		const today = todayLocalDate();
-		// Map user_id → list of comp names whose interval just ended for them.
-		const recapsByUser = new Map<string, string[]>();
-		// Map user_id → first comp_id so the push can deep-link sensibly.
-		const firstCompByUser = new Map<string, string>();
+    const today = todayLocalDate();
+    // Map user_id → list of comp names whose interval just ended for them.
+    const recapsByUser = new Map<string, string[]>();
+    // Map user_id → first comp_id so the push can deep-link sensibly.
+    const firstCompByUser = new Map<string, string>();
 
-		for (const comp of activeComps) {
-			const intervalSetting = comp.options?.interval ?? 'day';
-			if (!intervalJustEnded(intervalSetting, comp.start_date)) continue;
+    for (const comp of activeComps) {
+      const intervalSetting = comp.options?.interval ?? "day";
+      if (!intervalJustEnded(intervalSetting, comp.start_date)) continue;
 
-			const accepted = await db.query<{ user_id: string }>(
-				`SELECT user_id FROM competition_users
+      const accepted = await db.query<{ user_id: string }>(
+        `SELECT user_id FROM competition_users
 				WHERE competition_id = $1 AND invite_status = 'accepted'`,
-				[comp.id]
-			);
+        [comp.id],
+      );
 
-			for (const { user_id } of accepted) {
-				const list = recapsByUser.get(user_id) ?? [];
-				list.push(comp.competition_name);
-				recapsByUser.set(user_id, list);
-				if (!firstCompByUser.has(user_id)) firstCompByUser.set(user_id, comp.id);
-			}
-		}
+      for (const { user_id } of accepted) {
+        const list = recapsByUser.get(user_id) ?? [];
+        list.push(comp.competition_name);
+        recapsByUser.set(user_id, list);
+        if (!firstCompByUser.has(user_id))
+          firstCompByUser.set(user_id, comp.id);
+      }
+    }
 
-		for (const [userId, compNames] of recapsByUser.entries()) {
-			const milestoneKey = `interval_recap_${userId}_${today}`;
-			const claimed = await db.query(
-				`INSERT INTO milestone_notifications (milestone_key, user_id) VALUES ($1, $2)
+    for (const [userId, compNames] of recapsByUser.entries()) {
+      const milestoneKey = `interval_recap_${userId}_${today}`;
+      const claimed = await db.query(
+        `INSERT INTO milestone_notifications (milestone_key, user_id) VALUES ($1, $2)
 				ON CONFLICT (milestone_key) DO NOTHING RETURNING id`,
-				[milestoneKey, userId]
-			);
-			if (claimed.length === 0) continue;
+        [milestoneKey, userId],
+      );
+      if (claimed.length === 0) continue;
 
-			const shouldSend = await shouldSendNotification(userId, null, 'competition_milestone');
-			if (!shouldSend) continue;
+      const shouldSend = await shouldSendNotification(
+        userId,
+        null,
+        "competition_milestone",
+      );
+      if (!shouldSend) continue;
 
-			const title = "📊 Yesterday's results are in";
-			const body =
-				compNames.length === 1
-					? `Open ${compNames[0]} to see how everyone finished.`
-					: `Results are in for ${compNames.length} of your competitions — see who won.`;
+      const title = "📊 Yesterday's results are in";
+      const body =
+        compNames.length === 1
+          ? `Open ${compNames[0]} to see how everyone finished.`
+          : `Results are in for ${compNames.length} of your competitions — see who won.`;
 
-			sendPush(userId, {
-				title,
-				body,
-				type: 'competition_milestone',
-				data: {
-					kind: 'interval_recap',
-					comp_count: String(compNames.length),
-					competition_id: firstCompByUser.get(userId) ?? ''
-				}
-			}).catch(err => console.error('[Push] interval recap error:', err.message));
-		}
-	} catch (err: any) {
-		console.error('[Notifications] Error in notifyIntervalResults:', err.message);
-	}
+      sendPush(userId, {
+        title,
+        body,
+        type: "competition_milestone",
+        data: {
+          kind: "interval_recap",
+          comp_count: String(compNames.length),
+          competition_id: firstCompByUser.get(userId) ?? "",
+        },
+      }).catch((err) =>
+        console.error("[Push] interval recap error:", err.message),
+      );
+    }
+  } catch (err: any) {
+    console.error(
+      "[Notifications] Error in notifyIntervalResults:",
+      err.message,
+    );
+  }
 }
 
 /**
@@ -1138,30 +1394,41 @@ export async function notifyIntervalResults(): Promise<void> {
  * roll only when yesterday was the last day of a comp-anchored week; monthly
  * comps roll only on the 1st of a calendar month.
  */
-function intervalJustEnded(interval: string | undefined, startDate: string | null | undefined): boolean {
-	if (interval === 'day' || !interval) return true;
+function intervalJustEnded(
+  interval: string | undefined,
+  startDate: string | null | undefined,
+): boolean {
+  if (interval === "day" || !interval) return true;
 
-	const formatter = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' });
-	const todayStr = formatter.format(new Date());
-	const today = new Date(todayStr + 'T00:00:00Z');
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/New_York",
+  });
+  const todayStr = formatter.format(new Date());
+  const today = new Date(todayStr + "T00:00:00Z");
 
-	if (interval === 'month') {
-		// today.getUTCDate() reads the day-of-month of an ISO date — for the
-		// midnight-ET date string we just built that's the local day-of-month.
-		return today.getUTCDate() === 1;
-	}
+  if (interval === "month") {
+    // today.getUTCDate() reads the day-of-month of an ISO date — for the
+    // midnight-ET date string we just built that's the local day-of-month.
+    return today.getUTCDate() === 1;
+  }
 
-	if (interval === 'week') {
-		if (!startDate) return false;
-		const start = new Date(startDate);
-		const startMs = Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate());
-		const todayMs = today.getTime();
-		const daysSinceStart = Math.round((todayMs - startMs) / (24 * 60 * 60 * 1000));
-		// A new week begins every 7 days after the anchor day.
-		return daysSinceStart > 0 && daysSinceStart % 7 === 0;
-	}
+  if (interval === "week") {
+    if (!startDate) return false;
+    const start = new Date(startDate);
+    const startMs = Date.UTC(
+      start.getUTCFullYear(),
+      start.getUTCMonth(),
+      start.getUTCDate(),
+    );
+    const todayMs = today.getTime();
+    const daysSinceStart = Math.round(
+      (todayMs - startMs) / (24 * 60 * 60 * 1000),
+    );
+    // A new week begins every 7 days after the anchor day.
+    return daysSinceStart > 0 && daysSinceStart % 7 === 0;
+  }
 
-	return false;
+  return false;
 }
 
 /**
@@ -1169,29 +1436,42 @@ function intervalJustEnded(interval: string | undefined, startDate: string | nul
  * yesterday; for weekly/monthly it's the start date of the prior window so
  * it can be looked up in `intervals[]`.
  */
-function lastIntervalKey(interval: string | undefined, startDate: string | null | undefined): string {
-	if (interval === 'day' || !interval) return yesterdayLocalDate();
+function lastIntervalKey(
+  interval: string | undefined,
+  startDate: string | null | undefined,
+): string {
+  if (interval === "day" || !interval) return yesterdayLocalDate();
 
-	const formatter = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' });
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/New_York",
+  });
 
-	if (interval === 'month') {
-		const now = new Date();
-		const prior = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1));
-		return formatter.format(prior);
-	}
+  if (interval === "month") {
+    const now = new Date();
+    const prior = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1),
+    );
+    return formatter.format(prior);
+  }
 
-	if (interval === 'week' && startDate) {
-		const start = new Date(startDate);
-		const startMs = Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate());
-		const todayStr = formatter.format(new Date());
-		const todayMs = new Date(todayStr + 'T00:00:00Z').getTime();
-		const daysSinceStart = Math.round((todayMs - startMs) / (24 * 60 * 60 * 1000));
-		const priorWeekStartDays = daysSinceStart - 7;
-		const priorWeekStartMs = startMs + priorWeekStartDays * 24 * 60 * 60 * 1000;
-		return formatter.format(new Date(priorWeekStartMs));
-	}
+  if (interval === "week" && startDate) {
+    const start = new Date(startDate);
+    const startMs = Date.UTC(
+      start.getUTCFullYear(),
+      start.getUTCMonth(),
+      start.getUTCDate(),
+    );
+    const todayStr = formatter.format(new Date());
+    const todayMs = new Date(todayStr + "T00:00:00Z").getTime();
+    const daysSinceStart = Math.round(
+      (todayMs - startMs) / (24 * 60 * 60 * 1000),
+    );
+    const priorWeekStartDays = daysSinceStart - 7;
+    const priorWeekStartMs = startMs + priorWeekStartDays * 24 * 60 * 60 * 1000;
+    return formatter.format(new Date(priorWeekStartMs));
+  }
 
-	return yesterdayLocalDate();
+  return yesterdayLocalDate();
 }
 
 // ─── End-of-Day Tie Detection (Clash Mode) ─────────────────────────
@@ -1201,75 +1481,89 @@ function lastIntervalKey(interval: string | undefined, startDate: string | null 
  * Called by cron at end of day (11:55 PM ET).
  */
 export async function checkClashTies(): Promise<void> {
-	try {
-		const activeClash = await db.query<Competition & { id: string }>(
-			`SELECT c.*
+  try {
+    const activeClash = await db.query<Competition & { id: string }>(
+      `SELECT c.*
 			FROM competitions c
 			WHERE c.type = 'clash'
 				AND c.start_date IS NOT NULL
 				AND c.start_date <= NOW()
 				AND c.winner IS NULL
-				AND (c.end_date IS NULL OR c.end_date > NOW())`
-		);
+				AND (c.end_date IS NULL OR c.end_date > NOW())`,
+    );
 
-		const formatter = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' });
-		const today = formatter.format(new Date());
+    const formatter = new Intl.DateTimeFormat("en-CA", {
+      timeZone: "America/New_York",
+    });
+    const today = formatter.format(new Date());
 
-		for (const comp of activeClash) {
-			try {
-				const fullComp = await getCompetition(comp.id);
-				if (!fullComp) continue;
+    for (const comp of activeClash) {
+      try {
+        const fullComp = await getCompetition(comp.id);
+        if (!fullComp) continue;
 
-				const scores = await getUserScores(fullComp);
-				const acceptedUsers = fullComp.users.filter((u: CompetitionUser) => u.invite_status === 'accepted');
-				if (acceptedUsers.length < 2) continue;
+        const scores = await getUserScores(fullComp);
+        const acceptedUsers = fullComp.users.filter(
+          (u: CompetitionUser) => u.invite_status === "accepted",
+        );
+        if (acceptedUsers.length < 2) continue;
 
-				// Find users tied for the lead
-				let maxScore = -1;
-				const leaders: string[] = [];
+        // Find users tied for the lead
+        let maxScore = -1;
+        const leaders: string[] = [];
 
-				for (const u of acceptedUsers) {
-					const score = scores[u.user_id]?.score ?? 0;
-					if (score > maxScore) {
-						maxScore = score;
-						leaders.length = 0;
-						leaders.push(u.user_id);
-					} else if (score === maxScore) {
-						leaders.push(u.user_id);
-					}
-				}
+        for (const u of acceptedUsers) {
+          const score = scores[u.user_id]?.score ?? 0;
+          if (score > maxScore) {
+            maxScore = score;
+            leaders.length = 0;
+            leaders.push(u.user_id);
+          } else if (score === maxScore) {
+            leaders.push(u.user_id);
+          }
+        }
 
-				if (leaders.length < 2 || maxScore <= 0) continue;
+        if (leaders.length < 2 || maxScore <= 0) continue;
 
-				const milestoneKey = `clash_tie_${comp.id}_${today}`;
-				const claimed = await db.query(
-					`INSERT INTO milestone_notifications (milestone_key, competition_id) VALUES ($1, $2)
+        const milestoneKey = `clash_tie_${comp.id}_${today}`;
+        const claimed = await db.query(
+          `INSERT INTO milestone_notifications (milestone_key, competition_id) VALUES ($1, $2)
 					ON CONFLICT (milestone_key) DO NOTHING RETURNING id`,
-					[milestoneKey, comp.id]
-				);
-				if (claimed.length === 0) continue;
+          [milestoneKey, comp.id],
+        );
+        if (claimed.length === 0) continue;
 
-				// Get usernames for the tied users
-				const tiedNames = await db.query(`SELECT username FROM users WHERE user_id = ANY($1::text[])`, [leaders]);
-				const nameList = tiedNames.map((r: any) => r.username).join(' & ');
+        // Get usernames for the tied users
+        const tiedNames = await db.query(
+          `SELECT username FROM users WHERE user_id = ANY($1::text[])`,
+          [leaders],
+        );
+        const nameList = tiedNames.map((r: any) => r.username).join(" & ");
 
-				// Notify all accepted participants
-				for (const u of acceptedUsers) {
-					const shouldSend = await shouldSendNotification(u.user_id, null, 'competition_milestone');
-					if (!shouldSend) continue;
+        // Notify all accepted participants
+        for (const u of acceptedUsers) {
+          const shouldSend = await shouldSendNotification(
+            u.user_id,
+            null,
+            "competition_milestone",
+          );
+          if (!shouldSend) continue;
 
-					sendPush(u.user_id, {
-						title: "It's a tie!",
-						body: `${nameList} are tied at ${maxScore} ${maxScore === 1 ? 'win' : 'wins'} in ${fullComp.competition_name}!`,
-						type: 'competition_milestone',
-						data: { competition_id: fullComp.id }
-					}).catch(err => console.error('[Push] tie error:', err.message));
-				}
-			} catch (err: any) {
-				console.error(`[Notifications] Tie check error for comp ${comp.id}:`, err.message);
-			}
-		}
-	} catch (err: any) {
-		console.error('[Notifications] Error in checkClashTies:', err.message);
-	}
+          sendPush(u.user_id, {
+            title: "It's a tie!",
+            body: `${nameList} are tied at ${maxScore} ${maxScore === 1 ? "win" : "wins"} in ${fullComp.competition_name}!`,
+            type: "competition_milestone",
+            data: { competition_id: fullComp.id },
+          }).catch((err) => console.error("[Push] tie error:", err.message));
+        }
+      } catch (err: any) {
+        console.error(
+          `[Notifications] Tie check error for comp ${comp.id}:`,
+          err.message,
+        );
+      }
+    }
+  } catch (err: any) {
+    console.error("[Notifications] Error in checkClashTies:", err.message);
+  }
 }

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -232,25 +232,26 @@ export async function notifyFriendsOfMileCompletion(
       return true;
     }
 
-    const allowedRecipients = await getFriendActivityRecipientPool(
-      userId,
-      outgoing,
-      "mile_completed",
-      audienceActivity,
+    // Defer + merge: instead of pushing now, queue a single notification for
+    // ~10 minutes out. This gives the runner a window to snap a post-run photo
+    // that rides along as ONE feed item + ONE push (no "completed a mile" now
+    // followed by "shared a photo" later). The pending-send cron recomputes the
+    // recipient pool and delivers. The daily dedup slot above ensures we queue
+    // at most once per day.
+    await db.query(
+      `INSERT INTO pending_friend_notifications
+			 (user_id, event_type, activity_type, workout_id, payload, local_date, send_after_at)
+			 VALUES ($1, 'mile_completed', $2, $3, $4::jsonb, $5::date, NOW() + INTERVAL '10 minutes')
+			 ON CONFLICT (user_id, event_type, workout_id)
+			 WHERE workout_id IS NOT NULL AND status = 'pending' DO NOTHING`,
+      [
+        userId,
+        audienceActivity,
+        recentWorkout?.workout_id ?? null,
+        JSON.stringify(payload),
+        localDate,
+      ],
     );
-    if (allowedRecipients.length === 0) return true;
-
-    for (const recipientId of allowedRecipients) {
-      sendPush(recipientId, payload).catch((err) =>
-        console.error("[Push] Error sending friend activity:", err.message),
-      );
-    }
-
-    if (allowedRecipients.length > 0) {
-      console.log(
-        `[Notifications] Sent mile completion to ${allowedRecipients.length} recipients of ${user.username}`,
-      );
-    }
     return true;
   } catch (err: any) {
     console.error(

--- a/backend/src/services/pendingNotificationService.ts
+++ b/backend/src/services/pendingNotificationService.ts
@@ -1,28 +1,28 @@
-import { PostgresService } from './DbService.js';
-import { sendPush, NotificationType } from './pushNotificationService.js';
-import { filterRecipientsForNotification } from './notificationSettingsService.js';
+import { PostgresService } from "./DbService.js";
+import { sendPush, NotificationType } from "./pushNotificationService.js";
+import { filterRecipientsForNotification } from "./notificationSettingsService.js";
 import {
-	filterByIncomingAudience,
-	resolveAudience,
-	restrictToCloseFriends,
-	AudienceEventType,
-	AudienceActivity
-} from './audienceSettingsService.js';
-import { getFriendActivityRecipientPool } from './notificationService.js';
-import { getUserLocalDate } from './workoutService.js';
+  filterByIncomingAudience,
+  resolveAudience,
+  restrictToCloseFriends,
+  AudienceEventType,
+  AudienceActivity,
+} from "./audienceSettingsService.js";
+import { getFriendActivityRecipientPool } from "./notificationService.js";
+import { getUserLocalDate } from "./workoutService.js";
 
 const db = PostgresService.getInstance();
 
 // ─── Types ────────────────────────────────────────────────────────────
 
 export interface PendingRow {
-	id: string;
-	event_type: string;
-	activity_type: string;
-	workout_id: string | null;
-	payload: Record<string, any>;
-	local_date: string;
-	created_at: string;
+  id: string;
+  event_type: string;
+  activity_type: string;
+  workout_id: string | null;
+  payload: Record<string, any>;
+  local_date: string;
+  created_at: string;
 }
 
 // Global notification-preference type passed to filterRecipientsForNotification
@@ -33,13 +33,20 @@ export interface PendingRow {
 // ABSENT — notification_settings has no global pref field for them and the
 // live fan-outs (fanOutFriendBadgePush / fanOutFriendChallengePush) apply no
 // per-recipient pref check, so those events skip filterRecipientsForNotification.
-const PREF_FILTER_TYPE: Record<string, 'friend_personal_best' | 'friend_activity'> = {
-	personal_best: 'friend_personal_best',
-	streak_broken: 'friend_activity'
+const PREF_FILTER_TYPE: Record<
+  string,
+  "friend_personal_best" | "friend_activity"
+> = {
+  personal_best: "friend_personal_best",
+  streak_broken: "friend_activity",
 };
 
 // Workout-type events use the full friend+competition-participant pool.
-const WORKOUT_EVENT_TYPES = new Set(['mile_completed', 'extra_workout', 'workout']);
+const WORKOUT_EVENT_TYPES = new Set([
+  "mile_completed",
+  "extra_workout",
+  "workout",
+]);
 
 // ─── listPending ──────────────────────────────────────────────────────
 
@@ -49,30 +56,38 @@ const WORKOUT_EVENT_TYPES = new Set(['mile_completed', 'extra_workout', 'workout
  * date) as 'expired' so they don't pile up.
  */
 export async function listPending(userId: string): Promise<PendingRow[]> {
-	const localDate = await getUserLocalDate(userId);
+  const localDate = await getUserLocalDate(userId);
 
-	// Lazy expiry: mark stale rows expired before fetching active ones.
-	await db.query(
-		`UPDATE pending_friend_notifications
+  // Lazy expiry: mark stale rows expired before fetching active ones.
+  await db.query(
+    `UPDATE pending_friend_notifications
 		 SET status = 'expired'
 		 WHERE user_id = $1 AND status = 'pending' AND local_date < $2`,
-		[userId, localDate]
-	);
+    [userId, localDate],
+  );
 
-	return db.query<PendingRow>(
-		`SELECT id, event_type, activity_type, workout_id, payload, local_date, created_at
+  return db.query<PendingRow>(
+    `SELECT id, event_type, activity_type, workout_id, payload, local_date, created_at
 		 FROM pending_friend_notifications
 		 WHERE user_id = $1 AND status = 'pending' AND local_date >= $2
 		 ORDER BY created_at DESC`,
-		[userId, localDate]
-	);
+    [userId, localDate],
+  );
 }
 
 // ─── sendPending ──────────────────────────────────────────────────────
 
 export type SendPendingResult =
-	| { ok: true; sent: number }
-	| { ok: false; reason: 'not_found' | 'not_owner' | 'already_processed' | 'expired' | 'audience_blocked' };
+  | { ok: true; sent: number }
+  | {
+      ok: false;
+      reason:
+        | "not_found"
+        | "not_owner"
+        | "already_processed"
+        | "expired"
+        | "audience_blocked";
+    };
 
 /**
  * Confirm and send a pending notification.
@@ -88,169 +103,318 @@ export type SendPendingResult =
  *    'expired' (claim-then-expire is race-safe; nothing was sent yet).
  * 5. Build recipients exactly as the live senders do, then send.
  */
-export async function sendPending(userId: string, id: string, audience: 'close' | 'all' = 'all'): Promise<SendPendingResult> {
-	interface FullRow {
-		id: string;
-		user_id: string;
-		event_type: string;
-		activity_type: string;
-		workout_id: string | null;
-		payload: Record<string, any>;
-		local_date: string;
-		status: string;
-	}
+export async function sendPending(
+  userId: string,
+  id: string,
+  audience: "close" | "all" = "all",
+): Promise<SendPendingResult> {
+  interface FullRow {
+    id: string;
+    user_id: string;
+    event_type: string;
+    activity_type: string;
+    workout_id: string | null;
+    payload: Record<string, any>;
+    local_date: string;
+    status: string;
+  }
 
-	// 1. Read-only fetch for diagnosis + audience metadata.
-	const rows = await db.query<FullRow>(
-		`SELECT id, user_id, event_type, activity_type, workout_id, payload, local_date, status
+  // 1. Read-only fetch for diagnosis + audience metadata.
+  const rows = await db.query<FullRow>(
+    `SELECT id, user_id, event_type, activity_type, workout_id, payload, local_date, status
 		 FROM pending_friend_notifications
 		 WHERE id = $1`,
-		[id]
-	);
+    [id],
+  );
 
-	if (rows.length === 0) return { ok: false, reason: 'not_found' };
-	const preview = rows[0];
+  if (rows.length === 0) return { ok: false, reason: "not_found" };
+  const preview = rows[0];
 
-	if (preview.user_id !== userId) return { ok: false, reason: 'not_owner' };
-	if (preview.status === 'expired') return { ok: false, reason: 'expired' };
-	if (preview.status !== 'pending') return { ok: false, reason: 'already_processed' };
+  if (preview.user_id !== userId) return { ok: false, reason: "not_owner" };
+  if (preview.status === "expired") return { ok: false, reason: "expired" };
+  if (preview.status !== "pending")
+    return { ok: false, reason: "already_processed" };
 
-	const eventType = preview.event_type as AudienceEventType;
-	const activity = (preview.activity_type ?? '') as AudienceActivity;
+  const eventType = preview.event_type as AudienceEventType;
+  const activity = (preview.activity_type ?? "") as AudienceActivity;
 
-	// 2. Re-check the sender's CURRENT outgoing audience. The row was queued
-	// under an 'ask' setting that may since have changed.
-	const currentOutgoing = await resolveAudience(userId, 'outgoing', eventType, activity);
-	if (currentOutgoing === 'none') {
-		// Refuse without touching the row — the user can re-enable and retry.
-		return { ok: false, reason: 'audience_blocked' };
-	}
-	// The request can never widen beyond the current setting: current 'close'
-	// forces 'close'; current 'all'/'ask' honors the requested audience.
-	const effectiveAudience: 'close' | 'all' = currentOutgoing === 'close' ? 'close' : audience;
+  // 2. Re-check the sender's CURRENT outgoing audience. The row was queued
+  // under an 'ask' setting that may since have changed.
+  const currentOutgoing = await resolveAudience(
+    userId,
+    "outgoing",
+    eventType,
+    activity,
+  );
+  if (currentOutgoing === "none") {
+    // Refuse without touching the row — the user can re-enable and retry.
+    return { ok: false, reason: "audience_blocked" };
+  }
+  // The request can never widen beyond the current setting: current 'close'
+  // forces 'close'; current 'all'/'ask' honors the requested audience.
+  const effectiveAudience: "close" | "all" =
+    currentOutgoing === "close" ? "close" : audience;
 
-	// 3. Atomic claim — exactly one concurrent send can flip pending → sent.
-	const claimedRows = await db.query<FullRow>(
-		`UPDATE pending_friend_notifications
+  // 3. Atomic claim — exactly one concurrent send can flip pending → sent.
+  const claimedRows = await db.query<FullRow>(
+    `UPDATE pending_friend_notifications
 		 SET status = 'sent'
 		 WHERE id = $1 AND user_id = $2 AND status = 'pending'
 		 RETURNING id, user_id, event_type, activity_type, workout_id, payload, local_date, status`,
-		[id, userId]
-	);
+    [id, userId],
+  );
 
-	if (claimedRows.length === 0) {
-		// Claim failed — re-read for a precise diagnosis (read-only is fine here).
-		const lost = await db.query<{ user_id: string; status: string }>(
-			`SELECT user_id, status FROM pending_friend_notifications WHERE id = $1`,
-			[id]
-		);
-		if (lost.length === 0) return { ok: false, reason: 'not_found' };
-		if (lost[0].user_id !== userId) return { ok: false, reason: 'not_owner' };
-		if (lost[0].status === 'expired') return { ok: false, reason: 'expired' };
-		return { ok: false, reason: 'already_processed' };
-	}
-	const row = claimedRows[0];
+  if (claimedRows.length === 0) {
+    // Claim failed — re-read for a precise diagnosis (read-only is fine here).
+    const lost = await db.query<{ user_id: string; status: string }>(
+      `SELECT user_id, status FROM pending_friend_notifications WHERE id = $1`,
+      [id],
+    );
+    if (lost.length === 0) return { ok: false, reason: "not_found" };
+    if (lost[0].user_id !== userId) return { ok: false, reason: "not_owner" };
+    if (lost[0].status === "expired") return { ok: false, reason: "expired" };
+    return { ok: false, reason: "already_processed" };
+  }
+  const row = claimedRows[0];
 
-	// 4. Same-day check AFTER claiming. Stale claimed row → flip to expired.
-	const localDate = await getUserLocalDate(userId);
-	if (row.local_date !== localDate) {
-		await db.query(`UPDATE pending_friend_notifications SET status = 'expired' WHERE id = $1`, [id]);
-		return { ok: false, reason: 'expired' };
-	}
+  // 4. Same-day check AFTER claiming. Stale claimed row → flip to expired.
+  const localDate = await getUserLocalDate(userId);
+  if (row.local_date !== localDate) {
+    await db.query(
+      `UPDATE pending_friend_notifications SET status = 'expired' WHERE id = $1`,
+      [id],
+    );
+    return { ok: false, reason: "expired" };
+  }
 
-	// 5. Build recipients exactly as the live senders do. If anything past the
-	// claim throws, revert the row to 'pending' so the user can retry —
-	// otherwise the claim would consume the notification with nothing sent.
-	let allowedRecipients: string[];
-	try {
-		if (WORKOUT_EVENT_TYPES.has(row.event_type)) {
-			// Full pool: friends + active-competition co-participants (same as live senders).
-			allowedRecipients = await getFriendActivityRecipientPool(userId, effectiveAudience, eventType, activity);
-		} else {
-			// Non-workout events: friends only (no comp participants).
-			// This mirrors pushNotificationService.ts resolveFriendFanOutRecipients.
-			const friendRows = await db.query<{ friend_id: string }>(
-				`SELECT friend_id FROM friendships WHERE user_id = $1 AND status = 'accepted'`,
-				[userId]
-			);
-			let friendIds = friendRows.map(r => r.friend_id);
+  // 5. Build recipients exactly as the live senders do. If anything past the
+  // claim throws, revert the row to 'pending' so the user can retry —
+  // otherwise the claim would consume the notification with nothing sent.
+  let allowedRecipients: string[];
+  try {
+    if (WORKOUT_EVENT_TYPES.has(row.event_type)) {
+      // Full pool: friends + active-competition co-participants (same as live senders).
+      allowedRecipients = await getFriendActivityRecipientPool(
+        userId,
+        effectiveAudience,
+        eventType,
+        activity,
+      );
+    } else {
+      // Non-workout events: friends only (no comp participants).
+      // This mirrors pushNotificationService.ts resolveFriendFanOutRecipients.
+      const friendRows = await db.query<{ friend_id: string }>(
+        `SELECT friend_id FROM friendships WHERE user_id = $1 AND status = 'accepted'`,
+        [userId],
+      );
+      let friendIds = friendRows.map((r) => r.friend_id);
 
-			if (effectiveAudience === 'close') {
-				friendIds = await restrictToCloseFriends(userId, friendIds);
-			}
+      if (effectiveAudience === "close") {
+        friendIds = await restrictToCloseFriends(userId, friendIds);
+      }
 
-			if (friendIds.length === 0) {
-				allowedRecipients = [];
-			} else {
-				// Global-pref filter only for events the live fan-outs actually check
-				// (see PREF_FILTER_TYPE). badge_earned / challenge_completed skip it.
-				const prefType = PREF_FILTER_TYPE[row.event_type];
-				const prefAllowed = prefType ? await filterRecipientsForNotification(friendIds, userId, prefType) : friendIds;
-				allowedRecipients = await filterByIncomingAudience(prefAllowed, userId, eventType, activity);
-			}
-		}
-	} catch (err) {
-		await db
-			.query(`UPDATE pending_friend_notifications SET status = 'pending' WHERE id = $1 AND status = 'sent'`, [id])
-			.catch(rollbackErr =>
-				console.error('[PendingNotif] Failed to revert claim after error:', rollbackErr.message)
-			);
-		throw err;
-	}
+      if (friendIds.length === 0) {
+        allowedRecipients = [];
+      } else {
+        // Global-pref filter only for events the live fan-outs actually check
+        // (see PREF_FILTER_TYPE). badge_earned / challenge_completed skip it.
+        const prefType = PREF_FILTER_TYPE[row.event_type];
+        const prefAllowed = prefType
+          ? await filterRecipientsForNotification(friendIds, userId, prefType)
+          : friendIds;
+        allowedRecipients = await filterByIncomingAudience(
+          prefAllowed,
+          userId,
+          eventType,
+          activity,
+        );
+      }
+    }
+  } catch (err) {
+    await db
+      .query(
+        `UPDATE pending_friend_notifications SET status = 'pending' WHERE id = $1 AND status = 'sent'`,
+        [id],
+      )
+      .catch((rollbackErr) =>
+        console.error(
+          "[PendingNotif] Failed to revert claim after error:",
+          rollbackErr.message,
+        ),
+      );
+    throw err;
+  }
 
-	// Build push payload from stored JSONB. Cast type to NotificationType so
-	// sendPush's type signature is satisfied — the stored value was written by
-	// the live sender so it's already a valid NotificationType string.
-	const payload = {
-		title: row.payload.title as string,
-		body: row.payload.body as string,
-		type: row.payload.type as NotificationType,
-		category: row.payload.category as string | undefined,
-		data: row.payload.data as Record<string, string> | undefined
-	};
+  // Build push payload from stored JSONB. Cast type to NotificationType so
+  // sendPush's type signature is satisfied — the stored value was written by
+  // the live sender so it's already a valid NotificationType string.
+  const payload = {
+    title: row.payload.title as string,
+    body: row.payload.body as string,
+    type: row.payload.type as NotificationType,
+    category: row.payload.category as string | undefined,
+    data: row.payload.data as Record<string, string> | undefined,
+  };
 
-	for (const recipientId of allowedRecipients) {
-		sendPush(recipientId, payload).catch(err =>
-			console.error(`[Push] Error sending pending ${row.event_type} notification:`, err.message)
-		);
-	}
+  for (const recipientId of allowedRecipients) {
+    sendPush(recipientId, payload).catch((err) =>
+      console.error(
+        `[Push] Error sending pending ${row.event_type} notification:`,
+        err.message,
+      ),
+    );
+  }
 
-	// Status was already flipped to 'sent' by the atomic claim above.
-	console.log(`[PendingNotif] Sent pending ${row.event_type} for user ${userId} to ${allowedRecipients.length} recipients`);
+  // Status was already flipped to 'sent' by the atomic claim above.
+  console.log(
+    `[PendingNotif] Sent pending ${row.event_type} for user ${userId} to ${allowedRecipients.length} recipients`,
+  );
 
-	return { ok: true, sent: allowedRecipients.length };
+  return { ok: true, sent: allowedRecipients.length };
+}
+
+// ─── drainDueScheduled (time-delayed auto-send) ───────────────────────
+
+/**
+ * Deliver scheduled friend notifications whose delay has elapsed. These are the
+ * deferred mile-completion pushes (send_after_at = run time + ~10 min) that let
+ * a post-run photo ride along as one merged notification. Run by a ~1-min cron.
+ *
+ * Best-effort: a row is atomically claimed (pending → sent) before delivery, and
+ * recipients are recomputed at send time (audience may have changed). Delivery
+ * failures are logged but not retried, to avoid a stuck row looping the cron.
+ */
+export async function drainDueScheduled(): Promise<{
+  processed: number;
+  recipients: number;
+}> {
+  interface DueRow {
+    id: string;
+    user_id: string;
+    event_type: string;
+    activity_type: string;
+    payload: Record<string, any>;
+    local_date: string;
+  }
+
+  const due = await db.query<DueRow>(
+    `SELECT id, user_id, event_type, activity_type, payload, local_date
+		 FROM pending_friend_notifications
+		 WHERE status = 'pending' AND send_after_at IS NOT NULL AND send_after_at <= NOW()
+		 ORDER BY send_after_at ASC
+		 LIMIT 200`,
+  );
+
+  let processed = 0;
+  let recipients = 0;
+
+  for (const r of due) {
+    // Atomic claim so a second cron tick can't double-send.
+    const claimed = await db.query<{ id: string }>(
+      `UPDATE pending_friend_notifications SET status = 'sent'
+			 WHERE id = $1 AND status = 'pending' RETURNING id`,
+      [r.id],
+    );
+    if (claimed.length === 0) continue;
+    processed++;
+
+    try {
+      const eventType = r.event_type as AudienceEventType;
+      const activity = (r.activity_type ?? "") as AudienceActivity;
+
+      // Re-resolve the sender's current outgoing audience; they may have
+      // turned sharing off in the 10-minute window.
+      const outgoing = await resolveAudience(
+        r.user_id,
+        "outgoing",
+        eventType,
+        activity,
+      );
+      if (outgoing === "none") continue;
+      const effective: "close" | "all" = outgoing === "close" ? "close" : "all";
+
+      // The scheduled path is only used for workout events today; use the
+      // same full friend + competition-participant pool as the live sender.
+      const pool = WORKOUT_EVENT_TYPES.has(r.event_type)
+        ? await getFriendActivityRecipientPool(
+            r.user_id,
+            effective,
+            eventType,
+            activity,
+          )
+        : [];
+
+      const payload = {
+        title: r.payload.title as string,
+        body: r.payload.body as string,
+        type: r.payload.type as NotificationType,
+        category: r.payload.category as string | undefined,
+        data: r.payload.data as Record<string, string> | undefined,
+      };
+
+      for (const recipientId of pool) {
+        sendPush(recipientId, payload).catch((err) =>
+          console.error("[PendingSend] push error:", err?.message ?? err),
+        );
+      }
+      recipients += pool.length;
+    } catch (err: any) {
+      console.error(
+        "[PendingSend] failed to deliver scheduled row:",
+        err?.message ?? err,
+      );
+    }
+  }
+
+  if (processed > 0) {
+    console.log(
+      `[PendingSend] Delivered ${processed} scheduled notification(s) to ${recipients} recipient(s)`,
+    );
+  }
+  return { processed, recipients };
 }
 
 // ─── dismissPending ───────────────────────────────────────────────────
 
-export type DismissPendingResult = { ok: true } | { ok: false; reason: 'not_found' | 'not_owner' | 'already_processed' };
+export type DismissPendingResult =
+  | { ok: true }
+  | { ok: false; reason: "not_found" | "not_owner" | "already_processed" };
 
-export async function dismissPending(userId: string, id: string): Promise<DismissPendingResult> {
-	const rows = await db.query<{ user_id: string; status: string }>(
-		`SELECT user_id, status FROM pending_friend_notifications WHERE id = $1`,
-		[id]
-	);
-	if (rows.length === 0) return { ok: false, reason: 'not_found' };
-	if (rows[0].user_id !== userId) return { ok: false, reason: 'not_owner' };
-	if (rows[0].status !== 'pending') return { ok: false, reason: 'already_processed' };
+export async function dismissPending(
+  userId: string,
+  id: string,
+): Promise<DismissPendingResult> {
+  const rows = await db.query<{ user_id: string; status: string }>(
+    `SELECT user_id, status FROM pending_friend_notifications WHERE id = $1`,
+    [id],
+  );
+  if (rows.length === 0) return { ok: false, reason: "not_found" };
+  if (rows[0].user_id !== userId) return { ok: false, reason: "not_owner" };
+  if (rows[0].status !== "pending")
+    return { ok: false, reason: "already_processed" };
 
-	await db.query(`UPDATE pending_friend_notifications SET status = 'dismissed' WHERE id = $1`, [id]);
-	return { ok: true };
+  await db.query(
+    `UPDATE pending_friend_notifications SET status = 'dismissed' WHERE id = $1`,
+    [id],
+  );
+  return { ok: true };
 }
 
 // ─── dismissAllPending ────────────────────────────────────────────────
 
-export async function dismissAllPending(userId: string): Promise<{ dismissed: number }> {
-	const result = await db.query<{ count: string }>(
-		`WITH updated AS (
+export async function dismissAllPending(
+  userId: string,
+): Promise<{ dismissed: number }> {
+  const result = await db.query<{ count: string }>(
+    `WITH updated AS (
 			UPDATE pending_friend_notifications
 			SET status = 'dismissed'
 			WHERE user_id = $1 AND status = 'pending'
 			RETURNING id
 		) SELECT COUNT(*)::text AS count FROM updated`,
-		[userId]
-	);
-	return { dismissed: parseInt(result[0]?.count ?? '0', 10) };
+    [userId],
+  );
+  return { dismissed: parseInt(result[0]?.count ?? "0", 10) };
 }
 
 // ─── expireStale (for cron) ───────────────────────────────────────────
@@ -263,8 +427,8 @@ export async function dismissAllPending(userId: string): Promise<{ dismissed: nu
  * Safe to call repeatedly — only touches rows that are genuinely stale.
  */
 export async function expireStalePendingNotifications(): Promise<number> {
-	const result = await db.query<{ count: string }>(
-		`WITH user_local AS (
+  const result = await db.query<{ count: string }>(
+    `WITH user_local AS (
 			-- Compute each user's current local date using their most recent workout
 			-- timezone_offset (minutes), defaulting to UTC when unknown. Mirrors
 			-- getUserLocalDate exactly.
@@ -290,11 +454,11 @@ export async function expireStalePendingNotifications(): Promise<number> {
 			RETURNING pfn.id
 		)
 		SELECT COUNT(*)::text AS count FROM expired`,
-		[]
-	);
-	const count = parseInt(result[0]?.count ?? '0', 10);
-	if (count > 0) {
-		console.log(`[PendingNotif] Expired ${count} stale pending notifications`);
-	}
-	return count;
+    [],
+  );
+  const count = parseInt(result[0]?.count ?? "0", 10);
+  if (count > 0) {
+    console.log(`[PendingNotif] Expired ${count} stale pending notifications`);
+  }
+  return count;
 }

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -125,6 +125,7 @@ export async function createPost(input: CreatePostInput): Promise<PostRow> {
 					share_to_feed = EXCLUDED.share_to_feed,
 					share_to_story = EXCLUDED.share_to_story,
 					story_expires_at = CASE WHEN EXCLUDED.share_to_story THEN NOW() + INTERVAL '24 hours' ELSE NULL END
+				WHERE posts.user_id = $1
 			RETURNING *
 		)
 		SELECT
@@ -146,6 +147,11 @@ export async function createPost(input: CreatePostInput): Promise<PostRow> {
       input.shareToStory,
     ],
   );
+  // Zero rows = the workout_id conflicted with a post the caller doesn't own
+  // (the ownership guard on DO UPDATE skipped it) — reject rather than 500.
+  if (!rows[0]) {
+    throw new Error("workout_already_posted");
+  }
   return rows[0];
 }
 

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -371,6 +371,7 @@ export async function getUnifiedFeed(
 			LEFT JOIN notification_settings ns ON ns.user_id = w.user_id
 			WHERE w.user_id NOT IN (SELECT uid FROM blocked)
 				AND COALESCE(ns.share_workouts_to_feed, true) = true
+				AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL
 				AND NOT EXISTS (
 					SELECT 1 FROM posts p2
 					WHERE p2.workout_id = w.workout_id AND p2.deleted_at IS NULL AND p2.share_to_feed

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -117,6 +117,14 @@ export async function createPost(input: CreatePostInput): Promise<PostRow> {
 				$1, $2, $3, $4, $5::jsonb, $6::date, $7, $8,
 				CASE WHEN $8 THEN NOW() + INTERVAL '24 hours' ELSE NULL END
 			)
+				ON CONFLICT (workout_id) WHERE (deleted_at IS NULL AND workout_id IS NOT NULL)
+				DO UPDATE SET
+					media_url = EXCLUDED.media_url,
+					caption = COALESCE(EXCLUDED.caption, posts.caption),
+					stats_snapshot = COALESCE(EXCLUDED.stats_snapshot, posts.stats_snapshot),
+					share_to_feed = EXCLUDED.share_to_feed,
+					share_to_story = EXCLUDED.share_to_story,
+					story_expires_at = CASE WHEN EXCLUDED.share_to_story THEN NOW() + INTERVAL '24 hours' ELSE NULL END
 			RETURNING *
 		)
 		SELECT

--- a/backend/src/services/workoutDeletionService.ts
+++ b/backend/src/services/workoutDeletionService.ts
@@ -1,0 +1,65 @@
+import { PostgresService } from "./DbService.js";
+import { refreshCurrentStreak } from "./leaderboardService.js";
+import { revokeUnearnedBadges } from "./badgeService.js";
+
+const db = PostgresService.getInstance();
+
+export interface WorkoutDeletionResult {
+  deleted: boolean;
+  currentStreak: number;
+  revokedBadges: string[];
+}
+
+/**
+ * Soft-delete a single workout and heal the user's derived data.
+ *
+ * The workout row is kept (tombstoned via `deleted_at`) rather than removed so a
+ * HealthKit re-sync — which would re-upload the same `workout_id` — can't bring
+ * it back: the upload's `ON CONFLICT DO UPDATE` never clears `deleted_at`.
+ *
+ * After tombstoning we:
+ *  1. drop any daily-challenge completion this workout triggered (if the workout
+ *     was a bad/drive entry, the completion it earned is bogus too),
+ *  2. recompute and store the user's current streak from active workouts, and
+ *  3. revoke any badges the user no longer qualifies for (e.g. a total-miles or
+ *     fake-streak badge that only the deleted workout had pushed them over).
+ *
+ * Idempotent: deleting an already-deleted or non-existent workout is a no-op
+ * (returns deleted=false) and still returns the freshly recomputed streak.
+ */
+export async function softDeleteWorkout(
+  userId: string,
+  workoutId: string,
+): Promise<WorkoutDeletionResult> {
+  const active = await db.query<{ workout_id: string }>(
+    `SELECT workout_id FROM workouts
+		WHERE workout_id = $1 AND user_id = $2 AND deleted_at IS NULL`,
+    [workoutId, userId],
+  );
+
+  if (active.length === 0) {
+    // Nothing to delete — still return the current (recomputed) streak so the
+    // client stays in sync.
+    const streak = await refreshCurrentStreak(userId);
+    return { deleted: false, currentStreak: streak, revokedBadges: [] };
+  }
+
+  await db.query(
+    `UPDATE workouts SET deleted_at = NOW() WHERE workout_id = $1 AND user_id = $2`,
+    [workoutId, userId],
+  );
+
+  // Remove any challenge completion this specific workout earned.
+  await db
+    .query(
+      `DELETE FROM user_challenge_completions
+		WHERE user_id = $1 AND completing_workout_id = $2`,
+      [userId, workoutId],
+    )
+    .catch(() => {});
+
+  const currentStreak = await refreshCurrentStreak(userId);
+  const revokedBadges = await revokeUnearnedBadges(userId);
+
+  return { deleted: true, currentStreak, revokedBadges };
+}

--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -19,9 +19,11 @@ export async function uploadWorkouts(
         device_end_date,
         calories,
         total_duration,
-        source
+        source,
+        exclusion_reason,
+        speed_flagged
       )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
       ON CONFLICT (workout_id)
       DO UPDATE SET
         distance = EXCLUDED.distance,
@@ -35,7 +37,11 @@ export async function uploadWorkouts(
         source = CASE
           WHEN workouts.source IN ('manual', 'edited') THEN workouts.source
           ELSE EXCLUDED.source
-        END
+        END,
+        -- Recompute the speed classification from the latest figures, but never
+        -- clear a user soft-delete (deleted_at is intentionally not updated here).
+        exclusion_reason = EXCLUDED.exclusion_reason,
+        speed_flagged = EXCLUDED.speed_flagged
       RETURNING workout_id, (xmax = 0) AS inserted
     `;
 
@@ -51,6 +57,10 @@ export async function uploadWorkouts(
 
   await db.transaction(
     workouts.flatMap((workout: Workout) => {
+      const speed = classifyWorkoutSpeed(
+        workout.distance,
+        workout.totalDuration,
+      );
       return [
         {
           query: workoutQuery,
@@ -66,6 +76,8 @@ export async function uploadWorkouts(
             workout.calories,
             workout.totalDuration,
             workout.source || "healthkit",
+            speed.exclusionReason,
+            speed.speedFlagged,
           ],
         },
         ...workout.splits.map((split) => ({
@@ -83,6 +95,38 @@ export async function uploadWorkouts(
   );
 
   return workouts.map((w) => w.workoutId);
+}
+
+/**
+ * Classify a workout by its average speed to catch "left tracking on in the car".
+ * A human can't run/walk a mile faster than ~15 mph (the mile world record), and
+ * only running/walking workouts ever reach us, so:
+ *   - >= 20 mph  → physically impossible on foot → auto-exclude (does NOT count).
+ *                  Conservative on purpose: zero risk of rejecting a real run.
+ *   - 13–20 mph  → suspicious but theoretically human → flag for the user to
+ *                  review/delete; still counts.
+ * Guards against missing/zero data (returns "not flagged").
+ */
+const VEHICLE_EXCLUDE_MPH = 20;
+const VEHICLE_FLAG_MPH = 13;
+
+function classifyWorkoutSpeed(
+  distance: number | null | undefined,
+  totalDuration: number | null | undefined,
+): { exclusionReason: string | null; speedFlagged: boolean } {
+  const d = Number(distance);
+  const secs = Number(totalDuration);
+  if (!isFinite(d) || !isFinite(secs) || d <= 0 || secs <= 0) {
+    return { exclusionReason: null, speedFlagged: false };
+  }
+  const mph = (d * 3600) / secs;
+  if (mph >= VEHICLE_EXCLUDE_MPH) {
+    return { exclusionReason: "vehicle_speed", speedFlagged: true };
+  }
+  if (mph >= VEHICLE_FLAG_MPH) {
+    return { exclusionReason: null, speedFlagged: true };
+  }
+  return { exclusionReason: null, speedFlagged: false };
 }
 
 function dateStringMinus(dateStr: string, days: number): string {
@@ -120,6 +164,7 @@ export async function getActiveStreak(userId: string) {
     SELECT to_char(local_date, 'YYYY-MM-DD') AS local_date
     FROM workouts
     WHERE user_id = $1
+    AND deleted_at IS NULL AND exclusion_reason IS NULL
     GROUP BY local_date
     HAVING SUM(distance) >= 0.95
     ORDER BY local_date DESC
@@ -169,6 +214,7 @@ export async function getTotalMiles(userId: string, startDate?: string) {
   let distanceQuery = `
     SELECT SUM(distance) FROM workouts
     WHERE user_id = $1
+    AND deleted_at IS NULL AND exclusion_reason IS NULL
     `;
 
   const params: (string | number)[] = [userId];
@@ -185,6 +231,7 @@ export async function getBestMilesDay(userId: string, startDate?: string) {
   let bestDayQuery = `
     SELECT local_date, SUM(distance) as total_distance FROM workouts
     WHERE user_id = $1
+    AND deleted_at IS NULL AND exclusion_reason IS NULL
     `;
 
   const params: (string | number)[] = [userId];
@@ -245,6 +292,7 @@ export async function getRecentWorkouts(
   const recentWorkoutsQuery = `
 	SELECT * FROM workouts
 	WHERE user_id = $1
+	AND deleted_at IS NULL
 	ORDER BY device_end_date DESC
 	LIMIT $2
 	`;
@@ -281,6 +329,7 @@ export async function getTodayMiles(userId: string) {
 	SELECT SUM(w.distance) as total_distance FROM workouts w, user_tz
 	WHERE w.user_id = $1
 	AND w.local_date = (NOW() + (user_tz.tz_offset || ' minutes')::interval)::date
+	AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL
 	`;
 
   const result = await db.query(todayMilesQuery, [userId]);
@@ -299,7 +348,7 @@ export async function getMilesOnLocalDate(
   const result = await db.query<{ total_distance: string | number | null }>(
     `SELECT COALESCE(SUM(distance), 0) AS total_distance
 		FROM workouts
-		WHERE user_id = $1 AND local_date = $2::date`,
+		WHERE user_id = $1 AND local_date = $2::date AND deleted_at IS NULL AND exclusion_reason IS NULL`,
     [userId, localDate],
   );
   const value = result[0]?.total_distance;
@@ -362,6 +411,7 @@ export async function getTodayStats(userId: string): Promise<TodayStats> {
 		FROM workouts w, user_tz
 		WHERE w.user_id = $1
 			AND w.local_date = (NOW() + (user_tz.tz_offset || ' minutes')::interval)::date
+			AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL
 	),
 	totals AS (
 		SELECT
@@ -422,6 +472,7 @@ export async function getQuantityDateRange(
 			AND local_date >= $2
 			AND local_date <= $3
 			AND workout_type = ANY($4::text[])
+			AND deleted_at IS NULL AND exclusion_reason IS NULL
 		GROUP BY local_date
 		ORDER BY local_date ASC
 	`;
@@ -468,6 +519,7 @@ export async function getQuantityDateRangeBatch(
 			AND local_date >= $2
 			AND local_date <= $3
 			AND workout_type = ANY($4::text[])
+			AND deleted_at IS NULL AND exclusion_reason IS NULL
 		GROUP BY user_id, local_date
 		ORDER BY user_id, local_date ASC
 	`;
@@ -507,7 +559,8 @@ export async function getUsersWithManualWorkouts(
 		 WHERE user_id = ANY($1::text[])
 			AND local_date >= $2
 			AND local_date <= $3
-			AND source IN ('manual', 'edited')`,
+			AND source IN ('manual', 'edited')
+			AND deleted_at IS NULL AND exclusion_reason IS NULL`,
     [userIds, startDate, endDate],
   );
 
@@ -594,6 +647,7 @@ export async function computePersonalRecords(
 	       to_char(w.local_date, 'YYYY-MM-DD') AS best_day_date
 	   FROM workouts w
 	   WHERE w.user_id = $1 ${excludeClause}
+	       AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL
 	   GROUP BY w.local_date
 	   ORDER BY SUM(w.distance) DESC, w.local_date DESC
 	   LIMIT 1`;

--- a/website/app/.well-known/apple-app-site-association/route.ts
+++ b/website/app/.well-known/apple-app-site-association/route.ts
@@ -5,10 +5,9 @@
 // application/json content type with no file extension, which is what
 // Apple's CDN validator expects.
 //
-// TODO(rob): replace TEAMID with the Apple Developer Team ID
-// (developer.apple.com → Membership) and verify the bundle ID matches the
-// Xcode target. Format: "<TeamID>.<BundleID>".
-const APP_ID = 'TEAMID.com.mileaday'
+// Format: "<TeamID>.<BundleID>" — team + bundle confirmed from the app's
+// provisioning profile.
+const APP_ID = 'NS237SS5KD.org.robertwiscount.Mile-A-Day'
 
 export async function GET() {
   return Response.json({

--- a/website/app/u/[username]/page.tsx
+++ b/website/app/u/[username]/page.tsx
@@ -144,15 +144,22 @@ export default async function ProfilePage({
 
           <div className="mt-9 space-y-3">
             <a
-              href={APP_STORE_URL}
+              href={`mileaday://u/${encodeURIComponent(profile.username ?? '')}`}
               className="glass-button flex w-full items-center justify-center gap-2 rounded-2xl bg-[#c72554] px-6 py-4 text-[16px] font-semibold text-white transition-transform hover:scale-[1.02]"
             >
+              Open in Mile A Day
+            </a>
+            <a
+              href={APP_STORE_URL}
+              className="glass-button flex w-full items-center justify-center gap-2 rounded-2xl border border-[#c72554]/50 px-6 py-4 text-[16px] font-semibold text-[#f5f5f5] transition-transform hover:scale-[1.02]"
+            >
               <Apple className="h-5 w-5" aria-hidden />
-              Add {profile.first_name ?? profile.username} on Mile A Day
+              Get the app on the App Store
             </a>
             <p className="text-[13px] text-[#a0a0a0]/70">
-              Already have the app? Open this link on your iPhone and it&apos;ll take you straight
-              to {profile.first_name ? `${profile.first_name}’s` : 'their'} profile.
+              Have the app? &ldquo;Open in Mile A Day&rdquo; jumps straight to{' '}
+              {profile.first_name ? `${profile.first_name}’s` : 'their'} profile with an Add
+              Friend button.
             </p>
           </div>
         </div>


### PR DESCRIPTION
Several features on this branch. **iOS is Xcode-only here — please build before merge.** Backend is `tsc`-clean; website `next build` passes.

---

## 1. Premium 3D medals (follow-up to merged #178)
One shared `MedalView` everywhere a medal appears: rarity-tuned metallic faces, domed coin profile, engraved icon, milled edge; staggered shimmer; and `TiltableMedal` (CoreMotion) so you can tilt the phone and the medal rocks in 3D with a moving specular highlight. `BadgeDetailView` is now a `ScrollView` so the hero medal fits every screen (no more clipping under the dynamic island). Unlock celebration redone: rotating light rays (rare/legendary), a burst on the medal punch-in, heavier confetti, success haptics. `nudge_` badges now resolve their proper rarity.

## 2. Anti-cheat: vehicle detection + delete a workout (with streak/badge healing)
Problem: people leave tracking on and drive, inflating miles, and there was no way to remove a bad workout or undo the badges/streak it created. Miles come from HealthKit (the backend is the system of record), so this is **conservative plausibility-detection + reliable correction — it never hard-blocks a real run.**

**Prevention (can&#39;t reject a real run — the mile world record is ~15 mph):**
- On ingest, classify average speed. **≥20 mph** (impossible on foot) → auto-excluded, doesn&#39;t count. **13–20 mph** → flagged for review, still counts. New `workouts` columns `deleted_at` / `exclusion_reason` / `speed_flagged` (migration `0005`, additive). Re-upload recomputes the flag but never clears a user delete.
- iOS shows a &#34;looks like a drive&#34; banner on the workout detail when a workout is fast.

**Correction (the reliable catch-all):**
- `DELETE /users/:userId/workout/:workoutId` soft-deletes (the tombstone survives a HealthKit re-sync), recomputes the streak, drops the challenge completion that workout triggered, and **revokes badges no longer earned** — all-time-aware (uses max-ever streak) so legitimately-earned historical badges are never stripped; social/competition badges are never touched.
- **Every** aggregate read of `workouts` now excludes deleted + vehicle workouts (streak, total/best-day/pace, leaderboards, competition scoring, daily-challenge eval, mile-completion, notifications, unified feed) — 44 query sites. The user&#39;s *own* recent-workouts list still shows excluded ones so they can delete them.
- iOS: a Delete button + confirmation on the workout detail screen; a local `DeletedWorkoutRegistry` tombstones the id so the dashboard/streak/calendar drop it instantly and it isn&#39;t re-counted; badges + challenges refresh after delete.

## 3. BeReal-style run posts: one post + one notification per mile
- Completing the daily mile auto-creates **one** feed post linked to the workout: a rendered GPS route map when the run has one (MKMapSnapshotter), otherwise a branded stats card. A photo prompt (camera-only) appears after the celebration; taking a photo **replaces the media of the same post** — backend upserts by `workout_id` via a partial unique index (migration `0006`, additive).
- Friends get exactly **one** push, ~10 min later, via `pending_friend_notifications.send_after_at` + a 1-min drain cron. `notifyFriendsOfPost` stays gated OFF.
- Settings toggle: &#34;Photo prompt after a run&#34; (`autoShareRunsToFeed`).

## 4. Post-mile friends leaderboard + challenge polish
Duolingo-style today&#39;s-miles leaderboard fires after the daily mile **and** after extra workouts: your row climbs into place, with 👑/🚀/🔥 movement badges, gold burst + heavy haptic when you take #1. Challenge-complete celebration polished (gradient medallion, sweep ring, check badge).

## 5. QR scanning + profile link sharing — never through the website
The share/QR feature had all the in-app plumbing but the OS-level hooks were missing, so everything dead-ended on the website:
- **Registered the `mileaday://` URL scheme** (`CFBundleURLTypes`) — scanning a profile QR with the iPhone Camera now shows &#34;Open in Mile A Day&#34; and lands on the friend&#39;s profile with an Add Friend button. Previously nothing outside the app could open `mileaday://` links.
- **Fixed the site&#39;s `apple-app-site-association`** — it shipped with a `TEAMID.com.mileaday` placeholder, so universal links could never match. Now serves the real app ID (`NS237SS5KD.org.robertwiscount.Mile-A-Day`); once the entitlement below is enabled, tapping a shared `mileaday.run/u/&lt;username&gt;` link opens the app directly.
- Website `/u/&lt;username&gt;` page: primary **Open in Mile A Day** button (custom scheme) + App Store button — so even the Safari fallback is one tap back into the app.
- `DeepLinkRouter` also accepts `www.mileaday.run` links.

### ⚠️ One manual Xcode step (required for universal links)
In Xcode → target **Mile A Day** → Signing &amp; Capabilities → **+ Capability → Associated Domains** → add `applinks:mileaday.run`. Do **not** hand-edit the `.entitlements` file — if the capability isn&#39;t provisioned on the App ID, AMFI kills the app at launch (we&#39;ve hit this before). QR scanning + the website&#39;s open-in-app button work without this step; only direct link-taps from Messages need it. Deploy the website first so the AASA is live when Apple&#39;s CDN fetches it.

## Live-safety
All migrations additive (`0004`–`0006`). The mile-completion push moves from instant → ~10-min deferred + merged (the requested no-spam behavior). Backend deploys first and tolerates old clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxDWrDAbsnFQ2Jxj1qsgNu)_