### PR TITLE
Story vs feed: story = the moment, feed = the record (reactions, seen-by, promotion, photo flip, memories)

### DIFF
--- a/app/Mile A Day/Services/PostService.swift
+++ b/app/Mile A Day/Services/PostService.swift
@@ -94,6 +94,9 @@ struct FeedEntry: Codable, Identifiable {
     let media_url: String?
     let caption: String?
     let stats_snapshot: PostStats?
+    /// The run's story-only photo, when one exists — powers the photo/route
+    /// flip on the feed card without duplicating the run in the feed.
+    let story_photo_url: String?
     // workout-only
     let workout_type: String?
     let distance: Double?
@@ -109,13 +112,18 @@ struct FeedEntry: Codable, Identifiable {
         case kind
         case entryId = "id"
         case sort_ts, user_id, username, first_name, last_name, profile_image_url
-        case media_url, caption, stats_snapshot
+        case media_url, caption, stats_snapshot, story_photo_url
         case workout_type, distance, total_duration, calories, steps
         case is_self, is_hyped, hype_count
     }
 
     var id: String { "\(kind)-\(entryId)" }
     var isPost: Bool { kind == "post" }
+
+    var storyPhotoURL: URL? {
+        guard let story_photo_url, story_photo_url != media_url else { return nil }
+        return ProfileImageService.fullImageURL(for: story_photo_url)
+    }
 
     var displayName: String {
         if let username, !username.isEmpty { return username }
@@ -143,6 +151,32 @@ struct FeedEntry: Codable, Identifiable {
 struct UnifiedFeedResponse: Decodable {
     let items: [FeedEntry]
     let next_before: String?
+}
+
+/// One viewer of the caller's own story, with any emoji reaction they left.
+struct StoryViewer: Codable, Identifiable {
+    let user_id: String
+    let username: String?
+    let first_name: String?
+    let last_name: String?
+    let profile_image_url: String?
+    let viewed_at: String
+    let emoji: String?
+
+    var id: String { user_id }
+
+    var displayName: String {
+        if let username, !username.isEmpty { return username }
+        if let first_name, !first_name.isEmpty { return first_name }
+        return "Someone"
+    }
+
+    var relativeTime: String { RelativeTime.short(from: viewed_at) }
+}
+
+struct StoryViewersResponse: Decodable {
+    let viewers: [StoryViewer]
+    let count: Int
 }
 
 /// Generic `{ ok: true }` / `{ accepted: ... }` acknowledgements.
@@ -263,6 +297,36 @@ enum PostService {
             method: .POST,
             responseType: OKResponse.self
         )
+    }
+
+    /// Who saw the caller's own story, with any emoji reactions (reactors first).
+    static func storyViewers(postId: String) async throws -> StoryViewersResponse {
+        try await APIClient.fancyFetch(
+            endpoint: "/posts/stories/\(postId)/viewers",
+            responseType: StoryViewersResponse.self
+        )
+    }
+
+    /// Emoji-react to a friend's story. Re-reacting swaps the emoji.
+    static func reactToStory(postId: String, emoji: String) async throws {
+        struct Body: Encodable { let emoji: String }
+        let bodyData = try JSONEncoder().encode(Body(emoji: emoji))
+        _ = try await APIClient.fancyFetch(
+            endpoint: "/posts/stories/\(postId)/react",
+            method: .POST,
+            body: bodyData,
+            responseType: OKResponse.self
+        )
+    }
+
+    /// The caller's own post photos from this day in past years / a week ago /
+    /// a month ago — fuel for the "On this day" memories surface.
+    static func fetchPostMemories() async throws -> [PostItem] {
+        struct MemoriesResponse: Decodable { let items: [PostItem] }
+        return try await APIClient.fancyFetch(
+            endpoint: "/posts/memories",
+            responseType: MemoriesResponse.self
+        ).items
     }
 
     /// One page of the feed. Pass the previous page's `next_before` to paginate.

--- a/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
+++ b/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
@@ -42,7 +42,7 @@ struct PostRunPhotoPromptView: View {
                     Text(isWalk ? "Capture your walk" : "Capture your run")
                         .font(.system(size: 26, weight: .black, design: .rounded))
                         .foregroundColor(.white)
-                    Text("Add a photo to today's mile — it shares to your feed either way. Snap one before your friends get the heads-up.")
+                    Text("Snap a photo for your story — it disappears in 24 hours. Your run's route and stats post to the feed either way.")
                         .font(.system(size: 14, weight: .medium, design: .rounded))
                         .foregroundColor(.white.opacity(0.6))
                         .multilineTextAlignment(.center)
@@ -75,12 +75,19 @@ struct PostRunPhotoPromptView: View {
         }
         .onAppear { withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) { appeared = true } }
         .fullScreenCover(isPresented: $showComposer) {
-            PostComposerView(stats: RunPostService.todayStats(workoutId: workoutId), autoOpenCamera: true) { success in
+            PostComposerView(
+                stats: RunPostService.todayStats(workoutId: workoutId),
+                destination: .story,
+                autoOpenCamera: true
+            ) { outcome in
                 showComposer = false
                 didAct = true
-                // Cancelled the camera? Still publish the auto route/stats post so
-                // the run gets one nice feed item.
-                if !success {
+                // The feed always gets the run's route/stats card UNLESS the
+                // photo itself was sent to the feed (then it IS the feed item).
+                switch outcome {
+                case .published(let toFeed, _) where toFeed:
+                    break
+                default:
                     Task { await RunPostService.autoPostMile(workoutId: workoutId, workoutType: workoutType) }
                 }
                 finish()

--- a/app/Mile A Day/Views/Feed/Memories.swift
+++ b/app/Mile A Day/Views/Feed/Memories.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
-/// A walk/run the user did on today's calendar day in a previous year.
+/// A walk/run the user did on today's calendar day in a previous year — or a
+/// past post photo (a week / a month / years ago) resurfaced from the server.
 struct MemoryItem: Identifiable {
     let id = UUID()
     let date: Date
@@ -8,8 +9,16 @@ struct MemoryItem: Identifiable {
     let miles: Double
     let workoutType: String
     let durationSeconds: Double
+    /// The story/feed photo from that day, when one exists. Expired stories
+    /// live on here — the photo outlasts its 24 hours.
+    var photoURL: URL? = nil
+    /// Overrides the "N years ago" label for sub-year memories ("1 week ago").
+    var agoOverride: String? = nil
 
-    var yearsAgoText: String { yearsAgo == 1 ? "1 year ago" : "\(yearsAgo) years ago" }
+    var yearsAgoText: String {
+        if let agoOverride { return agoOverride }
+        return yearsAgo == 1 ? "1 year ago" : "\(yearsAgo) years ago"
+    }
 }
 
 /// Builds "On this day" memories from the locally-cached HealthKit workout
@@ -41,6 +50,54 @@ enum MemoriesService {
         }
         return out.sorted { $0.yearsAgo < $1.yearsAgo }
     }
+
+    /// Blend the server's photo memories (this day in past years, a week ago,
+    /// a month ago) into the local HealthKit ones: matching days get the photo
+    /// attached; days we have no workout record for become photo-only items.
+    static func mergingPostMemories(_ posts: [PostItem], into items: [MemoryItem]) -> [MemoryItem] {
+        var merged = items
+        let cal = Calendar.current
+        let parser: DateFormatter = {
+            let f = DateFormatter()
+            f.dateFormat = "yyyy-MM-dd"
+            return f
+        }()
+        let today = cal.startOfDay(for: Date())
+
+        for post in posts {
+            guard let localDate = post.local_date, let date = parser.date(from: localDate),
+                  let photoURL = post.mediaURL else { continue }
+            let days = cal.dateComponents([.day], from: cal.startOfDay(for: date), to: today).day ?? 0
+            guard days > 0 else { continue }
+
+            let ago: String? = {
+                if days == 7 { return "1 week ago" }
+                if days < 360 { return "1 month ago" }
+                return nil // exact-year memories use the standard label
+            }()
+            let years = cal.dateComponents([.year], from: date, to: today).year ?? 0
+
+            if let idx = merged.firstIndex(where: { cal.isDate($0.date, inSameDayAs: date) }) {
+                if merged[idx].photoURL == nil { merged[idx].photoURL = photoURL }
+                if merged[idx].agoOverride == nil, let ago { merged[idx].agoOverride = ago }
+            } else {
+                merged.append(MemoryItem(
+                    date: date,
+                    yearsAgo: max(years, 0),
+                    miles: post.stats_snapshot?.distance ?? 0,
+                    workoutType: "running",
+                    durationSeconds: post.stats_snapshot?.duration ?? 0,
+                    photoURL: photoURL,
+                    agoOverride: ago
+                ))
+            }
+        }
+        // Freshest memories first: sub-year (week/month) photos, then by years.
+        return merged.sorted {
+            if ($0.agoOverride != nil) != ($1.agoOverride != nil) { return $0.agoOverride != nil }
+            return $0.yearsAgo < $1.yearsAgo
+        }
+    }
 }
 
 /// Compact "On this day" card shown at the top of the feed when memories exist.
@@ -51,11 +108,23 @@ struct MemoriesCardView: View {
     var body: some View {
         Button(action: onTap) {
             HStack(spacing: MADTheme.Spacing.md) {
-                Image(systemName: "clock.arrow.circlepath")
-                    .font(.system(size: 22, weight: .bold))
-                    .foregroundColor(.white)
+                if let photoURL = memories.first(where: { $0.photoURL != nil })?.photoURL {
+                    AsyncImage(url: photoURL) { phase in
+                        if case .success(let image) = phase {
+                            image.resizable().scaledToFill()
+                        } else {
+                            Color.white.opacity(0.06)
+                        }
+                    }
                     .frame(width: 44, height: 44)
-                    .background(Circle().fill(MADTheme.Colors.redGradient))
+                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                } else {
+                    Image(systemName: "clock.arrow.circlepath")
+                        .font(.system(size: 22, weight: .bold))
+                        .foregroundColor(.white)
+                        .frame(width: 44, height: 44)
+                        .background(Circle().fill(MADTheme.Colors.redGradient))
+                }
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text("On this day")
@@ -129,11 +198,26 @@ struct MemoriesDetailView: View {
 
     private func row(_ memory: MemoryItem) -> some View {
         HStack(spacing: MADTheme.Spacing.md) {
-            Image(systemName: ActivityCardView.icon(memory.workoutType))
-                .font(.system(size: 20, weight: .bold))
-                .foregroundColor(ActivityCardView.color(memory.workoutType))
-                .frame(width: 44, height: 44)
-                .background(Circle().fill(Color.white.opacity(0.06)))
+            if let photoURL = memory.photoURL {
+                AsyncImage(url: photoURL) { phase in
+                    if case .success(let image) = phase {
+                        image.resizable().scaledToFill()
+                    } else {
+                        ZStack {
+                            Color.white.opacity(0.06)
+                            Image(systemName: "photo").foregroundColor(.white.opacity(0.3))
+                        }
+                    }
+                }
+                .frame(width: 56, height: 70)
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            } else {
+                Image(systemName: ActivityCardView.icon(memory.workoutType))
+                    .font(.system(size: 20, weight: .bold))
+                    .foregroundColor(ActivityCardView.color(memory.workoutType))
+                    .frame(width: 44, height: 44)
+                    .background(Circle().fill(Color.white.opacity(0.06)))
+            }
 
             VStack(alignment: .leading, spacing: 3) {
                 Text(memory.yearsAgoText)

--- a/app/Mile A Day/Views/Feed/PostCardView.swift
+++ b/app/Mile A Day/Views/Feed/PostCardView.swift
@@ -2,13 +2,19 @@ import SwiftUI
 
 /// A single post in the social feed: author header, photo (overlay already
 /// baked in), caption, hype + social-proof tally, and a report/block/delete menu.
+/// When the run also has a story photo, a corner thumbnail flips the card
+/// between the route/stats image and the photo.
 struct PostCardView: View {
     let post: PostItem
+    /// The run's story-only photo, when different from the post media.
+    var storyPhotoURL: URL? = nil
     var isHyping: Bool = false
     let onHype: () -> Void
     let onReport: () -> Void
     let onBlock: () -> Void
     let onDelete: () -> Void
+
+    @State private var showAltPhoto = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
@@ -66,8 +72,45 @@ struct PostCardView: View {
         }
     }
 
+    private var heroURL: URL? {
+        showAltPhoto ? storyPhotoURL : post.mediaURL
+    }
+    private var thumbURL: URL? {
+        showAltPhoto ? post.mediaURL : storyPhotoURL
+    }
+
     private var photo: some View {
-        AsyncImage(url: post.mediaURL) { phase in
+        cardImage(heroURL)
+            .frame(maxWidth: .infinity)
+            .aspectRatio(4.0 / 5.0, contentMode: .fit)
+            .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
+            .overlay(alignment: .bottomTrailing) {
+                // Corner thumbnail flips between the route/stats card and the
+                // run's story photo (BeReal-style).
+                if storyPhotoURL != nil {
+                    Button {
+                        withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                            showAltPhoto.toggle()
+                        }
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    } label: {
+                        cardImage(thumbURL)
+                            .frame(width: 64, height: 80)
+                            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                    .strokeBorder(Color.white.opacity(0.9), lineWidth: 1.5)
+                            )
+                            .shadow(color: .black.opacity(0.5), radius: 6, y: 3)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(10)
+                }
+            }
+    }
+
+    private func cardImage(_ url: URL?) -> some View {
+        AsyncImage(url: url) { phase in
             switch phase {
             case .success(let image):
                 image.resizable().scaledToFill()
@@ -80,9 +123,6 @@ struct PostCardView: View {
                 ZStack { Color.white.opacity(0.05); ProgressView().tint(.white) }
             }
         }
-        .frame(maxWidth: .infinity)
-        .aspectRatio(4.0 / 5.0, contentMode: .fit)
-        .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
     }
 
     private var footer: some View {

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -62,12 +62,51 @@ struct RunStatsInput {
     }
 }
 
+/// Where a post goes. Stories are the ephemeral 24h moment; the feed is the
+/// permanent record. Cross-posting is a deliberate "Both" choice, not the default.
+enum PostDestination: String, CaseIterable, Identifiable {
+    case story, feed, both
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .story: return "Story"
+        case .feed: return "Feed"
+        case .both: return "Both"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .story: return "circle.dashed"
+        case .feed: return "square.stack"
+        case .both: return "square.on.circle"
+        }
+    }
+
+    var footnote: String {
+        switch self {
+        case .story: return "Disappears in 24 hours — friends who've done their mile can watch."
+        case .feed: return "Stays on your profile and in friends' feeds."
+        case .both: return "Posts to your story and your permanent feed."
+        }
+    }
+
+    var toStory: Bool { self != .feed }
+    var toFeed: Bool { self != .story }
+}
+
+/// What the composer did, reported back to the presenter.
+enum PostComposeOutcome {
+    case cancelled
+    case published(toFeed: Bool, toStory: Bool)
+}
+
 @MainActor
 final class PostComposerViewModel: ObservableObject {
     @Published var pickedImage: UIImage?
     @Published var caption: String = ""
-    @Published var shareToStory: Bool = true
-    @Published var shareToFeed: Bool = true
+    @Published var destination: PostDestination
     @Published var stickerEnabled: Bool = true
     /// Sticker center in normalized canvas coordinates (0…1).
     @Published var stickerPos: CGPoint = CGPoint(x: 0.5, y: 0.82)
@@ -80,8 +119,9 @@ final class PostComposerViewModel: ObservableObject {
     /// Captured on-screen canvas size (points), reused to render the composite.
     var canvasSize: CGSize = .zero
 
-    init(stats: RunStatsInput) {
+    init(stats: RunStatsInput, destination: PostDestination) {
         self.stats = stats
+        self.destination = destination
         var cfg = StickerConfig.load()
         // Drop any remembered stats that aren't available today, and make sure
         // at least one available stat is shown.
@@ -92,7 +132,7 @@ final class PostComposerViewModel: ObservableObject {
     }
 
     var canPublish: Bool {
-        pickedImage != nil && (shareToStory || shareToFeed) && !isPublishing
+        pickedImage != nil && !isPublishing
     }
 
     /// Render the on-screen canvas (photo + sticker) to a flat JPEG-ready image
@@ -131,8 +171,8 @@ final class PostComposerViewModel: ObservableObject {
                 mediaUrl: mediaUrl,
                 caption: caption.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : caption,
                 workoutId: stats.workoutId,
-                shareToFeed: shareToFeed,
-                shareToStory: shareToStory,
+                shareToFeed: destination.toFeed,
+                shareToStory: destination.toStory,
                 stats: stats.snapshot
             )
             if stickerEnabled { config.save() } // remember the user's overlay style
@@ -188,11 +228,16 @@ struct PostComposerView: View {
     /// Launch straight into the camera on first appear (post-run prompt flow) —
     /// the user already tapped "Take a photo" once to get here.
     let autoOpenCamera: Bool
-    let onFinished: (Bool) -> Void
+    let onFinished: (PostComposeOutcome) -> Void
     @Environment(\.dismiss) private var dismiss
 
-    init(stats: RunStatsInput, autoOpenCamera: Bool = false, onFinished: @escaping (Bool) -> Void) {
-        _vm = StateObject(wrappedValue: PostComposerViewModel(stats: stats))
+    init(
+        stats: RunStatsInput,
+        destination: PostDestination = .feed,
+        autoOpenCamera: Bool = false,
+        onFinished: @escaping (PostComposeOutcome) -> Void
+    ) {
+        _vm = StateObject(wrappedValue: PostComposerViewModel(stats: stats, destination: destination))
         self.autoOpenCamera = autoOpenCamera
         self.onFinished = onFinished
     }
@@ -223,7 +268,7 @@ struct PostComposerView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { onFinished(false); dismiss() }
+                    Button("Cancel") { onFinished(.cancelled); dismiss() }
                         .foregroundColor(.white)
                 }
                 ToolbarItem(placement: .confirmationAction) {
@@ -233,7 +278,13 @@ struct PostComposerView: View {
                         Button("Share") {
                             Task {
                                 let ok = await vm.publish()
-                                if ok { onFinished(true); dismiss() }
+                                if ok {
+                                    onFinished(.published(
+                                        toFeed: vm.destination.toFeed,
+                                        toStory: vm.destination.toStory
+                                    ))
+                                    dismiss()
+                                }
                             }
                         }
                         .fontWeight(.bold)
@@ -497,28 +548,43 @@ struct PostComposerView: View {
         }
     }
 
+    /// Story / Feed / Both — a single deliberate destination choice, so the
+    /// story stays the ephemeral moment and the feed stays the curated record.
     private var destinationToggles: some View {
-        VStack(spacing: MADTheme.Spacing.sm) {
-            Toggle(isOn: $vm.shareToStory) {
-                Label("Share to Story", systemImage: "circle.dashed")
-                    .font(.system(size: 14, weight: .semibold, design: .rounded))
-                    .foregroundColor(.white)
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+            editorLabel("SHARE TO")
+            HStack(spacing: MADTheme.Spacing.sm) {
+                ForEach(PostDestination.allCases) { dest in
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.15)) { vm.destination = dest }
+                    } label: {
+                        VStack(spacing: 4) {
+                            Image(systemName: dest.icon)
+                                .font(.system(size: 16, weight: .bold))
+                            Text(dest.title)
+                                .font(.system(size: 13, weight: .bold, design: .rounded))
+                        }
+                        .foregroundColor(vm.destination == dest ? .white : .white.opacity(0.55))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 10)
+                        .background(
+                            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
+                                .fill(vm.destination == dest
+                                    ? AnyShapeStyle(MADTheme.Colors.redGradient)
+                                    : AnyShapeStyle(Color.white.opacity(0.06)))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
+                                .strokeBorder(Color.white.opacity(vm.destination == dest ? 0 : 0.1), lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
             }
-            .tint(MADTheme.Colors.madRed)
-
-            Toggle(isOn: $vm.shareToFeed) {
-                Label("Share to Feed", systemImage: "square.stack")
-                    .font(.system(size: 14, weight: .semibold, design: .rounded))
-                    .foregroundColor(.white)
-            }
-            .tint(MADTheme.Colors.madRed)
-
-            if !vm.shareToStory && !vm.shareToFeed {
-                Text("Pick at least one place to share.")
-                    .font(.system(size: 12, weight: .medium, design: .rounded))
-                    .foregroundColor(MADTheme.Colors.warning)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
+            Text(vm.destination.footnote)
+                .font(.system(size: 12, weight: .medium, design: .rounded))
+                .foregroundColor(.white.opacity(0.5))
+                .fixedSize(horizontal: false, vertical: true)
         }
         .padding(MADTheme.Spacing.md)
         .background(

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -105,8 +105,8 @@ struct SocialFeedView: View {
             }
         }
         .sheet(isPresented: $presentingComposer) {
-            PostComposerView(stats: statsInput) { success in
-                if success { Task { await refresh() } }
+            PostComposerView(stats: statsInput, destination: .feed) { outcome in
+                if case .published = outcome { Task { await refresh() } }
             }
         }
         .sheet(item: $reportingPost) { post in
@@ -133,6 +133,7 @@ struct SocialFeedView: View {
         if entry.isPost, let post = entry.asPostItem() {
             PostCardView(
                 post: post,
+                storyPhotoURL: entry.storyPhotoURL,
                 isHyping: hypingIds.contains(entry.id),
                 onHype: { Task { await hype(entry) } },
                 onReport: { reportingPost = post },
@@ -198,7 +199,16 @@ struct SocialFeedView: View {
     }
 
     private func loadMemories() {
+        // Local HealthKit memories show instantly; past post photos (this day
+        // in past years, a week ago, a month ago) blend in when they arrive.
         memories = MemoriesService.onThisDay(using: healthManager)
+        Task {
+            if let posts = try? await PostService.fetchPostMemories(), !posts.isEmpty {
+                await MainActor.run {
+                    memories = MemoriesService.mergingPostMemories(posts, into: memories)
+                }
+            }
+        }
     }
 
     // MARK: - Data

--- a/app/Mile A Day/Views/Feed/StoryViewerView.swift
+++ b/app/Mile A Day/Views/Feed/StoryViewerView.swift
@@ -22,7 +22,17 @@ struct StoryViewerView: View {
     @State private var imageReady = false
 
     @State private var showReport = false
-    @State private var hyping = false
+    /// postId → emoji the viewer sent this session (server keeps one per story).
+    @State private var myReactions: [String: String] = [:]
+    /// Own-story extras: seen-by counts per post + the viewers sheet.
+    @State private var viewerCounts: [String: Int] = [:]
+    @State private var viewersSheetFor: PostItem?
+    /// Stories promoted to the feed this session ("Add to feed").
+    @State private var promotedIds: Set<String> = []
+    @State private var promoting = false
+
+    /// The emoji palette — must match the backend's ALLOWED_STORY_REACTIONS.
+    private let reactionEmojis = ["❤️", "🔥", "👏", "💪", "😮"]
 
     private let stepDuration: CGFloat = 5.0
     private let tick = Timer.publish(every: 0.05, on: .main, in: .common).autoconnect()
@@ -76,6 +86,16 @@ struct StoryViewerView: View {
         .sheet(isPresented: $showReport, onDismiss: { paused = false }) {
             if let post = current {
                 ReportPostSheet(postId: post.post_id) { showReport = false }
+            }
+        }
+        .sheet(item: $viewersSheetFor, onDismiss: { paused = false }) { post in
+            StoryViewersSheet(postId: post.post_id)
+        }
+        .task(id: current?.post_id) {
+            // Own story: load who's seen it so the "Seen by" pill has a count.
+            guard let post = current, post.is_self else { return }
+            if let resp = try? await PostService.storyViewers(postId: post.post_id) {
+                viewerCounts[post.post_id] = resp.count
             }
         }
         .statusBarHidden(true)
@@ -152,12 +172,12 @@ struct StoryViewerView: View {
         .shadow(color: .black.opacity(0.4), radius: 6)
     }
 
-    // Instagram-style footer: caption bottom-left, hype bottom-right, over a soft
-    // bottom scrim. The run stats already live in the photo's baked-in overlay,
-    // so we don't repeat them here.
+    // Instagram-style footer over a soft bottom scrim: caption on top, then the
+    // ephemeral controls — emoji reactions on a friend's story, "Seen by" +
+    // "Add to feed" on your own. (Hype stays the feed's currency.)
     @ViewBuilder
     private func footer(_ post: PostItem) -> some View {
-        HStack(alignment: .bottom, spacing: 12) {
+        VStack(alignment: .leading, spacing: 12) {
             if let caption = post.caption, !caption.isEmpty {
                 Text(caption)
                     .font(.system(size: 15, weight: .semibold, design: .rounded))
@@ -165,14 +185,16 @@ struct StoryViewerView: View {
                     .shadow(color: .black.opacity(0.7), radius: 4, y: 1)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
-            } else {
-                Spacer(minLength: 0)
             }
 
-            if !post.is_self {
-                HypeButton(isHyped: post.is_hyped, isBusy: hyping) {
-                    Task { await hype(post) }
+            if post.is_self {
+                HStack(spacing: 10) {
+                    seenByPill(post)
+                    if canPromote(post) { addToFeedPill(post) }
+                    Spacer(minLength: 0)
                 }
+            } else {
+                reactionBar(post)
             }
         }
         .padding(.horizontal, 16)
@@ -185,6 +207,86 @@ struct StoryViewerView: View {
                 .allowsHitTesting(false)
                 .ignoresSafeArea()
         )
+    }
+
+    /// Ephemeral emoji reactions — the story counterpart to feed hype.
+    private func reactionBar(_ post: PostItem) -> some View {
+        HStack(spacing: 10) {
+            ForEach(reactionEmojis, id: \.self) { emoji in
+                let selected = myReactions[post.post_id] == emoji
+                Button {
+                    react(post, emoji)
+                } label: {
+                    Text(emoji)
+                        .font(.system(size: selected ? 26 : 22))
+                        .frame(width: 44, height: 44)
+                        .background(
+                            Circle().fill(selected ? Color.white.opacity(0.25) : Color.black.opacity(0.35))
+                        )
+                        .overlay(
+                            Circle().strokeBorder(Color.white.opacity(selected ? 0.7 : 0.15), lineWidth: 1)
+                        )
+                        .scaleEffect(selected ? 1.08 : 1.0)
+                }
+                .buttonStyle(.plain)
+            }
+            Spacer(minLength: 0)
+        }
+        .animation(.spring(response: 0.3, dampingFraction: 0.6), value: myReactions)
+    }
+
+    private func seenByPill(_ post: PostItem) -> some View {
+        Button {
+            paused = true
+            viewersSheetFor = post
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "eye.fill")
+                    .font(.system(size: 12, weight: .bold))
+                if let count = viewerCounts[post.post_id] {
+                    Text(count == 1 ? "Seen by 1" : "Seen by \(count)")
+                        .font(.system(size: 13, weight: .bold, design: .rounded))
+                } else {
+                    Text("Seen by")
+                        .font(.system(size: 13, weight: .bold, design: .rounded))
+                }
+            }
+            .foregroundColor(.white)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Capsule().fill(Color.black.opacity(0.4)))
+            .overlay(Capsule().strokeBorder(Color.white.opacity(0.2), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+    }
+
+    /// A story photo can be promoted into the permanent feed — it replaces the
+    /// run's auto route/stats card in place (upsert by workout).
+    private func canPromote(_ post: PostItem) -> Bool {
+        post.share_to_feed != true && !promotedIds.contains(post.post_id)
+    }
+
+    private func addToFeedPill(_ post: PostItem) -> some View {
+        Button {
+            Task { await promoteToFeed(post) }
+        } label: {
+            HStack(spacing: 6) {
+                if promoting {
+                    ProgressView().tint(.white).scaleEffect(0.7)
+                } else {
+                    Image(systemName: "square.stack.badge.plus")
+                        .font(.system(size: 12, weight: .bold))
+                }
+                Text("Add to feed")
+                    .font(.system(size: 13, weight: .bold, design: .rounded))
+            }
+            .foregroundColor(.white)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Capsule().fill(MADTheme.Colors.madRed.opacity(0.85)))
+        }
+        .buttonStyle(.plain)
+        .disabled(promoting)
     }
 
     @ViewBuilder
@@ -258,27 +360,36 @@ struct StoryViewerView: View {
         }
     }
 
-    private func hype(_ post: PostItem) async {
-        guard !hyping, !post.is_hyped else { return }
-        hyping = true
-        defer { hyping = false }
+    private func react(_ post: PostItem, _ emoji: String) {
+        // Optimistic — the server keeps one reaction per story and swapping is
+        // idempotent, so a failed call just means no push went out.
+        myReactions[post.post_id] = emoji
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        Task { try? await PostService.reactToStory(postId: post.post_id, emoji: emoji) }
+    }
+
+    private func promoteToFeed(_ post: PostItem) async {
+        guard !promoting else { return }
+        promoting = true
+        defer { promoting = false }
         do {
-            _ = try await HypeService.sendHype(
-                targetUserId: post.user_id,
-                context: HypeContext(
-                    contextType: "post",
-                    contextId: post.post_id,
-                    contextLabel: post.caption ?? group.displayName
-                )
+            // Carries the workout id, so this upserts the photo into the run's
+            // existing feed post (replacing the auto route/stats card in place).
+            _ = try await PostService.createPost(
+                mediaUrl: post.media_url,
+                caption: post.caption,
+                workoutId: post.workout_id,
+                shareToFeed: true,
+                shareToStory: false,
+                stats: post.stats_snapshot
             )
             await MainActor.run {
-                if stories.indices.contains(index) {
-                    stories[index].is_hyped = true
-                    stories[index].hype_count = (stories[index].hype_count ?? 0) + 1
-                }
+                promotedIds.insert(post.post_id)
+                changed = true
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
             }
         } catch {
-            // conflict (already hyped) / rate-limited — leave button as-is.
+            print("[StoryViewer] ❌ Add to feed failed: \(error)")
         }
     }
 
@@ -302,5 +413,90 @@ struct StoryViewerView: View {
             changed = true
             await MainActor.run { close() }
         } catch {}
+    }
+}
+
+/// "Seen by" list for the author's own story: who watched, when, and any emoji
+/// reaction they left (reactors sort first, matching the server order).
+struct StoryViewersSheet: View {
+    let postId: String
+    @Environment(\.dismiss) private var dismiss
+    @State private var viewers: [StoryViewer] = []
+    @State private var loaded = false
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                MADTheme.Colors.appBackgroundGradient.ignoresSafeArea()
+                Group {
+                    if !loaded {
+                        ProgressView().tint(.white)
+                    } else if viewers.isEmpty {
+                        VStack(spacing: MADTheme.Spacing.sm) {
+                            Image(systemName: "eye.slash")
+                                .font(.system(size: 30))
+                                .foregroundColor(.white.opacity(0.3))
+                            Text("No views yet")
+                                .font(.system(size: 15, weight: .bold, design: .rounded))
+                                .foregroundColor(.white)
+                            Text("Friends see your story once they've done their mile today.")
+                                .font(.system(size: 12, weight: .medium, design: .rounded))
+                                .foregroundColor(.white.opacity(0.5))
+                                .multilineTextAlignment(.center)
+                                .padding(.horizontal, MADTheme.Spacing.xl)
+                        }
+                    } else {
+                        ScrollView {
+                            VStack(spacing: MADTheme.Spacing.sm) {
+                                ForEach(viewers) { viewer in
+                                    row(viewer)
+                                }
+                            }
+                            .padding(MADTheme.Spacing.md)
+                        }
+                    }
+                }
+            }
+            .navigationTitle(loaded && !viewers.isEmpty ? "Seen by \(viewers.count)" : "Seen by")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .task {
+            if let resp = try? await PostService.storyViewers(postId: postId) {
+                viewers = resp.viewers
+            }
+            loaded = true
+        }
+    }
+
+    private func row(_ viewer: StoryViewer) -> some View {
+        HStack(spacing: MADTheme.Spacing.md) {
+            AvatarView(name: viewer.displayName, imageURL: viewer.profile_image_url, size: 44)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(viewer.displayName)
+                    .font(.system(size: 15, weight: .bold, design: .rounded))
+                    .foregroundColor(.white)
+                    .lineLimit(1)
+                Text(viewer.relativeTime)
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundColor(.white.opacity(0.5))
+            }
+            Spacer()
+            if let emoji = viewer.emoji {
+                Text(emoji)
+                    .font(.system(size: 24))
+            }
+        }
+        .padding(.horizontal, MADTheme.Spacing.md)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
+                .fill(Color.white.opacity(0.04))
+        )
     }
 }

--- a/app/Mile A Day/Views/NotificationSettingsView.swift
+++ b/app/Mile A Day/Views/NotificationSettingsView.swift
@@ -147,7 +147,7 @@ struct NotificationSettingsView: View {
                             description: "Friends see your activity in the unified feed")
                         settingsDivider
                         settingsToggle("Photo prompt after a run", isOn: $autoShareRunsToFeed,
-                            description: "Snap a photo of your mile — skipping shares the route map instead")
+                            description: "Snap a story photo of your mile — the route map posts to the feed either way")
                         settingsDivider
                         settingsToggle("New posts from friends", isOn: $prefs.friendPostsEnabled,
                             description: "Get notified when a friend shares a photo")

--- a/backend/src/controllers/postsController.ts
+++ b/backend/src/controllers/postsController.ts
@@ -17,6 +17,10 @@ import {
   moderatorDeletePost,
   hasAcceptedTerms,
   acceptTerms,
+  getStoryViewers,
+  reactToStory,
+  getOwnPostMemories,
+  ALLOWED_STORY_REACTIONS,
   PostStatsSnapshot,
 } from "../services/postService.js";
 import {
@@ -200,6 +204,66 @@ export async function markStoryViewedController(
   } catch (error: any) {
     console.error("Error marking story viewed:", error.message);
     res.status(500).json({ error: "Error marking story viewed" });
+  }
+}
+
+/** Who saw the caller's own story (with reactions). 404 unless it's theirs. */
+export async function getStoryViewersController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  try {
+    const viewers = await getStoryViewers(req.userId!, req.params.postId);
+    if (viewers === null) {
+      return res.status(404).json({ error: "story_not_found" });
+    }
+    res.json({ viewers, count: viewers.length });
+  } catch (error: any) {
+    console.error("Error getting story viewers:", error.message);
+    res.status(500).json({ error: "Error getting story viewers" });
+  }
+}
+
+/** Emoji-react to a friend's active story. Re-reacting swaps the emoji. */
+export async function reactToStoryController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  try {
+    const emoji = typeof req.body?.emoji === "string" ? req.body.emoji : "";
+    if (!ALLOWED_STORY_REACTIONS.has(emoji)) {
+      return res.status(400).json({ error: "invalid_reaction" });
+    }
+    const result = await reactToStory(req.userId!, req.params.postId, emoji);
+    if (result === "not_found") {
+      return res.status(404).json({ error: "story_not_found" });
+    }
+    if (result === "forbidden") {
+      return res.status(403).json({ error: "not_allowed" });
+    }
+    res.json({ ok: true });
+  } catch (error: any) {
+    console.error("Error reacting to story:", error.message);
+    res.status(500).json({ error: "Error reacting to story" });
+  }
+}
+
+/**
+ * The caller's own post photos from this day in past years / a week ago / a
+ * month ago, for the "On this day" memories surface. Uses the same
+ * timezone-aware local date as posting.
+ */
+export async function getPostMemoriesController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  try {
+    const goal = await getDailyGoalStatus(req.userId!);
+    const items = await getOwnPostMemories(req.userId!, goal.localDate);
+    res.json({ items });
+  } catch (error: any) {
+    console.error("Error getting post memories:", error.message);
+    res.status(500).json({ error: "Error getting post memories" });
   }
 }
 

--- a/backend/src/db/drizzle/0007_tearful_deathbird.sql
+++ b/backend/src/db/drizzle/0007_tearful_deathbird.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "story_reactions" (
+	"post_id" uuid NOT NULL,
+	"user_id" text NOT NULL,
+	"emoji" varchar(16) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "story_reactions_pkey" PRIMARY KEY("post_id","user_id")
+);
+--> statement-breakpoint
+DROP INDEX "uq_posts_workout_active";--> statement-breakpoint
+ALTER TABLE "story_reactions" ADD CONSTRAINT "story_reactions_post_id_fkey" FOREIGN KEY ("post_id") REFERENCES "public"."posts"("post_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "story_reactions" ADD CONSTRAINT "story_reactions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("user_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_posts_workout_story" ON "posts" USING btree ("workout_id") WHERE (deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_story AND NOT share_to_feed);--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_posts_workout_active" ON "posts" USING btree ("workout_id") WHERE (deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_feed);

--- a/backend/src/db/drizzle/meta/0007_snapshot.json
+++ b/backend/src/db/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,3570 @@
+{
+  "id": "2bd52430-7aa5-4bb3-b34f-070b6a369dc7",
+  "prevId": "46bfd06c-e404-4c37-b13b-48364f849bea",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_badges_category": {
+          "name": "idx_badges_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "badges_rarity_check": {
+          "name": "badges_rarity_check",
+          "value": "rarity = ANY (ARRAY['common'::text, 'rare'::text, 'legendary'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.close_friends": {
+      "name": "close_friends",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_friend_id": {
+          "name": "close_friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_close_friends_friend": {
+          "name": "idx_close_friends_friend",
+          "columns": [
+            {
+              "expression": "close_friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "close_friends_pkey": {
+          "name": "close_friends_pkey",
+          "columns": [
+            "user_id",
+            "close_friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_users": {
+      "name": "competition_users",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_rank": {
+          "name": "last_known_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_score": {
+          "name": "last_known_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rank_updated_at": {
+          "name": "last_rank_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_competition_users_comp": {
+          "name": "idx_competition_users_comp",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_competition": {
+          "name": "idx_competition_users_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_rank_cache": {
+          "name": "idx_competition_users_rank_cache",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_known_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((invite_status)::text = 'accepted'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user": {
+          "name": "idx_competition_users_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user_status": {
+          "name": "idx_competition_users_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invite_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_users_user_id_fkey": {
+          "name": "competition_users_user_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_users_competition_id_fkey": {
+          "name": "competition_users_competition_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_users_pkey": {
+          "name": "competition_users_pkey",
+          "columns": [
+            "competition_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_users_invite_status_check": {
+          "name": "competition_users_invite_status_check",
+          "value": "(invite_status)::text = ANY ((ARRAY['pending'::character varying, 'accepted'::character varying, 'declined'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workouts": {
+          "name": "workouts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_winner": {
+          "name": "idx_competitions_winner",
+          "columns": [
+            {
+              "expression": "winner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(winner IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_winner_fkey": {
+          "name": "competitions_winner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "competitions_owner_fkey": {
+          "name": "competitions_owner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitions_type_check": {
+          "name": "competitions_type_check",
+          "value": "(type)::text = ANY ((ARRAY['streaks'::character varying, 'apex'::character varying, 'clash'::character varying, 'targets'::character varying, 'race'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_challenges": {
+      "name": "daily_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_template": {
+          "name": "description_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_start": {
+          "name": "gradient_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_end": {
+          "name": "gradient_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rotation_index": {
+          "name": "rotation_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_challenges_rotation_index_key": {
+          "name": "daily_challenges_rotation_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rotation_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daily_challenges_type_check": {
+          "name": "daily_challenges_type_check",
+          "value": "type = ANY (ARRAY['pace'::text, 'distance'::text, 'time'::text, 'activity'::text, 'steps'::text, 'social'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_steps": {
+      "name": "daily_steps",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_steps_user_date": {
+          "name": "idx_daily_steps_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_steps_user_id_fkey": {
+          "name": "daily_steps_user_id_fkey",
+          "tableFrom": "daily_steps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_steps_pkey": {
+          "name": "daily_steps_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "daily_steps_steps_check": {
+          "name": "daily_steps_steps_check",
+          "value": "steps >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token": {
+          "name": "device_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_tokens_user_id": {
+          "name": "idx_device_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_user_id_fkey": {
+          "name": "device_tokens_user_id_fkey",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_user_id_device_token_key": {
+          "name": "device_tokens_user_id_device_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flex_log": {
+      "name": "flex_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flex_log_lookup": {
+          "name": "idx_flex_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_notification_settings": {
+      "name": "friend_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted": {
+          "name": "muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nudges_muted": {
+          "name": "nudges_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "activity_muted": {
+          "name": "activity_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "friend_notification_settings_pkey": {
+          "name": "friend_notification_settings_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_nudge_log": {
+      "name": "friend_nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_nudge_log_lookup": {
+          "name": "idx_friend_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_friendships_friend_status": {
+          "name": "idx_friendships_friend_status",
+          "columns": [
+            {
+              "expression": "friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_friendships_user_status": {
+          "name": "idx_friendships_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_user_id_fkey": {
+          "name": "friendships_user_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_friend_id_fkey": {
+          "name": "friendships_friend_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendships_pkey": {
+          "name": "friendships_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_friendship_pair": {
+          "name": "unique_friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hype_log": {
+      "name": "hype_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_label": {
+          "name": "context_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hype_log_context_dedupe_idx": {
+          "name": "hype_log_context_dedupe_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_lookup": {
+          "name": "idx_hype_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_app_notifications": {
+      "name": "in_app_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_in_app_notifications_unread": {
+          "name": "idx_in_app_notifications_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_read = false)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_app_notifications_user": {
+          "name": "idx_in_app_notifications_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_app_notifications_user_id_fkey": {
+          "name": "in_app_notifications_user_id_fkey",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_notifications": {
+      "name": "milestone_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_key": {
+          "name": "milestone_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_notifications_milestone_key_key": {
+          "name": "milestone_notifications_milestone_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_audience_settings": {
+      "name": "notification_audience_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_audience_settings_pkey": {
+          "name": "notification_audience_settings_pkey",
+          "columns": [
+            "user_id",
+            "direction",
+            "event_type",
+            "activity_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_audience_settings_direction_check": {
+          "name": "notification_audience_settings_direction_check",
+          "value": "direction = ANY (ARRAY['outgoing'::text, 'incoming'::text])"
+        },
+        "notification_audience_settings_audience_check": {
+          "name": "notification_audience_settings_audience_check",
+          "value": "audience = ANY (ARRAY['none'::text, 'close'::text, 'all'::text, 'ask'::text, 'match_run'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_user_date": {
+          "name": "idx_notification_log_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nudges_enabled": {
+          "name": "nudges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "flexes_enabled": {
+          "name": "flexes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_activity_enabled": {
+          "name": "friend_activity_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_invites_enabled": {
+          "name": "competition_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_updates_enabled": {
+          "name": "competition_updates_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_milestones_enabled": {
+          "name": "competition_milestones_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "hypes_enabled": {
+          "name": "hypes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "step_goal_enabled": {
+          "name": "step_goal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "friend_personal_best_enabled": {
+          "name": "friend_personal_best_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_enabled": {
+          "name": "daily_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_hour": {
+          "name": "daily_reminder_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 18
+        },
+        "timezone_offset_minutes": {
+          "name": "timezone_offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_workouts_to_feed": {
+          "name": "share_workouts_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_posts_enabled": {
+          "name": "friend_posts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nudge_log": {
+      "name": "nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_nudge_log_lookup": {
+          "name": "idx_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nudge_log_rate_limit": {
+          "name": "idx_nudge_log_rate_limit",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_friend_notifications": {
+      "name": "pending_friend_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "send_after_at": {
+          "name": "send_after_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_friend_notif_user": {
+          "name": "idx_pending_friend_notif_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_pending_friend_notif_workout": {
+          "name": "uq_pending_friend_notif_workout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((workout_id IS NOT NULL) AND (status = 'pending'::text))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pending_friend_notifications_status_check": {
+          "name": "pending_friend_notifications_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'sent'::text, 'dismissed'::text, 'expired'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_notifications": {
+      "name": "pending_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_notifications_unsent": {
+          "name": "idx_pending_notifications_unsent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(sent_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_notifications_user_id_fkey": {
+          "name": "pending_notifications_user_id_fkey",
+          "tableFrom": "pending_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_reports": {
+      "name": "post_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_reports_dedupe_idx": {
+          "name": "post_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_reports_status": {
+          "name": "idx_post_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_reports_post_id_fkey": {
+          "name": "post_reports_post_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_reports_reporter_id_fkey": {
+          "name": "post_reports_reporter_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_reports_reason_check": {
+          "name": "post_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_snapshot": {
+          "name": "stats_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_to_feed": {
+          "name": "share_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_to_story": {
+          "name": "share_to_story",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "story_expires_at": {
+          "name": "story_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_posts_user_created": {
+          "name": "idx_posts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_feed": {
+          "name": "idx_posts_feed",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_story_active": {
+          "name": "idx_posts_story_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "story_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_story)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_active": {
+          "name": "uq_posts_workout_active",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_story": {
+          "name": "uq_posts_workout_story",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_story AND NOT share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_fkey": {
+          "name": "posts_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_workout_id_fkey": {
+          "name": "posts_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_family_id": {
+          "name": "token_family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_hash": {
+          "name": "replaced_by_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "token_family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_revoked_at": {
+          "name": "idx_refresh_tokens_revoked_at",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(revoked_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_token_hash": {
+          "name": "idx_refresh_tokens_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_fkey": {
+          "name": "refresh_tokens_user_id_fkey",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_key": {
+          "name": "refresh_tokens_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_reactions": {
+      "name": "story_reactions",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_reactions_post_id_fkey": {
+          "name": "story_reactions_post_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_reactions_user_id_fkey": {
+          "name": "story_reactions_user_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_reactions_pkey": {
+          "name": "story_reactions_pkey",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_views": {
+      "name": "story_views",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_views_post_id_fkey": {
+          "name": "story_views_post_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_views_viewer_id_fkey": {
+          "name": "story_views_viewer_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_views_pkey": {
+          "name": "story_views_pkey",
+          "columns": [
+            "post_id",
+            "viewer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggering_workout_id": {
+          "name": "triggering_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_snapshot": {
+          "name": "progress_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_slot": {
+          "name": "pin_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_badges_user": {
+          "name": "idx_user_badges_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_new": {
+          "name": "idx_user_badges_user_new",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_new = true)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_pin_slot": {
+          "name": "idx_user_badges_user_pin_slot",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(pin_slot IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_workout": {
+          "name": "idx_user_badges_workout",
+          "columns": [
+            {
+              "expression": "triggering_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_badges_user_id_fkey": {
+          "name": "user_badges_user_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_fkey": {
+          "name": "user_badges_badge_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "badge_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_triggering_workout_id_fkey": {
+          "name": "user_badges_triggering_workout_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "triggering_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_badges_user_id_badge_id_key": {
+          "name": "user_badges_user_id_badge_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "badge_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_badges_pin_slot_range": {
+          "name": "user_badges_pin_slot_range",
+          "value": "(pin_slot IS NULL) OR ((pin_slot >= 0) AND (pin_slot <= 2))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_blocks_blocked": {
+          "name": "idx_user_blocks_blocked",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_fkey": {
+          "name": "user_blocks_blocker_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_blocks_blocked_id_fkey": {
+          "name": "user_blocks_blocked_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_pkey": {
+          "name": "user_blocks_pkey",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenge_completions": {
+      "name": "user_challenge_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completing_workout_id": {
+          "name": "completing_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ucc_user": {
+          "name": "idx_ucc_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ucc_user_date": {
+          "name": "idx_ucc_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenge_completions_user_id_fkey": {
+          "name": "user_challenge_completions_user_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_challenge_key_fkey": {
+          "name": "user_challenge_completions_challenge_key_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "daily_challenges",
+          "columnsFrom": [
+            "challenge_key"
+          ],
+          "columnsTo": [
+            "challenge_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_completing_workout_id_fkey": {
+          "name": "user_challenge_completions_completing_workout_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "completing_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_challenge_completions_user_id_local_date_key": {
+          "name": "user_challenge_completions_user_id_local_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_sub": {
+          "name": "apple_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "goal_miles": {
+          "name": "goal_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_current_streak_desc": {
+          "name": "idx_users_current_streak_desc",
+          "columns": [
+            {
+              "expression": "current_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email_trgm": {
+          "name": "idx_users_email_trgm",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_username_trgm": {
+          "name": "idx_users_username_trgm",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_apple_id_key": {
+          "name": "users_apple_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_apple_sub_key": {
+          "name": "users_apple_sub_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "apple_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_completion_notifications": {
+      "name": "workout_completion_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_date": {
+          "name": "notified_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_completion_notifications_user_id_notified_date_key": {
+          "name": "workout_completion_notifications_user_id_notified_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "notified_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_splits": {
+      "name": "workout_splits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_number": {
+          "name": "split_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_duration": {
+          "name": "split_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_distance": {
+          "name": "split_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_pace": {
+          "name": "split_pace",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_splits_time": {
+          "name": "idx_splits_time",
+          "columns": [
+            {
+              "expression": "split_duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_splits_workout": {
+          "name": "idx_splits_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_splits_workout_id_fkey": {
+          "name": "workout_splits_workout_id_fkey",
+          "tableFrom": "workout_splits",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_splits_workout_id_split_number_key": {
+          "name": "workout_splits_workout_id_split_number_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "split_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workouts": {
+      "name": "workouts",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_end_date": {
+          "name": "device_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthkit'"
+        },
+        "original_distance": {
+          "name": "original_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_duration": {
+          "name": "original_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_flagged": {
+          "name": "speed_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_workouts_local_date_user_id": {
+          "name": "idx_workouts_local_date_user_id",
+          "columns": [
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_device_end": {
+          "name": "idx_workouts_user_device_end",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_local_date": {
+          "name": "idx_workouts_user_local_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workouts_user_workout_unique": {
+          "name": "workouts_user_workout_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/drizzle/meta/_journal.json
+++ b/backend/src/db/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1782871587357,
       "tag": "0006_mean_lizard",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1782945046004,
+      "tag": "0007_tearful_deathbird",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/drizzle/schema.ts
+++ b/backend/src/db/drizzle/schema.ts
@@ -985,12 +985,21 @@ export const posts = pgTable(
         table.storyExpiresAt.asc().nullsLast(),
       )
       .where(sql`(deleted_at IS NULL AND share_to_story)`),
-    // One live post per workout — lets a run's auto route/stats post be replaced
-    // in place by a photo (upsert by workout_id) instead of creating a second
-    // feed item. NULL workout_ids (manual composer posts) don't conflict.
+    // One live FEED post per workout — lets a run's auto route/stats post be
+    // replaced in place by a promoted photo (upsert by workout_id) instead of
+    // creating a second feed item. Story-only posts are exempt so a run can
+    // have both its feed record and an ephemeral story photo.
     uniqueIndex("uq_posts_workout_active")
       .on(table.workoutId)
-      .where(sql`(deleted_at IS NULL AND workout_id IS NOT NULL)`),
+      .where(
+        sql`(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_feed)`,
+      ),
+    // ...and one live story-only photo per workout (retakes replace in place).
+    uniqueIndex("uq_posts_workout_story")
+      .on(table.workoutId)
+      .where(
+        sql`(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_story AND NOT share_to_feed)`,
+      ),
     foreignKey({
       columns: [table.userId],
       foreignColumns: [users.userId],
@@ -1029,6 +1038,37 @@ export const storyViews = pgTable(
     primaryKey({
       columns: [table.postId, table.viewerId],
       name: "story_views_pkey",
+    }),
+  ],
+);
+
+// One emoji reaction per (story, user) — the ephemeral counterpart to feed
+// hype. Re-reacting replaces the emoji. Shown to the author in the
+// "seen by" list and pushed as a lightweight notification.
+export const storyReactions = pgTable(
+  "story_reactions",
+  {
+    postId: uuid("post_id").notNull(),
+    userId: text("user_id").notNull(),
+    emoji: varchar({ length: 16 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.postId],
+      foreignColumns: [posts.postId],
+      name: "story_reactions_post_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.userId],
+      name: "story_reactions_user_id_fkey",
+    }).onDelete("cascade"),
+    primaryKey({
+      columns: [table.postId, table.userId],
+      name: "story_reactions_pkey",
     }),
   ],
 );

--- a/backend/src/routes/postsRoutes.ts
+++ b/backend/src/routes/postsRoutes.ts
@@ -6,6 +6,9 @@ import {
   getStoriesRailController,
   getUserStoriesController,
   markStoryViewedController,
+  getStoryViewersController,
+  reactToStoryController,
+  getPostMemoriesController,
   getFeedController,
   getUnifiedFeedController,
   getUserPostsController,
@@ -42,6 +45,11 @@ router.post("/", createPostController);
 router.get("/stories", getStoriesRailController);
 router.get("/stories/:userId", getUserStoriesController);
 router.post("/stories/:postId/view", markStoryViewedController);
+router.get("/stories/:postId/viewers", getStoryViewersController);
+router.post("/stories/:postId/react", reactToStoryController);
+
+// "On this day" — the caller's own past post photos.
+router.get("/memories", getPostMemoriesController);
 
 // Persistent feed (photo-only) + unified feed (posts + workout activity).
 router.get("/feed", getFeedController);

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -1,5 +1,6 @@
 import { PostgresService } from "./DbService.js";
 import { sendPush } from "./pushNotificationService.js";
+import { shouldSendNotification } from "./notificationSettingsService.js";
 
 const db = PostgresService.getInstance();
 
@@ -106,6 +107,12 @@ export interface CreatePostInput {
  * story_expires_at is set to now()+24h only when the post is shared to a story.
  */
 export async function createPost(input: CreatePostInput): Promise<PostRow> {
+  // A workout can have ONE live feed post and ONE live story-only photo
+  // (separate partial unique indexes); pick the arbiter matching the row
+  // being inserted so re-posting replaces the right one in place.
+  const conflictTarget = input.shareToFeed
+    ? `(workout_id) WHERE (deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_feed)`
+    : `(workout_id) WHERE (deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_story AND NOT share_to_feed)`;
   const rows = await db.query<PostRow>(
     `
 		WITH inserted AS (
@@ -117,7 +124,7 @@ export async function createPost(input: CreatePostInput): Promise<PostRow> {
 				$1, $2, $3, $4, $5::jsonb, $6::date, $7, $8,
 				CASE WHEN $8 THEN NOW() + INTERVAL '24 hours' ELSE NULL END
 			)
-				ON CONFLICT (workout_id) WHERE (deleted_at IS NULL AND workout_id IS NOT NULL)
+				ON CONFLICT ${conflictTarget}
 				DO UPDATE SET
 					media_url = EXCLUDED.media_url,
 					caption = COALESCE(EXCLUDED.caption, posts.caption),
@@ -262,6 +269,158 @@ export async function markStoryViewed(
   );
 }
 
+/** One row in a story's "seen by" list, with any emoji reaction. */
+export interface StoryViewerRow {
+  user_id: string;
+  username: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  profile_image_url: string | null;
+  viewed_at: string;
+  emoji: string | null;
+}
+
+/**
+ * Who viewed the caller's story (with their reactions), newest first. Returns
+ * null when the post isn't the caller's own story — the controller maps that
+ * to 404 so viewers stay private.
+ */
+export async function getStoryViewers(
+  authorId: string,
+  postId: string,
+): Promise<StoryViewerRow[] | null> {
+  const own = await db.query(
+    `SELECT 1 FROM posts
+		 WHERE post_id = $1 AND user_id = $2 AND share_to_story AND deleted_at IS NULL`,
+    [postId, authorId],
+  );
+  if (own.length === 0) return null;
+
+  return db.query<StoryViewerRow>(
+    `
+		SELECT u.user_id, u.username, u.first_name, u.last_name, u.profile_image_url,
+			sv.viewed_at, sr.emoji
+		FROM story_views sv
+		JOIN users u ON u.user_id = sv.viewer_id
+		LEFT JOIN story_reactions sr ON sr.post_id = sv.post_id AND sr.user_id = sv.viewer_id
+		WHERE sv.post_id = $1 AND sv.viewer_id <> $2
+		ORDER BY sr.emoji IS NULL, sv.viewed_at DESC
+		LIMIT 200
+		`,
+    [postId, authorId],
+  );
+}
+
+/** The ephemeral counterpart to feed hype — one emoji per (story, viewer). */
+export const ALLOWED_STORY_REACTIONS = new Set([
+  "\u2764\uFE0F",
+  "\uD83D\uDD25",
+  "\uD83D\uDC4F",
+  "\uD83D\uDCAA",
+  "\uD83D\uDE2E",
+]);
+
+/**
+ * React to a friend's active story with an emoji. Re-reacting replaces the
+ * previous emoji. Pushes a lightweight notification to the author (respects
+ * their per-friend "hype" notification preference). Returns a status the
+ * controller maps to HTTP.
+ */
+export async function reactToStory(
+  senderId: string,
+  postId: string,
+  emoji: string,
+): Promise<"ok" | "not_found" | "forbidden"> {
+  const rows = await db.query<{ user_id: string }>(
+    `SELECT user_id FROM posts
+		 WHERE post_id = $1 AND share_to_story AND deleted_at IS NULL
+			 AND story_expires_at > NOW()`,
+    [postId],
+  );
+  const authorId = rows[0]?.user_id;
+  if (!authorId) return "not_found";
+  if (authorId === senderId) return "forbidden";
+
+  // Sender must be an accepted friend of the author (stories are circle-only)
+  // with no block in either direction.
+  const allowed = await db.query(
+    `SELECT 1 FROM friendships f
+		 WHERE f.user_id = $1 AND f.friend_id = $2 AND f.status = 'accepted'
+			 AND NOT EXISTS (
+				 SELECT 1 FROM user_blocks b
+				 WHERE (b.blocker_id = $1 AND b.blocked_id = $2)
+						OR (b.blocker_id = $2 AND b.blocked_id = $1)
+			 )`,
+    [authorId, senderId],
+  );
+  if (allowed.length === 0) return "forbidden";
+
+  const inserted = await db.query<{ inserted: boolean }>(
+    `INSERT INTO story_reactions (post_id, user_id, emoji)
+		 VALUES ($1, $2, $3)
+		 ON CONFLICT (post_id, user_id)
+		 DO UPDATE SET emoji = EXCLUDED.emoji, created_at = NOW()
+		 RETURNING (xmax = 0) AS inserted`,
+    [postId, senderId, emoji],
+  );
+
+  // Notify only on the FIRST reaction to this story (emoji swaps stay quiet).
+  if (inserted[0]?.inserted) {
+    try {
+      const shouldSend = await shouldSendNotification(authorId, senderId, "hype");
+      if (shouldSend) {
+        const sender = await db.query<{ username: string | null }>(
+          `SELECT username FROM users WHERE user_id = $1`,
+          [senderId],
+        );
+        const name = sender[0]?.username ?? "A friend";
+        sendPush(authorId, {
+          title: `${name} reacted ${emoji}`,
+          body: "to your story",
+          type: "story_reaction",
+          data: { user_id: senderId, post_id: postId },
+        }).catch((e: any) =>
+          console.error("[reactToStory] push failed:", e?.message ?? e),
+        );
+      }
+    } catch (e: any) {
+      console.error("[reactToStory] notify failed:", e?.message ?? e);
+    }
+  }
+  return "ok";
+}
+
+/**
+ * The caller's own past post photos for the "On this day" memories surface:
+ * same calendar day in previous years, plus exactly one week and one month
+ * ago. Story-only photos count — expiry hides them from the rail, not from
+ * the author's memories.
+ */
+export async function getOwnPostMemories(
+  userId: string,
+  localDate: string,
+): Promise<PostRow[]> {
+  return db.query<PostRow>(
+    `
+		SELECT ${POST_SELECT}
+		FROM posts p
+		JOIN users u ON u.user_id = p.user_id
+		WHERE p.user_id = $1
+			AND p.deleted_at IS NULL
+			AND p.local_date < $2::date
+			AND (
+				(EXTRACT(MONTH FROM p.local_date) = EXTRACT(MONTH FROM $2::date)
+					AND EXTRACT(DAY FROM p.local_date) = EXTRACT(DAY FROM $2::date))
+				OR p.local_date = ($2::date - INTERVAL '1 month')::date
+				OR p.local_date = ($2::date - INTERVAL '7 days')::date
+			)
+		ORDER BY p.local_date DESC
+		LIMIT 12
+		`,
+    [userId, localDate],
+  );
+}
+
 /**
  * Persistent feed: photo posts from the viewer's circle, newest first, keyset
  * paginated on created_at. Pass `before` (an ISO timestamp) to fetch older.
@@ -305,6 +464,9 @@ export interface FeedEntryRow {
   media_url: string | null;
   caption: string | null;
   stats_snapshot: PostStatsSnapshot | null;
+  // The run's story-only photo (if one exists) so the feed card can offer a
+  // photo/route flip without duplicating the run in the feed.
+  story_photo_url: string | null;
   // workout-only
   workout_type: string | null;
   distance: number | null;
@@ -339,6 +501,17 @@ export async function getUnifiedFeed(
 				p.created_at AS sort_ts,
 				p.user_id, u.username, u.first_name, u.last_name, u.profile_image_url,
 				p.media_url, p.caption, p.stats_snapshot,
+				(
+					SELECT p3.media_url FROM posts p3
+					WHERE p.workout_id IS NOT NULL
+						AND p3.workout_id = p.workout_id
+						AND p3.user_id = p.user_id
+						AND p3.post_id <> p.post_id
+						AND p3.deleted_at IS NULL
+						AND p3.share_to_story AND NOT p3.share_to_feed
+					ORDER BY p3.created_at DESC
+					LIMIT 1
+				) AS story_photo_url,
 				NULL::varchar AS workout_type,
 				NULL::double precision AS distance,
 				NULL::double precision AS total_duration,
@@ -366,6 +539,7 @@ export async function getUnifiedFeed(
 				w.device_end_date AS sort_ts,
 				w.user_id, u.username, u.first_name, u.last_name, u.profile_image_url,
 				NULL::text AS media_url, NULL::text AS caption, NULL::jsonb AS stats_snapshot,
+				NULL::text AS story_photo_url,
 				w.workout_type,
 				w.distance::double precision,
 				w.total_duration::double precision,

--- a/backend/src/services/pushNotificationService.ts
+++ b/backend/src/services/pushNotificationService.ts
@@ -108,6 +108,7 @@ export type NotificationType =
   | "friend_challenge_completed"
   | "hype_received"
   | "friend_post"
+  | "story_reaction"
   | "daily_reminder";
 
 interface PushPayload {


### PR DESCRIPTION
Follow-up to #179. Stories and the feed were two frames around identical pixels — every post defaulted to both surfaces, so friends saw the same photo twice. This PR gives each surface its own job: **the story is the ephemeral in-the-moment photo; the feed is the permanent record of the run.**

**iOS is Xcode-only here — please build before merge.** Backend is `tsc`-clean.

## Backend (migration `0007`, additive)

- **One feed post + one story photo per workout.** `uq_posts_workout_active` is now scoped to `share_to_feed`, and a new `uq_posts_workout_story` covers story-only rows. `createPost` picks the conflict arbiter matching the row being inserted, so a retaken story photo replaces the story and a promoted photo replaces the feed card — never cross-clobbering.
- **`story_photo_url` on the unified feed** — each run&#39;s feed entry carries its story photo (when one exists) for the card flip below.
- **Story reactions**: `story_reactions` table + `POST /posts/stories/:postId/react`. One emoji per (story, viewer), re-reacting swaps it, allowlist enforced (❤️ 🔥 👏 💪 😮), friends-only, push to the author on first reaction (respects the per-friend hype notification preference — user-controllable per 4.5.4).
- **Seen-by**: `GET /posts/stories/:postId/viewers` — viewer list with reactions, own stories only (404 otherwise).
- **Memories**: `GET /posts/memories` — the caller&#39;s own post photos from this day in past years, one week ago, and one month ago. Expired stories included: the photo outlives its 24 hours.

## iOS

- **Composer: Story / Feed / Both selector** replaces the two share toggles, with a footnote explaining each (24h ephemeral vs. permanent). The post-run photo prompt defaults to **Story**; the feed&#39;s + button defaults to **Feed**. Cross-posting is now a deliberate choice.
- **Post-run flow**: the feed always gets the run&#39;s route/stats card unless the photo itself was sent to the feed — so the feed reads as a log of runs, stories as faces/scenery.
- **Story viewer**:
  - Emoji **reaction bar** on friends&#39; stories (replaces hype there — hype stays the feed&#39;s currency).
  - **&#34;Seen by N&#34;** pill on your own story → sheet listing viewers with their reactions (reactors first).
  - **&#34;Add to feed&#34;** pill promotes the story photo into the run&#39;s feed post in place (Instagram-highlight style; upsert by workout).
- **Feed cards**: when a run has both a route/stats card and a story photo, a corner thumbnail flips the card between them (BeReal-style).
- **Memories**: past story/feed photos blend into &#34;On this day&#34; — thumbnails on the card and detail rows, &#34;1 week ago&#34; / &#34;1 month ago&#34; labels for sub-year memories.

## Live-safety

Migration `0007` is additive (new table + index split; the index swap is a brief drop/recreate on the small `posts` table). All API changes are additive — old clients keep working: existing posts keep both flags, the old two-toggle client simply maps onto the same `share_to_feed`/`share_to_story` fields. `FRIEND_POST_NOTIFICATIONS_ENABLED` stays off.

## Verification

- Backend `tsc` clean; migration reviewed (no destructive statements).
- Swift changes verified by a compile-correctness review (all clear) — but please build in Xcode.
- Suggested on-device pass: finish a mile → prompt defaults to Story → photo lands in the story rail while the feed shows the route card → flip thumbnail on the feed card → react to a friend&#39;s story from a second account → check &#34;Seen by&#34; shows the reaction → &#34;Add to feed&#34; swaps the photo into the feed post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxDWrDAbsnFQ2Jxj1qsgNu

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxDWrDAbsnFQ2Jxj1qsgNu)_