### PR TITLE
Feed/story/hype overhaul: route maps, one post per workout, unified hypes, comp walk/run stats

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -40,6 +40,11 @@ globs: backend/**
 - Standings are recomputed LIVE on every read (`getUserScores` in `getCompetition`) — even for finished comps. So a competition's stored `end_date` directly bounds which days count (scoring includes `local_date <= end_date`; `local_date` = workout START date in user tz).
 - When resolving EARLY (target/goal/duration hit, not a preset end_date), set `end_date` to the last COMPLETED interval (`lastCompletedIntervalEnd`), NOT the resolution day. Resolution scoring excludes the current interval, so stamping `end_date = todayStr` makes the live recompute fold that day back in once the calendar advances → phantom points/placement drift.
 
+## Hypes & Posts
+- 'mile' hypes canonicalize to `<userId>:<localDate>` at send time (`canonicalizeMileContext`); legacy rows are keyed by workout_id. Reads MUST match both via `mileHypeKeyMatchSql` — never hand-write the OR.
+- `express.json` limit is 2mb because workout-sync bodies carry GPS routes. Don't shrink it.
+- `posts.is_auto` is tri-state at the API (`is_auto` absent = legacy client → upsert-in-place + auto-signature heuristic). A flagged user post may only replace an auto post; second user post → 409 `workout_already_posted`.
+
 ## ESM Reminder
 All imports MUST end with `.js` extension:
 ```typescript

--- a/Mile-A-Day-Complete-APIs.postman_collection.json
+++ b/Mile-A-Day-Complete-APIs.postman_collection.json
@@ -652,7 +652,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "[\n  {\n    \"workout_id\": \"workout123\",\n    \"date\": \"2025-01-15\",\n    \"distance\": 3.2,\n    \"duration\": 1800,\n    \"type\": \"run\"\n  },\n  {\n    \"workout_id\": \"workout124\",\n    \"date\": \"2025-01-16\",\n    \"distance\": 5.0,\n    \"duration\": 2400,\n    \"type\": \"run\"\n  }\n]"
+							"raw": "[\n  {\n    \"workoutId\": \"8F2C1D34-5678-4ABC-9DEF-0123456789AB\",\n    \"distance\": 1.25,\n    \"localDate\": \"2026-07-02\",\n    \"date\": \"2026-07-02\",\n    \"timezoneOffset\": -240,\n    \"workoutType\": \"running\",\n    \"deviceEndDate\": \"2026-07-02T12:34:56Z\",\n    \"calories\": 132.5,\n    \"totalDuration\": 780,\n    \"splits\": [\n      {\n        \"splitNumber\": 1,\n        \"distance\": 1.0,\n        \"duration\": 600,\n        \"pace\": 600\n      },\n      {\n        \"splitNumber\": 2,\n        \"distance\": 0.25,\n        \"duration\": 180,\n        \"pace\": 720\n      }\n    ],\n    \"source\": \"healthkit\",\n    \"route\": [\n      [\n        39.9526,\n        -75.1652\n      ],\n      [\n        39.9531,\n        -75.1644\n      ],\n      [\n        39.9537,\n        -75.1639\n      ]\n    ]\n  }\n]"
 						},
 						"url": {
 							"raw": "{{domain}}/workouts/:userId/upload",
@@ -671,7 +671,7 @@
 								}
 							]
 						},
-						"description": "Upload workouts array. Requires self-access."
+						"description": "Upload workouts array. Requires self-access.\n\n`route` is an optional simplified GPS trace ([[lat, lng], ...], max ~300 points) stored in workout_routes and surfaced on feed cards."
 					},
 					"response": []
 				},

--- a/app/Mile A Day/Models/Competition.swift
+++ b/app/Mile A Day/Models/Competition.swift
@@ -500,6 +500,14 @@ enum CompetitionActivity: String, Codable, CaseIterable {
         }
     }
 
+    /// Key the backend uses for this type inside `daily_activity` payloads.
+    var dailyActivityKey: String {
+        switch self {
+        case .run: return "running"
+        case .walk: return "walking"
+        }
+    }
+
     var color: Color {
         switch self {
         case .run: return MADTheme.Colors.madRed
@@ -628,6 +636,14 @@ enum CompetitionInterval: String, Codable, CaseIterable {
     }
 }
 
+/// One activity type's slice of a user's day — distance + workout count for
+/// "running" or "walking" on a single local date. Both fields optional so
+/// partial backend payloads decode safely.
+struct DailyActivityEntry: Codable, Equatable {
+    let distance: Double?
+    let count: Int?
+}
+
 /// Competition user with enriched data from backend
 struct CompetitionUser: Codable, Identifiable {
     let competition_id: String
@@ -639,6 +655,11 @@ struct CompetitionUser: Codable, Identifiable {
     let intervals: [String: Double]?
     let remaining_lives: Int?
     let has_manual_workouts: Bool?
+    /// Per-day activity-type breakdown, keyed by "YYYY-MM-DD" local date then
+    /// by activity type ("running"/"walking"). Already filtered server-side to
+    /// the comp's allowed types. Nil on older backends / pre-start / steps
+    /// comps — everything reading it must degrade gracefully.
+    let daily_activity: [String: [String: DailyActivityEntry]]?
 
     var id: String { "\(competition_id)-\(user_id)" }
 
@@ -653,7 +674,29 @@ struct CompetitionUser: Codable, Identifiable {
         return "Unknown"
     }
 
-    init(competition_id: String, user_id: String, invite_status: InviteStatus, username: String?, profile_image_url: String? = nil, score: Double?, intervals: [String: Double]?, remaining_lives: Int? = nil, has_manual_workouts: Bool? = nil) {
+    /// Summed distance across all intervals — the player's total for the comp.
+    var totalIntervalDistance: Double {
+        intervals?.values.reduce(0, +) ?? 0
+    }
+
+    /// True when the backend sent the per-activity daily breakdown.
+    var hasDailyActivity: Bool {
+        !(daily_activity?.isEmpty ?? true)
+    }
+
+    /// This user's distance/count split for one activity type on one
+    /// "YYYY-MM-DD" local day. Nil when the day or type has no data.
+    func dailyActivityEntry(for activity: CompetitionActivity, onDay dayKey: String) -> DailyActivityEntry? {
+        daily_activity?[dayKey]?[activity.dailyActivityKey]
+    }
+
+    /// Total workout count for one activity type across the whole competition.
+    func totalActivityCount(for activity: CompetitionActivity) -> Int {
+        guard let daily = daily_activity else { return 0 }
+        return daily.values.reduce(0) { $0 + ($1[activity.dailyActivityKey]?.count ?? 0) }
+    }
+
+    init(competition_id: String, user_id: String, invite_status: InviteStatus, username: String?, profile_image_url: String? = nil, score: Double?, intervals: [String: Double]?, remaining_lives: Int? = nil, has_manual_workouts: Bool? = nil, daily_activity: [String: [String: DailyActivityEntry]]? = nil) {
         self.competition_id = competition_id
         self.user_id = user_id
         self.invite_status = invite_status
@@ -663,6 +706,7 @@ struct CompetitionUser: Codable, Identifiable {
         self.intervals = intervals
         self.remaining_lives = remaining_lives
         self.has_manual_workouts = has_manual_workouts
+        self.daily_activity = daily_activity
     }
 
     init(from decoder: Decoder) throws {
@@ -676,6 +720,7 @@ struct CompetitionUser: Codable, Identifiable {
         intervals = try container.decodeIfPresent([String: Double].self, forKey: .intervals)
         remaining_lives = try container.decodeIfPresent(Int.self, forKey: .remaining_lives)
         has_manual_workouts = try container.decodeIfPresent(Bool.self, forKey: .has_manual_workouts)
+        daily_activity = try container.decodeIfPresent([String: [String: DailyActivityEntry]].self, forKey: .daily_activity)
     }
 }
 

--- a/app/Mile A Day/Models/HealthKitManager.swift
+++ b/app/Mile A Day/Models/HealthKitManager.swift
@@ -1160,6 +1160,24 @@ class HealthKitManager: ObservableObject {
         healthStore.execute(routeQuery)
     }
 
+    /// Whether the workout has ANY GPS route sample — a limit-1 existence probe
+    /// that never enumerates route locations, unlike fetchAllRouteLocations.
+    /// Use for cheap "offer the route toggle?" checks.
+    func hasRouteData(for workout: HKWorkout) async -> Bool {
+        await withCheckedContinuation { continuation in
+            let predicate = HKQuery.predicateForObjects(from: workout)
+            let query = HKAnchoredObjectQuery(
+                type: HKSeriesType.workoutRoute(),
+                predicate: predicate,
+                anchor: nil,
+                limit: 1
+            ) { _, samples, _, _, _ in
+                continuation.resume(returning: (samples?.isEmpty == false))
+            }
+            healthStore.execute(query)
+        }
+    }
+
     /// Fetches all GPS location points from the route associated with a workout.
     /// Returns an empty array if no route data exists (indoor/manual workouts).
     func fetchAllRouteLocations(for workout: HKWorkout) async -> [CLLocation] {

--- a/app/Mile A Day/Models/NotificationPreferences.swift
+++ b/app/Mile A Day/Models/NotificationPreferences.swift
@@ -37,6 +37,15 @@ struct NotificationPreferences: Codable {
     var shareWorkoutsToFeed: Bool = true
     /// Notify me when a friend shares a new photo post.
     var friendPostsEnabled: Bool = true
+    /// Show my GPS route maps on my feed entries and posts. Off = friends see
+    /// the cards without the route slide/map (I still see my own).
+    /// Optional backing field so prefs saved by older app versions (no key)
+    /// still decode instead of silently resetting everything to defaults.
+    private var shareRouteMapsRaw: Bool?
+    var shareRouteMaps: Bool {
+        get { shareRouteMapsRaw ?? true }
+        set { shareRouteMapsRaw = newValue }
+    }
 
     // Do Not Disturb schedule
     var dndEnabled: Bool = false

--- a/app/Mile A Day/Services/PostService.swift
+++ b/app/Mile A Day/Services/PostService.swift
@@ -49,14 +49,7 @@ struct PostItem: Codable, Identifiable {
     var id: String { post_id }
 
     /// Decoded route polyline (nil when absent or degenerate).
-    var routeCoordinates: [CLLocationCoordinate2D]? {
-        guard let route, route.count >= 2 else { return nil }
-        let coords = route.compactMap { pair -> CLLocationCoordinate2D? in
-            guard pair.count >= 2 else { return nil }
-            return CLLocationCoordinate2D(latitude: pair[0], longitude: pair[1])
-        }
-        return coords.count >= 2 ? coords : nil
-    }
+    var routeCoordinates: [CLLocationCoordinate2D]? { decodeRouteCoordinates(route) }
 
     var displayName: String {
         if let username, !username.isEmpty { return username }
@@ -68,6 +61,18 @@ struct PostItem: Codable, Identifiable {
 
     /// Short "2h", "5m", "now" relative time from created_at.
     var relativeTime: String { RelativeTime.short(from: created_at) }
+}
+
+/// Decode a backend `[[lat, lng], ...]` trace into map coordinates. Nil when
+/// absent or degenerate (fewer than 2 valid points) — the single definition of
+/// "drawable route" shared by post and feed-entry models.
+func decodeRouteCoordinates(_ route: [[Double]]?) -> [CLLocationCoordinate2D]? {
+    guard let route, route.count >= 2 else { return nil }
+    let coords = route.compactMap { pair -> CLLocationCoordinate2D? in
+        guard pair.count >= 2 else { return nil }
+        return CLLocationCoordinate2D(latitude: pair[0], longitude: pair[1])
+    }
+    return coords.count >= 2 ? coords : nil
 }
 
 /// One author's worth of active stories in the rail (lazy-loaded on tap).
@@ -142,14 +147,7 @@ struct FeedEntry: Codable, Identifiable {
     var isPost: Bool { kind == "post" }
 
     /// Decoded route polyline (nil when absent or degenerate).
-    var routeCoordinates: [CLLocationCoordinate2D]? {
-        guard let route, route.count >= 2 else { return nil }
-        let coords = route.compactMap { pair -> CLLocationCoordinate2D? in
-            guard pair.count >= 2 else { return nil }
-            return CLLocationCoordinate2D(latitude: pair[0], longitude: pair[1])
-        }
-        return coords.count >= 2 ? coords : nil
-    }
+    var routeCoordinates: [CLLocationCoordinate2D]? { decodeRouteCoordinates(route) }
 
     var storyPhotoURL: URL? {
         guard let story_photo_url, story_photo_url != media_url else { return nil }

--- a/app/Mile A Day/Services/PostService.swift
+++ b/app/Mile A Day/Services/PostService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import CoreLocation
 
 // MARK: - Models
 
@@ -34,12 +35,28 @@ struct PostItem: Codable, Identifiable {
     let share_to_story: Bool?
     let story_expires_at: String?
     let created_at: String
+    /// System-generated route/stats card (vs a deliberate user post).
+    var is_auto: Bool?
+    /// The linked workout's type ("running"/"walking") for the type icon.
+    var workout_type: String?
+    /// Simplified GPS trace [[lat, lng], ...] when synced + shared.
+    var route: [[Double]]?
     let is_self: Bool
     var is_hyped: Bool
     var hype_count: Int?
     var is_viewed: Bool?
 
     var id: String { post_id }
+
+    /// Decoded route polyline (nil when absent or degenerate).
+    var routeCoordinates: [CLLocationCoordinate2D]? {
+        guard let route, route.count >= 2 else { return nil }
+        let coords = route.compactMap { pair -> CLLocationCoordinate2D? in
+            guard pair.count >= 2 else { return nil }
+            return CLLocationCoordinate2D(latitude: pair[0], longitude: pair[1])
+        }
+        return coords.count >= 2 ? coords : nil
+    }
 
     var displayName: String {
         if let username, !username.isEmpty { return username }
@@ -97,12 +114,16 @@ struct FeedEntry: Codable, Identifiable {
     /// The run's story-only photo, when one exists — powers the photo/route
     /// flip on the feed card without duplicating the run in the feed.
     let story_photo_url: String?
-    // workout-only
+    /// post-only: system-generated route/stats card (vs a deliberate post).
+    let is_auto: Bool?
+    // workout columns (workout_type is also set for posts via their run)
     let workout_type: String?
     let distance: Double?
     let total_duration: Double?
     let calories: Double?
     let steps: Int?
+    /// Simplified GPS trace [[lat, lng], ...] for the entry's workout.
+    let route: [[Double]]?
     // shared
     let is_self: Bool
     var is_hyped: Bool
@@ -112,13 +133,23 @@ struct FeedEntry: Codable, Identifiable {
         case kind
         case entryId = "id"
         case sort_ts, user_id, username, first_name, last_name, profile_image_url
-        case media_url, caption, stats_snapshot, story_photo_url
-        case workout_type, distance, total_duration, calories, steps
+        case media_url, caption, stats_snapshot, story_photo_url, is_auto
+        case workout_type, distance, total_duration, calories, steps, route
         case is_self, is_hyped, hype_count
     }
 
     var id: String { "\(kind)-\(entryId)" }
     var isPost: Bool { kind == "post" }
+
+    /// Decoded route polyline (nil when absent or degenerate).
+    var routeCoordinates: [CLLocationCoordinate2D]? {
+        guard let route, route.count >= 2 else { return nil }
+        let coords = route.compactMap { pair -> CLLocationCoordinate2D? in
+            guard pair.count >= 2 else { return nil }
+            return CLLocationCoordinate2D(latitude: pair[0], longitude: pair[1])
+        }
+        return coords.count >= 2 ? coords : nil
+    }
 
     var storyPhotoURL: URL? {
         guard let story_photo_url, story_photo_url != media_url else { return nil }
@@ -142,7 +173,8 @@ struct FeedEntry: Codable, Identifiable {
             profile_image_url: profile_image_url, media_url: media, caption: caption,
             workout_id: nil, stats_snapshot: stats_snapshot, local_date: nil,
             share_to_feed: true, share_to_story: nil, story_expires_at: nil,
-            created_at: sort_ts, is_self: is_self, is_hyped: is_hyped,
+            created_at: sort_ts, is_auto: is_auto, workout_type: workout_type,
+            route: route, is_self: is_self, is_hyped: is_hyped,
             hype_count: hype_count, is_viewed: nil
         )
     }
@@ -248,14 +280,19 @@ enum PostService {
     }
 
     /// Create a post from an already-uploaded media_url. Throws APIError.apiError
-    /// with code "mile_not_completed" / "terms_not_accepted" when gated.
+    /// with code "mile_not_completed" / "terms_not_accepted" when gated, and
+    /// APIError.conflict ("workout_already_posted") when the workout already has
+    /// a live user post for that destination (one deliberate post per workout —
+    /// delete the old one to post again).
     static func createPost(
         mediaUrl: String,
         caption: String?,
         workoutId: String?,
         shareToFeed: Bool,
         shareToStory: Bool,
-        stats: PostStats?
+        stats: PostStats?,
+        isAuto: Bool = false,
+        includeRoute: Bool = true
     ) async throws -> PostItem {
         struct Body: Encodable {
             let media_url: String
@@ -264,6 +301,8 @@ enum PostService {
             let share_to_feed: Bool
             let share_to_story: Bool
             let stats_snapshot: PostStats?
+            let is_auto: Bool
+            let include_route: Bool
         }
         let bodyData = try JSONEncoder().encode(
             Body(
@@ -272,7 +311,9 @@ enum PostService {
                 workout_id: workoutId,
                 share_to_feed: shareToFeed,
                 share_to_story: shareToStory,
-                stats_snapshot: stats
+                stats_snapshot: stats,
+                is_auto: isAuto,
+                include_route: includeRoute
             )
         )
         return try await APIClient.fancyFetch(

--- a/app/Mile A Day/Services/RunPostService.swift
+++ b/app/Mile A Day/Services/RunPostService.swift
@@ -73,13 +73,16 @@ enum RunPostService {
 
         do {
             let mediaUrl = try await PostService.uploadMedia(finalImage)
+            // isAuto — the server may replace this card in place with a later
+            // photo post, but it never counts as the user's one post per workout.
             _ = try await PostService.createPost(
                 mediaUrl: mediaUrl,
                 caption: nil,
                 workoutId: workoutId,
                 shareToFeed: true,
                 shareToStory: false,
-                stats: stats.snapshot
+                stats: stats.snapshot,
+                isAuto: true
             )
         } catch {
             print("[RunPostService] autoPostMile failed: \(error)")

--- a/app/Mile A Day/Services/WorkoutSyncService.swift
+++ b/app/Mile A Day/Services/WorkoutSyncService.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import HealthKit
+import CoreLocation
 
 // MARK: - Sync Progress Models
 
@@ -507,8 +508,10 @@ class WorkoutSyncService: ObservableObject {
             throw SyncError.notAuthenticated
         }
 
-        // Transform workouts to backend format
-        let workoutData = try await transformWorkoutsForBackend(workouts)
+        // Transform workouts to backend format. GPS routes ride along for
+        // normal (incremental) syncs; the historical backfill skips them —
+        // reading years of HKWorkoutRoute data would make the initial sync crawl.
+        let workoutData = try await transformWorkoutsForBackend(workouts, includeRoutes: !fullSync)
 
         // Make API request using fancyFetch
         let endpoint = fullSync ? "/workouts/\(userId)/upload?fullSync=true" : "/workouts/\(userId)/upload"
@@ -582,11 +585,43 @@ class WorkoutSyncService: ObservableObject {
         }
     }
 
+    /// Cap uploaded routes to a drawing-friendly polyline; the backend stores
+    /// them verbatim (with its own backstop) and feeds them back to feed cards.
+    private static let maxRoutePoints = 150
+    /// Don't fetch routes for oversized batches — that's a backfill, not a
+    /// fresh run, and per-workout route queries would drag the whole upload.
+    private static let maxRouteFetchBatch = 25
+
+    /// The workout's GPS trace as [[lat, lng], ...], downsampled to
+    /// `maxRoutePoints` and rounded to ~1m precision. Nil when the workout has
+    /// no route (indoor/manual).
+    private func simplifiedRoute(for workout: HKWorkout) async -> [[Double]]? {
+        let locations = await HealthKitManager.shared.fetchAllRouteLocations(for: workout)
+        guard locations.count >= 2 else { return nil }
+
+        let sampled: [CLLocation]
+        if locations.count > Self.maxRoutePoints {
+            let stride = Double(locations.count - 1) / Double(Self.maxRoutePoints - 1)
+            sampled = (0..<Self.maxRoutePoints).map { locations[Int((Double($0) * stride).rounded())] }
+        } else {
+            sampled = locations
+        }
+        return sampled.map { location in
+            [
+                (location.coordinate.latitude * 100_000).rounded() / 100_000,
+                (location.coordinate.longitude * 100_000).rounded() / 100_000,
+            ]
+        }
+    }
+
     /// Transform HKWorkout objects to backend format
-    private func transformWorkoutsForBackend(_ workouts: [HKWorkout]) async throws -> [[String:
-        Any]]
+    private func transformWorkoutsForBackend(
+        _ workouts: [HKWorkout],
+        includeRoutes: Bool = false
+    ) async throws -> [[String: Any]]
     {
         var workoutData: [[String: Any]] = []
+        let fetchRoutes = includeRoutes && workouts.count <= Self.maxRouteFetchBatch
 
         for workout in workouts {
             // Get split data for this workout
@@ -616,7 +651,7 @@ class WorkoutSyncService: ObservableObject {
             let calories = await activeEnergyKilocalories(for: workout)
             let distance = workout.totalDistance?.doubleValue(for: HKUnit.mile()) ?? 0
 
-            let workoutDict: [String: Any] = [
+            var workoutDict: [String: Any] = [
                 "workoutId": workout.uuid.uuidString,
                 "distance": distance,
                 "localDate": localDate,
@@ -629,6 +664,12 @@ class WorkoutSyncService: ObservableObject {
                 "splits": splitsData,
                 "source": "healthkit",
             ]
+
+            // Attach the simplified GPS path when the workout has one, so the
+            // backend can store it and feed cards can draw the mile's route.
+            if fetchRoutes, let route = await simplifiedRoute(for: workout) {
+                workoutDict["route"] = route
+            }
 
             workoutData.append(workoutDict)
         }

--- a/app/Mile A Day/Services/WorkoutSyncService.swift
+++ b/app/Mile A Day/Services/WorkoutSyncService.swift
@@ -478,9 +478,14 @@ class WorkoutSyncService: ObservableObject {
     private func uploadBatchWithRetry(_ workouts: [HKWorkout], fullSync: Bool = false) async throws {
         var lastError: Error?
 
+        // Build the payload ONCE — it's deterministic, and the transform now
+        // reads GPS routes from HealthKit, which must not be re-enumerated on
+        // every network retry.
+        let workoutData = try await transformWorkoutsForBackend(workouts, includeRoutes: !fullSync)
+
         for attempt in 1...maxRetries {
             do {
-                try await uploadBatch(workouts, fullSync: fullSync)
+                try await uploadBatch(workoutData, count: workouts.count, fullSync: fullSync)
                 return  // Success!
             } catch {
                 lastError = error
@@ -500,18 +505,13 @@ class WorkoutSyncService: ObservableObject {
         }
     }
 
-    /// Upload a single batch to the backend.
+    /// Upload one pre-transformed batch to the backend.
     /// When `fullSync` is true the request carries ?fullSync=true so the backend
     /// suppresses friend-facing notifications for this historical backfill.
-    private func uploadBatch(_ workouts: [HKWorkout], fullSync: Bool = false) async throws {
+    private func uploadBatch(_ workoutData: [[String: Any]], count: Int, fullSync: Bool = false) async throws {
         guard let userId = currentUserId else {
             throw SyncError.notAuthenticated
         }
-
-        // Transform workouts to backend format. GPS routes ride along for
-        // normal (incremental) syncs; the historical backfill skips them —
-        // reading years of HKWorkoutRoute data would make the initial sync crawl.
-        let workoutData = try await transformWorkoutsForBackend(workouts, includeRoutes: !fullSync)
 
         // Make API request using fancyFetch
         let endpoint = fullSync ? "/workouts/\(userId)/upload?fullSync=true" : "/workouts/\(userId)/upload"
@@ -540,7 +540,7 @@ class WorkoutSyncService: ObservableObject {
                 body: requestBody,
                 responseType: UploadResponse.self
             )
-            print("[WorkoutSyncService] ✅ Uploaded batch of \(workouts.count) workouts")
+            print("[WorkoutSyncService] ✅ Uploaded batch of \(count) workouts")
 
             let badgeCount = response.newlyEarnedBadges?.count ?? 0
             let completionCount = response.newChallengeCompletions?.count ?? 0

--- a/app/Mile A Day/Views/BadgeDetailView.swift
+++ b/app/Mile A Day/Views/BadgeDetailView.swift
@@ -47,24 +47,31 @@ struct BadgeDetailView: View {
             
             // Scrollable so the medal + details always fit on any screen size and
             // the hero is never clipped under the dynamic island (the ScrollView
-            // respects the top safe area).
-            ScrollView(showsIndicators: false) {
-                VStack(spacing: 0) {
-                    Color.clear.frame(height: 16)
+            // respects the top safe area). The content is min-height-pinned to
+            // the viewport with flexible spacers so that on taller screens the
+            // medal + details sit vertically CENTERED instead of hugging the top.
+            GeometryReader { geo in
+                ScrollView(showsIndicators: false) {
+                    VStack(spacing: 0) {
+                        Spacer(minLength: 16)
 
-                    // Medal display — centered horizontally
-                    medalSection
-                        .scaleEffect(showMedal ? 1 : 0.5)
-                        .opacity(showMedal ? 1 : 0)
+                        // Medal display — centered horizontally
+                        medalSection
+                            .scaleEffect(showMedal ? 1 : 0.5)
+                            .opacity(showMedal ? 1 : 0)
 
-                    Color.clear.frame(height: 32)
+                        Color.clear.frame(height: 32)
 
-                    // Details section
-                    detailsSection
-                        .opacity(showContent ? 1 : 0)
-                        .offset(y: showContent ? 0 : 30)
+                        // Details section
+                        detailsSection
+                            .opacity(showContent ? 1 : 0)
+                            .offset(y: showContent ? 0 : 30)
+
+                        Spacer(minLength: 24)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .frame(minHeight: geo.size.height)
                 }
-                .frame(maxWidth: .infinity, alignment: .center)
             }
         }
         .onAppear {

--- a/app/Mile A Day/Views/Celebrations/LeaderboardMoveUpView.swift
+++ b/app/Mile A Day/Views/Celebrations/LeaderboardMoveUpView.swift
@@ -52,8 +52,9 @@ struct LeaderboardMoveUpView: View {
 
     var body: some View {
         ZStack {
-            LinearGradient(colors: [Color(red: 0.10, green: 0.05, blue: 0.08), .black],
-                           startPoint: .top, endPoint: .bottom)
+            // Match the app's standard backdrop so the celebration doesn't feel
+            // like a different product from the screens around it.
+            MADTheme.Colors.appBackgroundGradient
                 .ignoresSafeArea()
                 .opacity(showOverlay ? 1 : 0)
 

--- a/app/Mile A Day/Views/Competitions/CompetitionDetailView+Leaderboard.swift
+++ b/app/Mile A Day/Views/Competitions/CompetitionDetailView+Leaderboard.swift
@@ -976,10 +976,66 @@ struct DailyActivityCalendar: View {
     /// Total summed distance — focused user's only when focused, otherwise comp-wide.
     private var aggregateTotalDistance: Double {
         if let user = focusedUser {
-            return user.intervals?.values.reduce(0, +) ?? 0
+            return user.totalIntervalDistance
         }
         return allUsers.reduce(0) { sum, u in
-            sum + (u.intervals?.values.reduce(0, +) ?? 0)
+            sum + u.totalIntervalDistance
+        }
+    }
+
+    // MARK: - Daily activity (run/walk) helpers
+    // The backend's `daily_activity` field (per-day, per-type distance + count)
+    // only exists on newer responses — every consumer below must render nothing
+    // when it's absent so older payloads fall back to the pre-split UI.
+
+    /// True when at least one relevant competitor carries the per-activity
+    /// breakdown. Scoped to the focused user when focused.
+    private var hasDailyActivityData: Bool {
+        if let user = focusedUser { return user.hasDailyActivity }
+        return allUsers.contains { $0.hasDailyActivity }
+    }
+
+    /// Plain per-day key ("YYYY-MM-DD") matching `daily_activity`'s keys.
+    /// Unlike `key(for:)` this never widens to week/month buckets — the
+    /// activity split is always daily regardless of the comp's interval.
+    private func dayKey(for date: Date) -> String {
+        isoDateFormatter.string(from: Calendar.current.startOfDay(for: date))
+    }
+
+    /// Total workout count for one activity type — focused user's when
+    /// focused, comp-wide otherwise.
+    private func activityCount(for activity: CompetitionActivity) -> Int {
+        if let user = focusedUser {
+            return user.totalActivityCount(for: activity)
+        }
+        return allUsers.reduce(0) { $0 + $1.totalActivityCount(for: activity) }
+    }
+
+    /// Activity types with any logged workout on this day — any player's in
+    /// aggregate mode, the focused player's when focused. Drives the tiny
+    /// calendar-cell dots, so it's limited to comps that allow BOTH types
+    /// (a single-type comp's dot carries no extra information, just clutter).
+    private func activityTypes(on date: Date) -> [CompetitionActivity] {
+        guard competition.workouts.count > 1, isInRange(date) else { return [] }
+        let k = dayKey(for: date)
+        let users = focusedUser.map { [$0] } ?? allUsers
+        return competition.workouts.filter { activity in
+            users.contains { u in
+                guard let entry = u.dailyActivityEntry(for: activity, onDay: k) else { return false }
+                return (entry.count ?? 0) > 0 || (entry.distance ?? 0) > 0
+            }
+        }
+    }
+
+    /// One user's per-type split for one day, ordered by the comp's allowed
+    /// activities. Empty when the backend didn't send `daily_activity` or the
+    /// user logged nothing that day.
+    private func activitySplits(for user: CompetitionUser, on date: Date) -> [(activity: CompetitionActivity, entry: DailyActivityEntry)] {
+        let k = dayKey(for: date)
+        return competition.workouts.compactMap { (activity: CompetitionActivity) -> (activity: CompetitionActivity, entry: DailyActivityEntry)? in
+            guard let entry = user.dailyActivityEntry(for: activity, onDay: k),
+                  (entry.count ?? 0) > 0 || (entry.distance ?? 0) > 0 else { return nil }
+            return (activity, entry)
         }
     }
 
@@ -1190,6 +1246,10 @@ struct DailyActivityCalendar: View {
             focusBar
             summaryHeader
 
+            if hasDailyActivityData {
+                activityCountsRow
+            }
+
             if months.count > 1 {
                 monthNavigator
             } else {
@@ -1383,13 +1443,42 @@ struct DailyActivityCalendar: View {
 
             Spacer()
 
-            HStack(spacing: 4) {
+            // Display-only allowed-activity icons. Hidden once real run/walk
+            // counts exist — `activityCountsRow` supersedes them with the same
+            // icons plus counts, and doubling up just eats header width.
+            if !hasDailyActivityData {
+                HStack(spacing: 4) {
+                    ForEach(competition.workouts, id: \.self) { activity in
+                        Image(systemName: activity.icon)
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundColor(activity.color)
+                            .frame(width: 22, height: 22)
+                            .background(Circle().fill(activity.backgroundColor))
+                    }
+                }
+            }
+        }
+    }
+
+    /// Run/walk workout-count chips under the stats columns — comp-wide by
+    /// default, the focused player's when focused. Wrapped in a horizontal
+    /// ScrollView so big counts can't overflow narrow (SE-width) screens.
+    private var activityCountsRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
                 ForEach(competition.workouts, id: \.self) { activity in
-                    Image(systemName: activity.icon)
-                        .font(.system(size: 10, weight: .bold))
-                        .foregroundColor(activity.color)
-                        .frame(width: 22, height: 22)
-                        .background(Circle().fill(activity.backgroundColor))
+                    let count = activityCount(for: activity)
+                    HStack(spacing: 4) {
+                        Image(systemName: activity.icon)
+                            .font(.system(size: 10, weight: .bold))
+                        Text("\(count) \(activity.displayName.lowercased())\(count == 1 ? "" : "s")")
+                            .font(.system(size: 11, weight: .bold, design: .rounded))
+                            .lineLimit(1)
+                    }
+                    .foregroundColor(activity.color)
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 5)
+                    .background(Capsule().fill(activity.backgroundColor))
                 }
             }
         }
@@ -1481,7 +1570,8 @@ struct DailyActivityCalendar: View {
                             isInRange: isInRange(date),
                             isSelected: selectedDay.map { Calendar.current.isDate($0, inSameDayAs: date) } ?? false,
                             accent: effectiveAccent,
-                            streakStatus: streakStatus(for: date)
+                            streakStatus: streakStatus(for: date),
+                            activityDots: activityTypes(on: date)
                         )
                     }
                     .buttonStyle(.plain)
@@ -1543,7 +1633,8 @@ struct DailyActivityCalendar: View {
                         goal: goal,
                         unit: competition.options.unit,
                         accent: effectiveAccent,
-                        isCurrentUser: entry.user.user_id == currentUserId
+                        isCurrentUser: entry.user.user_id == currentUserId,
+                        activitySplits: activitySplits(for: entry.user, on: date)
                     )
                 }
             }
@@ -1633,6 +1724,10 @@ private struct DailyCalendarCell: View {
     /// When set (streaks comp + focused user), trumps the aggregate hit-ratio
     /// rendering and shows life-loss / elimination state instead.
     var streakStatus: DailyActivityCalendar.FocusedDayStatus? = nil
+    /// Activity types (run/walk) with a logged workout this day — rendered as
+    /// tiny color-coded dots under the day number. Empty = no dots (no
+    /// `daily_activity` data, single-type comp, or an off day).
+    var activityDots: [CompetitionActivity] = []
 
     private var hasAnyHits: Bool { hitRatio > 0 }
     private var isAllHit: Bool { hitRatio >= 0.999 }
@@ -1696,9 +1791,31 @@ private struct DailyCalendarCell: View {
                     hasAnyHits ? .white.opacity(0.9) :
                     .white.opacity(0.55)
                 )
+
+            if isInRange {
+                activityDotsRow
+            }
         }
         .frame(height: 36)
         .aspectRatio(1, contentMode: .fit)
+    }
+
+    /// Tiny run/walk type dots pinned under the day number. A hairline white
+    /// ring keeps them legible on top of solid accent/green fills. Renders
+    /// nothing when `activityDots` is empty.
+    @ViewBuilder
+    private var activityDotsRow: some View {
+        if !activityDots.isEmpty {
+            HStack(spacing: 2) {
+                ForEach(activityDots, id: \.self) { activity in
+                    Circle()
+                        .fill(activity.color)
+                        .frame(width: 3.5, height: 3.5)
+                        .overlay(Circle().strokeBorder(Color.white.opacity(0.5), lineWidth: 0.5))
+                }
+            }
+            .offset(y: 11)
+        }
     }
 
     // MARK: - Streak rendering
@@ -1770,6 +1887,15 @@ private struct DailyCalendarCell: View {
                     .font(.system(size: 11, weight: .bold, design: .rounded))
                     .foregroundColor(.white.opacity(0.28))
             }
+
+            // Run/walk type dots only make sense on days with activity —
+            // miss/elimination cells keep their uncluttered warning look.
+            switch status {
+            case .completed, .today:
+                activityDotsRow
+            default:
+                EmptyView()
+            }
         }
         .frame(height: 36)
         .aspectRatio(1, contentMode: .fit)
@@ -1785,6 +1911,10 @@ private struct DayDetailRow: View {
     let unit: CompetitionUnit
     let accent: Color
     let isCurrentUser: Bool
+    /// This user's run/walk split for the tapped day. Empty when the backend
+    /// didn't send `daily_activity` (older responses) or there's no data —
+    /// the row then renders exactly as before.
+    var activitySplits: [(activity: CompetitionActivity, entry: DailyActivityEntry)] = []
 
     private var hitGoal: Bool { goal > 0 && distance >= goal }
     private var hasActivity: Bool { distance > 0 }
@@ -1794,6 +1924,16 @@ private struct DayDetailRow: View {
             ? String(format: "%.1f", distance)
             : String(format: "%.2f", distance)
         return "\(formatted) \(unit.shortDisplayName)"
+    }
+
+    /// Chip label for one activity's slice of the day — distance when we have
+    /// it ("1.2 mi"), workout count otherwise ("×2").
+    private func splitText(for entry: DailyActivityEntry) -> String {
+        let d = entry.distance ?? 0
+        if d > 0 {
+            return "\(String(format: "%.1f", d)) \(unit.shortDisplayName)"
+        }
+        return "×\(entry.count ?? 0)"
     }
 
     var body: some View {
@@ -1818,6 +1958,26 @@ private struct DayDetailRow: View {
                 Text(hasActivity ? distanceText : "Off day")
                     .font(.system(size: 11, weight: .medium, design: .rounded))
                     .foregroundColor(hasActivity ? accent : .white.opacity(0.35))
+
+                // Per-type run/walk split chips for this day (new backends only).
+                if !activitySplits.isEmpty {
+                    HStack(spacing: 4) {
+                        ForEach(activitySplits, id: \.activity) { split in
+                            HStack(spacing: 3) {
+                                Image(systemName: split.activity.icon)
+                                    .font(.system(size: 8, weight: .bold))
+                                Text(splitText(for: split.entry))
+                                    .font(.system(size: 9, weight: .bold, design: .rounded))
+                                    .lineLimit(1)
+                            }
+                            .foregroundColor(split.activity.color)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Capsule().fill(split.activity.backgroundColor))
+                        }
+                    }
+                    .padding(.top, 1)
+                }
             }
 
             Spacer()

--- a/app/Mile A Day/Views/Components/CompetitionComponents.swift
+++ b/app/Mile A Day/Views/Components/CompetitionComponents.swift
@@ -1002,6 +1002,28 @@ struct CompetitionLeaderboardRow: View {
         }
     }
 
+    /// Whether to surface the player's summed interval distance as a secondary
+    /// line. Apex and race scores already ARE distance, so it would duplicate
+    /// the score there; steps comps track steps, not miles. Hidden pre-start
+    /// (no `intervals` yet) so the row degrades to its old look.
+    private var showsTotalDistance: Bool {
+        guard unit != .steps, user.intervals != nil else { return false }
+        switch competitionType {
+        case .streaks, .targets, .clash: return true
+        case .apex, .race: return false
+        }
+    }
+
+    /// "128 mi" / "42.7 mi" — matches the activity calendar's formatting
+    /// (no decimals once totals reach triple digits).
+    private var totalDistanceText: String {
+        let total = user.totalIntervalDistance
+        let formatted = total >= 100
+            ? String(format: "%.0f", total)
+            : String(format: "%.1f", total)
+        return "\(formatted) \(unit.shortDisplayName)"
+    }
+
     var body: some View {
         HStack(spacing: MADTheme.Spacing.md) {
             // Rank badge
@@ -1095,6 +1117,21 @@ struct CompetitionLeaderboardRow: View {
                                 .font(.system(size: 8, weight: .medium))
                                 .foregroundColor(.white.opacity(0.3))
                         }
+                    }
+                }
+
+                // Secondary total-distance line — the streak/points score alone
+                // hides how far a player has actually gone in the comp.
+                if showsTotalDistance {
+                    HStack(spacing: 3) {
+                        Image(systemName: "point.topleft.down.curvedto.point.bottomright.up")
+                            .font(.system(size: 8, weight: .bold))
+                            .foregroundColor(.white.opacity(isEliminated ? 0.2 : 0.35))
+                        Text(totalDistanceText)
+                            .font(.system(size: 10, weight: .semibold, design: .rounded))
+                            .foregroundColor(.white.opacity(isEliminated ? 0.3 : 0.5))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.8)
                     }
                 }
             }

--- a/app/Mile A Day/Views/Components/PhotoLightboxView.swift
+++ b/app/Mile A Day/Views/Components/PhotoLightboxView.swift
@@ -11,23 +11,31 @@ struct PhotoLightboxView: View {
         ZStack {
             Color.black.ignoresSafeArea()
 
-            AsyncImage(url: url) { phase in
-                switch phase {
-                case .success(let image):
-                    ZoomableScrollView {
-                        image
-                            .resizable()
-                            .scaledToFit()
+            if url == nil {
+                // AsyncImage(url: nil) never resolves — show the placeholder,
+                // not an eternal spinner.
+                Image(systemName: "photo")
+                    .font(.largeTitle)
+                    .foregroundColor(.white.opacity(0.3))
+            } else {
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case .success(let image):
+                        ZoomableScrollView {
+                            image
+                                .resizable()
+                                .scaledToFit()
+                        }
+                    case .failure:
+                        Image(systemName: "photo")
+                            .font(.largeTitle)
+                            .foregroundColor(.white.opacity(0.3))
+                    default:
+                        ProgressView().tint(.white)
                     }
-                case .failure:
-                    Image(systemName: "photo")
-                        .font(.largeTitle)
-                        .foregroundColor(.white.opacity(0.3))
-                default:
-                    ProgressView().tint(.white)
                 }
+                .ignoresSafeArea()
             }
-            .ignoresSafeArea()
         }
         .overlay(alignment: .topTrailing) {
             Button { dismiss() } label: {

--- a/app/Mile A Day/Views/Components/PhotoLightboxView.swift
+++ b/app/Mile A Day/Views/Components/PhotoLightboxView.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+import UIKit
+
+/// Full-screen photo lightbox: pinch to zoom, double-tap to zoom in/out, pan
+/// while zoomed (Instagram-style). Presented when a feed photo is tapped.
+struct PhotoLightboxView: View {
+    let url: URL?
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    ZoomableScrollView {
+                        image
+                            .resizable()
+                            .scaledToFit()
+                    }
+                case .failure:
+                    Image(systemName: "photo")
+                        .font(.largeTitle)
+                        .foregroundColor(.white.opacity(0.3))
+                default:
+                    ProgressView().tint(.white)
+                }
+            }
+            .ignoresSafeArea()
+        }
+        .overlay(alignment: .topTrailing) {
+            Button { dismiss() } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(.white)
+                    .padding(10)
+                    .background(Circle().fill(Color.black.opacity(0.5)))
+            }
+            .padding(.trailing, MADTheme.Spacing.md)
+            .padding(.top, MADTheme.Spacing.sm)
+        }
+        .statusBarHidden(true)
+    }
+}
+
+/// UIScrollView-backed zoom container — smooth native pinch/pan that SwiftUI
+/// gestures can't match. Double-tap toggles between fit and ~2.5x at the tap
+/// point; zooming out past fit snaps back.
+struct ZoomableScrollView<Content: View>: UIViewRepresentable {
+    private let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(hostingController: UIHostingController(rootView: content))
+    }
+
+    func makeUIView(context: Context) -> UIScrollView {
+        let scrollView = UIScrollView()
+        scrollView.delegate = context.coordinator
+        scrollView.minimumZoomScale = 1
+        scrollView.maximumZoomScale = 4
+        scrollView.bouncesZoom = true
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.backgroundColor = .clear
+        scrollView.contentInsetAdjustmentBehavior = .never
+
+        guard let hosted = context.coordinator.hostingController.view else { return scrollView }
+        hosted.translatesAutoresizingMaskIntoConstraints = false
+        hosted.backgroundColor = .clear
+        scrollView.addSubview(hosted)
+        NSLayoutConstraint.activate([
+            hosted.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            hosted.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            hosted.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            hosted.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            hosted.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+            hosted.heightAnchor.constraint(equalTo: scrollView.frameLayoutGuide.heightAnchor),
+        ])
+
+        let doubleTap = UITapGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handleDoubleTap(_:))
+        )
+        doubleTap.numberOfTapsRequired = 2
+        scrollView.addGestureRecognizer(doubleTap)
+
+        return scrollView
+    }
+
+    func updateUIView(_ uiView: UIScrollView, context: Context) {
+        context.coordinator.hostingController.rootView = content
+    }
+
+    final class Coordinator: NSObject, UIScrollViewDelegate {
+        let hostingController: UIHostingController<Content>
+
+        init(hostingController: UIHostingController<Content>) {
+            self.hostingController = hostingController
+        }
+
+        func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+            hostingController.view
+        }
+
+        @objc func handleDoubleTap(_ gesture: UITapGestureRecognizer) {
+            guard let scrollView = gesture.view as? UIScrollView else { return }
+            if scrollView.zoomScale > 1.01 {
+                scrollView.setZoomScale(1, animated: true)
+            } else if let target = hostingController.view {
+                let point = gesture.location(in: target)
+                let size = CGSize(
+                    width: scrollView.bounds.width / 2.5,
+                    height: scrollView.bounds.height / 2.5
+                )
+                let rect = CGRect(
+                    x: point.x - size.width / 2,
+                    y: point.y - size.height / 2,
+                    width: size.width,
+                    height: size.height
+                )
+                scrollView.zoom(to: rect, animated: true)
+            }
+        }
+    }
+}

--- a/app/Mile A Day/Views/Feed/ActivityCardView.swift
+++ b/app/Mile A Day/Views/Feed/ActivityCardView.swift
@@ -2,7 +2,8 @@ import SwiftUI
 
 /// A raw walk/run in the unified feed (no photo) — the auto activity card.
 /// Shares the visual language of PostCardView: author header, the run line,
-/// a compact stat strip, and a hype affordance.
+/// the GPS route map when the workout has one, a compact stat strip, and a
+/// hype affordance.
 struct ActivityCardView: View {
     let entry: FeedEntry
     var isHyping: Bool = false
@@ -17,6 +18,15 @@ struct ActivityCardView: View {
         VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
             header
             runLine
+            if let coords = entry.routeCoordinates {
+                WorkoutRouteMapView(
+                    coordinates: coords,
+                    routeColor: Self.color(entry.workout_type)
+                )
+                .frame(maxWidth: .infinity)
+                .frame(height: 160)
+                .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
+            }
             statStrip
             footer
         }

--- a/app/Mile A Day/Views/Feed/Memories.swift
+++ b/app/Mile A Day/Views/Feed/Memories.swift
@@ -70,9 +70,12 @@ enum MemoriesService {
             let days = cal.dateComponents([.day], from: cal.startOfDay(for: date), to: today).day ?? 0
             guard days > 0 else { continue }
 
+            // Bucket by RANGE, not exact day counts — the server computes "a
+            // week/month ago" against its own date, and timezone or midnight
+            // drift makes the client's day math land on 6/8 or 29/31.
             let ago: String? = {
-                if days == 7 { return "1 week ago" }
-                if days < 360 { return "1 month ago" }
+                if (5...9).contains(days) { return "1 week ago" }
+                if (25...45).contains(days) { return "1 month ago" }
                 return nil // exact-year memories use the standard label
             }()
             let years = cal.dateComponents([.year], from: date, to: today).year ?? 0

--- a/app/Mile A Day/Views/Feed/PostCardView.swift
+++ b/app/Mile A Day/Views/Feed/PostCardView.swift
@@ -1,12 +1,12 @@
 import SwiftUI
 import CoreLocation
 
-/// A single post in the social feed: author header, photo (overlay already
-/// baked in), caption, hype + social-proof tally, and a report/block/delete menu.
-/// When the run also has a story photo, a corner thumbnail flips the card
-/// between the route/stats image and the photo. When the run has GPS route
-/// data, the photo becomes a swipeable photo → route-map carousel, and tapping
-/// the photo opens a pinch-to-zoom lightbox.
+/// A single post in the social feed: author header, media, caption, hype +
+/// social-proof tally, and a report/block/delete menu. The media is a single
+/// photo, or a swipeable full-size carousel when the run has more to show —
+/// always the real PHOTO first, then the route/stats card, then the route map
+/// (each slide full 4:5, with page dots). Tapping a photo slide opens the
+/// pinch-to-zoom lightbox.
 struct PostCardView: View {
     let post: PostItem
     /// The run's story-only photo, when different from the post media.
@@ -19,8 +19,12 @@ struct PostCardView: View {
     /// Tap the author's avatar or name to open their profile.
     var onTapAuthor: (() -> Void)? = nil
 
-    @State private var showAltPhoto = false
-    @State private var showLightbox = false
+    /// The tapped slide's image, presented in the zoom lightbox.
+    private struct LightboxItem: Identifiable {
+        let url: URL
+        var id: String { url.absoluteString }
+    }
+    @State private var lightboxItem: LightboxItem?
 
     var body: some View {
         VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
@@ -42,13 +46,8 @@ struct PostCardView: View {
             RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
                 .fill(Color.white.opacity(0.04))
         )
-        .fullScreenCover(isPresented: $showLightbox) {
-            PhotoLightboxView(url: heroURL)
-        }
-        // If the story photo disappears (author deleted it) while the card was
-        // flipped to it, flip back — otherwise heroURL is nil forever.
-        .onChange(of: storyPhotoURL) { _, newValue in
-            if newValue == nil { showAltPhoto = false }
+        .fullScreenCover(item: $lightboxItem) { item in
+            PhotoLightboxView(url: item.url)
         }
     }
 
@@ -99,13 +98,6 @@ struct PostCardView: View {
         }
     }
 
-    private var heroURL: URL? {
-        showAltPhoto ? storyPhotoURL : post.mediaURL
-    }
-    private var thumbURL: URL? {
-        showAltPhoto ? post.mediaURL : storyPhotoURL
-    }
-
     /// Route slide coordinates — hidden for auto posts, whose media already IS
     /// the rendered route/stats card (a second identical slide would be noise).
     private var routeSlideCoordinates: [CLLocationCoordinate2D]? {
@@ -113,20 +105,39 @@ struct PostCardView: View {
         return post.routeCoordinates
     }
 
-    /// Photo, or a photo → route-map carousel when the run has a GPS path.
+    /// Image slides, real moment first: when the run has a story photo it
+    /// leads, and the post media (photo or route/stats card) becomes the
+    /// second slide — never a cramped corner thumbnail.
+    private var photoURLs: [URL?] {
+        if let storyPhotoURL {
+            return [storyPhotoURL, post.mediaURL]
+        }
+        return [post.mediaURL]
+    }
+
+    /// A single photo, or a full-size swipeable carousel:
+    /// photo → route/stats card → route map.
     @ViewBuilder
     private var media: some View {
-        if let coords = routeSlideCoordinates {
+        let slides = photoURLs
+        let coords = routeSlideCoordinates
+        if slides.count > 1 || coords != nil {
             TabView {
-                photo
-                routeSlide(coords)
+                ForEach(Array(slides.enumerated()), id: \.offset) { index, url in
+                    // When the story photo leads, badge the trailing auto
+                    // route/stats card so the swipe reads as "photo → stats".
+                    photoSlide(url, badge: index > 0 && post.is_auto == true ? "Stats" : nil)
+                }
+                if let coords {
+                    routeSlide(coords)
+                }
             }
             .tabViewStyle(.page(indexDisplayMode: .always))
             .indexViewStyle(.page(backgroundDisplayMode: .interactive))
             .frame(maxWidth: .infinity)
             .aspectRatio(4.0 / 5.0, contentMode: .fit)
         } else {
-            photo
+            photoSlide(post.mediaURL)
         }
     }
 
@@ -139,50 +150,38 @@ struct PostCardView: View {
         .aspectRatio(4.0 / 5.0, contentMode: .fit)
         .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
         .overlay(alignment: .topLeading) {
-            HStack(spacing: 5) {
-                Image(systemName: "map.fill")
-                    .font(.system(size: 11, weight: .bold))
-                Text("Route")
-                    .font(.system(size: 12, weight: .bold, design: .rounded))
-            }
-            .foregroundColor(.white)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(Capsule().fill(Color.black.opacity(0.55)))
-            .padding(10)
+            slideBadge("Route", icon: "map.fill")
         }
     }
 
-    private var photo: some View {
-        cardImage(heroURL)
+    private func photoSlide(_ url: URL?, badge: String? = nil) -> some View {
+        cardImage(url)
             .frame(maxWidth: .infinity)
             .aspectRatio(4.0 / 5.0, contentMode: .fit)
             .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
             .contentShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
-            .onTapGesture { showLightbox = true }
-            .overlay(alignment: .bottomTrailing) {
-                // Corner thumbnail flips between the route/stats card and the
-                // run's story photo (BeReal-style).
-                if storyPhotoURL != nil {
-                    Button {
-                        withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
-                            showAltPhoto.toggle()
-                        }
-                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                    } label: {
-                        cardImage(thumbURL)
-                            .frame(width: 64, height: 80)
-                            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                    .strokeBorder(Color.white.opacity(0.9), lineWidth: 1.5)
-                            )
-                            .shadow(color: .black.opacity(0.5), radius: 6, y: 3)
-                    }
-                    .buttonStyle(.plain)
-                    .padding(10)
+            .onTapGesture {
+                if let url { lightboxItem = LightboxItem(url: url) }
+            }
+            .overlay(alignment: .topLeading) {
+                if let badge {
+                    slideBadge(badge, icon: "chart.bar.fill")
                 }
             }
+    }
+
+    private func slideBadge(_ text: String, icon: String) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: icon)
+                .font(.system(size: 11, weight: .bold))
+            Text(text)
+                .font(.system(size: 12, weight: .bold, design: .rounded))
+        }
+        .foregroundColor(.white)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Capsule().fill(Color.black.opacity(0.55)))
+        .padding(10)
     }
 
     @ViewBuilder

--- a/app/Mile A Day/Views/Feed/PostCardView.swift
+++ b/app/Mile A Day/Views/Feed/PostCardView.swift
@@ -45,6 +45,11 @@ struct PostCardView: View {
         .fullScreenCover(isPresented: $showLightbox) {
             PhotoLightboxView(url: heroURL)
         }
+        // If the story photo disappears (author deleted it) while the card was
+        // flipped to it, flip back — otherwise heroURL is nil forever.
+        .onChange(of: storyPhotoURL) { _, newValue in
+            if newValue == nil { showAltPhoto = false }
+        }
     }
 
     private var header: some View {
@@ -180,18 +185,28 @@ struct PostCardView: View {
             }
     }
 
+    @ViewBuilder
     private func cardImage(_ url: URL?) -> some View {
-        AsyncImage(url: url) { phase in
-            switch phase {
-            case .success(let image):
-                image.resizable().scaledToFill()
-            case .failure:
-                ZStack {
-                    Color.white.opacity(0.05)
-                    Image(systemName: "photo").foregroundColor(.white.opacity(0.3))
+        if url == nil {
+            // AsyncImage(url: nil) never leaves .empty — show the broken-photo
+            // placeholder instead of an eternal spinner.
+            ZStack {
+                Color.white.opacity(0.05)
+                Image(systemName: "photo").foregroundColor(.white.opacity(0.3))
+            }
+        } else {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().scaledToFill()
+                case .failure:
+                    ZStack {
+                        Color.white.opacity(0.05)
+                        Image(systemName: "photo").foregroundColor(.white.opacity(0.3))
+                    }
+                default:
+                    ZStack { Color.white.opacity(0.05); ProgressView().tint(.white) }
                 }
-            default:
-                ZStack { Color.white.opacity(0.05); ProgressView().tint(.white) }
             }
         }
     }

--- a/app/Mile A Day/Views/Feed/PostCardView.swift
+++ b/app/Mile A Day/Views/Feed/PostCardView.swift
@@ -1,9 +1,12 @@
 import SwiftUI
+import CoreLocation
 
 /// A single post in the social feed: author header, photo (overlay already
 /// baked in), caption, hype + social-proof tally, and a report/block/delete menu.
 /// When the run also has a story photo, a corner thumbnail flips the card
-/// between the route/stats image and the photo.
+/// between the route/stats image and the photo. When the run has GPS route
+/// data, the photo becomes a swipeable photo → route-map carousel, and tapping
+/// the photo opens a pinch-to-zoom lightbox.
 struct PostCardView: View {
     let post: PostItem
     /// The run's story-only photo, when different from the post media.
@@ -17,11 +20,12 @@ struct PostCardView: View {
     var onTapAuthor: (() -> Void)? = nil
 
     @State private var showAltPhoto = false
+    @State private var showLightbox = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
             header
-            photo
+            media
             if let stats = post.stats_snapshot {
                 PostStatStrip(stats: stats).padding(.horizontal, 2)
             }
@@ -38,6 +42,9 @@ struct PostCardView: View {
             RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
                 .fill(Color.white.opacity(0.04))
         )
+        .fullScreenCover(isPresented: $showLightbox) {
+            PhotoLightboxView(url: heroURL)
+        }
     }
 
     private var header: some View {
@@ -61,6 +68,11 @@ struct PostCardView: View {
             .buttonStyle(.plain)
             .disabled(onTapAuthor == nil)
             Spacer()
+            if let type = post.workout_type {
+                Image(systemName: ActivityCardView.icon(type))
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(ActivityCardView.color(type))
+            }
             Menu {
                 if post.is_self {
                     Button(role: .destructive, action: onDelete) {
@@ -89,11 +101,60 @@ struct PostCardView: View {
         showAltPhoto ? post.mediaURL : storyPhotoURL
     }
 
+    /// Route slide coordinates — hidden for auto posts, whose media already IS
+    /// the rendered route/stats card (a second identical slide would be noise).
+    private var routeSlideCoordinates: [CLLocationCoordinate2D]? {
+        guard post.is_auto != true else { return nil }
+        return post.routeCoordinates
+    }
+
+    /// Photo, or a photo → route-map carousel when the run has a GPS path.
+    @ViewBuilder
+    private var media: some View {
+        if let coords = routeSlideCoordinates {
+            TabView {
+                photo
+                routeSlide(coords)
+            }
+            .tabViewStyle(.page(indexDisplayMode: .always))
+            .indexViewStyle(.page(backgroundDisplayMode: .interactive))
+            .frame(maxWidth: .infinity)
+            .aspectRatio(4.0 / 5.0, contentMode: .fit)
+        } else {
+            photo
+        }
+    }
+
+    private func routeSlide(_ coords: [CLLocationCoordinate2D]) -> some View {
+        WorkoutRouteMapView(
+            coordinates: coords,
+            routeColor: ActivityCardView.color(post.workout_type)
+        )
+        .frame(maxWidth: .infinity)
+        .aspectRatio(4.0 / 5.0, contentMode: .fit)
+        .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
+        .overlay(alignment: .topLeading) {
+            HStack(spacing: 5) {
+                Image(systemName: "map.fill")
+                    .font(.system(size: 11, weight: .bold))
+                Text("Route")
+                    .font(.system(size: 12, weight: .bold, design: .rounded))
+            }
+            .foregroundColor(.white)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(Capsule().fill(Color.black.opacity(0.55)))
+            .padding(10)
+        }
+    }
+
     private var photo: some View {
         cardImage(heroURL)
             .frame(maxWidth: .infinity)
             .aspectRatio(4.0 / 5.0, contentMode: .fit)
             .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
+            .contentShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
+            .onTapGesture { showLightbox = true }
             .overlay(alignment: .bottomTrailing) {
                 // Corner thumbnail flips between the route/stats card and the
                 // run's story photo (BeReal-style).

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -195,7 +195,18 @@ final class PostComposerViewModel: ObservableObject {
                 isAuto: false,
                 includeRoute: includeRoute
             )
-            if stickerEnabled { config.save() } // remember the user's overlay style
+            if stickerEnabled {
+                // Remember the user's overlay style — but merge back any stats
+                // that were remembered and merely had no data TODAY (init
+                // filters those out of the session config); otherwise one
+                // treadmill day permanently erases a saved choice like pace.
+                var toSave = config
+                let available = Set(stats.availableStats())
+                let rememberedUnavailable = StickerConfig.load().enabled
+                    .filter { !available.contains($0) }
+                toSave.enabled = config.enabled + rememberedUnavailable
+                toSave.save()
+            }
             return true
         } catch let APIError.apiError(message) where message == "mile_not_completed" {
             errorMessage = "Finish today's mile before you post."
@@ -249,6 +260,9 @@ struct PostComposerView: View {
     @StateObject private var vm: PostComposerViewModel
     @State private var showCamera = false
     @State private var gestureBaseScale: CGFloat = 1.0
+    /// Sticker position at drag start (normalized) — drags apply translation
+    /// relative to this instead of jumping to the touch point.
+    @State private var gestureBasePos: CGPoint? = nil
     /// Launch straight into the camera on first appear (post-run prompt flow) —
     /// the user already tapped "Take a photo" once to get here.
     let autoOpenCamera: Bool
@@ -478,10 +492,19 @@ struct PostComposerView: View {
                 SimultaneousGesture(
                     DragGesture()
                         .onChanged { value in
-                            let x = min(max(value.location.x / canvas.width, 0.12), 0.88)
-                            let y = min(max(value.location.y / canvas.height, 0.1), 0.9)
-                            vm.stickerPos = CGPoint(x: x, y: y)
-                        },
+                            // Move RELATIVE to where the sticker started — a
+                            // location-based move teleports the sticker to
+                            // wherever the finger first lands on the canvas.
+                            let base = gestureBasePos ?? vm.stickerPos
+                            if gestureBasePos == nil { gestureBasePos = vm.stickerPos }
+                            let x = base.x + value.translation.width / canvas.width
+                            let y = base.y + value.translation.height / canvas.height
+                            vm.stickerPos = CGPoint(
+                                x: min(max(x, 0.12), 0.88),
+                                y: min(max(y, 0.1), 0.9)
+                            )
+                        }
+                        .onEnded { _ in gestureBasePos = nil },
                     MagnificationGesture()
                         .onChanged { value in
                             vm.stickerScale = min(max(gestureBaseScale * value, 0.6), 1.9)

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -114,6 +114,10 @@ final class PostComposerViewModel: ObservableObject {
     @Published var config: StickerConfig
     @Published var isPublishing = false
     @Published var errorMessage: String?
+    /// Whether the linked workout has a GPS route to offer alongside the photo.
+    @Published var hasRoute = false
+    /// User choice: show the route map with this post (carousel slide 2).
+    @Published var includeRoute = true
 
     let stats: RunStatsInput
     /// Captured on-screen canvas size (points), reused to render the composite.
@@ -133,6 +137,17 @@ final class PostComposerViewModel: ObservableObject {
 
     var canPublish: Bool {
         pickedImage != nil && !isPublishing
+    }
+
+    /// Check whether the linked workout has GPS route data, enabling the
+    /// "Include route map" toggle. No route (indoor/manual) → toggle hidden.
+    func checkRouteAvailability() async {
+        guard let workoutId = stats.workoutId else { return }
+        let workout = HealthKitManager.shared.todaysWorkouts
+            .first { $0.uuid.uuidString == workoutId }
+        guard let workout else { return }
+        let locations = await HealthKitManager.shared.fetchAllRouteLocations(for: workout)
+        hasRoute = locations.count >= 2
     }
 
     /// Render the on-screen canvas (photo + sticker) to a flat JPEG-ready image
@@ -173,7 +188,9 @@ final class PostComposerViewModel: ObservableObject {
                 workoutId: stats.workoutId,
                 shareToFeed: destination.toFeed,
                 shareToStory: destination.toStory,
-                stats: stats.snapshot
+                stats: stats.snapshot,
+                isAuto: false,
+                includeRoute: hasRoute ? includeRoute : true
             )
             if stickerEnabled { config.save() } // remember the user's overlay style
             return true
@@ -182,6 +199,10 @@ final class PostComposerViewModel: ObservableObject {
             return false
         } catch let APIError.apiError(message) where message == "terms_not_accepted" {
             errorMessage = "Please accept the community terms to post."
+            return false
+        } catch APIError.conflict {
+            // One deliberate post per workout — a reward, not a redo.
+            errorMessage = "You've already shared a post for this workout. Delete it first if you want to post a new one."
             return false
         } catch {
             errorMessage = (error as? LocalizedError)?.errorDescription ?? "Couldn't share your post. Try again."
@@ -251,6 +272,7 @@ struct PostComposerView: View {
                         canvasSection
                         if vm.pickedImage != nil {
                             overlayEditor
+                            if vm.hasRoute { routeToggle }
                             captionField
                             destinationToggles
                         }
@@ -304,7 +326,31 @@ struct PostComposerView: View {
                     showCamera = true
                 }
             }
+            .task { await vm.checkRouteAvailability() }
         }
+    }
+
+    /// Offer to ride the run's GPS route along with the photo (shown as a
+    /// second, swipeable slide on the feed card). Only offered when the linked
+    /// workout actually has route data.
+    private var routeToggle: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Toggle(isOn: $vm.includeRoute.animation(.easeInOut)) {
+                Label("Include route map", systemImage: "map.fill")
+                    .font(.system(size: 15, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white)
+            }
+            .tint(MADTheme.Colors.madRed)
+            Text("Friends can swipe to see your mile's path next to the photo.")
+                .font(.system(size: 12, weight: .medium, design: .rounded))
+                .foregroundColor(.white.opacity(0.5))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(MADTheme.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
+                .fill(Color.white.opacity(0.04))
+        )
     }
 
     // MARK: - Canvas

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -141,13 +141,13 @@ final class PostComposerViewModel: ObservableObject {
 
     /// Check whether the linked workout has GPS route data, enabling the
     /// "Include route map" toggle. No route (indoor/manual) → toggle hidden.
+    /// Cheap existence probe — never enumerates the route's locations.
     func checkRouteAvailability() async {
-        guard let workoutId = stats.workoutId else { return }
+        guard !hasRoute, let workoutId = stats.workoutId else { return }
         let workout = HealthKitManager.shared.todaysWorkouts
             .first { $0.uuid.uuidString == workoutId }
         guard let workout else { return }
-        let locations = await HealthKitManager.shared.fetchAllRouteLocations(for: workout)
-        hasRoute = locations.count >= 2
+        hasRoute = await HealthKitManager.shared.hasRouteData(for: workout)
     }
 
     /// Render the on-screen canvas (photo + sticker) to a flat JPEG-ready image
@@ -190,7 +190,7 @@ final class PostComposerViewModel: ObservableObject {
                 shareToStory: destination.toStory,
                 stats: stats.snapshot,
                 isAuto: false,
-                includeRoute: hasRoute ? includeRoute : true
+                includeRoute: includeRoute
             )
             if stickerEnabled { config.save() } // remember the user's overlay style
             return true
@@ -327,6 +327,12 @@ struct PostComposerView: View {
                 }
             }
             .task { await vm.checkRouteAvailability() }
+            // Re-probe once a photo lands — todaysWorkouts may not have been
+            // loaded yet when the composer first appeared.
+            .onChange(of: vm.pickedImage) { _, newImage in
+                guard newImage != nil else { return }
+                Task { await vm.checkRouteAvailability() }
+            }
         }
     }
 

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -143,6 +143,9 @@ final class PostComposerViewModel: ObservableObject {
     /// "Include route map" toggle. No route (indoor/manual) → toggle hidden.
     /// Cheap existence probe — never enumerates the route's locations.
     func checkRouteAvailability() async {
+        // Master "Share route maps" setting off → never offer the per-post
+        // toggle (the server wouldn't ship the route to friends anyway).
+        guard NotificationPreferences.load().shareRouteMaps else { return }
         guard !hasRoute, let workoutId = stats.workoutId else { return }
         let workout = HealthKitManager.shared.todaysWorkouts
             .first { $0.uuid.uuidString == workoutId }

--- a/app/Mile A Day/Views/Feed/ProfilePostsGridView.swift
+++ b/app/Mile A Day/Views/Feed/ProfilePostsGridView.swift
@@ -170,7 +170,16 @@ struct ProfilePostsFeedSheet: View {
                         .padding(MADTheme.Spacing.md)
                         .padding(.bottom, MADTheme.Spacing.xl)
                     }
-                    .onAppear { proxy.scrollTo(initialPostId, anchor: .top) }
+                    .onAppear {
+                        // LazyVStack hasn't laid out far-down cards yet when
+                        // onAppear fires, so a single scrollTo can land short
+                        // for deep taps — jump, then correct once layout has
+                        // caught up.
+                        proxy.scrollTo(initialPostId, anchor: .top)
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                            proxy.scrollTo(initialPostId, anchor: .top)
+                        }
+                    }
                 }
             }
             .navigationTitle(title)

--- a/app/Mile A Day/Views/Feed/ProfilePostsGridView.swift
+++ b/app/Mile A Day/Views/Feed/ProfilePostsGridView.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
 /// Instagram-style 3-column grid of a user's permanent posts, used on both the
-/// owner's profile and a friend's profile. Tapping a thumbnail opens a detail
-/// sheet. Paginates as the user scrolls.
+/// owner's profile and a friend's profile. Tapping a thumbnail opens the
+/// person's posts as a scrollable feed (starting at the tapped post) so you can
+/// keep swiping through their history. Paginates as the user scrolls.
 struct ProfilePostsGridView: View {
     let userId: String
     var isSelf: Bool = false
@@ -14,7 +15,7 @@ struct ProfilePostsGridView: View {
     @State private var loaded = false
     @State private var selectedPost: PostItem?
 
-    private let columns = Array(repeating: GridItem(.flexible(), spacing: 3), count: 3)
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 4), count: 3)
 
     var body: some View {
         Group {
@@ -25,7 +26,7 @@ struct ProfilePostsGridView: View {
             } else if posts.isEmpty {
                 emptyState
             } else {
-                LazyVGrid(columns: columns, spacing: 3) {
+                LazyVGrid(columns: columns, spacing: 4) {
                     ForEach(posts) { post in
                         Button { selectedPost = post } label: { thumbnail(post) }
                             .buttonStyle(.plain)
@@ -40,7 +41,14 @@ struct ProfilePostsGridView: View {
             }
         }
         .task { if !loaded { await load() } }
-        .sheet(item: $selectedPost) { post in PostDetailSheet(post: post) }
+        .sheet(item: $selectedPost) { post in
+            ProfilePostsFeedSheet(
+                title: isSelf ? "Your Posts" : "Posts",
+                posts: $posts,
+                initialPostId: post.post_id,
+                onNeedMore: { Task { await loadMore() } }
+            )
+        }
     }
 
     private func thumbnail(_ post: PostItem) -> some View {
@@ -57,7 +65,11 @@ struct ProfilePostsGridView: View {
                     }
                 }
             )
-            .clipped()
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .strokeBorder(Color.white.opacity(0.06), lineWidth: 0.5)
+            )
             .overlay(alignment: .topTrailing) {
                 if post.stats_snapshot?.streak != nil {
                     Image(systemName: "flame.fill")
@@ -65,6 +77,16 @@ struct ProfilePostsGridView: View {
                         .foregroundColor(.orange)
                         .padding(4)
                         .background(Circle().fill(.black.opacity(0.4)))
+                        .padding(4)
+                }
+            }
+            .overlay(alignment: .bottomLeading) {
+                if let type = post.workout_type {
+                    Image(systemName: ActivityCardView.icon(type))
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundColor(ActivityCardView.color(type))
+                        .padding(4)
+                        .background(Circle().fill(.black.opacity(0.45)))
                         .padding(4)
                 }
             }
@@ -117,60 +139,112 @@ struct ProfilePostsGridView: View {
     }
 }
 
-/// Read-only detail for a single post opened from the grid: the photo, caption,
-/// and a stat strip. (Hype/moderation live on the main feed.)
-struct PostDetailSheet: View {
-    let post: PostItem
+/// A user's posts as a scrollable, read-only feed — opened from the profile
+/// grid at the tapped post, so browsing someone's history feels like reading a
+/// feed instead of opening photos one at a time. Shares the grid's post array
+/// (and its pagination) via a binding, and taps open the pinch-zoom lightbox.
+struct ProfilePostsFeedSheet: View {
+    let title: String
+    @Binding var posts: [PostItem]
+    let initialPostId: String
+    let onNeedMore: () -> Void
     @Environment(\.dismiss) private var dismiss
+    @State private var lightboxPost: PostItem?
 
     var body: some View {
         NavigationStack {
             ZStack {
-                Color.black.ignoresSafeArea()
-                ScrollView {
-                    VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
-                        HStack(spacing: 10) {
-                            AvatarView(name: post.displayName, imageURL: post.profile_image_url, size: 40)
-                            VStack(alignment: .leading, spacing: 1) {
-                                Text(post.displayName)
-                                    .font(.system(size: 15, weight: .bold, design: .rounded))
-                                    .foregroundColor(.white)
-                                Text(post.relativeTime)
-                                    .font(.system(size: 12, weight: .medium, design: .rounded))
-                                    .foregroundColor(.white.opacity(0.5))
-                            }
-                            Spacer()
-                        }
+                MADTheme.Colors.appBackgroundGradient.ignoresSafeArea()
 
-                        AsyncImage(url: post.mediaURL) { phase in
-                            switch phase {
-                            case .success(let image): image.resizable().scaledToFit()
-                            default: ZStack { Color.white.opacity(0.05); ProgressView().tint(.white) }
-                                    .aspectRatio(4.0 / 5.0, contentMode: .fit)
+                ScrollViewReader { proxy in
+                    ScrollView(showsIndicators: false) {
+                        LazyVStack(spacing: MADTheme.Spacing.md) {
+                            ForEach(posts) { post in
+                                card(post)
+                                    .id(post.post_id)
+                                    .onAppear {
+                                        if post.id == posts.last?.id { onNeedMore() }
+                                    }
                             }
                         }
-                        .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
-
-                        if let stats = post.stats_snapshot {
-                            PostStatStrip(stats: stats)
-                        }
-                        if let caption = post.caption, !caption.isEmpty {
-                            Text(caption)
-                                .font(.system(size: 14, weight: .medium, design: .rounded))
-                                .foregroundColor(.white.opacity(0.9))
-                        }
+                        .padding(MADTheme.Spacing.md)
+                        .padding(.bottom, MADTheme.Spacing.xl)
                     }
-                    .padding(MADTheme.Spacing.md)
+                    .onAppear { proxy.scrollTo(initialPostId, anchor: .top) }
                 }
             }
+            .navigationTitle(title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") { dismiss() }.foregroundColor(.white)
+                    Button("Done") { dismiss() }
+                        .fontWeight(.bold)
+                        .foregroundColor(.white)
                 }
             }
             .toolbarBackground(.black, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
+            .toolbarColorScheme(.dark, for: .navigationBar)
         }
+        .fullScreenCover(item: $lightboxPost) { post in
+            PhotoLightboxView(url: ProfileImageService.fullImageURL(for: post.media_url))
+        }
+    }
+
+    private func card(_ post: PostItem) -> some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+            HStack(spacing: 10) {
+                AvatarView(name: post.displayName, imageURL: post.profile_image_url, size: 40)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(post.displayName)
+                        .font(.system(size: 15, weight: .bold, design: .rounded))
+                        .foregroundColor(.white)
+                        .lineLimit(1)
+                    Text(post.relativeTime)
+                        .font(.system(size: 12, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.5))
+                }
+                Spacer()
+                if let type = post.workout_type {
+                    Image(systemName: ActivityCardView.icon(type))
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundColor(ActivityCardView.color(type))
+                }
+            }
+
+            AsyncImage(url: post.mediaURL) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().scaledToFill()
+                case .failure:
+                    ZStack { Color.white.opacity(0.05); Image(systemName: "photo").foregroundColor(.white.opacity(0.3)) }
+                default:
+                    ZStack { Color.white.opacity(0.05); ProgressView().tint(.white) }
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .aspectRatio(4.0 / 5.0, contentMode: .fit)
+            .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
+            .contentShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
+            .onTapGesture { lightboxPost = post }
+
+            if let stats = post.stats_snapshot {
+                PostStatStrip(stats: stats).padding(.horizontal, 2)
+            }
+            if let caption = post.caption, !caption.isEmpty {
+                Text(caption)
+                    .font(.system(size: 14, weight: .medium, design: .rounded))
+                    .foregroundColor(.white.opacity(0.9))
+                    .padding(.horizontal, 2)
+            }
+            if let count = post.hype_count, count > 0 {
+                HypeTally(count: count).padding(.horizontal, 2)
+            }
+        }
+        .padding(MADTheme.Spacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
+                .fill(Color.white.opacity(0.04))
+        )
     }
 }

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -24,6 +24,10 @@ struct SocialFeedView: View {
     @State private var viewerGroup: StoryGroup?
     @State private var reportingPost: PostItem?
     @State private var showTermsGate = false
+    /// Compose was requested but blocked on the terms gate — open the composer
+    /// AFTER the gate sheet dismisses (presenting both at once is a SwiftUI
+    /// sheet-over-sheet race that can drop the composer entirely).
+    @State private var pendingCompose = false
     @State private var showMileHint = false
     @State private var showMemories = false
     @State private var profileUser: BackendUser?
@@ -108,7 +112,13 @@ struct SocialFeedView: View {
         .fullScreenCover(item: $viewerGroup) { group in
             StoryViewerView(group: group, currentUserId: currentUserId) { changed in
                 viewerGroup = nil
-                if changed { Task { await refresh() } }
+                if changed {
+                    Task { await refresh() }
+                } else {
+                    // Even a plain watch-through changes rail state (viewed
+                    // rings) — refresh just the rail so rings gray out.
+                    Task { await refreshRail() }
+                }
             }
         }
         .sheet(isPresented: $presentingComposer) {
@@ -119,10 +129,15 @@ struct SocialFeedView: View {
         .sheet(item: $reportingPost) { post in
             ReportPostSheet(postId: post.post_id) { reportingPost = nil }
         }
-        .sheet(isPresented: $showTermsGate) {
+        .sheet(isPresented: $showTermsGate, onDismiss: {
+            // Present the composer only after the gate sheet is fully gone.
+            if pendingCompose && termsAccepted == true {
+                presentingComposer = true
+            }
+            pendingCompose = false
+        }) {
             PostTermsGateView {
                 termsAccepted = true
-                presentingComposer = true
             }
         }
         .sheet(isPresented: $showMemories) {
@@ -217,6 +232,7 @@ struct SocialFeedView: View {
         if termsAccepted == true {
             presentingComposer = true
         } else {
+            pendingCompose = true
             showTermsGate = true
         }
     }
@@ -257,6 +273,14 @@ struct SocialFeedView: View {
         }
     }
 
+    /// Reload just the stories rail (viewed rings, expired groups) without the
+    /// heavier full feed refresh.
+    private func refreshRail() async {
+        if let groups = try? await PostService.fetchStoriesRail() {
+            await MainActor.run { stories = groups }
+        }
+    }
+
     private func loadMore() async {
         guard let before = nextBefore, !isLoadingMore else { return }
         await MainActor.run { isLoadingMore = true }
@@ -287,7 +311,13 @@ struct SocialFeedView: View {
                 context: HypeContext(contextType: ctxType, contextId: entry.entryId, contextLabel: label)
             )
             await MainActor.run {
-                updateEntry(entry.id) { $0.is_hyped = true; $0.hype_count = ($0.hype_count ?? 0) + 1 }
+                updateEntry(entry.id) { e in
+                    // A refresh may have landed mid-request and already carry
+                    // this hype — don't count it twice.
+                    guard !e.is_hyped else { return }
+                    e.is_hyped = true
+                    e.hype_count = (e.hype_count ?? 0) + 1
+                }
                 UINotificationFeedbackGenerator().notificationOccurred(.success)
             }
         } catch {

--- a/app/Mile A Day/Views/Feed/StoryViewerView.swift
+++ b/app/Mile A Day/Views/Feed/StoryViewerView.swift
@@ -22,6 +22,10 @@ struct StoryViewerView: View {
     @State private var imageReady = false
 
     @State private var showReport = false
+    /// The story the overflow options were opened FOR — captured at tap time so
+    /// the auto-advance can never re-target a destructive action mid-dialog.
+    @State private var optionsPost: PostItem?
+    @State private var showOptions = false
     /// postId → emoji the viewer sent this session (server keeps one per story).
     @State private var myReactions: [String: String] = [:]
     /// Own-story extras: seen-by counts per post + the viewers sheet.
@@ -85,7 +89,9 @@ struct StoryViewerView: View {
         // onDismiss also covers swiping the sheet away, which would otherwise
         // leave `paused` stuck true and freeze the story.
         .sheet(isPresented: $showReport, onDismiss: { paused = false }) {
-            if let post = current {
+            // Report the story the options were opened for, not whatever is
+            // current by the time the sheet lands.
+            if let post = optionsPost ?? current {
                 ReportPostSheet(postId: post.post_id) { showReport = false }
             }
         }
@@ -106,6 +112,27 @@ struct StoryViewerView: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text(promoteError ?? "")
+        }
+        .confirmationDialog("Story options", isPresented: $showOptions, titleVisibility: .hidden) {
+            if let post = optionsPost {
+                if post.is_self {
+                    Button("Delete story", role: .destructive) {
+                        Task { await deleteOwn(post) }
+                    }
+                } else {
+                    Button("Report") { showReport = true }
+                    Button("Block \(group.displayName)", role: .destructive) {
+                        Task { await block(post) }
+                    }
+                }
+            }
+        }
+        .onChange(of: showOptions) { _, open in
+            // Resume when the dialog closes — unless it handed off to another
+            // pausing surface (report sheet) or a destructive action is running.
+            if !open && !showReport && promoteError == nil {
+                paused = false
+            }
         }
         .statusBarHidden(true)
     }
@@ -317,21 +344,14 @@ struct StoryViewerView: View {
         .disabled(promoting)
     }
 
-    @ViewBuilder
+    /// Pauses playback and opens the options dialog for THIS story. A plain
+    /// Menu can't pause the auto-advance (no open/close signal), which let the
+    /// story change underneath an open menu and mis-target "Delete story".
     private func overflowMenu(_ post: PostItem) -> some View {
-        Menu {
-            if post.is_self {
-                Button(role: .destructive) {
-                    Task { await deleteOwn(post) }
-                } label: { Label("Delete story", systemImage: "trash") }
-            } else {
-                Button { paused = true; showReport = true } label: {
-                    Label("Report", systemImage: "flag")
-                }
-                Button(role: .destructive) {
-                    Task { await block(post) }
-                } label: { Label("Block \(group.displayName)", systemImage: "hand.raised") }
-            }
+        Button {
+            paused = true
+            optionsPost = post
+            showOptions = true
         } label: {
             Image(systemName: "ellipsis")
                 .font(.system(size: 16, weight: .bold))
@@ -349,7 +369,8 @@ struct StoryViewerView: View {
     }
 
     private func advanceProgress() {
-        guard !isLoading, !paused, !showReport, imageReady, current != nil else { return }
+        guard !isLoading, !paused, !showReport, !showOptions, !promoting,
+              imageReady, current != nil else { return }
         progress += 0.05 / stepDuration
         if progress >= 1 { step(1) }
     }
@@ -381,7 +402,15 @@ struct StoryViewerView: View {
             await MainActor.run {
                 stories = loaded
                 isLoading = false
-                if loaded.isEmpty { close() } else { markViewed() }
+                if loaded.isEmpty {
+                    // The group's stories expired/vanished since the rail
+                    // loaded — report changed so the parent removes the dead
+                    // ring instead of re-presenting a black flash forever.
+                    changed = true
+                    close()
+                } else {
+                    markViewed()
+                }
             }
         } catch {
             await MainActor.run { isLoading = false; close() }

--- a/app/Mile A Day/Views/Feed/StoryViewerView.swift
+++ b/app/Mile A Day/Views/Feed/StoryViewerView.swift
@@ -140,34 +140,43 @@ struct StoryViewerView: View {
     // MARK: - Pieces
 
     private func storyImage(_ post: PostItem) -> some View {
-        AsyncImage(url: post.mediaURL) { phase in
-            switch phase {
-            case .success(let image):
-                // The media is composed at 4:5 with the stats sticker baked in,
-                // so it must be shown WHOLE. Fit it (never fill-crop — that cut
-                // off the sticker/edges on tall screens) over a blurred,
-                // edge-to-edge copy that fills the letterbox space.
-                ZStack {
-                    image.resizable()
-                        .scaledToFill()
-                        .blur(radius: 40, opaque: true)
-                        .opacity(0.6)
-                    image.resizable()
-                        .scaledToFit()
-                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-                }
-                .onAppear { imageReady = true }
-            case .failure:
-                Image(systemName: "photo").font(.largeTitle).foregroundColor(.white.opacity(0.3))
+        // The media is composed at 4:5 with the stats sticker baked in, so it
+        // must be shown WHOLE — fit within the screen (never fill-crop; that
+        // cut off the sticker/edges on tall phones) over a blurred, dimmed
+        // edge-to-edge copy that fills the letterbox space. Both layers are
+        // sized EXPLICITLY from the screen geometry so no proposal quirk can
+        // ever regress this into a crop.
+        GeometryReader { geo in
+            AsyncImage(url: post.mediaURL) { phase in
+                switch phase {
+                case .success(let image):
+                    ZStack {
+                        image.resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: geo.size.width, height: geo.size.height)
+                            .clipped()
+                            .blur(radius: 40, opaque: true)
+                            .opacity(0.55)
+                        image.resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                            .frame(width: geo.size.width, height: geo.size.height)
+                    }
                     .onAppear { imageReady = true }
-            default:
-                ProgressView().tint(.white)
+                case .failure:
+                    Image(systemName: "photo")
+                        .font(.largeTitle)
+                        .foregroundColor(.white.opacity(0.3))
+                        .frame(width: geo.size.width, height: geo.size.height)
+                        .onAppear { imageReady = true }
+                default:
+                    ProgressView().tint(.white)
+                        .frame(width: geo.size.width, height: geo.size.height)
+                }
             }
+            // Re-identify per story so the readiness onAppear refires every step.
+            .id(post.post_id)
         }
-        // Re-identify per story so the readiness onAppear refires every step.
-        .id(post.post_id)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .clipped()
         .ignoresSafeArea()
     }
 

--- a/app/Mile A Day/Views/Feed/StoryViewerView.swift
+++ b/app/Mile A Day/Views/Feed/StoryViewerView.swift
@@ -30,6 +30,7 @@ struct StoryViewerView: View {
     /// Stories promoted to the feed this session ("Add to feed").
     @State private var promotedIds: Set<String> = []
     @State private var promoting = false
+    @State private var promoteError: String?
 
     /// The emoji palette — must match the backend's ALLOWED_STORY_REACTIONS.
     private let reactionEmojis = ["❤️", "🔥", "👏", "💪", "😮"]
@@ -98,6 +99,14 @@ struct StoryViewerView: View {
                 viewerCounts[post.post_id] = resp.count
             }
         }
+        .alert("Couldn't add to feed", isPresented: Binding(
+            get: { promoteError != nil },
+            set: { if !$0 { promoteError = nil; paused = false } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(promoteError ?? "")
+        }
         .statusBarHidden(true)
     }
 
@@ -107,8 +116,20 @@ struct StoryViewerView: View {
         AsyncImage(url: post.mediaURL) { phase in
             switch phase {
             case .success(let image):
-                image.resizable().scaledToFill()
-                    .onAppear { imageReady = true }
+                // The media is composed at 4:5 with the stats sticker baked in,
+                // so it must be shown WHOLE. Fit it (never fill-crop — that cut
+                // off the sticker/edges on tall screens) over a blurred,
+                // edge-to-edge copy that fills the letterbox space.
+                ZStack {
+                    image.resizable()
+                        .scaledToFill()
+                        .blur(radius: 40, opaque: true)
+                        .opacity(0.6)
+                    image.resizable()
+                        .scaledToFit()
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                }
+                .onAppear { imageReady = true }
             case .failure:
                 Image(systemName: "photo").font(.largeTitle).foregroundColor(.white.opacity(0.3))
                     .onAppear { imageReady = true }
@@ -154,9 +175,16 @@ struct StoryViewerView: View {
                 Text(group.displayName)
                     .font(.system(size: 14, weight: .bold, design: .rounded))
                     .foregroundColor(.white)
-                Text(post.relativeTime)
-                    .font(.system(size: 11, weight: .medium, design: .rounded))
-                    .foregroundColor(.white.opacity(0.7))
+                HStack(spacing: 4) {
+                    Text(post.relativeTime)
+                        .font(.system(size: 11, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.7))
+                    if let type = post.workout_type {
+                        Image(systemName: ActivityCardView.icon(type))
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundColor(ActivityCardView.color(type))
+                    }
+                }
             }
             Spacer()
             overflowMenu(post)
@@ -373,20 +401,27 @@ struct StoryViewerView: View {
         promoting = true
         defer { promoting = false }
         do {
-            // Carries the workout id, so this upserts the photo into the run's
-            // existing feed post (replacing the auto route/stats card in place).
+            // Carries the workout id, so this replaces the run's auto
+            // route/stats card in place. If the run already has a deliberate
+            // feed post, the server rejects it (one post per workout).
             _ = try await PostService.createPost(
                 mediaUrl: post.media_url,
                 caption: post.caption,
                 workoutId: post.workout_id,
                 shareToFeed: true,
                 shareToStory: false,
-                stats: post.stats_snapshot
+                stats: post.stats_snapshot,
+                isAuto: false
             )
             await MainActor.run {
                 promotedIds.insert(post.post_id)
                 changed = true
                 UINotificationFeedbackGenerator().notificationOccurred(.success)
+            }
+        } catch APIError.conflict {
+            await MainActor.run {
+                paused = true
+                promoteError = "This workout already has a feed post. Delete it first to share this photo instead."
             }
         } catch {
             print("[StoryViewer] ❌ Add to feed failed: \(error)")

--- a/app/Mile A Day/Views/NotificationInboxView.swift
+++ b/app/Mile A Day/Views/NotificationInboxView.swift
@@ -357,11 +357,20 @@ struct NotificationInboxView: View {
         }
     }
 
-    /// Derive hype affordance directly from the notification's type + data payload.
-    /// Independent of server enrichment so the button works against any backend version.
-    /// Returns nil for non-celebratory rows (streak broken, friend requests, competition
+    /// Hype affordance for a notification row. Prefers the server-enriched
+    /// context fields — those use the canonical keys shared with the feed, so a
+    /// hype sent here and one sent from the feed dedupe as the same hype — and
+    /// falls back to local derivation for older backends. Returns nil for
+    /// non-celebratory rows (streak broken, friend requests, competition
     /// notifications, etc.).
     private func hypeAffordance(for notification: InAppNotification) -> HypeContext? {
+        if let type = notification.hype_context_type, !type.isEmpty,
+           let contextId = notification.hype_context_id, !contextId.isEmpty,
+           let label = notification.hype_context_label,
+           notification.hype_target_user_id?.isEmpty == false {
+            return HypeContext(contextType: type, contextId: contextId, contextLabel: label)
+        }
+
         let data = notification.data ?? [:]
 
         switch notification.type {
@@ -422,6 +431,9 @@ struct NotificationInboxView: View {
 
     /// The user_id of the friend we'd hype for this notification (or nil if not hype-able).
     private func hypeTargetUserId(for notification: InAppNotification) -> String? {
+        if let target = notification.hype_target_user_id, !target.isEmpty {
+            return target
+        }
         let data = notification.data ?? [:]
         switch notification.type {
         case "friend_activity":

--- a/app/Mile A Day/Views/NotificationSettingsView.swift
+++ b/app/Mile A Day/Views/NotificationSettingsView.swift
@@ -146,6 +146,9 @@ struct NotificationSettingsView: View {
                         settingsToggle("Share my walks & runs to the feed", isOn: $prefs.shareWorkoutsToFeed,
                             description: "Friends see your activity in the unified feed")
                         settingsDivider
+                        settingsToggle("Share route maps", isOn: $prefs.shareRouteMaps,
+                            description: "Show the GPS path of your walks and runs on your feed cards — turn off to keep your routes to yourself")
+                        settingsDivider
                         settingsToggle("Photo prompt after a run", isOn: $autoShareRunsToFeed,
                             description: "Snap a story photo of your mile — the route map posts to the feed either way")
                         settingsDivider
@@ -427,6 +430,7 @@ struct NotificationSettingsView: View {
                     "timezone_offset_minutes": TimeZone.current.secondsFromGMT() / 60,
                     "share_workouts_to_feed": prefs.shareWorkoutsToFeed,
                     "friend_posts_enabled": prefs.friendPostsEnabled,
+                    "share_route_maps": prefs.shareRouteMaps,
                 ]
                 _ = try await friendService.updateNotificationSettings(backendSettings)
             } catch {

--- a/app/Mile A Day/Views/Profile/EditProfileView.swift
+++ b/app/Mile A Day/Views/Profile/EditProfileView.swift
@@ -50,49 +50,63 @@ struct EditProfileView: View {
     }
 
     var body: some View {
-        NavigationView {
-            ScrollView {
-                VStack(spacing: MADTheme.Spacing.xl) {
-                    // Profile Image
-                    profileImageSection
+        NavigationStack {
+            ZStack {
+                // Full-bleed app backdrop — this is a real screen, not a form card.
+                MADTheme.Colors.appBackgroundGradient.ignoresSafeArea()
 
-                    // Name Fields
-                    nameSection
+                ScrollView {
+                    VStack(spacing: MADTheme.Spacing.lg) {
+                        // Profile Image
+                        profileImageSection
+                            .padding(.top, MADTheme.Spacing.md)
 
-                    // Username
-                    usernameSection
+                        // Name Fields
+                        nameSection
 
-                    // Bio
-                    bioSection
+                        // Username
+                        usernameSection
 
-                    // Error
-                    if let error = saveError {
-                        Text(error)
-                            .font(MADTheme.Typography.caption)
-                            .foregroundColor(MADTheme.Colors.error)
-                            .padding(.horizontal, MADTheme.Spacing.md)
+                        // Bio
+                        bioSection
+
+                        // Error
+                        if let error = saveError {
+                            Text(error)
+                                .font(MADTheme.Typography.caption)
+                                .foregroundColor(MADTheme.Colors.error)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, MADTheme.Spacing.md)
+                        }
                     }
+                    .padding(MADTheme.Spacing.lg)
+                    .padding(.bottom, MADTheme.Spacing.xl)
                 }
-                .padding(MADTheme.Spacing.lg)
-                .padding(.bottom, MADTheme.Spacing.xl)
+                .scrollDismissesKeyboard(.interactively)
             }
-            .background(MADTheme.Colors.secondaryBackground)
             .navigationTitle("Edit Profile")
             .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(.black, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .toolbarColorScheme(.dark, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") {
                         onDismiss()
                     }
-                    .foregroundColor(MADTheme.Colors.secondaryText)
+                    .foregroundColor(.white.opacity(0.7))
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") {
-                        saveProfile()
+                    if isSaving {
+                        ProgressView().tint(.white)
+                    } else {
+                        Button("Save") {
+                            saveProfile()
+                        }
+                        .fontWeight(.bold)
+                        .foregroundColor(canSave ? MADTheme.Colors.madRed : .white.opacity(0.3))
+                        .disabled(!canSave)
                     }
-                    .fontWeight(.semibold)
-                    .foregroundColor(canSave ? MADTheme.Colors.madRed : MADTheme.Colors.secondaryText)
-                    .disabled(!canSave)
                 }
             }
             .sheet(isPresented: $showingImagePicker) {
@@ -132,14 +146,19 @@ struct EditProfileView: View {
         VStack(spacing: MADTheme.Spacing.md) {
             Button(action: { showingImagePicker = true }) {
                 ZStack {
+                    Circle()
+                        .strokeBorder(MADTheme.Colors.redGradient, lineWidth: 3)
+                        .frame(width: 122, height: 122)
+                        .shadow(color: MADTheme.Colors.madRed.opacity(0.35), radius: 14, y: 4)
+
                     if let image = currentProfileImage {
                         Image(uiImage: image)
                             .resizable()
                             .aspectRatio(contentMode: .fill)
-                            .frame(width: 100, height: 100)
+                            .frame(width: 110, height: 110)
                             .clipShape(Circle())
                     } else {
-                        AvatarView(name: userManager.currentUser.name, imageURL: userManager.currentUser.profileImageUrl, size: 100)
+                        AvatarView(name: userManager.currentUser.name, imageURL: userManager.currentUser.profileImageUrl, size: 110)
                     }
 
                     VStack {
@@ -147,84 +166,88 @@ struct EditProfileView: View {
                         HStack {
                             Spacer()
                             Circle()
-                                .fill(Color.black.opacity(0.7))
-                                .frame(width: 28, height: 28)
+                                .fill(MADTheme.Colors.madRed)
+                                .frame(width: 32, height: 32)
                                 .overlay(
                                     Image(systemName: "camera.fill")
-                                        .font(.system(size: 14, weight: .medium))
+                                        .font(.system(size: 14, weight: .semibold))
                                         .foregroundColor(.white)
                                 )
+                                .overlay(Circle().strokeBorder(Color.black.opacity(0.4), lineWidth: 1))
                         }
                     }
-                    .frame(width: 100, height: 100)
+                    .frame(width: 116, height: 116)
                 }
             }
             .buttonStyle(.plain)
 
             Text("Change Photo")
-                .font(MADTheme.Typography.caption)
+                .font(.system(size: 13, weight: .bold, design: .rounded))
                 .foregroundColor(MADTheme.Colors.madRed)
         }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Dark form styling
+
+    /// Section label in the app's editor style (caps, dimmed, tracked).
+    private func sectionLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 11, weight: .heavy, design: .rounded))
+            .tracking(1.2)
+            .foregroundColor(.white.opacity(0.45))
+    }
+
+    /// Dark rounded field backdrop shared by every input on this screen.
+    private func fieldBackground(stroke: Color = Color.white.opacity(0.12)) -> some View {
+        RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
+            .fill(Color.white.opacity(0.06))
+            .stroke(stroke, lineWidth: 1)
     }
 
     // MARK: - Name Section
 
     private var nameSection: some View {
-        VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
-            Text("Name")
-                .font(MADTheme.Typography.headline)
-                .foregroundColor(MADTheme.Colors.primaryText)
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+            sectionLabel("NAME")
 
             HStack(spacing: MADTheme.Spacing.md) {
-                VStack(alignment: .leading, spacing: MADTheme.Spacing.xs) {
-                    Text("First")
-                        .font(MADTheme.Typography.caption)
-                        .foregroundColor(MADTheme.Colors.secondaryText)
-                    TextField("First name", text: $firstName)
-                        .font(MADTheme.Typography.body)
-                        .textFieldStyle(.plain)
-                        .padding(MADTheme.Spacing.md)
-                        .background(
-                            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
-                                .fill(MADTheme.Colors.cardBackground)
-                                .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                        )
-                }
+                TextField("", text: $firstName, prompt: Text("First name").foregroundColor(.white.opacity(0.35)))
+                    .font(.system(size: 15, weight: .medium, design: .rounded))
+                    .foregroundColor(.white)
+                    .textFieldStyle(.plain)
+                    .padding(MADTheme.Spacing.md)
+                    .background(fieldBackground())
 
-                VStack(alignment: .leading, spacing: MADTheme.Spacing.xs) {
-                    Text("Last")
-                        .font(MADTheme.Typography.caption)
-                        .foregroundColor(MADTheme.Colors.secondaryText)
-                    TextField("Last name", text: $lastName)
-                        .font(MADTheme.Typography.body)
-                        .textFieldStyle(.plain)
-                        .padding(MADTheme.Spacing.md)
-                        .background(
-                            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
-                                .fill(MADTheme.Colors.cardBackground)
-                                .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                        )
-                }
+                TextField("", text: $lastName, prompt: Text("Last name").foregroundColor(.white.opacity(0.35)))
+                    .font(.system(size: 15, weight: .medium, design: .rounded))
+                    .foregroundColor(.white)
+                    .textFieldStyle(.plain)
+                    .padding(MADTheme.Spacing.md)
+                    .background(fieldBackground())
             }
         }
+        .padding(MADTheme.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
+                .fill(Color.white.opacity(0.04))
+        )
     }
 
     // MARK: - Username Section
 
     private var usernameSection: some View {
-        VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
-            Text("Username")
-                .font(MADTheme.Typography.headline)
-                .foregroundColor(MADTheme.Colors.primaryText)
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+            sectionLabel("USERNAME")
 
-            HStack {
+            HStack(spacing: 4) {
                 Text("@")
-                    .font(MADTheme.Typography.body)
-                    .foregroundColor(MADTheme.Colors.secondaryText)
-                    .padding(.leading, MADTheme.Spacing.md)
+                    .font(.system(size: 15, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.45))
 
-                TextField("Username", text: $username)
-                    .font(MADTheme.Typography.body)
+                TextField("", text: $username, prompt: Text("username").foregroundColor(.white.opacity(0.35)))
+                    .font(.system(size: 15, weight: .medium, design: .rounded))
+                    .foregroundColor(.white)
                     .textFieldStyle(.plain)
                     .autocapitalization(.none)
                     .disableAutocorrection(true)
@@ -233,49 +256,55 @@ struct EditProfileView: View {
                     }
             }
             .padding(MADTheme.Spacing.md)
-            .padding(.leading, -MADTheme.Spacing.md + 4)
-            .background(
-                RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
-                    .fill(MADTheme.Colors.cardBackground)
-                    .stroke(usernameBorderColor, lineWidth: 2)
-            )
+            .background(fieldBackground(stroke: usernameBorderColor))
 
             if !usernameValidationMessage.isEmpty {
-                HStack {
+                HStack(spacing: 5) {
                     Image(systemName: usernameIcon)
+                        .font(.system(size: 12, weight: .bold))
                         .foregroundColor(usernameColor)
                     Text(usernameValidationMessage)
-                        .font(MADTheme.Typography.caption)
+                        .font(.system(size: 12, weight: .semibold, design: .rounded))
                         .foregroundColor(usernameColor)
                 }
             }
         }
+        .padding(MADTheme.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
+                .fill(Color.white.opacity(0.04))
+        )
     }
 
     // MARK: - Bio Section
 
     private var bioSection: some View {
-        VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
-            Text("Bio")
-                .font(MADTheme.Typography.headline)
-                .foregroundColor(MADTheme.Colors.primaryText)
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+            sectionLabel("BIO")
 
-            TextField("Tell others about yourself...", text: $bio, axis: .vertical)
-                .font(MADTheme.Typography.body)
-                .textFieldStyle(.plain)
-                .lineLimit(3...6)
-                .padding(MADTheme.Spacing.md)
-                .background(
-                    RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
-                        .fill(MADTheme.Colors.cardBackground)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
+            TextField(
+                "",
+                text: $bio,
+                prompt: Text("Tell others about yourself…").foregroundColor(.white.opacity(0.35)),
+                axis: .vertical
+            )
+            .font(.system(size: 15, weight: .medium, design: .rounded))
+            .foregroundColor(.white)
+            .textFieldStyle(.plain)
+            .lineLimit(3...6)
+            .padding(MADTheme.Spacing.md)
+            .background(fieldBackground())
 
-            Text("\(bio.count)/150 characters")
-                .font(MADTheme.Typography.caption)
-                .foregroundColor(bio.count > 150 ? MADTheme.Colors.error : MADTheme.Colors.secondaryText)
+            Text("\(bio.count)/150")
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .foregroundColor(bio.count > 150 ? MADTheme.Colors.error : .white.opacity(0.4))
                 .frame(maxWidth: .infinity, alignment: .trailing)
         }
+        .padding(MADTheme.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
+                .fill(Color.white.opacity(0.04))
+        )
     }
 
     // MARK: - Username Validation

--- a/app/Mile A Day/Views/Profile/ProfileView.swift
+++ b/app/Mile A Day/Views/Profile/ProfileView.swift
@@ -6,6 +6,7 @@ struct ProfileView: View {
     @ObservedObject var healthManager: HealthKitManager
 
     @State private var activeSheet: ProfileSheetType?
+    @State private var showingEditProfile = false
     @State private var showingLogoutConfirmation = false
     @State private var showingDeleteAccountConfirmation = false
     @State private var isDeletingAccount = false
@@ -44,7 +45,7 @@ struct ProfileView: View {
 
     enum ProfileSheetType: String, Identifiable {
         case totalMiles, fastestPace, mostMiles
-        case editProfile, usernameSetup, privacySettings
+        case usernameSetup, privacySettings
         var id: String { rawValue }
     }
 
@@ -57,7 +58,7 @@ struct ProfileView: View {
                         showingShareProfile = true
                     },
                     MADHeaderAction(id: "edit", systemImage: "pencil") {
-                        activeSheet = .editProfile
+                        showingEditProfile = true
                     },
                     MADHeaderAction(id: "settings", systemImage: "gearshape.fill") {
                         showingSettings = true
@@ -123,16 +124,18 @@ struct ProfileView: View {
                 FastestPaceDetailView(healthManager: healthManager, userManager: userManager)
             case .mostMiles:
                 MostMilesDetailView(miles: userManager.currentUser.mostMilesInOneDay, healthManager: healthManager)
-            case .editProfile:
-                EditProfileView(userManager: userManager) {
-                    activeSheet = nil
-                    currentProfileImage = getCustomProfileImage() ?? getAppleProfileImage()
-                }
             case .usernameSetup:
                 UsernameSetupView()
                     .environmentObject(userManager)
             case .privacySettings:
                 PrivacySettingsView()
+            }
+        }
+        // Edit Profile is a real screen, not a form sheet.
+        .fullScreenCover(isPresented: $showingEditProfile) {
+            EditProfileView(userManager: userManager) {
+                showingEditProfile = false
+                currentProfileImage = getCustomProfileImage() ?? getAppleProfileImage()
             }
         }
         .sheet(isPresented: $showingManagePins) {
@@ -399,7 +402,7 @@ struct ProfileView: View {
                 VStack(spacing: MADTheme.Spacing.lg) {
                     // Profile Image with edit overlay
                     Button {
-                        activeSheet = .editProfile
+                        showingEditProfile = true
                     } label: {
                         ZStack {
                             Circle()
@@ -486,7 +489,7 @@ struct ProfileView: View {
 
                     // Edit Profile Button
                     Button {
-                        activeSheet = .editProfile
+                        showingEditProfile = true
                     } label: {
                         HStack(spacing: MADTheme.Spacing.sm) {
                             Image(systemName: "pencil")

--- a/backend/src/controllers/competitionController.ts
+++ b/backend/src/controllers/competitionController.ts
@@ -1,359 +1,483 @@
-import { AuthenticatedRequest } from '../middleware/auth.js';
-import { Response } from 'express';
-import hasRequiredKeys from '../utils/hasRequiredKeys.js';
-import { BadRequestError } from '../errors/Errors.js';
+import { AuthenticatedRequest } from "../middleware/auth.js";
+import { Response } from "express";
+import hasRequiredKeys from "../utils/hasRequiredKeys.js";
+import { BadRequestError } from "../errors/Errors.js";
 import {
-	createCompetition,
-	getCompetition,
-	getCompetitions,
-	sendCompetitionInvite,
-	updateCompetitionInvite,
-	updateCompetition,
-	deleteCompetition,
-	removeUserFromCompetition,
-	getTodayET,
-	autoStartIfAllAccepted
-} from '../services/competitionService.js';
-import { getUser } from '../services/userService.js';
-import { CompetitionUser } from '../types/competitions.js';
-import { sendPush, sendOrQueueCompetitionNotification } from '../services/pushNotificationService.js';
+  createCompetition,
+  getCompetition,
+  getCompetitions,
+  sendCompetitionInvite,
+  updateCompetitionInvite,
+  updateCompetition,
+  deleteCompetition,
+  removeUserFromCompetition,
+  getTodayET,
+  autoStartIfAllAccepted,
+} from "../services/competitionService.js";
+import { getUser } from "../services/userService.js";
+import { CompetitionUser } from "../types/competitions.js";
+import {
+  sendPush,
+  sendOrQueueCompetitionNotification,
+} from "../services/pushNotificationService.js";
 
 export async function createComp(req: AuthenticatedRequest, res: Response) {
-	if (!hasRequiredKeys(['competition_name', 'type'], req, res)) return;
+  if (!hasRequiredKeys(["competition_name", "type"], req, res)) return;
 
-	const { competition_name, start_date, end_date, workouts, type, options } = req.body;
+  const { competition_name, start_date, end_date, workouts, type, options } =
+    req.body;
 
-	try {
-		const competitionId = await createCompetition({
-			competition_name,
-			start_date,
-			end_date,
-			workouts,
-			type,
-			options,
-			owner: req.userId!
-		});
+  try {
+    const competitionId = await createCompetition({
+      competition_name,
+      start_date,
+      end_date,
+      workouts,
+      type,
+      options,
+      owner: req.userId!,
+    });
 
-		res.status(200).json({ competition_id: competitionId });
-	} catch (error: any) {
-		if (error instanceof BadRequestError) {
-			return res.status(400).json({ error: error.message });
-		}
+    res.status(200).json({ competition_id: competitionId });
+  } catch (error: any) {
+    if (error instanceof BadRequestError) {
+      return res.status(400).json({ error: error.message });
+    }
 
-		console.error('Error creating competition:', error.message);
-		res.status(500).json({ error: 'Error creating competition: ' + error.message });
-	}
+    console.error("Error creating competition:", error.message);
+    res
+      .status(500)
+      .json({ error: "Error creating competition: " + error.message });
+  }
 }
 
 export async function startComp(req: AuthenticatedRequest, res: Response) {
-	if (!hasRequiredKeys(['competitionId'], req, res)) return;
+  if (!hasRequiredKeys(["competitionId"], req, res)) return;
 
-	const competitionId = req.params.competitionId;
+  const competitionId = req.params.competitionId;
 
-	try {
-		const competition = await getCompetition(competitionId);
+  try {
+    const competition = await getCompetition(competitionId);
 
-		if (!competition) {
-			return res.status(404).json({ error: `No competition found with id: ${competitionId}` });
-		}
+    if (!competition) {
+      return res
+        .status(404)
+        .json({ error: `No competition found with id: ${competitionId}` });
+    }
 
-		// Only owner can start
-		if (competition.owner !== req.userId!) {
-			return res.status(403).json({ error: 'Only the competition owner can start it' });
-		}
+    // Only owner can start
+    if (competition.owner !== req.userId!) {
+      return res
+        .status(403)
+        .json({ error: "Only the competition owner can start it" });
+    }
 
-		// Must not be already started
-		if (competition.start_date && competition.start_date <= getTodayET()) {
-			return res.status(400).json({ error: 'Competition has already started' });
-		}
+    // Must not be already started
+    if (competition.start_date && competition.start_date <= getTodayET()) {
+      return res.status(400).json({ error: "Competition has already started" });
+    }
 
-		// Need at least 2 accepted participants
-		const acceptedCount = competition.users.filter((u: CompetitionUser) => u.invite_status === 'accepted').length;
+    // Need at least 2 accepted participants
+    const acceptedCount = competition.users.filter(
+      (u: CompetitionUser) => u.invite_status === "accepted",
+    ).length;
 
-		if (acceptedCount < 2) {
-			return res.status(400).json({
-				error: `Need at least 2 accepted participants to start. Currently have ${acceptedCount}.`
-			});
-		}
+    if (acceptedCount < 2) {
+      return res.status(400).json({
+        error: `Need at least 2 accepted participants to start. Currently have ${acceptedCount}.`,
+      });
+    }
 
-		// Start at midnight ET tomorrow so the first official day is a full day for everyone
-		const todayET = getTodayET(); // 'YYYY-MM-DD' in ET
-		const [y, m, d] = todayET.split('-').map(Number);
-		const tomorrowUTC = new Date(Date.UTC(y, m - 1, d + 1));
-		const startDate = tomorrowUTC.toISOString().split('T')[0];
+    // Start at midnight ET tomorrow so the first official day is a full day for everyone
+    const todayET = getTodayET(); // 'YYYY-MM-DD' in ET
+    const [y, m, d] = todayET.split("-").map(Number);
+    const tomorrowUTC = new Date(Date.UTC(y, m - 1, d + 1));
+    const startDate = tomorrowUTC.toISOString().split("T")[0];
 
-		let endDate: string | undefined;
-		if (competition.options.duration_hours) {
-			const end = new Date(tomorrowUTC.getTime() + competition.options.duration_hours * 60 * 60 * 1000);
-			endDate = end.toISOString().split('T')[0];
-		}
+    let endDate: string | undefined;
+    if (competition.options.duration_hours) {
+      const end = new Date(
+        tomorrowUTC.getTime() +
+          competition.options.duration_hours * 60 * 60 * 1000,
+      );
+      endDate = end.toISOString().split("T")[0];
+    }
 
-		const updatedCompetition = await updateCompetition({
-			competitionId,
-			start_date: startDate,
-			...(endDate ? { end_date: endDate } : {})
-		});
+    const updatedCompetition = await updateCompetition({
+      competitionId,
+      start_date: startDate,
+      ...(endDate ? { end_date: endDate } : {}),
+    });
 
-		// Notify all accepted participants (except the owner who started it)
-		const participants = competition.users.filter(
-			(u: CompetitionUser) => u.invite_status === 'accepted' && u.user_id !== req.userId!
-		);
-		for (const participant of participants) {
-			sendOrQueueCompetitionNotification(
-				participant.user_id,
-				'competition_started',
-				competitionId,
-				competition.competition_name
-			).catch(err => console.error('[Push] Error sending competition start notification:', err.message));
-		}
+    // Notify all accepted participants (except the owner who started it)
+    const participants = competition.users.filter(
+      (u: CompetitionUser) =>
+        u.invite_status === "accepted" && u.user_id !== req.userId!,
+    );
+    for (const participant of participants) {
+      sendOrQueueCompetitionNotification(
+        participant.user_id,
+        "competition_started",
+        competitionId,
+        competition.competition_name,
+      ).catch((err) =>
+        console.error(
+          "[Push] Error sending competition start notification:",
+          err.message,
+        ),
+      );
+    }
 
-		res.status(200).json({ competition: updatedCompetition });
-	} catch (error: any) {
-		console.error('Error starting competition:', error.message);
-		res.status(500).json({ error: 'Error starting competition: ' + error.message });
-	}
+    res.status(200).json({ competition: updatedCompetition });
+  } catch (error: any) {
+    console.error("Error starting competition:", error.message);
+    res
+      .status(500)
+      .json({ error: "Error starting competition: " + error.message });
+  }
 }
 
 export async function deleteComp(req: AuthenticatedRequest, res: Response) {
-	if (!hasRequiredKeys(['competitionId'], req, res)) return;
+  if (!hasRequiredKeys(["competitionId"], req, res)) return;
 
-	try {
-		await deleteCompetition(req.params.competitionId, req.userId!);
-		res.status(200).json({ message: 'Competition deleted successfully' });
-	} catch (error: any) {
-		if (error instanceof BadRequestError) {
-			return res.status(400).json({ error: error.message });
-		}
-		console.error('Error deleting competition:', error.message);
-		res.status(500).json({ error: 'Error deleting competition: ' + error.message });
-	}
+  try {
+    await deleteCompetition(req.params.competitionId, req.userId!);
+    res.status(200).json({ message: "Competition deleted successfully" });
+  } catch (error: any) {
+    if (error instanceof BadRequestError) {
+      return res.status(400).json({ error: error.message });
+    }
+    console.error("Error deleting competition:", error.message);
+    res
+      .status(500)
+      .json({ error: "Error deleting competition: " + error.message });
+  }
 }
 
 export async function getComp(req: AuthenticatedRequest, res: Response) {
-	if (!hasRequiredKeys(['competitionId'], req, res)) return;
+  if (!hasRequiredKeys(["competitionId"], req, res)) return;
 
-	try {
-		const competition = await getCompetition(req.params.competitionId);
+  try {
+    // The detail view is the only consumer of the per-day walk/run breakdown.
+    const competition = await getCompetition(req.params.competitionId, {
+      includeActivityBreakdown: true,
+    });
 
-		if (!competition) {
-			return res.status(404).json({ error: `No competition found with id: ${req.params.competitionId}` });
-		}
+    if (!competition) {
+      return res
+        .status(404)
+        .json({
+          error: `No competition found with id: ${req.params.competitionId}`,
+        });
+    }
 
-		return res.status(200).json({ competition });
-	} catch (error: any) {
-		console.error('Error getting competition:', error.message);
-		res.status(500).json({ error: 'Error getting competition: ' + error.message });
-	}
+    return res.status(200).json({ competition });
+  } catch (error: any) {
+    console.error("Error getting competition:", error.message);
+    res
+      .status(500)
+      .json({ error: "Error getting competition: " + error.message });
+  }
 }
 
 export async function getAllComps(req: AuthenticatedRequest, res: Response) {
-	const page = req.query.page as string;
-	const status = req.query.status as string;
-	const pageSize = req.query.pageSize as string;
+  const page = req.query.page as string;
+  const status = req.query.status as string;
+  const pageSize = req.query.pageSize as string;
 
-	try {
-		const competitions = await getCompetitions(req.userId!, {
-			page: page ? parseInt(page) : 1,
-			pageSize: pageSize ? parseInt(pageSize) : 25,
-			status: status || 'active'
-		});
+  try {
+    const competitions = await getCompetitions(req.userId!, {
+      page: page ? parseInt(page) : 1,
+      pageSize: pageSize ? parseInt(pageSize) : 25,
+      status: status || "active",
+    });
 
-		res.status(200).json({ competitions });
-	} catch (error: any) {
-		console.error('Error getting comps:', error.message);
-		res.status(500).json({ error: 'Error getting comps: ' + error.message });
-	}
+    res.status(200).json({ competitions });
+  } catch (error: any) {
+    console.error("Error getting comps:", error.message);
+    res.status(500).json({ error: "Error getting comps: " + error.message });
+  }
 }
 
-export async function inviteUsersToComp(req: AuthenticatedRequest, res: Response) {
-	if (!hasRequiredKeys(['competitionId', 'inviteUser'], req, res)) return;
+export async function inviteUsersToComp(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  if (!hasRequiredKeys(["competitionId", "inviteUser"], req, res)) return;
 
-	const competitionId = req.params.competitionId;
-	const inviteUserId = req.body.inviteUser;
+  const competitionId = req.params.competitionId;
+  const inviteUserId = req.body.inviteUser;
 
-	try {
-		const invitee = await getUser({ userId: inviteUserId });
+  try {
+    const invitee = await getUser({ userId: inviteUserId });
 
-		if (!invitee) {
-			return res.status(404).json({ error: `No user found with id: ${inviteUserId}` });
-		}
+    if (!invitee) {
+      return res
+        .status(404)
+        .json({ error: `No user found with id: ${inviteUserId}` });
+    }
 
-		const competition = await getCompetition(competitionId);
+    const competition = await getCompetition(competitionId);
 
-		if (!competition) {
-			return res.status(404).json({ error: `No competition found with id: ${req.params.competitionId}` });
-		}
+    if (!competition) {
+      return res
+        .status(404)
+        .json({
+          error: `No competition found with id: ${req.params.competitionId}`,
+        });
+    }
 
-		if (competition.users.find(u => u.user_id === inviteUserId && u.invite_status === 'accepted')) {
-			return res.status(400).json({ error: `User ${inviteUserId} is already in this competition` });
-		}
+    if (
+      competition.users.find(
+        (u) => u.user_id === inviteUserId && u.invite_status === "accepted",
+      )
+    ) {
+      return res
+        .status(400)
+        .json({ error: `User ${inviteUserId} is already in this competition` });
+    }
 
-		if (!competition.users.find(u => u.user_id === req.userId! && u.invite_status === 'accepted')) {
-			return res.status(401).json({ error: 'User does not have access to this competition' });
-		}
+    if (
+      !competition.users.find(
+        (u) => u.user_id === req.userId! && u.invite_status === "accepted",
+      )
+    ) {
+      return res
+        .status(401)
+        .json({ error: "User does not have access to this competition" });
+    }
 
-		await sendCompetitionInvite(competitionId, inviteUserId);
+    await sendCompetitionInvite(competitionId, inviteUserId);
 
-		// Notify the invited user
-		const inviter = await getUser({ userId: req.userId! });
-		const inviterName = inviter?.username || 'Someone';
-		sendPush(inviteUserId, {
-			title: 'Competition invite',
-			body: `${inviterName} invited you to ${competition.competition_name}`,
-			type: 'competition_invite',
-			data: { competition_id: competitionId }
-		}).catch(err => console.error('[Push] Error sending competition invite notification:', err.message));
+    // Notify the invited user
+    const inviter = await getUser({ userId: req.userId! });
+    const inviterName = inviter?.username || "Someone";
+    sendPush(inviteUserId, {
+      title: "Competition invite",
+      body: `${inviterName} invited you to ${competition.competition_name}`,
+      type: "competition_invite",
+      data: { competition_id: competitionId },
+    }).catch((err) =>
+      console.error(
+        "[Push] Error sending competition invite notification:",
+        err.message,
+      ),
+    );
 
-		res.status(200).json({ message: `Successfully invited user ${inviteUserId} to competition ${competitionId}` });
-	} catch (error: any) {
-		console.error('Error inviting user:', error.message);
-		res.status(500).json({ error: 'Error inviting user: ' + error.message });
-	}
+    res
+      .status(200)
+      .json({
+        message: `Successfully invited user ${inviteUserId} to competition ${competitionId}`,
+      });
+  } catch (error: any) {
+    console.error("Error inviting user:", error.message);
+    res.status(500).json({ error: "Error inviting user: " + error.message });
+  }
 }
 
-export async function removeUserFromComp(req: AuthenticatedRequest, res: Response) {
-	if (!hasRequiredKeys(['competitionId', 'userId'], req, res)) return;
+export async function removeUserFromComp(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  if (!hasRequiredKeys(["competitionId", "userId"], req, res)) return;
 
-	const competitionId = req.params.competitionId;
-	const targetUserId = req.params.userId;
+  const competitionId = req.params.competitionId;
+  const targetUserId = req.params.userId;
 
-	try {
-		const competition = await getCompetition(competitionId);
+  try {
+    const competition = await getCompetition(competitionId);
 
-		if (!competition) {
-			return res.status(404).json({ error: `No competition found with id: ${competitionId}` });
-		}
+    if (!competition) {
+      return res
+        .status(404)
+        .json({ error: `No competition found with id: ${competitionId}` });
+    }
 
-		// Only the owner can remove users
-		if (competition.owner !== req.userId!) {
-			return res.status(403).json({ error: 'Only the competition owner can remove users' });
-		}
+    // Only the owner can remove users
+    if (competition.owner !== req.userId!) {
+      return res
+        .status(403)
+        .json({ error: "Only the competition owner can remove users" });
+    }
 
-		// Can't remove yourself (owner)
-		if (targetUserId === req.userId!) {
-			return res.status(400).json({ error: 'Cannot remove yourself from the competition' });
-		}
+    // Can't remove yourself (owner)
+    if (targetUserId === req.userId!) {
+      return res
+        .status(400)
+        .json({ error: "Cannot remove yourself from the competition" });
+    }
 
-		// Can only remove from lobby (not started yet)
-		if (competition.start_date && competition.start_date <= getTodayET()) {
-			return res.status(400).json({ error: 'Cannot remove users from a competition that has already started' });
-		}
+    // Can only remove from lobby (not started yet)
+    if (competition.start_date && competition.start_date <= getTodayET()) {
+      return res
+        .status(400)
+        .json({
+          error:
+            "Cannot remove users from a competition that has already started",
+        });
+    }
 
-		// Check user is actually in the competition
-		if (!competition.users.find(u => u.user_id === targetUserId)) {
-			return res.status(400).json({ error: 'User is not in this competition' });
-		}
+    // Check user is actually in the competition
+    if (!competition.users.find((u) => u.user_id === targetUserId)) {
+      return res.status(400).json({ error: "User is not in this competition" });
+    }
 
-		await removeUserFromCompetition(competitionId, targetUserId);
+    await removeUserFromCompetition(competitionId, targetUserId);
 
-		res.status(200).json({ message: `Successfully removed user ${targetUserId} from competition ${competitionId}` });
-	} catch (error: any) {
-		console.error('Error removing user from competition:', error.message);
-		res.status(500).json({ error: 'Error removing user: ' + error.message });
-	}
+    res
+      .status(200)
+      .json({
+        message: `Successfully removed user ${targetUserId} from competition ${competitionId}`,
+      });
+  } catch (error: any) {
+    console.error("Error removing user from competition:", error.message);
+    res.status(500).json({ error: "Error removing user: " + error.message });
+  }
 }
 
 export async function getCompInvites(req: AuthenticatedRequest, res: Response) {
-	try {
-		const competitions = await getCompetitions(req.userId!, {
-			page: parseInt(req.query.page as string) || 1,
-			status: 'on_your_mark',
-			pageSize: 25
-		});
-		res.status(200).json({ competitionInvites: competitions });
-	} catch (error: any) {
-		console.error('Error getting competition invites:', error.message);
-		res.status(500).json({ error: 'Error getting competition invites: ' + error.message });
-	}
+  try {
+    const competitions = await getCompetitions(req.userId!, {
+      page: parseInt(req.query.page as string) || 1,
+      status: "on_your_mark",
+      pageSize: 25,
+    });
+    res.status(200).json({ competitionInvites: competitions });
+  } catch (error: any) {
+    console.error("Error getting competition invites:", error.message);
+    res
+      .status(500)
+      .json({ error: "Error getting competition invites: " + error.message });
+  }
 }
 
 export async function updateComp(req: AuthenticatedRequest, res: Response) {
-	if (!hasRequiredKeys(['competitionId'], req, res)) return;
+  if (!hasRequiredKeys(["competitionId"], req, res)) return;
 
-	const { competition_name, start_date, end_date, workouts, type, options } = req.body;
-	const competitionId = req.params.competitionId;
+  const { competition_name, start_date, end_date, workouts, type, options } =
+    req.body;
+  const competitionId = req.params.competitionId;
 
-	try {
-		const existingCompetition = await getCompetition(competitionId);
+  try {
+    const existingCompetition = await getCompetition(competitionId);
 
-		if (!existingCompetition) {
-			return res.status(404).json({ error: `No competition found with id: ${competitionId}` });
-		}
+    if (!existingCompetition) {
+      return res
+        .status(404)
+        .json({ error: `No competition found with id: ${competitionId}` });
+    }
 
-		if (existingCompetition.owner !== req.userId!) {
-			return res.status(403).json({ error: 'Only the competition owner can update it' });
-		}
+    if (existingCompetition.owner !== req.userId!) {
+      return res
+        .status(403)
+        .json({ error: "Only the competition owner can update it" });
+    }
 
-		if (existingCompetition.start_date && new Date(existingCompetition.start_date) <= new Date()) {
-			return res.status(400).json({ error: 'Cannot update a competition that has already started' });
-		}
+    if (
+      existingCompetition.start_date &&
+      new Date(existingCompetition.start_date) <= new Date()
+    ) {
+      return res
+        .status(400)
+        .json({
+          error: "Cannot update a competition that has already started",
+        });
+    }
 
-		const updatedCompetition = await updateCompetition({
-			competitionId,
-			competition_name,
-			start_date,
-			end_date,
-			workouts,
-			type,
-			options
-		});
+    const updatedCompetition = await updateCompetition({
+      competitionId,
+      competition_name,
+      start_date,
+      end_date,
+      workouts,
+      type,
+      options,
+    });
 
-		res.status(200).json({ competition: updatedCompetition });
-	} catch (error: any) {
-		if (error instanceof BadRequestError) {
-			return res.status(400).json({ error: error.message });
-		}
+    res.status(200).json({ competition: updatedCompetition });
+  } catch (error: any) {
+    if (error instanceof BadRequestError) {
+      return res.status(400).json({ error: error.message });
+    }
 
-		console.error('Error updating competition:', error.message);
-		res.status(500).json({ error: 'Error updating competition: ' + error.message });
-	}
+    console.error("Error updating competition:", error.message);
+    res
+      .status(500)
+      .json({ error: "Error updating competition: " + error.message });
+  }
 }
 
-export function getCompInviteHandler(status: 'accepted' | 'declined') {
-	return async function acceptCompInvite(req: AuthenticatedRequest, res: Response) {
-		if (!hasRequiredKeys(['competitionId'], req, res)) return;
+export function getCompInviteHandler(status: "accepted" | "declined") {
+  return async function acceptCompInvite(
+    req: AuthenticatedRequest,
+    res: Response,
+  ) {
+    if (!hasRequiredKeys(["competitionId"], req, res)) return;
 
-		try {
-			const competitionId = req.params.competitionId;
+    try {
+      const competitionId = req.params.competitionId;
 
-			const competition = await getCompetition(competitionId);
+      const competition = await getCompetition(competitionId);
 
-			if (!competition) {
-				return res.status(404).json({ error: `No competition found with id ${competitionId}` });
-			}
+      if (!competition) {
+        return res
+          .status(404)
+          .json({ error: `No competition found with id ${competitionId}` });
+      }
 
-			if (!competition.users.find(u => u.user_id === req.userId! && u.invite_status === 'pending')) {
-				return res
-					.status(400)
-					.json({ error: `User ${req.userId!} does not have a pending invite to competition ${competitionId}` });
-			}
+      if (
+        !competition.users.find(
+          (u) => u.user_id === req.userId! && u.invite_status === "pending",
+        )
+      ) {
+        return res
+          .status(400)
+          .json({
+            error: `User ${req.userId!} does not have a pending invite to competition ${competitionId}`,
+          });
+      }
 
-			const updatedUserInfo = await updateCompetitionInvite(competitionId, req.userId!, status);
+      const updatedUserInfo = await updateCompetitionInvite(
+        competitionId,
+        req.userId!,
+        status,
+      );
 
-			competition.users = competition.users.map(u => (u.user_id === req.userId! ? { ...u, ...updatedUserInfo } : u));
+      competition.users = competition.users.map((u) =>
+        u.user_id === req.userId! ? { ...u, ...updatedUserInfo } : u,
+      );
 
-			// Notify the competition owner when someone accepts
-			if (status === 'accepted') {
-				const accepter = await getUser({ userId: req.userId! });
-				const accepterName = accepter?.username || 'Someone';
-				sendPush(competition.owner, {
-					title: 'Invite accepted',
-					body: `${accepterName} joined ${competition.competition_name}`,
-					type: 'competition_accepted',
-					data: { competition_id: competitionId }
-				}).catch(err => console.error('[Push] Error sending competition accepted notification:', err.message));
+      // Notify the competition owner when someone accepts
+      if (status === "accepted") {
+        const accepter = await getUser({ userId: req.userId! });
+        const accepterName = accepter?.username || "Someone";
+        sendPush(competition.owner, {
+          title: "Invite accepted",
+          body: `${accepterName} joined ${competition.competition_name}`,
+          type: "competition_accepted",
+          data: { competition_id: competitionId },
+        }).catch((err) =>
+          console.error(
+            "[Push] Error sending competition accepted notification:",
+            err.message,
+          ),
+        );
 
-				// Auto-start once everyone invited has accepted (starts at midnight
-				// ET, same as the manual Start button)
-				if (await autoStartIfAllAccepted(competitionId)) {
-					return res.status(200).json({ competition: await getCompetition(competitionId) });
-				}
-			}
+        // Auto-start once everyone invited has accepted (starts at midnight
+        // ET, same as the manual Start button)
+        if (await autoStartIfAllAccepted(competitionId)) {
+          return res
+            .status(200)
+            .json({ competition: await getCompetition(competitionId) });
+        }
+      }
 
-			res.status(200).json({ competition });
-		} catch (error: any) {
-			console.error('Error handling invite:', error.message);
-			res.status(500).json({ error: 'Error handling invite: ' + error.message });
-		}
-	};
+      res.status(200).json({ competition });
+    } catch (error: any) {
+      console.error("Error handling invite:", error.message);
+      res
+        .status(500)
+        .json({ error: "Error handling invite: " + error.message });
+    }
+  };
 }

--- a/backend/src/controllers/hypeController.ts
+++ b/backend/src/controllers/hypeController.ts
@@ -11,6 +11,8 @@ import {
   getDailyHypeCount,
   getHypeResetsAt,
   hasHypedContext,
+  hasHypedMile,
+  canonicalizeMileContext,
   HYPE_DAILY_LIMIT,
   HypeContext,
   getReceivedHypes,
@@ -152,14 +154,23 @@ export async function sendHype(req: AuthenticatedRequest, res: Response) {
     // Abuse is bounded by the friend/co-participant gate, per-context dedupe,
     // and the daily hype limit below.
 
+    // Canonicalize mile hypes so the feed (workout_id-keyed) and the
+    // notifications inbox (user:date-keyed) write and dedupe the same context.
+    if (context?.contextType === "mile") {
+      context = await canonicalizeMileContext(targetUserId, context);
+    }
+
     // Context-aware dedupe pre-check (legacy no-context hypes skip this).
     if (context) {
-      const alreadyHyped = await hasHypedContext(
-        senderId,
-        targetUserId,
-        context.contextType,
-        context.contextId,
-      );
+      const alreadyHyped =
+        context.contextType === "mile"
+          ? await hasHypedMile(senderId, targetUserId, context.contextId)
+          : await hasHypedContext(
+              senderId,
+              targetUserId,
+              context.contextType,
+              context.contextId,
+            );
       if (alreadyHyped) {
         return res.status(409).json({ error: "already_hyped" });
       }

--- a/backend/src/controllers/hypeController.ts
+++ b/backend/src/controllers/hypeController.ts
@@ -5,6 +5,7 @@ import { getFriendship } from "../services/friendshipService.js";
 import { getUser } from "../services/userService.js";
 import { sendPush } from "../services/pushNotificationService.js";
 import { shouldSendNotification } from "../services/notificationSettingsService.js";
+import { getPostAuthor } from "../services/postService.js";
 import { evaluateSocialBadgesForUser } from "../services/badgeService.js";
 import {
   logHypeIfUnderLimit,
@@ -154,10 +155,30 @@ export async function sendHype(req: AuthenticatedRequest, res: Response) {
     // Abuse is bounded by the friend/co-participant gate, per-context dedupe,
     // and the daily hype limit below.
 
+    // Post hypes must reference a real post authored by the target — without
+    // this, mismatched (target, post) pairs bypass dedupe and pollute counts.
+    // (Non-uuid ids short-circuit before they'd blow up the ::uuid cast.)
+    if (context?.contextType === "post") {
+      const isUuid =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+          context.contextId,
+        );
+      const author = isUuid ? await getPostAuthor(context.contextId) : null;
+      if (author !== targetUserId) {
+        return res
+          .status(400)
+          .json({ error: "context_id does not reference the target's post" });
+      }
+    }
+
     // Canonicalize mile hypes so the feed (workout_id-keyed) and the
     // notifications inbox (user:date-keyed) write and dedupe the same context.
     if (context?.contextType === "mile") {
-      context = await canonicalizeMileContext(targetUserId, context);
+      try {
+        context = await canonicalizeMileContext(targetUserId, context);
+      } catch {
+        return res.status(400).json({ error: "Invalid mile context" });
+      }
     }
 
     // Context-aware dedupe pre-check (legacy no-context hypes skip this).
@@ -177,7 +198,17 @@ export async function sendHype(req: AuthenticatedRequest, res: Response) {
     }
 
     // Atomic: insert iff still under the limit. Closes the concurrent-sender race.
-    const inserted = await logHypeIfUnderLimit(senderId, targetUserId, context);
+    let inserted;
+    try {
+      inserted = await logHypeIfUnderLimit(senderId, targetUserId, context);
+    } catch (err: any) {
+      // Two identical requests can both pass the dedupe pre-check; the loser
+      // hits the partial unique index — that's an "already hyped", not a 500.
+      if (err?.code === "23505") {
+        return res.status(409).json({ error: "already_hyped" });
+      }
+      throw err;
+    }
     if (!inserted) {
       const resetsAt = await getHypeResetsAt(senderId);
       const resetIn = formatTimeUntil(resetsAt);

--- a/backend/src/controllers/inAppNotificationController.ts
+++ b/backend/src/controllers/inAppNotificationController.ts
@@ -1,13 +1,13 @@
-import { Request, Response } from 'express';
-import { PostgresService } from '../services/DbService.js';
+import { Request, Response } from "express";
+import { PostgresService } from "../services/DbService.js";
 
 const db = PostgresService.getInstance();
 
 interface HypeDerivation {
-	hype_target_user_id: string | null;
-	hype_context_type: 'mile' | 'badge' | 'pr' | 'challenge' | null;
-	hype_context_id: string | null;
-	hype_context_label: string | null;
+  hype_target_user_id: string | null;
+  hype_context_type: "mile" | "badge" | "pr" | "challenge" | null;
+  hype_context_id: string | null;
+  hype_context_label: string | null;
 }
 
 /**
@@ -15,210 +15,254 @@ interface HypeDerivation {
  * for notification types that aren't hype-able.
  */
 function deriveHypeContext(row: {
-	type: string;
-	title: string;
-	body: string | null;
-	data: Record<string, any> | null;
-	created_at: Date | string;
+  type: string;
+  title: string;
+  body: string | null;
+  data: Record<string, any> | null;
+  created_at: Date | string;
 }): HypeDerivation {
-	const data = row.data ?? {};
-	const empty: HypeDerivation = {
-		hype_target_user_id: null,
-		hype_context_type: null,
-		hype_context_id: null,
-		hype_context_label: null
-	};
+  const data = row.data ?? {};
+  const empty: HypeDerivation = {
+    hype_target_user_id: null,
+    hype_context_type: null,
+    hype_context_id: null,
+    hype_context_label: null,
+  };
 
-	if (row.type === 'friend_activity') {
-		// New pushes carry an explicit kind discriminator. Legacy rows (pre-kind)
-		// fall back to the title: "Streak broken!" is sympathetic and not hype-able;
-		// anything else for friend_activity is the celebratory mile-completion variant.
-		const isStreakBroken =
-			data.kind === 'streak_broken' || (data.kind === undefined && row.title?.startsWith('Streak broken'));
-		if (isStreakBroken) return empty;
-		const targetId = data.user_id;
-		if (!targetId) return empty;
-		// Use user_id:YYYY-MM-DD as the context id since the push payload doesn't
-		// carry a workout_id and a user only completes one daily mile per day.
-		const localDate = new Date(row.created_at).toISOString().slice(0, 10);
-		return {
-			hype_target_user_id: targetId,
-			hype_context_type: 'mile',
-			hype_context_id: `${targetId}:${localDate}`,
-			hype_context_label: "today's mile"
-		};
-	}
+  if (row.type === "friend_activity") {
+    // New pushes carry an explicit kind discriminator. Legacy rows (pre-kind)
+    // fall back to the title: "Streak broken!" is sympathetic and not hype-able;
+    // anything else for friend_activity is the celebratory mile-completion variant.
+    const isStreakBroken =
+      data.kind === "streak_broken" ||
+      (data.kind === undefined && row.title?.startsWith("Streak broken"));
+    if (isStreakBroken) return empty;
+    const targetId = data.user_id;
+    if (!targetId) return empty;
+    // Use user_id:YYYY-MM-DD as the context id — a user completes one daily
+    // mile per day, and this is the canonical mile-hype key shared with the
+    // feed (which resolves workout ids to it server-side). Prefer the runner's
+    // local_date from the payload; the created_at fallback is the UTC date,
+    // which is off-by-one for evening miles.
+    const localDate =
+      typeof data.local_date === "string" &&
+      /^\d{4}-\d{2}-\d{2}$/.test(data.local_date)
+        ? data.local_date
+        : new Date(row.created_at).toISOString().slice(0, 10);
+    return {
+      hype_target_user_id: targetId,
+      hype_context_type: "mile",
+      hype_context_id: `${targetId}:${localDate}`,
+      hype_context_label: "today's mile",
+    };
+  }
 
-	if (row.type === 'friend_badge_earned') {
-		const targetId = data.sender_id;
-		const badgeId = data.badge_id;
-		const badgeName = data.badge_name;
-		if (!targetId || !badgeId) return empty;
-		return {
-			hype_target_user_id: targetId,
-			hype_context_type: 'badge',
-			hype_context_id: String(badgeId),
-			hype_context_label: badgeName ? String(badgeName) : 'a medal'
-		};
-	}
+  if (row.type === "friend_badge_earned") {
+    const targetId = data.sender_id;
+    const badgeId = data.badge_id;
+    const badgeName = data.badge_name;
+    if (!targetId || !badgeId) return empty;
+    return {
+      hype_target_user_id: targetId,
+      hype_context_type: "badge",
+      hype_context_id: String(badgeId),
+      hype_context_label: badgeName ? String(badgeName) : "a medal",
+    };
+  }
 
-	if (row.type === 'friend_personal_best') {
-		const targetId = data.sender_id;
-		const prType = data.pr_type;
-		const workoutId = data.workout_id;
-		const label = data.pr_label;
-		if (!targetId || !prType || !workoutId) return empty;
-		return {
-			hype_target_user_id: targetId,
-			hype_context_type: 'pr',
-			hype_context_id: `${prType}:${workoutId}`,
-			hype_context_label: label ? String(label) : 'personal best'
-		};
-	}
+  if (row.type === "friend_personal_best") {
+    const targetId = data.sender_id;
+    const prType = data.pr_type;
+    const workoutId = data.workout_id;
+    const label = data.pr_label;
+    if (!targetId || !prType || !workoutId) return empty;
+    return {
+      hype_target_user_id: targetId,
+      hype_context_type: "pr",
+      hype_context_id: `${prType}:${workoutId}`,
+      hype_context_label: label ? String(label) : "personal best",
+    };
+  }
 
-	if (row.type === 'friend_challenge_completed') {
-		const targetId = data.sender_id;
-		const localDate = data.local_date;
-		if (!targetId || !localDate) return empty;
-		// challenge_title was added to the push payload; older rows fall back to
-		// the notification body, which is the challenge title verbatim.
-		const label = data.challenge_title || row.body || "today's challenge";
-		return {
-			hype_target_user_id: String(targetId),
-			hype_context_type: 'challenge',
-			hype_context_id: `${targetId}:${localDate}`,
-			hype_context_label: String(label)
-		};
-	}
+  if (row.type === "friend_challenge_completed") {
+    const targetId = data.sender_id;
+    const localDate = data.local_date;
+    if (!targetId || !localDate) return empty;
+    // challenge_title was added to the push payload; older rows fall back to
+    // the notification body, which is the challenge title verbatim.
+    const label = data.challenge_title || row.body || "today's challenge";
+    return {
+      hype_target_user_id: String(targetId),
+      hype_context_type: "challenge",
+      hype_context_id: `${targetId}:${localDate}`,
+      hype_context_label: String(label),
+    };
+  }
 
-	return empty;
+  return empty;
 }
 
 export async function getInAppNotifications(req: Request, res: Response) {
-	try {
-		const userId = (req as any).userId;
-		const limit = parseInt(req.query.limit as string) || 50;
-		const offset = parseInt(req.query.offset as string) || 0;
+  try {
+    const userId = (req as any).userId;
+    const limit = parseInt(req.query.limit as string) || 50;
+    const offset = parseInt(req.query.offset as string) || 0;
 
-		const rows = await db.query<any>(
-			`SELECT id, title, body, type, data, is_read, created_at
+    const rows = await db.query<any>(
+      `SELECT id, title, body, type, data, is_read, created_at
 			FROM in_app_notifications
 			WHERE user_id = $1
 			ORDER BY created_at DESC
 			LIMIT $2 OFFSET $3`,
-			[userId, limit, offset]
-		);
+      [userId, limit, offset],
+    );
 
-		// Pass 1: derive hype context for each row.
-		const derived = rows.map(r => ({ row: r, hype: deriveHypeContext(r) }));
+    // Pass 1: derive hype context for each row.
+    const derived = rows.map((r) => ({ row: r, hype: deriveHypeContext(r) }));
 
-		// Pass 2: batch-query is_hyped for rows that have a context.
-		const ctxKeys = derived
-			.filter(
-				d => d.hype.hype_target_user_id !== null && d.hype.hype_context_type !== null && d.hype.hype_context_id !== null
-			)
-			.map(d => ({
-				targetId: d.hype.hype_target_user_id!,
-				type: d.hype.hype_context_type!,
-				id: d.hype.hype_context_id!
-			}));
+    // Pass 2: batch-query is_hyped for rows that have a context.
+    const ctxKeys = derived
+      .filter(
+        (d) =>
+          d.hype.hype_target_user_id !== null &&
+          d.hype.hype_context_type !== null &&
+          d.hype.hype_context_id !== null,
+      )
+      .map((d) => ({
+        targetId: d.hype.hype_target_user_id!,
+        type: d.hype.hype_context_type!,
+        id: d.hype.hype_context_id!,
+      }));
 
-		const hypedSet = new Set<string>();
-		if (ctxKeys.length > 0) {
-			const targetIds = ctxKeys.map(k => k.targetId);
-			const types = ctxKeys.map(k => k.type);
-			const ids = ctxKeys.map(k => k.id);
-			const hyped = await db.query<{ target_id: string; context_type: string; context_id: string }>(
-				`SELECT target_id, context_type, context_id
+    const hypedSet = new Set<string>();
+    if (ctxKeys.length > 0) {
+      const targetIds = ctxKeys.map((k) => k.targetId);
+      const types = ctxKeys.map((k) => k.type);
+      const ids = ctxKeys.map((k) => k.id);
+      const hyped = await db.query<{
+        target_id: string;
+        context_type: string;
+        context_id: string;
+      }>(
+        `SELECT target_id, context_type, context_id
 				FROM hype_log
 				WHERE sender_id = $1
 					AND (target_id, context_type, context_id) IN (
 						SELECT * FROM UNNEST($2::text[], $3::text[], $4::text[])
 					)`,
-				[userId, targetIds, types, ids]
-			);
-			for (const h of hyped) {
-				hypedSet.add(`${h.target_id}|${h.context_type}|${h.context_id}`);
-			}
-		}
+        [userId, targetIds, types, ids],
+      );
+      for (const h of hyped) {
+        hypedSet.add(`${h.target_id}|${h.context_type}|${h.context_id}`);
+      }
 
-		const notifications = derived.map(({ row, hype }) => {
-			const key =
-				hype.hype_target_user_id && hype.hype_context_type && hype.hype_context_id
-					? `${hype.hype_target_user_id}|${hype.hype_context_type}|${hype.hype_context_id}`
-					: null;
-			const isHyped = key !== null && hypedSet.has(key);
-			return {
-				id: row.id,
-				title: row.title,
-				body: row.body,
-				type: row.type,
-				data: row.data,
-				is_read: row.is_read,
-				created_at: row.created_at,
-				hype_target_user_id: hype.hype_target_user_id,
-				hype_context_type: hype.hype_context_type,
-				hype_context_id: hype.hype_context_id,
-				hype_context_label: hype.hype_context_label,
-				is_hyped: isHyped
-			};
-		});
+      // Mile hypes sent from the feed were historically keyed by workout_id
+      // rather than the canonical user:local_date composite. Map those legacy
+      // rows onto the composite keys we derived so they read as hyped here too.
+      const mileKeys = ctxKeys
+        .filter((k) => k.type === "mile")
+        .map((k) => k.id);
+      if (mileKeys.length > 0) {
+        const legacy = await db.query<{ target_id: string; key: string }>(
+          `SELECT h.target_id, (w.user_id || ':' || w.local_date::text) AS key
+					FROM hype_log h
+					JOIN workouts w ON w.workout_id = h.context_id
+					WHERE h.sender_id = $1
+						AND h.context_type = 'mile'
+						AND (w.user_id || ':' || w.local_date::text) = ANY($2::text[])`,
+          [userId, mileKeys],
+        );
+        for (const h of legacy) {
+          hypedSet.add(`${h.target_id}|mile|${h.key}`);
+        }
+      }
+    }
 
-		const unreadCount = await db.query(
-			`SELECT COUNT(*) as count FROM in_app_notifications
+    const notifications = derived.map(({ row, hype }) => {
+      const key =
+        hype.hype_target_user_id &&
+        hype.hype_context_type &&
+        hype.hype_context_id
+          ? `${hype.hype_target_user_id}|${hype.hype_context_type}|${hype.hype_context_id}`
+          : null;
+      const isHyped = key !== null && hypedSet.has(key);
+      return {
+        id: row.id,
+        title: row.title,
+        body: row.body,
+        type: row.type,
+        data: row.data,
+        is_read: row.is_read,
+        created_at: row.created_at,
+        hype_target_user_id: hype.hype_target_user_id,
+        hype_context_type: hype.hype_context_type,
+        hype_context_id: hype.hype_context_id,
+        hype_context_label: hype.hype_context_label,
+        is_hyped: isHyped,
+      };
+    });
+
+    const unreadCount = await db.query(
+      `SELECT COUNT(*) as count FROM in_app_notifications
 			WHERE user_id = $1 AND is_read = FALSE`,
-			[userId]
-		);
+      [userId],
+    );
 
-		res.json({
-			notifications,
-			unread_count: parseInt(unreadCount[0]?.count ?? '0')
-		});
-	} catch (error: any) {
-		console.error('Error getting in-app notifications:', error.message);
-		res.status(500).json({ error: 'Failed to get notifications' });
-	}
+    res.json({
+      notifications,
+      unread_count: parseInt(unreadCount[0]?.count ?? "0"),
+    });
+  } catch (error: any) {
+    console.error("Error getting in-app notifications:", error.message);
+    res.status(500).json({ error: "Failed to get notifications" });
+  }
 }
 
 export async function markNotificationRead(req: Request, res: Response) {
-	try {
-		const userId = (req as any).userId;
-		const { notificationId } = req.params;
+  try {
+    const userId = (req as any).userId;
+    const { notificationId } = req.params;
 
-		await db.query('UPDATE in_app_notifications SET is_read = TRUE WHERE id = $1 AND user_id = $2', [notificationId, userId]);
+    await db.query(
+      "UPDATE in_app_notifications SET is_read = TRUE WHERE id = $1 AND user_id = $2",
+      [notificationId, userId],
+    );
 
-		res.json({ success: true });
-	} catch (error: any) {
-		console.error('Error marking notification read:', error.message);
-		res.status(500).json({ error: 'Failed to mark notification read' });
-	}
+    res.json({ success: true });
+  } catch (error: any) {
+    console.error("Error marking notification read:", error.message);
+    res.status(500).json({ error: "Failed to mark notification read" });
+  }
 }
 
 export async function markAllRead(req: Request, res: Response) {
-	try {
-		const userId = (req as any).userId;
+  try {
+    const userId = (req as any).userId;
 
-		await db.query('UPDATE in_app_notifications SET is_read = TRUE WHERE user_id = $1 AND is_read = FALSE', [userId]);
+    await db.query(
+      "UPDATE in_app_notifications SET is_read = TRUE WHERE user_id = $1 AND is_read = FALSE",
+      [userId],
+    );
 
-		res.json({ success: true });
-	} catch (error: any) {
-		console.error('Error marking all notifications read:', error.message);
-		res.status(500).json({ error: 'Failed to mark all read' });
-	}
+    res.json({ success: true });
+  } catch (error: any) {
+    console.error("Error marking all notifications read:", error.message);
+    res.status(500).json({ error: "Failed to mark all read" });
+  }
 }
 
 export async function getUnreadCount(req: Request, res: Response) {
-	try {
-		const userId = (req as any).userId;
+  try {
+    const userId = (req as any).userId;
 
-		const result = await db.query(
-			'SELECT COUNT(*) as count FROM in_app_notifications WHERE user_id = $1 AND is_read = FALSE',
-			[userId]
-		);
+    const result = await db.query(
+      "SELECT COUNT(*) as count FROM in_app_notifications WHERE user_id = $1 AND is_read = FALSE",
+      [userId],
+    );
 
-		res.json({ unread_count: parseInt(result[0]?.count ?? '0') });
-	} catch (error: any) {
-		console.error('Error getting unread count:', error.message);
-		res.status(500).json({ error: 'Failed to get unread count' });
-	}
+    res.json({ unread_count: parseInt(result[0]?.count ?? "0") });
+  } catch (error: any) {
+    console.error("Error getting unread count:", error.message);
+    res.status(500).json({ error: "Failed to get unread count" });
+  }
 }

--- a/backend/src/controllers/inAppNotificationController.ts
+++ b/backend/src/controllers/inAppNotificationController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import { PostgresService } from "../services/DbService.js";
+import { getLegacyHypedMileKeys } from "../services/hypeService.js";
 
 const db = PostgresService.getInstance();
 
@@ -134,48 +135,44 @@ export async function getInAppNotifications(req: Request, res: Response) {
         id: d.hype.hype_context_id!,
       }));
 
-    const hypedSet = new Set<string>();
-    if (ctxKeys.length > 0) {
-      const targetIds = ctxKeys.map((k) => k.targetId);
-      const types = ctxKeys.map((k) => k.type);
-      const ids = ctxKeys.map((k) => k.id);
-      const hyped = await db.query<{
-        target_id: string;
-        context_type: string;
-        context_id: string;
-      }>(
-        `SELECT target_id, context_type, context_id
-				FROM hype_log
-				WHERE sender_id = $1
-					AND (target_id, context_type, context_id) IN (
-						SELECT * FROM UNNEST($2::text[], $3::text[], $4::text[])
-					)`,
-        [userId, targetIds, types, ids],
-      );
-      for (const h of hyped) {
-        hypedSet.add(`${h.target_id}|${h.context_type}|${h.context_id}`);
-      }
+    const targetIds = ctxKeys.map((k) => k.targetId);
+    const types = ctxKeys.map((k) => k.type);
+    const ids = ctxKeys.map((k) => k.id);
+    // Mile hypes sent from the feed were historically keyed by workout_id
+    // rather than the canonical user:local_date composite -- map those legacy
+    // rows onto the derived composite keys so they read as hyped here too.
+    const mileKeys = ctxKeys.filter((k) => k.type === "mile").map((k) => k.id);
 
-      // Mile hypes sent from the feed were historically keyed by workout_id
-      // rather than the canonical user:local_date composite. Map those legacy
-      // rows onto the composite keys we derived so they read as hyped here too.
-      const mileKeys = ctxKeys
-        .filter((k) => k.type === "mile")
-        .map((k) => k.id);
-      if (mileKeys.length > 0) {
-        const legacy = await db.query<{ target_id: string; key: string }>(
-          `SELECT h.target_id, (w.user_id || ':' || w.local_date::text) AS key
-					FROM hype_log h
-					JOIN workouts w ON w.workout_id = h.context_id
-					WHERE h.sender_id = $1
-						AND h.context_type = 'mile'
-						AND (w.user_id || ':' || w.local_date::text) = ANY($2::text[])`,
-          [userId, mileKeys],
-        );
-        for (const h of legacy) {
-          hypedSet.add(`${h.target_id}|mile|${h.key}`);
-        }
-      }
+    const [hyped, legacyMile, unreadCount] = await Promise.all([
+      ctxKeys.length > 0
+        ? db.query<{
+            target_id: string;
+            context_type: string;
+            context_id: string;
+          }>(
+            `SELECT target_id, context_type, context_id
+					FROM hype_log
+					WHERE sender_id = $1
+						AND (target_id, context_type, context_id) IN (
+							SELECT * FROM UNNEST($2::text[], $3::text[], $4::text[])
+						)`,
+            [userId, targetIds, types, ids],
+          )
+        : Promise.resolve([]),
+      getLegacyHypedMileKeys(userId, mileKeys),
+      db.query(
+        `SELECT COUNT(*) as count FROM in_app_notifications
+			WHERE user_id = $1 AND is_read = FALSE`,
+        [userId],
+      ),
+    ]);
+
+    const hypedSet = new Set<string>();
+    for (const h of hyped) {
+      hypedSet.add(`${h.target_id}|${h.context_type}|${h.context_id}`);
+    }
+    for (const h of legacyMile) {
+      hypedSet.add(`${h.target_id}|mile|${h.key}`);
     }
 
     const notifications = derived.map(({ row, hype }) => {
@@ -201,12 +198,6 @@ export async function getInAppNotifications(req: Request, res: Response) {
         is_hyped: isHyped,
       };
     });
-
-    const unreadCount = await db.query(
-      `SELECT COUNT(*) as count FROM in_app_notifications
-			WHERE user_id = $1 AND is_read = FALSE`,
-      [userId],
-    );
 
     res.json({
       notifications,

--- a/backend/src/controllers/postsController.ts
+++ b/backend/src/controllers/postsController.ts
@@ -151,9 +151,11 @@ export async function createPostController(
       shareToFeed,
       shareToStory,
       statsSnapshot: (stats_snapshot ?? null) as PostStatsSnapshot | null,
-      // Absent on legacy clients — createPost keeps the old upsert behavior then.
+      // Absent on legacy clients — createPost keeps the old upsert behavior
+      // and owns the include_route default.
       isAuto: typeof is_auto === "boolean" ? is_auto : undefined,
-      includeRoute: include_route !== false, // default true
+      includeRoute:
+        typeof include_route === "boolean" ? include_route : undefined,
     });
 
     // Fire-and-forget: tell friends about a new feed post (respects their

--- a/backend/src/controllers/postsController.ts
+++ b/backend/src/controllers/postsController.ts
@@ -88,6 +88,8 @@ export async function createPostController(
     share_to_feed,
     share_to_story,
     stats_snapshot,
+    is_auto,
+    include_route,
   } = req.body ?? {};
 
   try {
@@ -149,6 +151,9 @@ export async function createPostController(
       shareToFeed,
       shareToStory,
       statsSnapshot: (stats_snapshot ?? null) as PostStatsSnapshot | null,
+      // Absent on legacy clients — createPost keeps the old upsert behavior then.
+      isAuto: typeof is_auto === "boolean" ? is_auto : undefined,
+      includeRoute: include_route !== false, // default true
     });
 
     // Fire-and-forget: tell friends about a new feed post (respects their
@@ -163,6 +168,11 @@ export async function createPostController(
 
     res.status(201).json(post);
   } catch (error: any) {
+    // One deliberate post per workout — the slot is taken until that post is
+    // deleted. Surface as a conflict the client can message, not a 500.
+    if (error?.message === "workout_already_posted") {
+      return res.status(409).json({ error: "workout_already_posted" });
+    }
     console.error("Error creating post:", error.message);
     res.status(500).json({ error: "Error creating post" });
   }

--- a/backend/src/controllers/postsController.ts
+++ b/backend/src/controllers/postsController.ts
@@ -1,4 +1,5 @@
 import { Response } from "express";
+import crypto from "crypto";
 import fs from "fs";
 import path from "path";
 import sharp from "sharp";
@@ -20,6 +21,7 @@ import {
   getStoryViewers,
   reactToStory,
   getOwnPostMemories,
+  userOwnsWorkout,
   ALLOWED_STORY_REACTIONS,
   PostStatsSnapshot,
 } from "../services/postService.js";
@@ -44,6 +46,15 @@ const MAX_CAPTION = 280;
 const DEFAULT_FEED_LIMIT = 20;
 const MAX_FEED_LIMIT = 50;
 
+// posts.post_id is a uuid — validate route params before they hit a ::uuid
+// cast, so garbage ids 404 instead of bubbling a cast error into a 500.
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isUuid(value: string | undefined): value is string {
+  return typeof value === "string" && UUID_RE.test(value);
+}
+
 /**
  * Upload a post photo. The image arrives already flattened (run-stats overlay
  * baked in by the client). Mirrors uploadProfileImage: Multer memory buffer →
@@ -59,7 +70,10 @@ export async function uploadPostMedia(
     return res.status(400).json({ error: "No image file provided" });
   }
   try {
-    const filename = `${userId}-${Date.now()}.jpg`;
+    // Random suffix: two uploads in the same millisecond (double-tap retry)
+    // must not overwrite each other. The `<userId>-` prefix doubles as the
+    // ownership check when the media_url is referenced in POST /posts.
+    const filename = `${userId}-${Date.now()}-${crypto.randomBytes(4).toString("hex")}.jpg`;
     const outputPath = path.join(process.cwd(), "uploads", "posts", filename);
     await sharp(req.file.buffer)
       .rotate() // honor EXIF orientation before resizing (portrait photos)
@@ -109,6 +123,14 @@ export async function createPostController(
         .status(400)
         .json({ error: "media_url does not reference an uploaded file" });
     }
+    // Ownership: upload filenames are `<userId>-<ts>-<rand>.jpg`, and media
+    // urls are visible to the whole circle — without this check anyone could
+    // republish a friend's photo (including story-only photos) as their own.
+    if (!path.basename(media_url).startsWith(`${userId}-`)) {
+      return res
+        .status(403)
+        .json({ error: "media_url must reference your own upload" });
+    }
 
     const shareToFeed = share_to_feed !== false; // default true
     const shareToStory = share_to_story === true; // default false
@@ -142,11 +164,24 @@ export async function createPostController(
       });
     }
 
+    // Only link the post to a workout the caller actually owns. Workout ids are
+    // visible to the whole circle in feed payloads, so an unchecked id would let
+    // a user occupy a friend's one-post-per-workout slot (blocking their posts
+    // and hiding their workout card). Unknown/foreign ids also FK-fail, so an
+    // unlinked post beats a 500 either way.
+    let workoutId = typeof workout_id === "string" ? workout_id : null;
+    if (workoutId && !(await userOwnsWorkout(userId, workoutId))) {
+      console.warn(
+        `[createPost] Ignoring workout_id not owned by poster ${userId}`,
+      );
+      workoutId = null;
+    }
+
     const post = await createPost({
       userId,
       mediaUrl: media_url,
       caption: typeof caption === "string" ? caption.trim() || null : null,
-      workoutId: typeof workout_id === "string" ? workout_id : null,
+      workoutId,
       localDate: goal.localDate,
       shareToFeed,
       shareToStory,
@@ -211,6 +246,9 @@ export async function markStoryViewedController(
   res: Response,
 ) {
   try {
+    if (!isUuid(req.params.postId)) {
+      return res.status(404).json({ error: "story_not_found" });
+    }
     await markStoryViewed(req.userId!, req.params.postId);
     res.json({ ok: true });
   } catch (error: any) {
@@ -225,6 +263,9 @@ export async function getStoryViewersController(
   res: Response,
 ) {
   try {
+    if (!isUuid(req.params.postId)) {
+      return res.status(404).json({ error: "story_not_found" });
+    }
     const viewers = await getStoryViewers(req.userId!, req.params.postId);
     if (viewers === null) {
       return res.status(404).json({ error: "story_not_found" });
@@ -242,6 +283,9 @@ export async function reactToStoryController(
   res: Response,
 ) {
   try {
+    if (!isUuid(req.params.postId)) {
+      return res.status(404).json({ error: "story_not_found" });
+    }
     const emoji = typeof req.body?.emoji === "string" ? req.body.emoji : "";
     if (!ALLOWED_STORY_REACTIONS.has(emoji)) {
       return res.status(400).json({ error: "invalid_reaction" });
@@ -291,8 +335,11 @@ export async function getFeedController(
     const before =
       typeof req.query.before === "string" ? req.query.before : null;
     const items = await getFeed(req.userId!, limit, before);
+    // `cursor` is the microsecond-precise Postgres text timestamp; created_at
+    // (a ms-truncated JS Date) would skip same-millisecond rows at boundaries.
+    const last = items[items.length - 1];
     const nextBefore =
-      items.length === limit ? items[items.length - 1].created_at : null;
+      items.length === limit ? (last.cursor ?? last.created_at) : null;
     res.status(200).json({ items, next_before: nextBefore });
   } catch (error: any) {
     console.error("Error fetching feed:", error.message);
@@ -313,8 +360,9 @@ export async function getUnifiedFeedController(
     const before =
       typeof req.query.before === "string" ? req.query.before : null;
     const items = await getUnifiedFeed(req.userId!, limit, before);
+    const last = items[items.length - 1];
     const nextBefore =
-      items.length === limit ? items[items.length - 1].sort_ts : null;
+      items.length === limit ? (last.cursor ?? last.sort_ts) : null;
     res.status(200).json({ items, next_before: nextBefore });
   } catch (error: any) {
     console.error("Error fetching unified feed:", error.message);
@@ -340,8 +388,9 @@ export async function getUserPostsController(
       limit,
       before,
     );
+    const last = items[items.length - 1];
     const nextBefore =
-      items.length === limit ? items[items.length - 1].created_at : null;
+      items.length === limit ? (last.cursor ?? last.created_at) : null;
     res.status(200).json({ items, next_before: nextBefore });
   } catch (error: any) {
     console.error("Error fetching user posts:", error.message);
@@ -356,6 +405,9 @@ export async function deletePostController(
   const userId = req.userId!;
   const postId = req.params.postId;
   try {
+    if (!isUuid(postId)) {
+      return res.status(404).json({ error: "Post not found" });
+    }
     const deleted = await softDeletePost(userId, postId);
     if (deleted) return res.json({ ok: true });
 
@@ -381,6 +433,9 @@ export async function reportPostController(
   const postId = req.params.postId;
   const { reason, details } = req.body ?? {};
   try {
+    if (!isUuid(postId)) {
+      return res.status(404).json({ error: "Post not found" });
+    }
     if (!REPORT_REASONS.includes(reason)) {
       return res
         .status(400)

--- a/backend/src/db/drizzle/0008_heavy_nightmare.sql
+++ b/backend/src/db/drizzle/0008_heavy_nightmare.sql
@@ -7,4 +7,15 @@ CREATE TABLE "workout_routes" (
 --> statement-breakpoint
 ALTER TABLE "posts" ADD COLUMN "is_auto" boolean DEFAULT false NOT NULL;--> statement-breakpoint
 ALTER TABLE "posts" ADD COLUMN "include_route" boolean DEFAULT true NOT NULL;--> statement-breakpoint
-ALTER TABLE "workout_routes" ADD CONSTRAINT "workout_routes_workout_id_fkey" FOREIGN KEY ("workout_id") REFERENCES "public"."workouts"("workout_id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "workout_routes" ADD CONSTRAINT "workout_routes_workout_id_fkey" FOREIGN KEY ("workout_id") REFERENCES "public"."workouts"("workout_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+-- Backfill: classify pre-existing auto route/stats cards (published by the app
+-- when the user skips the post-run photo prompt) as auto, so a later
+-- deliberate photo post can replace them instead of hitting the new
+-- one-post-per-workout 409. Signature: caption-less feed-only post linked to a
+-- workout with a stats snapshot.
+UPDATE "posts" SET "is_auto" = true
+WHERE "workout_id" IS NOT NULL
+	AND "caption" IS NULL
+	AND "stats_snapshot" IS NOT NULL
+	AND "share_to_feed"
+	AND NOT "share_to_story";

--- a/backend/src/db/drizzle/0008_heavy_nightmare.sql
+++ b/backend/src/db/drizzle/0008_heavy_nightmare.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "workout_routes" (
+	"workout_id" varchar(255) PRIMARY KEY NOT NULL,
+	"route" jsonb NOT NULL,
+	"point_count" integer NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "posts" ADD COLUMN "is_auto" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "posts" ADD COLUMN "include_route" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "workout_routes" ADD CONSTRAINT "workout_routes_workout_id_fkey" FOREIGN KEY ("workout_id") REFERENCES "public"."workouts"("workout_id") ON DELETE cascade ON UPDATE no action;

--- a/backend/src/db/drizzle/0009_moaning_peter_parker.sql
+++ b/backend/src/db/drizzle/0009_moaning_peter_parker.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "notification_settings" ADD COLUMN "share_route_maps" boolean DEFAULT true;

--- a/backend/src/db/drizzle/meta/0008_snapshot.json
+++ b/backend/src/db/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,3636 @@
+{
+  "id": "12395ad5-4273-4e13-b6b1-5d5da8dd7a95",
+  "prevId": "2bd52430-7aa5-4bb3-b34f-070b6a369dc7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_badges_category": {
+          "name": "idx_badges_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "badges_rarity_check": {
+          "name": "badges_rarity_check",
+          "value": "rarity = ANY (ARRAY['common'::text, 'rare'::text, 'legendary'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.close_friends": {
+      "name": "close_friends",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_friend_id": {
+          "name": "close_friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_close_friends_friend": {
+          "name": "idx_close_friends_friend",
+          "columns": [
+            {
+              "expression": "close_friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "close_friends_pkey": {
+          "name": "close_friends_pkey",
+          "columns": [
+            "user_id",
+            "close_friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_users": {
+      "name": "competition_users",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_rank": {
+          "name": "last_known_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_score": {
+          "name": "last_known_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rank_updated_at": {
+          "name": "last_rank_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_competition_users_comp": {
+          "name": "idx_competition_users_comp",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_competition": {
+          "name": "idx_competition_users_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_rank_cache": {
+          "name": "idx_competition_users_rank_cache",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_known_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((invite_status)::text = 'accepted'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user": {
+          "name": "idx_competition_users_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user_status": {
+          "name": "idx_competition_users_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invite_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_users_user_id_fkey": {
+          "name": "competition_users_user_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_users_competition_id_fkey": {
+          "name": "competition_users_competition_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_users_pkey": {
+          "name": "competition_users_pkey",
+          "columns": [
+            "competition_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_users_invite_status_check": {
+          "name": "competition_users_invite_status_check",
+          "value": "(invite_status)::text = ANY ((ARRAY['pending'::character varying, 'accepted'::character varying, 'declined'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workouts": {
+          "name": "workouts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_winner": {
+          "name": "idx_competitions_winner",
+          "columns": [
+            {
+              "expression": "winner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(winner IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_winner_fkey": {
+          "name": "competitions_winner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "competitions_owner_fkey": {
+          "name": "competitions_owner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitions_type_check": {
+          "name": "competitions_type_check",
+          "value": "(type)::text = ANY ((ARRAY['streaks'::character varying, 'apex'::character varying, 'clash'::character varying, 'targets'::character varying, 'race'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_challenges": {
+      "name": "daily_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_template": {
+          "name": "description_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_start": {
+          "name": "gradient_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_end": {
+          "name": "gradient_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rotation_index": {
+          "name": "rotation_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_challenges_rotation_index_key": {
+          "name": "daily_challenges_rotation_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rotation_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daily_challenges_type_check": {
+          "name": "daily_challenges_type_check",
+          "value": "type = ANY (ARRAY['pace'::text, 'distance'::text, 'time'::text, 'activity'::text, 'steps'::text, 'social'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_steps": {
+      "name": "daily_steps",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_steps_user_date": {
+          "name": "idx_daily_steps_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_steps_user_id_fkey": {
+          "name": "daily_steps_user_id_fkey",
+          "tableFrom": "daily_steps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_steps_pkey": {
+          "name": "daily_steps_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "daily_steps_steps_check": {
+          "name": "daily_steps_steps_check",
+          "value": "steps >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token": {
+          "name": "device_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_tokens_user_id": {
+          "name": "idx_device_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_user_id_fkey": {
+          "name": "device_tokens_user_id_fkey",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_user_id_device_token_key": {
+          "name": "device_tokens_user_id_device_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flex_log": {
+      "name": "flex_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flex_log_lookup": {
+          "name": "idx_flex_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_notification_settings": {
+      "name": "friend_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted": {
+          "name": "muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nudges_muted": {
+          "name": "nudges_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "activity_muted": {
+          "name": "activity_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "friend_notification_settings_pkey": {
+          "name": "friend_notification_settings_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_nudge_log": {
+      "name": "friend_nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_nudge_log_lookup": {
+          "name": "idx_friend_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_friendships_friend_status": {
+          "name": "idx_friendships_friend_status",
+          "columns": [
+            {
+              "expression": "friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_friendships_user_status": {
+          "name": "idx_friendships_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_user_id_fkey": {
+          "name": "friendships_user_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_friend_id_fkey": {
+          "name": "friendships_friend_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendships_pkey": {
+          "name": "friendships_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_friendship_pair": {
+          "name": "unique_friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hype_log": {
+      "name": "hype_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_label": {
+          "name": "context_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hype_log_context_dedupe_idx": {
+          "name": "hype_log_context_dedupe_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_lookup": {
+          "name": "idx_hype_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_app_notifications": {
+      "name": "in_app_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_in_app_notifications_unread": {
+          "name": "idx_in_app_notifications_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_read = false)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_app_notifications_user": {
+          "name": "idx_in_app_notifications_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_app_notifications_user_id_fkey": {
+          "name": "in_app_notifications_user_id_fkey",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_notifications": {
+      "name": "milestone_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_key": {
+          "name": "milestone_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_notifications_milestone_key_key": {
+          "name": "milestone_notifications_milestone_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_audience_settings": {
+      "name": "notification_audience_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_audience_settings_pkey": {
+          "name": "notification_audience_settings_pkey",
+          "columns": [
+            "user_id",
+            "direction",
+            "event_type",
+            "activity_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_audience_settings_direction_check": {
+          "name": "notification_audience_settings_direction_check",
+          "value": "direction = ANY (ARRAY['outgoing'::text, 'incoming'::text])"
+        },
+        "notification_audience_settings_audience_check": {
+          "name": "notification_audience_settings_audience_check",
+          "value": "audience = ANY (ARRAY['none'::text, 'close'::text, 'all'::text, 'ask'::text, 'match_run'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_user_date": {
+          "name": "idx_notification_log_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nudges_enabled": {
+          "name": "nudges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "flexes_enabled": {
+          "name": "flexes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_activity_enabled": {
+          "name": "friend_activity_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_invites_enabled": {
+          "name": "competition_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_updates_enabled": {
+          "name": "competition_updates_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_milestones_enabled": {
+          "name": "competition_milestones_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "hypes_enabled": {
+          "name": "hypes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "step_goal_enabled": {
+          "name": "step_goal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "friend_personal_best_enabled": {
+          "name": "friend_personal_best_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_enabled": {
+          "name": "daily_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_hour": {
+          "name": "daily_reminder_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 18
+        },
+        "timezone_offset_minutes": {
+          "name": "timezone_offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_workouts_to_feed": {
+          "name": "share_workouts_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_posts_enabled": {
+          "name": "friend_posts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nudge_log": {
+      "name": "nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_nudge_log_lookup": {
+          "name": "idx_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nudge_log_rate_limit": {
+          "name": "idx_nudge_log_rate_limit",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_friend_notifications": {
+      "name": "pending_friend_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "send_after_at": {
+          "name": "send_after_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_friend_notif_user": {
+          "name": "idx_pending_friend_notif_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_pending_friend_notif_workout": {
+          "name": "uq_pending_friend_notif_workout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((workout_id IS NOT NULL) AND (status = 'pending'::text))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pending_friend_notifications_status_check": {
+          "name": "pending_friend_notifications_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'sent'::text, 'dismissed'::text, 'expired'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_notifications": {
+      "name": "pending_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_notifications_unsent": {
+          "name": "idx_pending_notifications_unsent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(sent_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_notifications_user_id_fkey": {
+          "name": "pending_notifications_user_id_fkey",
+          "tableFrom": "pending_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_reports": {
+      "name": "post_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_reports_dedupe_idx": {
+          "name": "post_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_reports_status": {
+          "name": "idx_post_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_reports_post_id_fkey": {
+          "name": "post_reports_post_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_reports_reporter_id_fkey": {
+          "name": "post_reports_reporter_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_reports_reason_check": {
+          "name": "post_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_snapshot": {
+          "name": "stats_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_to_feed": {
+          "name": "share_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_to_story": {
+          "name": "share_to_story",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "story_expires_at": {
+          "name": "story_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto": {
+          "name": "is_auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_route": {
+          "name": "include_route",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_posts_user_created": {
+          "name": "idx_posts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_feed": {
+          "name": "idx_posts_feed",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_story_active": {
+          "name": "idx_posts_story_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "story_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_story)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_active": {
+          "name": "uq_posts_workout_active",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_story": {
+          "name": "uq_posts_workout_story",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_story AND NOT share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_fkey": {
+          "name": "posts_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_workout_id_fkey": {
+          "name": "posts_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_family_id": {
+          "name": "token_family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_hash": {
+          "name": "replaced_by_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "token_family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_revoked_at": {
+          "name": "idx_refresh_tokens_revoked_at",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(revoked_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_token_hash": {
+          "name": "idx_refresh_tokens_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_fkey": {
+          "name": "refresh_tokens_user_id_fkey",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_key": {
+          "name": "refresh_tokens_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_reactions": {
+      "name": "story_reactions",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_reactions_post_id_fkey": {
+          "name": "story_reactions_post_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_reactions_user_id_fkey": {
+          "name": "story_reactions_user_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_reactions_pkey": {
+          "name": "story_reactions_pkey",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_views": {
+      "name": "story_views",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_views_post_id_fkey": {
+          "name": "story_views_post_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_views_viewer_id_fkey": {
+          "name": "story_views_viewer_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_views_pkey": {
+          "name": "story_views_pkey",
+          "columns": [
+            "post_id",
+            "viewer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggering_workout_id": {
+          "name": "triggering_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_snapshot": {
+          "name": "progress_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_slot": {
+          "name": "pin_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_badges_user": {
+          "name": "idx_user_badges_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_new": {
+          "name": "idx_user_badges_user_new",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_new = true)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_pin_slot": {
+          "name": "idx_user_badges_user_pin_slot",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(pin_slot IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_workout": {
+          "name": "idx_user_badges_workout",
+          "columns": [
+            {
+              "expression": "triggering_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_badges_user_id_fkey": {
+          "name": "user_badges_user_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_fkey": {
+          "name": "user_badges_badge_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "badge_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_triggering_workout_id_fkey": {
+          "name": "user_badges_triggering_workout_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "triggering_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_badges_user_id_badge_id_key": {
+          "name": "user_badges_user_id_badge_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "badge_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_badges_pin_slot_range": {
+          "name": "user_badges_pin_slot_range",
+          "value": "(pin_slot IS NULL) OR ((pin_slot >= 0) AND (pin_slot <= 2))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_blocks_blocked": {
+          "name": "idx_user_blocks_blocked",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_fkey": {
+          "name": "user_blocks_blocker_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_blocks_blocked_id_fkey": {
+          "name": "user_blocks_blocked_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_pkey": {
+          "name": "user_blocks_pkey",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenge_completions": {
+      "name": "user_challenge_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completing_workout_id": {
+          "name": "completing_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ucc_user": {
+          "name": "idx_ucc_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ucc_user_date": {
+          "name": "idx_ucc_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenge_completions_user_id_fkey": {
+          "name": "user_challenge_completions_user_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_challenge_key_fkey": {
+          "name": "user_challenge_completions_challenge_key_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "daily_challenges",
+          "columnsFrom": [
+            "challenge_key"
+          ],
+          "columnsTo": [
+            "challenge_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_completing_workout_id_fkey": {
+          "name": "user_challenge_completions_completing_workout_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "completing_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_challenge_completions_user_id_local_date_key": {
+          "name": "user_challenge_completions_user_id_local_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_sub": {
+          "name": "apple_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "goal_miles": {
+          "name": "goal_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_current_streak_desc": {
+          "name": "idx_users_current_streak_desc",
+          "columns": [
+            {
+              "expression": "current_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email_trgm": {
+          "name": "idx_users_email_trgm",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_username_trgm": {
+          "name": "idx_users_username_trgm",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_apple_id_key": {
+          "name": "users_apple_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_apple_sub_key": {
+          "name": "users_apple_sub_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "apple_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_completion_notifications": {
+      "name": "workout_completion_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_date": {
+          "name": "notified_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_completion_notifications_user_id_notified_date_key": {
+          "name": "workout_completion_notifications_user_id_notified_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "notified_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_routes": {
+      "name": "workout_routes",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "point_count": {
+          "name": "point_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workout_routes_workout_id_fkey": {
+          "name": "workout_routes_workout_id_fkey",
+          "tableFrom": "workout_routes",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_splits": {
+      "name": "workout_splits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_number": {
+          "name": "split_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_duration": {
+          "name": "split_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_distance": {
+          "name": "split_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_pace": {
+          "name": "split_pace",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_splits_time": {
+          "name": "idx_splits_time",
+          "columns": [
+            {
+              "expression": "split_duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_splits_workout": {
+          "name": "idx_splits_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_splits_workout_id_fkey": {
+          "name": "workout_splits_workout_id_fkey",
+          "tableFrom": "workout_splits",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_splits_workout_id_split_number_key": {
+          "name": "workout_splits_workout_id_split_number_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "split_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workouts": {
+      "name": "workouts",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_end_date": {
+          "name": "device_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthkit'"
+        },
+        "original_distance": {
+          "name": "original_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_duration": {
+          "name": "original_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_flagged": {
+          "name": "speed_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_workouts_local_date_user_id": {
+          "name": "idx_workouts_local_date_user_id",
+          "columns": [
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_device_end": {
+          "name": "idx_workouts_user_device_end",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_local_date": {
+          "name": "idx_workouts_user_local_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workouts_user_workout_unique": {
+          "name": "workouts_user_workout_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/drizzle/meta/0009_snapshot.json
+++ b/backend/src/db/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,3643 @@
+{
+  "id": "8f392d05-d95a-4405-bc45-1fe30e94d3e4",
+  "prevId": "12395ad5-4273-4e13-b6b1-5d5da8dd7a95",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_badges_category": {
+          "name": "idx_badges_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "badges_rarity_check": {
+          "name": "badges_rarity_check",
+          "value": "rarity = ANY (ARRAY['common'::text, 'rare'::text, 'legendary'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.close_friends": {
+      "name": "close_friends",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_friend_id": {
+          "name": "close_friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_close_friends_friend": {
+          "name": "idx_close_friends_friend",
+          "columns": [
+            {
+              "expression": "close_friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "close_friends_pkey": {
+          "name": "close_friends_pkey",
+          "columns": [
+            "user_id",
+            "close_friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_users": {
+      "name": "competition_users",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_rank": {
+          "name": "last_known_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_score": {
+          "name": "last_known_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rank_updated_at": {
+          "name": "last_rank_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_competition_users_comp": {
+          "name": "idx_competition_users_comp",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_competition": {
+          "name": "idx_competition_users_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_rank_cache": {
+          "name": "idx_competition_users_rank_cache",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_known_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((invite_status)::text = 'accepted'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user": {
+          "name": "idx_competition_users_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user_status": {
+          "name": "idx_competition_users_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invite_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_users_user_id_fkey": {
+          "name": "competition_users_user_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_users_competition_id_fkey": {
+          "name": "competition_users_competition_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_users_pkey": {
+          "name": "competition_users_pkey",
+          "columns": [
+            "competition_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_users_invite_status_check": {
+          "name": "competition_users_invite_status_check",
+          "value": "(invite_status)::text = ANY ((ARRAY['pending'::character varying, 'accepted'::character varying, 'declined'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workouts": {
+          "name": "workouts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_winner": {
+          "name": "idx_competitions_winner",
+          "columns": [
+            {
+              "expression": "winner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(winner IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_winner_fkey": {
+          "name": "competitions_winner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "competitions_owner_fkey": {
+          "name": "competitions_owner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitions_type_check": {
+          "name": "competitions_type_check",
+          "value": "(type)::text = ANY ((ARRAY['streaks'::character varying, 'apex'::character varying, 'clash'::character varying, 'targets'::character varying, 'race'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_challenges": {
+      "name": "daily_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_template": {
+          "name": "description_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_start": {
+          "name": "gradient_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_end": {
+          "name": "gradient_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rotation_index": {
+          "name": "rotation_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_challenges_rotation_index_key": {
+          "name": "daily_challenges_rotation_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rotation_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daily_challenges_type_check": {
+          "name": "daily_challenges_type_check",
+          "value": "type = ANY (ARRAY['pace'::text, 'distance'::text, 'time'::text, 'activity'::text, 'steps'::text, 'social'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_steps": {
+      "name": "daily_steps",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_steps_user_date": {
+          "name": "idx_daily_steps_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_steps_user_id_fkey": {
+          "name": "daily_steps_user_id_fkey",
+          "tableFrom": "daily_steps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_steps_pkey": {
+          "name": "daily_steps_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "daily_steps_steps_check": {
+          "name": "daily_steps_steps_check",
+          "value": "steps >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token": {
+          "name": "device_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_tokens_user_id": {
+          "name": "idx_device_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_user_id_fkey": {
+          "name": "device_tokens_user_id_fkey",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_user_id_device_token_key": {
+          "name": "device_tokens_user_id_device_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flex_log": {
+      "name": "flex_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flex_log_lookup": {
+          "name": "idx_flex_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_notification_settings": {
+      "name": "friend_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted": {
+          "name": "muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nudges_muted": {
+          "name": "nudges_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "activity_muted": {
+          "name": "activity_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "friend_notification_settings_pkey": {
+          "name": "friend_notification_settings_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_nudge_log": {
+      "name": "friend_nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_nudge_log_lookup": {
+          "name": "idx_friend_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_friendships_friend_status": {
+          "name": "idx_friendships_friend_status",
+          "columns": [
+            {
+              "expression": "friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_friendships_user_status": {
+          "name": "idx_friendships_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_user_id_fkey": {
+          "name": "friendships_user_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_friend_id_fkey": {
+          "name": "friendships_friend_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendships_pkey": {
+          "name": "friendships_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_friendship_pair": {
+          "name": "unique_friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hype_log": {
+      "name": "hype_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_label": {
+          "name": "context_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hype_log_context_dedupe_idx": {
+          "name": "hype_log_context_dedupe_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_lookup": {
+          "name": "idx_hype_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_app_notifications": {
+      "name": "in_app_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_in_app_notifications_unread": {
+          "name": "idx_in_app_notifications_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_read = false)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_app_notifications_user": {
+          "name": "idx_in_app_notifications_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_app_notifications_user_id_fkey": {
+          "name": "in_app_notifications_user_id_fkey",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_notifications": {
+      "name": "milestone_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_key": {
+          "name": "milestone_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_notifications_milestone_key_key": {
+          "name": "milestone_notifications_milestone_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_audience_settings": {
+      "name": "notification_audience_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_audience_settings_pkey": {
+          "name": "notification_audience_settings_pkey",
+          "columns": [
+            "user_id",
+            "direction",
+            "event_type",
+            "activity_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_audience_settings_direction_check": {
+          "name": "notification_audience_settings_direction_check",
+          "value": "direction = ANY (ARRAY['outgoing'::text, 'incoming'::text])"
+        },
+        "notification_audience_settings_audience_check": {
+          "name": "notification_audience_settings_audience_check",
+          "value": "audience = ANY (ARRAY['none'::text, 'close'::text, 'all'::text, 'ask'::text, 'match_run'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_user_date": {
+          "name": "idx_notification_log_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nudges_enabled": {
+          "name": "nudges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "flexes_enabled": {
+          "name": "flexes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_activity_enabled": {
+          "name": "friend_activity_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_invites_enabled": {
+          "name": "competition_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_updates_enabled": {
+          "name": "competition_updates_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_milestones_enabled": {
+          "name": "competition_milestones_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "hypes_enabled": {
+          "name": "hypes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "step_goal_enabled": {
+          "name": "step_goal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "friend_personal_best_enabled": {
+          "name": "friend_personal_best_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_enabled": {
+          "name": "daily_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_hour": {
+          "name": "daily_reminder_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 18
+        },
+        "timezone_offset_minutes": {
+          "name": "timezone_offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_workouts_to_feed": {
+          "name": "share_workouts_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_posts_enabled": {
+          "name": "friend_posts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "share_route_maps": {
+          "name": "share_route_maps",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nudge_log": {
+      "name": "nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_nudge_log_lookup": {
+          "name": "idx_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nudge_log_rate_limit": {
+          "name": "idx_nudge_log_rate_limit",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_friend_notifications": {
+      "name": "pending_friend_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "send_after_at": {
+          "name": "send_after_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_friend_notif_user": {
+          "name": "idx_pending_friend_notif_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_pending_friend_notif_workout": {
+          "name": "uq_pending_friend_notif_workout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((workout_id IS NOT NULL) AND (status = 'pending'::text))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pending_friend_notifications_status_check": {
+          "name": "pending_friend_notifications_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'sent'::text, 'dismissed'::text, 'expired'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_notifications": {
+      "name": "pending_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_notifications_unsent": {
+          "name": "idx_pending_notifications_unsent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(sent_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_notifications_user_id_fkey": {
+          "name": "pending_notifications_user_id_fkey",
+          "tableFrom": "pending_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_reports": {
+      "name": "post_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_reports_dedupe_idx": {
+          "name": "post_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_reports_status": {
+          "name": "idx_post_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_reports_post_id_fkey": {
+          "name": "post_reports_post_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_reports_reporter_id_fkey": {
+          "name": "post_reports_reporter_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_reports_reason_check": {
+          "name": "post_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_snapshot": {
+          "name": "stats_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_to_feed": {
+          "name": "share_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_to_story": {
+          "name": "share_to_story",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "story_expires_at": {
+          "name": "story_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto": {
+          "name": "is_auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_route": {
+          "name": "include_route",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_posts_user_created": {
+          "name": "idx_posts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_feed": {
+          "name": "idx_posts_feed",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_story_active": {
+          "name": "idx_posts_story_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "story_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_story)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_active": {
+          "name": "uq_posts_workout_active",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_story": {
+          "name": "uq_posts_workout_story",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_story AND NOT share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_fkey": {
+          "name": "posts_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_workout_id_fkey": {
+          "name": "posts_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_family_id": {
+          "name": "token_family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_hash": {
+          "name": "replaced_by_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "token_family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_revoked_at": {
+          "name": "idx_refresh_tokens_revoked_at",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(revoked_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_token_hash": {
+          "name": "idx_refresh_tokens_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_fkey": {
+          "name": "refresh_tokens_user_id_fkey",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_key": {
+          "name": "refresh_tokens_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_reactions": {
+      "name": "story_reactions",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_reactions_post_id_fkey": {
+          "name": "story_reactions_post_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_reactions_user_id_fkey": {
+          "name": "story_reactions_user_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_reactions_pkey": {
+          "name": "story_reactions_pkey",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_views": {
+      "name": "story_views",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_views_post_id_fkey": {
+          "name": "story_views_post_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_views_viewer_id_fkey": {
+          "name": "story_views_viewer_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_views_pkey": {
+          "name": "story_views_pkey",
+          "columns": [
+            "post_id",
+            "viewer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggering_workout_id": {
+          "name": "triggering_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_snapshot": {
+          "name": "progress_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_slot": {
+          "name": "pin_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_badges_user": {
+          "name": "idx_user_badges_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_new": {
+          "name": "idx_user_badges_user_new",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_new = true)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_pin_slot": {
+          "name": "idx_user_badges_user_pin_slot",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(pin_slot IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_workout": {
+          "name": "idx_user_badges_workout",
+          "columns": [
+            {
+              "expression": "triggering_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_badges_user_id_fkey": {
+          "name": "user_badges_user_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_fkey": {
+          "name": "user_badges_badge_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "badge_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_triggering_workout_id_fkey": {
+          "name": "user_badges_triggering_workout_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "triggering_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_badges_user_id_badge_id_key": {
+          "name": "user_badges_user_id_badge_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "badge_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_badges_pin_slot_range": {
+          "name": "user_badges_pin_slot_range",
+          "value": "(pin_slot IS NULL) OR ((pin_slot >= 0) AND (pin_slot <= 2))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_blocks_blocked": {
+          "name": "idx_user_blocks_blocked",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_fkey": {
+          "name": "user_blocks_blocker_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_blocks_blocked_id_fkey": {
+          "name": "user_blocks_blocked_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_pkey": {
+          "name": "user_blocks_pkey",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenge_completions": {
+      "name": "user_challenge_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completing_workout_id": {
+          "name": "completing_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ucc_user": {
+          "name": "idx_ucc_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ucc_user_date": {
+          "name": "idx_ucc_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenge_completions_user_id_fkey": {
+          "name": "user_challenge_completions_user_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_challenge_key_fkey": {
+          "name": "user_challenge_completions_challenge_key_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "daily_challenges",
+          "columnsFrom": [
+            "challenge_key"
+          ],
+          "columnsTo": [
+            "challenge_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_completing_workout_id_fkey": {
+          "name": "user_challenge_completions_completing_workout_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "completing_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_challenge_completions_user_id_local_date_key": {
+          "name": "user_challenge_completions_user_id_local_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_sub": {
+          "name": "apple_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "goal_miles": {
+          "name": "goal_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_current_streak_desc": {
+          "name": "idx_users_current_streak_desc",
+          "columns": [
+            {
+              "expression": "current_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email_trgm": {
+          "name": "idx_users_email_trgm",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_username_trgm": {
+          "name": "idx_users_username_trgm",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_apple_id_key": {
+          "name": "users_apple_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_apple_sub_key": {
+          "name": "users_apple_sub_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "apple_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_completion_notifications": {
+      "name": "workout_completion_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_date": {
+          "name": "notified_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_completion_notifications_user_id_notified_date_key": {
+          "name": "workout_completion_notifications_user_id_notified_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "notified_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_routes": {
+      "name": "workout_routes",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "point_count": {
+          "name": "point_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workout_routes_workout_id_fkey": {
+          "name": "workout_routes_workout_id_fkey",
+          "tableFrom": "workout_routes",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_splits": {
+      "name": "workout_splits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_number": {
+          "name": "split_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_duration": {
+          "name": "split_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_distance": {
+          "name": "split_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_pace": {
+          "name": "split_pace",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_splits_time": {
+          "name": "idx_splits_time",
+          "columns": [
+            {
+              "expression": "split_duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_splits_workout": {
+          "name": "idx_splits_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_splits_workout_id_fkey": {
+          "name": "workout_splits_workout_id_fkey",
+          "tableFrom": "workout_splits",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_splits_workout_id_split_number_key": {
+          "name": "workout_splits_workout_id_split_number_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "split_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workouts": {
+      "name": "workouts",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_end_date": {
+          "name": "device_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthkit'"
+        },
+        "original_distance": {
+          "name": "original_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_duration": {
+          "name": "original_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_flagged": {
+          "name": "speed_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_workouts_local_date_user_id": {
+          "name": "idx_workouts_local_date_user_id",
+          "columns": [
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_device_end": {
+          "name": "idx_workouts_user_device_end",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_local_date": {
+          "name": "idx_workouts_user_local_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workouts_user_workout_unique": {
+          "name": "workouts_user_workout_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/drizzle/meta/_journal.json
+++ b/backend/src/db/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1782959504600,
       "tag": "0008_heavy_nightmare",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1783005444459,
+      "tag": "0009_moaning_peter_parker",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/drizzle/meta/_journal.json
+++ b/backend/src/db/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1782945046004,
       "tag": "0007_tearful_deathbird",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1782959504600,
+      "tag": "0008_heavy_nightmare",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/drizzle/schema.ts
+++ b/backend/src/db/drizzle/schema.ts
@@ -255,6 +255,10 @@ export const notificationSettings = pgTable("notification_settings", {
   // notify me when a friend shares a new photo post.
   shareWorkoutsToFeed: boolean("share_workouts_to_feed").default(true),
   friendPostsEnabled: boolean("friend_posts_enabled").default(true),
+  // share_route_maps: expose my GPS route maps (workout_routes traces) on my
+  // feed entries/posts. Explicit consent surface — when off, friends see the
+  // cards without the route slide/map.
+  shareRouteMaps: boolean("share_route_maps").default(true),
 });
 
 export const competitions = pgTable(

--- a/backend/src/db/drizzle/schema.ts
+++ b/backend/src/db/drizzle/schema.ts
@@ -196,6 +196,28 @@ export const workouts = pgTable(
   ],
 );
 
+// Simplified GPS trace for a workout, synced from HealthKit when available
+// (outdoor walks/runs). One row per workout; re-syncs replace the trace in
+// place. Points are client-downsampled ([[lat, lng], ...], ~5 decimal places).
+export const workoutRoutes = pgTable(
+  "workout_routes",
+  {
+    workoutId: varchar("workout_id", { length: 255 }).primaryKey().notNull(),
+    route: jsonb().notNull(),
+    pointCount: integer("point_count").notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.workoutId],
+      foreignColumns: [workouts.workoutId],
+      name: "workout_routes_workout_id_fkey",
+    }).onDelete("cascade"),
+  ],
+);
+
 export const notificationSettings = pgTable("notification_settings", {
   userId: text("user_id").primaryKey().notNull(),
   nudgesEnabled: boolean("nudges_enabled").default(true),
@@ -968,6 +990,13 @@ export const posts = pgTable(
       .defaultNow()
       .notNull(),
     deletedAt: timestamp("deleted_at", { withTimezone: true, mode: "string" }),
+    // Auto-generated post (the route/stats card published when the user skips
+    // the photo prompt) vs a deliberate user post. An auto post may be replaced
+    // in place by a user post; a live user post blocks re-posting for the same
+    // workout until it's deleted (one deliberate post per workout).
+    isAuto: boolean("is_auto").default(false).notNull(),
+    // Whether the post surfaces the workout's route map alongside the photo.
+    includeRoute: boolean("include_route").default(true).notNull(),
   },
   (table) => [
     index("idx_posts_user_created").using(

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -37,7 +37,9 @@ const app = express();
 const PORT = parseInt(process.env.PORT ?? "3000");
 
 app.use(compression());
-app.use(express.json());
+// 2mb (default is 100kb): a workout-sync batch can now carry GPS route traces
+// (~3-4KB per workout x 25-workout batches) and must never 413 mid-sync.
+app.use(express.json({ limit: "2mb" }));
 
 // Ensure uploads directories exist
 const uploadsDir = path.join(process.cwd(), "uploads", "profile-images");

--- a/backend/src/services/competitionService.ts
+++ b/backend/src/services/competitionService.ts
@@ -227,6 +227,9 @@ const USERS_AGG_SQL = `
 
 export async function getCompetition(
   competitionId: string,
+  {
+    includeActivityBreakdown = false,
+  }: { includeActivityBreakdown?: boolean } = {},
 ): Promise<Competition> {
   const competition = (
     await db.query(
@@ -248,22 +251,25 @@ export async function getCompetition(
 
   // Calculate scores for started competitions (start_date on or before today in ET)
   if (competition.start_date && competition.start_date <= getTodayET()) {
+    // Per-day walk/run breakdown (distance + workout counts) for the detail
+    // view's stats panel and calendar — opt-in because getCompetition is also
+    // on hot paths (nudges, flexes, cron resolution) that never read it.
+    // Steps comps don't read workouts, so they never get one.
+    const withBreakdown =
+      includeActivityBreakdown && competition.options?.unit !== "steps";
     const acceptedIds = competition.users
       .filter((u: CompetitionUser) => u.invite_status === "accepted")
       .map((u: CompetitionUser) => u.user_id);
-    // Per-day walk/run breakdown (distance + workout counts) for the detail
-    // view's stats panel and calendar. Steps comps don't read workouts.
-    const isStepUnit = competition.options?.unit === "steps";
     const [userScores, breakdownRows] = await Promise.all([
       getUserScores(competition),
-      isStepUnit
-        ? Promise.resolve([])
-        : getActivityBreakdownBatch(
+      withBreakdown
+        ? getActivityBreakdownBatch(
             acceptedIds,
             competition.start_date,
             competition.end_date ?? undefined,
             competition.workouts,
-          ),
+          )
+        : Promise.resolve([]),
     ]);
     const activityByUser: Record<
       string,
@@ -280,9 +286,9 @@ export async function getCompetition(
     competition.users = competition.users.map((user: CompetitionUser) => ({
       ...user,
       ...userScores[user.user_id],
-      ...(isStepUnit
-        ? {}
-        : { daily_activity: activityByUser[user.user_id] ?? {} }),
+      ...(withBreakdown
+        ? { daily_activity: activityByUser[user.user_id] ?? {} }
+        : {}),
     }));
   }
 

--- a/backend/src/services/competitionService.ts
+++ b/backend/src/services/competitionService.ts
@@ -9,6 +9,7 @@ import {
 import { PostgresService } from "./DbService.js";
 import {
   getQuantityDateRangeBatch,
+  getActivityBreakdownBatch,
   getUsersWithManualWorkouts,
 } from "./workoutService.js";
 import { getStepsDateRangeBatch } from "./dailyStepsService.js";
@@ -247,10 +248,41 @@ export async function getCompetition(
 
   // Calculate scores for started competitions (start_date on or before today in ET)
   if (competition.start_date && competition.start_date <= getTodayET()) {
-    const userScores = await getUserScores(competition);
+    const acceptedIds = competition.users
+      .filter((u: CompetitionUser) => u.invite_status === "accepted")
+      .map((u: CompetitionUser) => u.user_id);
+    // Per-day walk/run breakdown (distance + workout counts) for the detail
+    // view's stats panel and calendar. Steps comps don't read workouts.
+    const isStepUnit = competition.options?.unit === "steps";
+    const [userScores, breakdownRows] = await Promise.all([
+      getUserScores(competition),
+      isStepUnit
+        ? Promise.resolve([])
+        : getActivityBreakdownBatch(
+            acceptedIds,
+            competition.start_date,
+            competition.end_date ?? undefined,
+            competition.workouts,
+          ),
+    ]);
+    const activityByUser: Record<
+      string,
+      NonNullable<CompetitionUser["daily_activity"]>
+    > = {};
+    for (const row of breakdownRows) {
+      const byDate = (activityByUser[row.user_id] ??= {});
+      const byType = (byDate[row.local_date] ??= {});
+      byType[row.workout_type] = {
+        distance: Number(row.total_distance),
+        count: Number(row.workout_count),
+      };
+    }
     competition.users = competition.users.map((user: CompetitionUser) => ({
       ...user,
       ...userScores[user.user_id],
+      ...(isStepUnit
+        ? {}
+        : { daily_activity: activityByUser[user.user_id] ?? {} }),
     }));
   }
 

--- a/backend/src/services/friendshipService.ts
+++ b/backend/src/services/friendshipService.ts
@@ -1,5 +1,6 @@
 import { Friendship, User } from "../types/user.js";
 import { PostgresService } from "./DbService.js";
+import { mileHypeKeyMatchSql } from "./hypeService.js";
 
 const db = PostgresService.getInstance();
 
@@ -362,20 +363,20 @@ export async function getFriendsWorkoutFeed(
 			w.steps,
 			(w.user_id = $1) AS is_self,
 			-- Mile hypes are keyed by workout_id (feed) or user:local_date
-			-- (notifications) — match both so the surfaces stay in sync.
+			-- (notifications) — match both so the surfaces stay in sync, and
+			-- count DISTINCT senders so dual-keyed legacy pairs count once.
 			EXISTS (
 				SELECT 1 FROM hype_log h
 				WHERE h.sender_id = $1
 					AND h.target_id = w.user_id
 					AND h.context_type = 'mile'
-					AND (h.context_id = w.workout_id
-						OR h.context_id = (w.user_id || ':' || w.local_date::text))
+					AND ${mileHypeKeyMatchSql("h", "w")}
 			) AS is_hyped,
 			(
-				SELECT COUNT(*)::int FROM hype_log hc
+				SELECT COUNT(DISTINCT hc.sender_id)::int FROM hype_log hc
 				WHERE hc.context_type = 'mile'
-					AND (hc.context_id = w.workout_id
-						OR hc.context_id = (w.user_id || ':' || w.local_date::text))
+					AND hc.target_id = w.user_id
+					AND ${mileHypeKeyMatchSql("hc", "w")}
 			) AS hype_count
 		FROM workouts w
 		JOIN circle c ON c.uid = w.user_id

--- a/backend/src/services/friendshipService.ts
+++ b/backend/src/services/friendshipService.ts
@@ -381,8 +381,12 @@ export async function getFriendsWorkoutFeed(
 		FROM workouts w
 		JOIN circle c ON c.uid = w.user_id
 		JOIN users u ON u.user_id = w.user_id
+		LEFT JOIN notification_settings ns ON ns.user_id = w.user_id
 		WHERE w.device_end_date >= NOW() - INTERVAL '48 hours'
 		AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL
+		-- Respect the owner's share_workouts_to_feed opt-out on this legacy
+		-- feed too, not just the unified feed (the viewer still sees their own).
+		AND (COALESCE(ns.share_workouts_to_feed, true) = true OR w.user_id = $1)
 		ORDER BY w.device_end_date DESC
 		LIMIT 100
 		`,

--- a/backend/src/services/friendshipService.ts
+++ b/backend/src/services/friendshipService.ts
@@ -361,17 +361,21 @@ export async function getFriendsWorkoutFeed(
 			w.calories::float AS calories,
 			w.steps,
 			(w.user_id = $1) AS is_self,
+			-- Mile hypes are keyed by workout_id (feed) or user:local_date
+			-- (notifications) — match both so the surfaces stay in sync.
 			EXISTS (
 				SELECT 1 FROM hype_log h
 				WHERE h.sender_id = $1
 					AND h.target_id = w.user_id
 					AND h.context_type = 'mile'
-					AND h.context_id = w.workout_id
+					AND (h.context_id = w.workout_id
+						OR h.context_id = (w.user_id || ':' || w.local_date::text))
 			) AS is_hyped,
 			(
 				SELECT COUNT(*)::int FROM hype_log hc
 				WHERE hc.context_type = 'mile'
-					AND hc.context_id = w.workout_id
+					AND (hc.context_id = w.workout_id
+						OR hc.context_id = (w.user_id || ':' || w.local_date::text))
 			) AS hype_count
 		FROM workouts w
 		JOIN circle c ON c.uid = w.user_id

--- a/backend/src/services/hypeService.ts
+++ b/backend/src/services/hypeService.ts
@@ -122,6 +122,63 @@ export async function logHypeIfUnderLimit(
   return rows[0] ?? null;
 }
 
+// A 'mile' hype's canonical context id: `<userId>:<YYYY-MM-DD>` — one hype per
+// friend's daily mile, regardless of which surface it was sent from.
+const MILE_COMPOSITE_RE = /:(\d{4}-\d{2}-\d{2})$/;
+
+/**
+ * Canonicalize a 'mile' hype context. The feed historically keys mile hypes by
+ * workout_id while the notifications inbox keys them by `<userId>:<localDate>`;
+ * we resolve a workout_id to the composite form so both surfaces write (and
+ * dedupe on) the same key. Unresolvable ids pass through unchanged.
+ */
+export async function canonicalizeMileContext(
+  targetId: string,
+  context: HypeContext,
+): Promise<HypeContext> {
+  if (context.contextType !== "mile") return context;
+  if (MILE_COMPOSITE_RE.test(context.contextId)) return context;
+  const rows = await db.query<{ local_date: string }>(
+    `SELECT local_date::text AS local_date FROM workouts
+		WHERE workout_id = $1 AND user_id = $2`,
+    [context.contextId, targetId],
+  );
+  const localDate = rows[0]?.local_date;
+  if (!localDate) return context;
+  return { ...context, contextId: `${targetId}:${localDate}` };
+}
+
+/**
+ * Dedupe check for 'mile' contexts that spans BOTH key forms: the canonical
+ * `<userId>:<localDate>` composite and legacy rows keyed by any of the target's
+ * workout ids on that date.
+ */
+export async function hasHypedMile(
+  senderId: string,
+  targetId: string,
+  contextId: string,
+): Promise<boolean> {
+  const match = MILE_COMPOSITE_RE.exec(contextId);
+  if (!match) {
+    return hasHypedContext(senderId, targetId, "mile", contextId);
+  }
+  const localDate = match[1];
+  const rows = await db.query<{ exists: boolean }>(
+    `SELECT EXISTS (
+			SELECT 1 FROM hype_log h
+			WHERE h.sender_id = $1 AND h.target_id = $2
+				AND h.context_type = 'mile'
+				AND (h.context_id = $3
+					OR h.context_id IN (
+						SELECT w.workout_id FROM workouts w
+						WHERE w.user_id = $2 AND w.local_date = $4::date
+					))
+		) AS exists`,
+    [senderId, targetId, contextId, localDate],
+  );
+  return rows[0]?.exists === true;
+}
+
 /**
  * Returns true if the sender has already hyped this exact context.
  * Only meaningful when context is provided; legacy NULL-context hypes are not deduped.

--- a/backend/src/services/hypeService.ts
+++ b/backend/src/services/hypeService.ts
@@ -147,6 +147,15 @@ export function mileHypeKeyMatchSql(
  * client can't write a key that pollutes another user's counts. Unresolvable
  * ids pass through unchanged.
  */
+/** True when the string is a real calendar date, not just \d{4}-\d{2}-\d{2}. */
+function isRealDate(value: string): boolean {
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return (
+    !Number.isNaN(parsed.getTime()) &&
+    parsed.toISOString().slice(0, 10) === value
+  );
+}
+
 export async function canonicalizeMileContext(
   targetId: string,
   context: HypeContext,
@@ -154,6 +163,11 @@ export async function canonicalizeMileContext(
   if (context.contextType !== "mile") return context;
   const composite = MILE_COMPOSITE_RE.exec(context.contextId);
   if (composite) {
+    // Shape-valid but impossible dates ('9999-99-99') would blow up the
+    // ::date casts downstream — treat them as invalid context.
+    if (!isRealDate(composite[1])) {
+      throw new Error("invalid_mile_context");
+    }
     return { ...context, contextId: `${targetId}:${composite[1]}` };
   }
   const rows = await db.query<{ local_date: string }>(

--- a/backend/src/services/hypeService.ts
+++ b/backend/src/services/hypeService.ts
@@ -127,17 +127,35 @@ export async function logHypeIfUnderLimit(
 const MILE_COMPOSITE_RE = /:(\d{4}-\d{2}-\d{2})$/;
 
 /**
+ * SQL fragment matching a mile hype row against a workout row by EITHER key
+ * form: the legacy workout_id or the canonical user:local_date composite.
+ * Owns the composite encoding so read sites can't drift from the write side.
+ */
+export function mileHypeKeyMatchSql(
+  hypeAlias: string,
+  workoutAlias: string,
+): string {
+  return `(${hypeAlias}.context_id = ${workoutAlias}.workout_id
+		OR ${hypeAlias}.context_id = (${workoutAlias}.user_id || ':' || ${workoutAlias}.local_date::text))`;
+}
+
+/**
  * Canonicalize a 'mile' hype context. The feed historically keys mile hypes by
  * workout_id while the notifications inbox keys them by `<userId>:<localDate>`;
  * we resolve a workout_id to the composite form so both surfaces write (and
- * dedupe on) the same key. Unresolvable ids pass through unchanged.
+ * dedupe on) the same key. A composite id is re-prefixed with the target so a
+ * client can't write a key that pollutes another user's counts. Unresolvable
+ * ids pass through unchanged.
  */
 export async function canonicalizeMileContext(
   targetId: string,
   context: HypeContext,
 ): Promise<HypeContext> {
   if (context.contextType !== "mile") return context;
-  if (MILE_COMPOSITE_RE.test(context.contextId)) return context;
+  const composite = MILE_COMPOSITE_RE.exec(context.contextId);
+  if (composite) {
+    return { ...context, contextId: `${targetId}:${composite[1]}` };
+  }
   const rows = await db.query<{ local_date: string }>(
     `SELECT local_date::text AS local_date FROM workouts
 		WHERE workout_id = $1 AND user_id = $2`,
@@ -146,6 +164,27 @@ export async function canonicalizeMileContext(
   const localDate = rows[0]?.local_date;
   if (!localDate) return context;
   return { ...context, contextId: `${targetId}:${localDate}` };
+}
+
+/**
+ * Of the given canonical `<userId>:<localDate>` mile keys, the ones this
+ * sender has already hyped under the LEGACY workout_id form — maps old
+ * feed-sent hype rows onto canonical keys for batch is_hyped checks.
+ */
+export async function getLegacyHypedMileKeys(
+  senderId: string,
+  compositeKeys: string[],
+): Promise<{ target_id: string; key: string }[]> {
+  if (compositeKeys.length === 0) return [];
+  return db.query<{ target_id: string; key: string }>(
+    `SELECT h.target_id, (w.user_id || ':' || w.local_date::text) AS key
+		FROM hype_log h
+		JOIN workouts w ON w.workout_id = h.context_id
+		WHERE h.sender_id = $1
+			AND h.context_type = 'mile'
+			AND (w.user_id || ':' || w.local_date::text) = ANY($2::text[])`,
+    [senderId, compositeKeys],
+  );
 }
 
 /**

--- a/backend/src/services/notificationSettingsService.ts
+++ b/backend/src/services/notificationSettingsService.ts
@@ -21,6 +21,7 @@ export interface NotificationPreferences {
   timezone_offset_minutes: number | null; // user's current UTC offset in minutes
   share_workouts_to_feed: boolean; // include my raw walks/runs in friends' feed
   friend_posts_enabled: boolean; // notify me when a friend shares a new post
+  share_route_maps: boolean; // show my GPS route maps on my feed entries/posts
 }
 
 const DEFAULT_PREFERENCES: NotificationPreferences = {
@@ -40,6 +41,7 @@ const DEFAULT_PREFERENCES: NotificationPreferences = {
   timezone_offset_minutes: null,
   share_workouts_to_feed: true,
   friend_posts_enabled: true,
+  share_route_maps: true,
 };
 
 export async function getNotificationPreferences(
@@ -70,6 +72,7 @@ export async function getNotificationPreferences(
     timezone_offset_minutes: row.timezone_offset_minutes ?? null,
     share_workouts_to_feed: row.share_workouts_to_feed ?? true,
     friend_posts_enabled: row.friend_posts_enabled ?? true,
+    share_route_maps: row.share_route_maps ?? true,
   };
 }
 
@@ -112,6 +115,7 @@ export async function updateNotificationPreferences(
     { key: "timezone_offset_minutes", value: prefs.timezone_offset_minutes },
     { key: "share_workouts_to_feed", value: prefs.share_workouts_to_feed },
     { key: "friend_posts_enabled", value: prefs.friend_posts_enabled },
+    { key: "share_route_maps", value: prefs.share_route_maps },
   ];
 
   for (const field of fields) {

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -51,6 +51,10 @@ export interface PostRow {
   is_hyped: boolean;
   hype_count: number;
   is_viewed?: boolean;
+  // Microsecond-precise created_at (Postgres text form) for keyset pagination.
+  // node-pg parses timestamptz to a ms-truncated JS Date, and a truncated
+  // `before` cursor silently skips same-millisecond rows at page boundaries.
+  cursor?: string;
 }
 
 export interface StoryGroup {
@@ -100,8 +104,10 @@ const POST_SELECT = `${POST_COLUMNS},
 			AND h.context_id = p.post_id::text
 	) AS is_hyped,
 	(
-		SELECT COUNT(*)::int FROM hype_log hc
-		WHERE hc.context_type = 'post' AND hc.context_id = p.post_id::text
+		SELECT COUNT(DISTINCT hc.sender_id)::int FROM hype_log hc
+		WHERE hc.context_type = 'post'
+			AND hc.target_id = p.user_id
+			AND hc.context_id = p.post_id::text
 	) AS hype_count`;
 
 export interface CreatePostInput {
@@ -330,16 +336,51 @@ export async function getUserActiveStories(
   return rows;
 }
 
-/** Record that the viewer saw a story. Idempotent. */
+/**
+ * Record that the viewer saw a story. Idempotent, and guarded: only records a
+ * view for an ACTIVE story the viewer is actually allowed to see (author, or
+ * an accepted friend of the author with no block either way) — otherwise a
+ * relayed post id could inject a stranger into the author's "Seen by" list.
+ */
 export async function markStoryViewed(
   viewerId: string,
   postId: string,
 ): Promise<void> {
   await db.query(
-    `INSERT INTO story_views (post_id, viewer_id) VALUES ($1, $2)
+    `INSERT INTO story_views (post_id, viewer_id)
+		 SELECT p.post_id, $2
+		 FROM posts p
+		 WHERE p.post_id = $1
+			 AND p.share_to_story
+			 AND p.deleted_at IS NULL
+			 AND p.story_expires_at > NOW()
+			 AND (
+				 p.user_id = $2
+				 OR EXISTS (
+					 SELECT 1 FROM friendships f
+					 WHERE f.user_id = p.user_id AND f.friend_id = $2 AND f.status = 'accepted'
+				 )
+			 )
+			 AND NOT EXISTS (
+				 SELECT 1 FROM user_blocks b
+				 WHERE (b.blocker_id = p.user_id AND b.blocked_id = $2)
+						OR (b.blocker_id = $2 AND b.blocked_id = p.user_id)
+			 )
 		 ON CONFLICT (post_id, viewer_id) DO NOTHING`,
     [postId, viewerId],
   );
+}
+
+/** Whether the workout exists and belongs to the user (post-link guard). */
+export async function userOwnsWorkout(
+  userId: string,
+  workoutId: string,
+): Promise<boolean> {
+  const rows = await db.query(
+    `SELECT 1 FROM workouts WHERE workout_id = $1 AND user_id = $2`,
+    [workoutId, userId],
+  );
+  return rows.length > 0;
 }
 
 /** One row in a story's "seen by" list, with any emoji reaction. */
@@ -510,7 +551,8 @@ export async function getFeed(
   const rows = await db.query<PostRow>(
     `
 		${CIRCLE_CTE}
-		SELECT ${POST_SELECT}
+		SELECT ${POST_SELECT},
+			p.created_at::text AS cursor
 		FROM posts p
 		JOIN circle c ON c.uid = p.user_id
 		JOIN users u ON u.user_id = p.user_id
@@ -559,6 +601,8 @@ export interface FeedEntryRow {
   is_self: boolean;
   is_hyped: boolean;
   hype_count: number;
+  // Microsecond-precise sort_ts (Postgres text form) for keyset pagination.
+  cursor?: string;
 }
 
 /**
@@ -576,13 +620,15 @@ export async function getUnifiedFeed(
   const rows = await db.query<FeedEntryRow>(
     `
 		${CIRCLE_CTE}
-		SELECT * FROM (
+		SELECT feed.*, feed.sort_ts::text AS cursor FROM (
 			SELECT
 				'post' AS kind,
 				p.post_id::text AS id,
 				p.created_at AS sort_ts,
 				p.user_id, u.username, u.first_name, u.last_name, u.profile_image_url,
 				p.media_url, p.caption, p.stats_snapshot,
+				-- Story photos are a 24h moment: once expired they must stop
+				-- riding along on the permanent feed card.
 				(
 					SELECT p3.media_url FROM posts p3
 					WHERE p.workout_id IS NOT NULL
@@ -591,6 +637,7 @@ export async function getUnifiedFeed(
 						AND p3.post_id <> p.post_id
 						AND p3.deleted_at IS NULL
 						AND p3.share_to_story AND NOT p3.share_to_feed
+						AND p3.story_expires_at > NOW()
 					ORDER BY p3.created_at DESC
 					LIMIT 1
 				) AS story_photo_url,
@@ -614,8 +661,10 @@ export async function getUnifiedFeed(
 					WHERE h.sender_id = $1 AND h.target_id = p.user_id
 						AND h.context_type = 'post' AND h.context_id = p.post_id::text
 				) AS is_hyped,
-				(SELECT COUNT(*)::int FROM hype_log hc
-					WHERE hc.context_type = 'post' AND hc.context_id = p.post_id::text) AS hype_count
+				(SELECT COUNT(DISTINCT hc.sender_id)::int FROM hype_log hc
+					WHERE hc.context_type = 'post'
+						AND hc.target_id = p.user_id
+						AND hc.context_id = p.post_id::text) AS hype_count
 			FROM posts p
 			JOIN circle c ON c.uid = p.user_id
 			JOIN users u ON u.user_id = p.user_id
@@ -693,7 +742,8 @@ export async function getUserPosts(
   const rows = await db.query<PostRow>(
     `
 		${CIRCLE_CTE}
-		SELECT ${POST_SELECT}
+		SELECT ${POST_SELECT},
+			p.created_at::text AS cursor
 		FROM posts p
 		JOIN users u ON u.user_id = p.user_id
 		WHERE p.user_id = $2

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -602,8 +602,11 @@ export async function getUnifiedFeed(
 				NULL::integer AS steps,
 				-- Auto posts' media already IS the rendered route card, so shipping
 				-- the polyline too would only duplicate pixels and bloat the page.
+				-- Gated on the author's global "Share route maps" consent setting
+				-- on top of the per-post include_route choice.
 				(SELECT wr.route FROM workout_routes wr
 					WHERE p.include_route AND NOT p.is_auto
+						AND (COALESCE(nsp.share_route_maps, true) OR p.user_id = $1)
 						AND wr.workout_id = p.workout_id) AS route,
 				(p.user_id = $1) AS is_self,
 				EXISTS (
@@ -616,6 +619,7 @@ export async function getUnifiedFeed(
 			FROM posts p
 			JOIN circle c ON c.uid = p.user_id
 			JOIN users u ON u.user_id = p.user_id
+			LEFT JOIN notification_settings nsp ON nsp.user_id = p.user_id
 			WHERE p.share_to_feed AND p.deleted_at IS NULL
 				AND p.user_id NOT IN (SELECT uid FROM blocked)
 
@@ -634,7 +638,11 @@ export async function getUnifiedFeed(
 				w.total_duration::double precision,
 				w.calories::double precision,
 				w.steps,
-				(SELECT wr.route FROM workout_routes wr WHERE wr.workout_id = w.workout_id) AS route,
+				-- Raw workout routes respect the owner's "Share route maps" setting
+				-- (the owner always sees their own).
+				(SELECT wr.route FROM workout_routes wr
+					WHERE (COALESCE(ns.share_route_maps, true) OR w.user_id = $1)
+						AND wr.workout_id = w.workout_id) AS route,
 				(w.user_id = $1) AS is_self,
 				-- Mile hypes are keyed two ways historically: by workout_id (feed)
 				-- and by user:local_date (notifications). Match both so a hype from

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -43,6 +43,10 @@ export interface PostRow {
   share_to_story: boolean;
   story_expires_at: string | null;
   created_at: string;
+  is_auto: boolean;
+  include_route: boolean;
+  workout_type: string | null;
+  route: [number, number][] | null;
   is_self: boolean;
   is_hyped: boolean;
   hype_count: number;
@@ -78,6 +82,11 @@ const POST_SELECT = `
 	p.share_to_story,
 	p.story_expires_at,
 	p.created_at,
+	p.is_auto,
+	p.include_route,
+	(SELECT w.workout_type FROM workouts w WHERE w.workout_id = p.workout_id) AS workout_type,
+	(SELECT wr.route FROM workout_routes wr
+		WHERE p.include_route AND wr.workout_id = p.workout_id) AS route,
 	(p.user_id = $1) AS is_self,
 	EXISTS (
 		SELECT 1 FROM hype_log h
@@ -100,11 +109,37 @@ export interface CreatePostInput {
   shareToFeed: boolean;
   shareToStory: boolean;
   statsSnapshot?: PostStatsSnapshot | null;
+  // Tri-state: true = system auto post (route/stats card), false = deliberate
+  // user post, undefined = legacy client that didn't send the flag (keeps the
+  // original always-upsert behavior so shipped app versions don't break).
+  isAuto?: boolean;
+  includeRoute?: boolean;
 }
+
+// Shape the freshly inserted/updated row like a PostRow (is_self=true).
+const CREATED_POST_SELECT = `
+	SELECT
+		p.post_id, p.user_id, u.username, u.first_name, u.last_name, u.profile_image_url,
+		p.media_url, p.caption, p.workout_id, p.stats_snapshot, p.local_date::text AS local_date,
+		p.share_to_feed, p.share_to_story, p.story_expires_at, p.created_at,
+		p.is_auto, p.include_route,
+		(SELECT w.workout_type FROM workouts w WHERE w.workout_id = p.workout_id) AS workout_type,
+		(SELECT wr.route FROM workout_routes wr
+			WHERE p.include_route AND wr.workout_id = p.workout_id) AS route,
+		true AS is_self, false AS is_hyped, 0 AS hype_count`;
 
 /**
  * Insert a post and return it shaped as a PostRow (is_self=true, no hypes yet).
  * story_expires_at is set to now()+24h only when the post is shared to a story.
+ *
+ * One-post-per-workout rules (per destination — feed and story-only are
+ * separate slots, enforced by partial unique indexes):
+ * - Legacy clients (isAuto undefined) keep the original upsert-in-place.
+ * - An AUTO post fills an empty slot or replaces an existing auto post; it
+ *   never clobbers a deliberate user post (returns the existing post instead).
+ * - A USER post fills an empty slot or replaces the auto post; if a live user
+ *   post already exists for the workout it throws "workout_already_posted" —
+ *   deleting the old post frees the slot again.
  */
 export async function createPost(input: CreatePostInput): Promise<PostRow> {
   // A workout can have ONE live feed post and ONE live story-only photo
@@ -113,16 +148,24 @@ export async function createPost(input: CreatePostInput): Promise<PostRow> {
   const conflictTarget = input.shareToFeed
     ? `(workout_id) WHERE (deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_feed)`
     : `(workout_id) WHERE (deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_story AND NOT share_to_feed)`;
+  // Legacy requests may overwrite anything the caller owns; flagged requests
+  // may only overwrite the slot's AUTO post.
+  const updateGuard =
+    input.isAuto === undefined
+      ? `WHERE posts.user_id = $1`
+      : `WHERE posts.user_id = $1 AND posts.is_auto`;
   const rows = await db.query<PostRow>(
     `
 		WITH inserted AS (
 			INSERT INTO posts (
 				user_id, media_url, caption, workout_id, stats_snapshot,
-				local_date, share_to_feed, share_to_story, story_expires_at
+				local_date, share_to_feed, share_to_story, story_expires_at,
+				is_auto, include_route
 			)
 			VALUES (
 				$1, $2, $3, $4, $5::jsonb, $6::date, $7, $8,
-				CASE WHEN $8 THEN NOW() + INTERVAL '24 hours' ELSE NULL END
+				CASE WHEN $8 THEN NOW() + INTERVAL '24 hours' ELSE NULL END,
+				$9, $10
 			)
 				ON CONFLICT ${conflictTarget}
 				DO UPDATE SET
@@ -131,15 +174,13 @@ export async function createPost(input: CreatePostInput): Promise<PostRow> {
 					stats_snapshot = COALESCE(EXCLUDED.stats_snapshot, posts.stats_snapshot),
 					share_to_feed = EXCLUDED.share_to_feed,
 					share_to_story = EXCLUDED.share_to_story,
-					story_expires_at = CASE WHEN EXCLUDED.share_to_story THEN NOW() + INTERVAL '24 hours' ELSE NULL END
-				WHERE posts.user_id = $1
+					story_expires_at = CASE WHEN EXCLUDED.share_to_story THEN NOW() + INTERVAL '24 hours' ELSE NULL END,
+					is_auto = EXCLUDED.is_auto,
+					include_route = EXCLUDED.include_route
+				${updateGuard}
 			RETURNING *
 		)
-		SELECT
-			p.post_id, p.user_id, u.username, u.first_name, u.last_name, u.profile_image_url,
-			p.media_url, p.caption, p.workout_id, p.stats_snapshot, p.local_date::text AS local_date,
-			p.share_to_feed, p.share_to_story, p.story_expires_at, p.created_at,
-			true AS is_self, false AS is_hyped, 0 AS hype_count
+		${CREATED_POST_SELECT}
 		FROM inserted p
 		JOIN users u ON u.user_id = p.user_id
 		`,
@@ -152,14 +193,30 @@ export async function createPost(input: CreatePostInput): Promise<PostRow> {
       input.localDate,
       input.shareToFeed,
       input.shareToStory,
+      input.isAuto === true,
+      input.includeRoute !== false,
     ],
   );
-  // Zero rows = the workout_id conflicted with a post the caller doesn't own
-  // (the ownership guard on DO UPDATE skipped it) — reject rather than 500.
-  if (!rows[0]) {
-    throw new Error("workout_already_posted");
+  if (rows[0]) return rows[0];
+
+  // Zero rows — the slot is taken and the update guard skipped it. An auto
+  // post quietly yields to the caller's existing user post; anything else
+  // (another user's post, or a second deliberate post) is rejected.
+  if (input.isAuto === true && input.workoutId) {
+    const existing = await db.query<PostRow>(
+      `
+			${CREATED_POST_SELECT}
+			FROM posts p
+			JOIN users u ON u.user_id = p.user_id
+			WHERE p.workout_id = $2 AND p.user_id = $1 AND p.deleted_at IS NULL
+				AND ${input.shareToFeed ? "p.share_to_feed" : "(p.share_to_story AND NOT p.share_to_feed)"}
+			LIMIT 1
+			`,
+      [input.userId, input.workoutId],
+    );
+    if (existing[0]) return existing[0];
   }
-  return rows[0];
+  throw new Error("workout_already_posted");
 }
 
 /**
@@ -367,7 +424,11 @@ export async function reactToStory(
   // Notify only on the FIRST reaction to this story (emoji swaps stay quiet).
   if (inserted[0]?.inserted) {
     try {
-      const shouldSend = await shouldSendNotification(authorId, senderId, "hype");
+      const shouldSend = await shouldSendNotification(
+        authorId,
+        senderId,
+        "hype",
+      );
       if (shouldSend) {
         const sender = await db.query<{ username: string | null }>(
           `SELECT username FROM users WHERE user_id = $1`,
@@ -467,12 +528,17 @@ export interface FeedEntryRow {
   // The run's story-only photo (if one exists) so the feed card can offer a
   // photo/route flip without duplicating the run in the feed.
   story_photo_url: string | null;
-  // workout-only
+  // post-only: system-generated route/stats card vs deliberate user post.
+  is_auto: boolean | null;
+  // workout columns (also populated for posts via their linked workout)
   workout_type: string | null;
   distance: number | null;
   total_duration: number | null;
   calories: number | null;
   steps: number | null;
+  // Simplified GPS trace for the entry's workout, when synced (and, for
+  // posts, when the author chose to include it).
+  route: [number, number][] | null;
   // shared
   is_self: boolean;
   is_hyped: boolean;
@@ -512,11 +578,14 @@ export async function getUnifiedFeed(
 					ORDER BY p3.created_at DESC
 					LIMIT 1
 				) AS story_photo_url,
-				NULL::varchar AS workout_type,
+				p.is_auto,
+				(SELECT w2.workout_type FROM workouts w2 WHERE w2.workout_id = p.workout_id) AS workout_type,
 				NULL::double precision AS distance,
 				NULL::double precision AS total_duration,
 				NULL::double precision AS calories,
 				NULL::integer AS steps,
+				(SELECT wr.route FROM workout_routes wr
+					WHERE p.include_route AND wr.workout_id = p.workout_id) AS route,
 				(p.user_id = $1) AS is_self,
 				EXISTS (
 					SELECT 1 FROM hype_log h
@@ -540,19 +609,28 @@ export async function getUnifiedFeed(
 				w.user_id, u.username, u.first_name, u.last_name, u.profile_image_url,
 				NULL::text AS media_url, NULL::text AS caption, NULL::jsonb AS stats_snapshot,
 				NULL::text AS story_photo_url,
+				NULL::boolean AS is_auto,
 				w.workout_type,
 				w.distance::double precision,
 				w.total_duration::double precision,
 				w.calories::double precision,
 				w.steps,
+				(SELECT wr.route FROM workout_routes wr WHERE wr.workout_id = w.workout_id) AS route,
 				(w.user_id = $1) AS is_self,
+				-- Mile hypes are keyed two ways historically: by workout_id (feed)
+				-- and by user:local_date (notifications). Match both so a hype from
+				-- either surface shows up here.
 				EXISTS (
 					SELECT 1 FROM hype_log h
 					WHERE h.sender_id = $1 AND h.target_id = w.user_id
-						AND h.context_type = 'mile' AND h.context_id = w.workout_id
+						AND h.context_type = 'mile'
+						AND (h.context_id = w.workout_id
+							OR h.context_id = (w.user_id || ':' || w.local_date::text))
 				) AS is_hyped,
 				(SELECT COUNT(*)::int FROM hype_log hc
-					WHERE hc.context_type = 'mile' AND hc.context_id = w.workout_id) AS hype_count
+					WHERE hc.context_type = 'mile'
+						AND (hc.context_id = w.workout_id
+							OR hc.context_id = (w.user_id || ':' || w.local_date::text))) AS hype_count
 			FROM workouts w
 			JOIN circle c ON c.uid = w.user_id
 			JOIN users u ON u.user_id = w.user_id

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -1,6 +1,7 @@
 import { PostgresService } from "./DbService.js";
 import { sendPush } from "./pushNotificationService.js";
 import { shouldSendNotification } from "./notificationSettingsService.js";
+import { mileHypeKeyMatchSql } from "./hypeService.js";
 
 const db = PostgresService.getInstance();
 
@@ -46,7 +47,6 @@ export interface PostRow {
   is_auto: boolean;
   include_route: boolean;
   workout_type: string | null;
-  route: [number, number][] | null;
   is_self: boolean;
   is_hyped: boolean;
   hype_count: number;
@@ -64,9 +64,11 @@ export interface StoryGroup {
   latest_at: string;
 }
 
-// SELECT list shared by feed + story-detail reads so both shapes match PostRow.
-// `$1` must be the viewer id (drives is_self / is_hyped).
-const POST_SELECT = `
+// Base post columns shared by every post-shaped read (viewer-independent).
+// Routes are deliberately NOT here — only the unified feed ships them (the
+// story viewer / memories / profile grid never render a route map, and the
+// jsonb payload is not free).
+const POST_COLUMNS = `
 	p.post_id,
 	p.user_id,
 	u.username,
@@ -84,9 +86,11 @@ const POST_SELECT = `
 	p.created_at,
 	p.is_auto,
 	p.include_route,
-	(SELECT w.workout_type FROM workouts w WHERE w.workout_id = p.workout_id) AS workout_type,
-	(SELECT wr.route FROM workout_routes wr
-		WHERE p.include_route AND wr.workout_id = p.workout_id) AS route,
+	(SELECT w.workout_type FROM workouts w WHERE w.workout_id = p.workout_id) AS workout_type`;
+
+// SELECT list shared by feed + story-detail reads so both shapes match PostRow.
+// `$1` must be the viewer id (drives is_self / is_hyped).
+const POST_SELECT = `${POST_COLUMNS},
 	(p.user_id = $1) AS is_self,
 	EXISTS (
 		SELECT 1 FROM hype_log h
@@ -118,14 +122,7 @@ export interface CreatePostInput {
 
 // Shape the freshly inserted/updated row like a PostRow (is_self=true).
 const CREATED_POST_SELECT = `
-	SELECT
-		p.post_id, p.user_id, u.username, u.first_name, u.last_name, u.profile_image_url,
-		p.media_url, p.caption, p.workout_id, p.stats_snapshot, p.local_date::text AS local_date,
-		p.share_to_feed, p.share_to_story, p.story_expires_at, p.created_at,
-		p.is_auto, p.include_route,
-		(SELECT w.workout_type FROM workouts w WHERE w.workout_id = p.workout_id) AS workout_type,
-		(SELECT wr.route FROM workout_routes wr
-			WHERE p.include_route AND wr.workout_id = p.workout_id) AS route,
+	SELECT ${POST_COLUMNS},
 		true AS is_self, false AS is_hyped, 0 AS hype_count`;
 
 /**
@@ -148,12 +145,33 @@ export async function createPost(input: CreatePostInput): Promise<PostRow> {
   const conflictTarget = input.shareToFeed
     ? `(workout_id) WHERE (deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_feed)`
     : `(workout_id) WHERE (deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_story AND NOT share_to_feed)`;
+  // Legacy clients (still in the wild) don't send is_auto, but their auto
+  // route/stats cards must stay replaceable by an updated device's photo post.
+  // Classify legacy inserts with the same signature the 0008 backfill used:
+  // a caption-less, feed-only post with a stats snapshot is the auto card.
+  // A misfire only makes a caption-less legacy photo replaceable — which is
+  // exactly the pre-flag behavior those clients already have.
+  const legacyLooksAuto =
+    input.caption == null &&
+    input.statsSnapshot != null &&
+    input.shareToFeed &&
+    !input.shareToStory;
+  const isAutoValue =
+    input.isAuto === undefined ? legacyLooksAuto : input.isAuto === true;
   // Legacy requests may overwrite anything the caller owns; flagged requests
   // may only overwrite the slot's AUTO post.
   const updateGuard =
     input.isAuto === undefined
       ? `WHERE posts.user_id = $1`
       : `WHERE posts.user_id = $1 AND posts.is_auto`;
+  // Legacy clients never sent the flags, so their upserts must not clobber a
+  // stored is_auto/include_route (e.g. resetting a route opt-out to true).
+  const flagUpdates =
+    input.isAuto === undefined
+      ? ""
+      : `,
+					is_auto = EXCLUDED.is_auto,
+					include_route = EXCLUDED.include_route`;
   const rows = await db.query<PostRow>(
     `
 		WITH inserted AS (
@@ -174,9 +192,7 @@ export async function createPost(input: CreatePostInput): Promise<PostRow> {
 					stats_snapshot = COALESCE(EXCLUDED.stats_snapshot, posts.stats_snapshot),
 					share_to_feed = EXCLUDED.share_to_feed,
 					share_to_story = EXCLUDED.share_to_story,
-					story_expires_at = CASE WHEN EXCLUDED.share_to_story THEN NOW() + INTERVAL '24 hours' ELSE NULL END,
-					is_auto = EXCLUDED.is_auto,
-					include_route = EXCLUDED.include_route
+					story_expires_at = CASE WHEN EXCLUDED.share_to_story THEN NOW() + INTERVAL '24 hours' ELSE NULL END${flagUpdates}
 				${updateGuard}
 			RETURNING *
 		)
@@ -193,7 +209,7 @@ export async function createPost(input: CreatePostInput): Promise<PostRow> {
       input.localDate,
       input.shareToFeed,
       input.shareToStory,
-      input.isAuto === true,
+      isAutoValue,
       input.includeRoute !== false,
     ],
   );
@@ -584,8 +600,11 @@ export async function getUnifiedFeed(
 				NULL::double precision AS total_duration,
 				NULL::double precision AS calories,
 				NULL::integer AS steps,
+				-- Auto posts' media already IS the rendered route card, so shipping
+				-- the polyline too would only duplicate pixels and bloat the page.
 				(SELECT wr.route FROM workout_routes wr
-					WHERE p.include_route AND wr.workout_id = p.workout_id) AS route,
+					WHERE p.include_route AND NOT p.is_auto
+						AND wr.workout_id = p.workout_id) AS route,
 				(p.user_id = $1) AS is_self,
 				EXISTS (
 					SELECT 1 FROM hype_log h
@@ -619,18 +638,18 @@ export async function getUnifiedFeed(
 				(w.user_id = $1) AS is_self,
 				-- Mile hypes are keyed two ways historically: by workout_id (feed)
 				-- and by user:local_date (notifications). Match both so a hype from
-				-- either surface shows up here.
+				-- either surface shows up here; DISTINCT sender so a pre-migration
+				-- pair of dual-keyed rows from one person counts once.
 				EXISTS (
 					SELECT 1 FROM hype_log h
 					WHERE h.sender_id = $1 AND h.target_id = w.user_id
 						AND h.context_type = 'mile'
-						AND (h.context_id = w.workout_id
-							OR h.context_id = (w.user_id || ':' || w.local_date::text))
+						AND ${mileHypeKeyMatchSql("h", "w")}
 				) AS is_hyped,
-				(SELECT COUNT(*)::int FROM hype_log hc
+				(SELECT COUNT(DISTINCT hc.sender_id)::int FROM hype_log hc
 					WHERE hc.context_type = 'mile'
-						AND (hc.context_id = w.workout_id
-							OR hc.context_id = (w.user_id || ':' || w.local_date::text))) AS hype_count
+						AND hc.target_id = w.user_id
+						AND ${mileHypeKeyMatchSql("hc", "w")}) AS hype_count
 			FROM workouts w
 			JOIN circle c ON c.uid = w.user_id
 			JOIN users u ON u.user_id = w.user_id

--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -518,6 +518,36 @@ export async function getTodayStats(userId: string): Promise<TodayStats> {
   };
 }
 
+// Shared normalization for the date-range aggregation queries below: clamp the
+// range to calendar dates (default end = today) and map competition activity
+// aliases (run/walk) onto stored workout_type values. ONE definition so the
+// scoring sum, the per-type breakdown, and the single-user variant can never
+// disagree on what counts.
+function normalizeDateRange(
+  startDate: string,
+  endDate?: string,
+): { start: string; end: string } {
+  const todaysDate = new Date().toISOString().split("T")[0];
+  return {
+    start: new Date(startDate).toISOString().split("T")[0],
+    end: endDate ? new Date(endDate).toISOString().split("T")[0] : todaysDate,
+  };
+}
+
+function normalizeWorkoutTypes(
+  workoutTypes?: ("running" | "walking")[],
+): string[] {
+  const typeMap: Record<string, "running" | "walking"> = {
+    run: "running",
+    walk: "walking",
+    running: "running",
+    walking: "walking",
+  };
+  return (workoutTypes ?? ["running", "walking"])
+    .map((t) => typeMap[t])
+    .filter(Boolean);
+}
+
 export async function getQuantityDateRange(
   userId: string,
   startDate: string,
@@ -538,21 +568,8 @@ export async function getQuantityDateRange(
 		ORDER BY local_date ASC
 	`;
 
-  const todaysDate = new Date().toISOString().split("T")[0];
-  const start = new Date(startDate).toISOString().split("T")[0];
-  const end = endDate
-    ? new Date(endDate).toISOString().split("T")[0]
-    : todaysDate;
-
-  const typeMap: Record<string, "running" | "walking"> = {
-    run: "running",
-    walk: "walking",
-    running: "running",
-    walking: "walking",
-  };
-  const normalizedTypes = (workoutTypes ?? ["running", "walking"])
-    .map((t) => typeMap[t])
-    .filter(Boolean);
+  const { start, end } = normalizeDateRange(startDate, endDate);
+  const normalizedTypes = normalizeWorkoutTypes(workoutTypes);
 
   return await db.query(query, [userId, start, end, normalizedTypes]);
 }
@@ -585,21 +602,8 @@ export async function getQuantityDateRangeBatch(
 		ORDER BY user_id, local_date ASC
 	`;
 
-  const todaysDate = new Date().toISOString().split("T")[0];
-  const start = new Date(startDate).toISOString().split("T")[0];
-  const end = endDate
-    ? new Date(endDate).toISOString().split("T")[0]
-    : todaysDate;
-
-  const typeMap: Record<string, "running" | "walking"> = {
-    run: "running",
-    walk: "walking",
-    running: "running",
-    walking: "walking",
-  };
-  const normalizedTypes = (workoutTypes ?? ["running", "walking"])
-    .map((t) => typeMap[t])
-    .filter(Boolean);
+  const { start, end } = normalizeDateRange(startDate, endDate);
+  const normalizedTypes = normalizeWorkoutTypes(workoutTypes);
 
   return await db.query(query, [userIds, start, end, normalizedTypes]);
 }
@@ -643,21 +647,8 @@ export async function getActivityBreakdownBatch(
 		ORDER BY user_id, local_date ASC
 	`;
 
-  const todaysDate = new Date().toISOString().split("T")[0];
-  const start = new Date(startDate).toISOString().split("T")[0];
-  const end = endDate
-    ? new Date(endDate).toISOString().split("T")[0]
-    : todaysDate;
-
-  const typeMap: Record<string, "running" | "walking"> = {
-    run: "running",
-    walk: "walking",
-    running: "running",
-    walking: "walking",
-  };
-  const normalizedTypes = (workoutTypes ?? ["running", "walking"])
-    .map((t) => typeMap[t])
-    .filter(Boolean);
+  const { start, end } = normalizeDateRange(startDate, endDate);
+  const normalizedTypes = normalizeWorkoutTypes(workoutTypes);
 
   return await db.query(query, [userIds, start, end, normalizedTypes]);
 }

--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -55,12 +55,23 @@ export async function uploadWorkouts(
 			split_pace = EXCLUDED.split_pace
       `;
 
+  const routeQuery = `
+        INSERT INTO workout_routes (workout_id, route, point_count, updated_at)
+        VALUES ($1, $2::jsonb, $3, NOW())
+        ON CONFLICT (workout_id)
+        DO UPDATE SET
+			route = EXCLUDED.route,
+			point_count = EXCLUDED.point_count,
+			updated_at = NOW()
+      `;
+
   await db.transaction(
     workouts.flatMap((workout: Workout) => {
       const speed = classifyWorkoutSpeed(
         workout.distance,
         workout.totalDuration,
       );
+      const route = sanitizeRoute(workout.route);
       return [
         {
           query: workoutQuery,
@@ -90,11 +101,61 @@ export async function uploadWorkouts(
             split.pace,
           ],
         })),
+        ...(route
+          ? [
+              {
+                query: routeQuery,
+                params: [
+                  workout.workoutId,
+                  JSON.stringify(route),
+                  route.length,
+                ],
+              },
+            ]
+          : []),
       ];
     }),
   );
 
   return workouts.map((w) => w.workoutId);
+}
+
+// A trace only needs enough fidelity to draw a small map; clients downsample
+// before upload and this is the server-side backstop.
+const MAX_ROUTE_POINTS = 300;
+
+/**
+ * Validate + normalize an uploaded GPS trace. Returns null (skip storage) for
+ * anything that isn't a plausible [[lat, lng], ...] polyline with >= 2 points.
+ * Coordinates are rounded to 5 decimals (~1m) and long traces are downsampled.
+ */
+function sanitizeRoute(route: unknown): [number, number][] | null {
+  if (!Array.isArray(route) || route.length < 2) return null;
+  const points: [number, number][] = [];
+  for (const p of route) {
+    if (!Array.isArray(p) || p.length < 2) return null;
+    const lat = Number(p[0]);
+    const lng = Number(p[1]);
+    if (
+      !Number.isFinite(lat) ||
+      !Number.isFinite(lng) ||
+      Math.abs(lat) > 90 ||
+      Math.abs(lng) > 180
+    ) {
+      return null;
+    }
+    points.push([
+      Math.round(lat * 100000) / 100000,
+      Math.round(lng * 100000) / 100000,
+    ]);
+  }
+  if (points.length <= MAX_ROUTE_POINTS) return points;
+  const stride = (points.length - 1) / (MAX_ROUTE_POINTS - 1);
+  const sampled: [number, number][] = [];
+  for (let i = 0; i < MAX_ROUTE_POINTS; i++) {
+    sampled.push(points[Math.round(i * stride)]);
+  }
+  return sampled;
 }
 
 /**
@@ -521,6 +582,64 @@ export async function getQuantityDateRangeBatch(
 			AND workout_type = ANY($4::text[])
 			AND deleted_at IS NULL AND exclusion_reason IS NULL
 		GROUP BY user_id, local_date
+		ORDER BY user_id, local_date ASC
+	`;
+
+  const todaysDate = new Date().toISOString().split("T")[0];
+  const start = new Date(startDate).toISOString().split("T")[0];
+  const end = endDate
+    ? new Date(endDate).toISOString().split("T")[0]
+    : todaysDate;
+
+  const typeMap: Record<string, "running" | "walking"> = {
+    run: "running",
+    walk: "walking",
+    running: "running",
+    walking: "walking",
+  };
+  const normalizedTypes = (workoutTypes ?? ["running", "walking"])
+    .map((t) => typeMap[t])
+    .filter(Boolean);
+
+  return await db.query(query, [userIds, start, end, normalizedTypes]);
+}
+
+/**
+ * Per-day, per-workout-type distance + workout counts for a set of users —
+ * powers the competition detail view's walk/run breakdown (stats panel,
+ * calendar day detail). Same filters as getQuantityDateRangeBatch, but keeps
+ * workout_type instead of collapsing it.
+ */
+export async function getActivityBreakdownBatch(
+  userIds: string[],
+  startDate: string,
+  endDate?: string,
+  workoutTypes?: ("running" | "walking")[],
+): Promise<
+  {
+    user_id: string;
+    local_date: string;
+    workout_type: string;
+    total_distance: number;
+    workout_count: number;
+  }[]
+> {
+  if (userIds.length === 0) return [];
+
+  const query = `
+		SELECT
+			user_id,
+			TO_CHAR(local_date, 'YYYY-MM-DD') as local_date,
+			workout_type,
+			SUM(distance) as total_distance,
+			COUNT(*)::int as workout_count
+		FROM workouts
+		WHERE user_id = ANY($1::text[])
+			AND local_date >= $2
+			AND local_date <= $3
+			AND workout_type = ANY($4::text[])
+			AND deleted_at IS NULL AND exclusion_reason IS NULL
+		GROUP BY user_id, local_date, workout_type
 		ORDER BY user_id, local_date ASC
 	`;
 

--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -7,6 +7,27 @@ export async function uploadWorkouts(
   userId: string,
   workouts: Workout[],
 ): Promise<string[]> {
+  // Ownership guard: workout ids are visible to friends in feed payloads, so a
+  // crafted upload could otherwise ON CONFLICT into ANOTHER user's row (and its
+  // splits/route) and corrupt their data. Drop any id already owned by someone
+  // else before building the transaction; the DO UPDATE below is additionally
+  // guarded as a race backstop.
+  if (workouts.length > 0) {
+    const foreign = await db.query<{ workout_id: string }>(
+      `SELECT workout_id FROM workouts
+			WHERE workout_id = ANY($1::text[]) AND user_id <> $2`,
+      [workouts.map((w) => w.workoutId), userId],
+    );
+    if (foreign.length > 0) {
+      const foreignIds = new Set(foreign.map((r) => r.workout_id));
+      console.warn(
+        `[uploadWorkouts] Dropping ${foreign.length} workout(s) owned by another user (uploader ${userId})`,
+      );
+      workouts = workouts.filter((w) => !foreignIds.has(w.workoutId));
+      if (workouts.length === 0) return [];
+    }
+  }
+
   const workoutQuery = `
       INSERT INTO workouts (
         user_id,
@@ -42,6 +63,7 @@ export async function uploadWorkouts(
         -- clear a user soft-delete (deleted_at is intentionally not updated here).
         exclusion_reason = EXCLUDED.exclusion_reason,
         speed_flagged = EXCLUDED.speed_flagged
+      WHERE workouts.user_id = $1
       RETURNING workout_id, (xmax = 0) AS inserted
     `;
 

--- a/backend/src/types/competitions.ts
+++ b/backend/src/types/competitions.ts
@@ -1,37 +1,46 @@
-export type CompetitionActivity = 'running' | 'walking';
+export type CompetitionActivity = "running" | "walking";
 
-export type CompetitionType = 'streaks' | 'apex' | 'clash' | 'targets' | 'race';
+export type CompetitionType = "streaks" | "apex" | "clash" | "targets" | "race";
 
 export interface CompetitionOptions {
-	history?: boolean;
-	interval?: 'day' | 'week' | 'month';
-	goal: number;
-	unit: 'miles' | 'steps';
-	first_to: number;
-	duration_hours?: number;
-	lives?: number;
+  history?: boolean;
+  interval?: "day" | "week" | "month";
+  goal: number;
+  unit: "miles" | "steps";
+  first_to: number;
+  duration_hours?: number;
+  lives?: number;
 }
 
+// Per-day activity split by workout type ("running"/"walking"):
+// { "2026-07-01": { running: { distance: 1.2, count: 1 } } }
+export type DailyActivityBreakdown = {
+  [localDate: string]: {
+    [workoutType: string]: { distance: number; count: number };
+  };
+};
+
 export interface CompetitionUser {
-	competition_id: string;
-	user_id: string;
-	invite_status: string;
-	intervals?: { [intervalKey: string]: number };
-	score?: number;
-	remaining_lives?: number;
-	username?: string;
-	placement?: number;
+  competition_id: string;
+  user_id: string;
+  invite_status: string;
+  intervals?: { [intervalKey: string]: number };
+  score?: number;
+  remaining_lives?: number;
+  username?: string;
+  placement?: number;
+  daily_activity?: DailyActivityBreakdown;
 }
 
 export interface Competition {
-	id: string;
-	competition_name: string;
-	start_date: string | null;
-	end_date: string | null;
-	workouts: CompetitionActivity[];
-	type: CompetitionType;
-	options: CompetitionOptions;
-	owner: string;
-	winner: string | null;
-	users: CompetitionUser[];
+  id: string;
+  competition_name: string;
+  start_date: string | null;
+  end_date: string | null;
+  workouts: CompetitionActivity[];
+  type: CompetitionType;
+  options: CompetitionOptions;
+  owner: string;
+  winner: string | null;
+  users: CompetitionUser[];
 }

--- a/backend/src/types/workouts.ts
+++ b/backend/src/types/workouts.ts
@@ -1,22 +1,24 @@
-export type WorkoutSource = 'healthkit' | 'manual' | 'edited';
+export type WorkoutSource = "healthkit" | "manual" | "edited";
 
 export type Workout = {
-	workoutId: string;
-	distance: number;
-	localDate: string;
-	date: string;
-	timezoneOffset: number;
-	workoutType: string;
-	deviceEndDate: string;
-	calories: number;
-	totalDuration: number;
-	splits: WorkoutSplit[];
-	source?: WorkoutSource;
+  workoutId: string;
+  distance: number;
+  localDate: string;
+  date: string;
+  timezoneOffset: number;
+  workoutType: string;
+  deviceEndDate: string;
+  calories: number;
+  totalDuration: number;
+  splits: WorkoutSplit[];
+  source?: WorkoutSource;
+  // Optional simplified GPS trace ([[lat, lng], ...]) for outdoor walks/runs.
+  route?: [number, number][];
 };
 
 export type WorkoutSplit = {
-	splitNumber: number;
-	distance: number;
-	duration: number;
-	pace: number;
+  splitNumber: number;
+  distance: number;
+  duration: number;
+  pace: number;
 };


### PR DESCRIPTION
# Summary

## Story viewer layout fix
The composer bakes the stats sticker into a 4:5 image, but the story viewer displayed it `scaledToFill` full-screen — on tall phones that crops ~35% of the width, cutting off the sticker and edges (the bug in the screenshot). The viewer now shows the media whole (`scaledToFit`, rounded corners) over a blurred edge-to-edge copy of the same photo, and shows the walk/run icon in the header.

## Hypes: notifications ↔ feed unified
Mile hypes were keyed two different ways — `workout_id` from the feed, `userId:createdAtUTCDate` from the notifications inbox — so a hype sent on one surface never showed on the other (and could be sent twice).
- The server canonicalizes `mile` hype contexts to `userId:localDate` at send time (resolving workout ids via the workouts table). Composite keys are re-prefixed with the target so a crafted key can't inflate another user's counts.
- Feed + friends-feed `is_hyped`/`hype_count` and the inbox `is_hyped` check match **both** legacy key forms via a single shared SQL fragment (`mileHypeKeyMatchSql`), counting DISTINCT senders so pre-existing dual-keyed pairs count once.
- The inbox affordance fixes the UTC off-by-one by preferring the payload's `local_date`, and its queries run in parallel.
- iOS prefers the server-enriched hype context with local derivation as a fallback for older backends.

## GPS route ("mile path") storage + display
- New `workout_routes` table (migration `0008`); the workout upload payload accepts an optional simplified `[[lat, lng]]` trace. iOS fetches `HKWorkoutRoute` data during incremental sync, downsamples to ≤150 points, and uploads it (the historical backfill skips routes). Server sanitizes + caps at 300 points; `express.json` limit raised to 2mb so route-bearing batches can't 413.
- The unified feed returns `route` + `workout_type` for posts (via their linked workout) and raw workout entries. Routes only ship where they render: not for auto posts and not on story/memories/profile responses.
- **Feed cards:** photo + route = swipeable carousel (photo first, route map second); photo only = just the photo; route only (raw workout card) = just the route map.
- **Composer:** "Include route map" per-post toggle (`posts.include_route`), shown only when the workout has a route.

## "Share route maps" setting (new)
Explicit consent surface for route sharing (migration `0009`, `notification_settings.share_route_maps`, default on):
- Toggle lives in Settings → Feed & Stories, synced to the backend with the other preferences.
- When off, the feed never ships that user's route data — raw workout cards AND photo posts — regardless of per-post choices; the owner still sees their own routes.
- The composer hides its per-post route toggle when the master setting is off.

## One post per workout
New `posts.is_auto` column distinguishes the system route/stats card from deliberate posts:
- A user post fills an empty slot or replaces the auto card in place; a **second** deliberate post for the same workout gets 409 `workout_already_posted` — deleting the first frees the slot.
- Auto posts never clobber a user post.
- **Rollout-safe:** migration `0008` backfills `is_auto` for existing auto cards, and unflagged (old-client) posts are classified by the same signature. Legacy requests keep the exact old upsert behavior and never reset a stored route opt-out.

## Feed/story UX
- Tap any feed photo → full-screen lightbox with native pinch-to-zoom, double-tap zoom, pan.
- Walk/run icon on picture posts (own and friends').

## Streak competition stats
Competition detail responses attach `daily_activity` (per-day, per-type distance + workout counts, filtered to the comp's allowed activities; opt-in per call so cron/nudge/flex paths skip it). The Standings tab shows per-player total miles, run/walk count chips, run/walk calendar dots, and per-day walk/run splits in the tapped-day detail — all respecting run-only/walk-only comp settings and small screens.

## Screen polish
- Edit Profile is a full-screen, dark-themed screen (was a light form sheet).
- Profile Posts: rounded thumbs + type badges; tapping opens a scrollable read-only feed of that user's posts with the pinch-zoom lightbox.
- Medal detail vertically centered; post-run leaderboard celebration uses the standard app background.

## Story/feed hardening sweep (full-feature review, all fixed)
**Backend trust boundaries:**
- A crafted sync can no longer overwrite another user's workout/splits/route (`uploadWorkouts` ownership guard); posts can't hijack a friend's workout slot or republish a friend's uploaded photo (`workout_id` + `media_url` ownership checks).
- `markStoryViewed` only records views for active stories the viewer may actually see — no injected "Seen by" rows from relayed post ids.
- Story-only photos stop appearing on the permanent feed card's photo flip after they expire (24h means 24h).
- Post hypes validate the (target, post) pair; hype counts are target-scoped and DISTINCT-sender; malformed ids/dates 404/400 instead of 500; the hype dedupe race returns 409 instead of 500.
- The legacy 48h friends feed now honors `share_workouts_to_feed` too.
- Keyset pagination uses microsecond-precise cursors (same-millisecond rows were silently skipped at page boundaries); upload filenames can't collide.

**iOS lifecycle/state:**
- Story options became a pausing dialog that captures its story — the 5s auto-advance can no longer retarget "Delete story"/"Block" at the *next* story while a menu is open.
- Expired story groups remove their ring instead of flashing black forever; finishing stories grays out the ring immediately.
- First-post terms gate no longer races sheet-over-sheet (could permanently wedge the compose button).
- Optimistic hype can't double-count across a mid-request refresh; nil image URLs show placeholders instead of eternal spinners; the BeReal photo flip resets if the story photo is deleted.
- Sticker drags are relative (no teleport to the touch point); saved sticker stat choices survive days where a stat has no data; memories "1 week/month ago" labels bucket by range.

# Backwards compatibility
- All API changes are additive; legacy clients keep their existing behavior (including old post-upsert semantics).
- Migrations `0008` (table + defaulted columns + is_auto backfill) and `0009` (share_route_maps column). Run `npm run db:migrate` on deploy **before** shipping the iOS build.

# Test plan
- `cd backend && npm run build` ✅, `npx drizzle-kit check` ✅
- Two full multi-agent review passes (diff-level, then whole-feature story/feed sweep); every CONFIRMED finding fixed.
- iOS must be built via Xcode (no CI): verify story viewer (letterboxing, options dialog, ring refresh), feed carousel/lightbox, composer route toggle + "Share route maps" setting, duplicate-post messaging, Edit Profile, profile posts feed, comp standings on iPhone SE width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQh9bdXHFoZag7ehNxh4Ak