### PR TITLE
Hotfix 2: idempotent startup migrations (handles empty bookkeeping) + /status/schema diagnostics

### DIFF
--- a/backend/src/db/runMigrations.ts
+++ b/backend/src/db/runMigrations.ts
@@ -1,80 +1,204 @@
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { migrate } from "drizzle-orm/node-postgres/migrator";
+import { fileURLToPath } from "node:url";
 import { PostgresService } from "../services/DbService.js";
 
 // Deploys are git-driven with no shell access to the host, so the server owns
-// its own schema migrations: any journal entry not yet recorded in
-// drizzle.__drizzle_migrations is applied at boot, before traffic is accepted.
-// Idempotent — an already-migrated database is a fast no-op.
-const MIGRATIONS_DIR = path.join(process.cwd(), "src", "db", "drizzle");
+// its own schema migrations: at boot, every journal entry not yet recorded in
+// drizzle.__drizzle_migrations is applied, before traffic is accepted.
+//
+// The applier is a statement-level idempotent catch-up, NOT drizzle's strict
+// migrator, because production's bookkeeping state is unknowable (it may be
+// empty, partial, or current — nobody has ever been able to run `db:migrate`
+// there). Each migration runs in a transaction with a savepoint per statement;
+// a statement failing with an "already exists" error class is skipped (that
+// object predates the bookkeeping), anything else aborts the migration. This
+// converges ANY additive-schema state onto the journal without ever touching
+// data it shouldn't.
+//
+// Bookkeeping stays byte-compatible with drizzle-kit migrate (same table, the
+// hash is sha256 of the .sql file, created_at is the journal `when`).
 
-/**
- * Mirror of scripts/drizzle-baseline.mjs, run automatically when the
- * bookkeeping table is empty: the `0000` migration is the introspection
- * snapshot of the schema that ALREADY exists in production — record it as
- * applied (never execute it) so the migrator starts from `0001`.
- */
-async function baselineIfNeeded(db: PostgresService): Promise<void> {
-  await db.query(`CREATE SCHEMA IF NOT EXISTS "drizzle"`);
-  await db.query(
-    `CREATE TABLE IF NOT EXISTS "drizzle"."__drizzle_migrations" (
-			id SERIAL PRIMARY KEY,
-			hash text NOT NULL,
-			created_at bigint
-		)`,
-  );
+// PG error codes meaning "this object already exists" — safe to treat the
+// statement as already applied. Anything else is a real failure.
+const ALREADY_EXISTS_CODES = new Set([
+  "42P07", // duplicate table / index
+  "42701", // duplicate column
+  "42710", // duplicate object (constraint, extension, ...)
+  "42P06", // duplicate schema
+  "42723", // duplicate function
+]);
 
-  const applied = await db.query<{ count: string }>(
-    `SELECT COUNT(*)::text AS count FROM "drizzle"."__drizzle_migrations"`,
-  );
-  if (parseInt(applied[0]?.count ?? "0", 10) > 0) return;
+interface JournalEntry {
+  idx: number;
+  when: number;
+  tag: string;
+}
 
-  const journal = JSON.parse(
-    readFileSync(path.join(MIGRATIONS_DIR, "meta", "_journal.json"), "utf8"),
-  ) as { entries: { idx: number; when: number; tag: string }[] };
-  const baseline = journal.entries.find((e) => e.idx === 0);
-  if (!baseline) return;
+/** Boot report, exposed via /status/schema so it can be read without host access. */
+export interface MigrationReport {
+  at: string;
+  ok: boolean;
+  migrationsDir: string | null;
+  journalCount: number;
+  alreadyRecorded: number;
+  appliedNow: string[];
+  skippedStatements: number;
+  error: string | null;
+}
 
-  const sql = readFileSync(
-    path.join(MIGRATIONS_DIR, `${baseline.tag}.sql`),
-    "utf8",
-  );
-  const hash = createHash("sha256").update(sql).digest("hex");
-  await db.query(
-    `INSERT INTO "drizzle"."__drizzle_migrations" ("hash", "created_at") VALUES ($1, $2)`,
-    [hash, baseline.when],
-  );
-  console.log(
-    `[migrations] Baselined ${baseline.tag} (recorded as applied, not executed)`,
-  );
+let lastReport: MigrationReport | null = null;
+export function getMigrationReport(): MigrationReport | null {
+  return lastReport;
+}
+
+function resolveMigrationsDir(): string | null {
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(process.cwd(), "src", "db", "drizzle"),
+    // dist/db/runMigrations.js → <backend root>/src/db/drizzle
+    path.join(moduleDir, "..", "..", "src", "db", "drizzle"),
+    path.join(moduleDir, "..", "..", "..", "src", "db", "drizzle"),
+  ];
+  for (const dir of candidates) {
+    if (existsSync(path.join(dir, "meta", "_journal.json"))) return dir;
+  }
+  return null;
 }
 
 /**
  * Apply pending migrations. Returns true when the schema is up to date.
- * Never throws — a failure is logged loudly and the server still boots
- * (endpoints not touching new columns keep working; crashing the process
- * would take those down too).
+ * Never throws — failures are logged loudly and captured in the boot report,
+ * and the server still starts (endpoints not touching new columns keep
+ * working; crashing the process would take those down too).
  */
 export async function runPendingMigrations(): Promise<boolean> {
+  const report: MigrationReport = {
+    at: new Date().toISOString(),
+    ok: false,
+    migrationsDir: null,
+    journalCount: 0,
+    alreadyRecorded: 0,
+    appliedNow: [],
+    skippedStatements: 0,
+    error: null,
+  };
+  lastReport = report;
+
   try {
-    if (!existsSync(MIGRATIONS_DIR)) {
-      console.error(
-        `[migrations] ❌ Migrations folder missing at ${MIGRATIONS_DIR} — deploy must include src/db/drizzle`,
-      );
+    const dir = resolveMigrationsDir();
+    if (!dir) {
+      report.error = "migrations folder not found (src/db/drizzle)";
+      console.error(`[migrations] ❌ ${report.error}`);
       return false;
     }
+    report.migrationsDir = dir;
+
     const db = PostgresService.getInstance();
-    await baselineIfNeeded(db);
-    await migrate(db.orm, { migrationsFolder: MIGRATIONS_DIR });
-    console.log("[migrations] ✅ Schema is up to date");
+
+    await db.query(`CREATE SCHEMA IF NOT EXISTS "drizzle"`);
+    await db.query(
+      `CREATE TABLE IF NOT EXISTS "drizzle"."__drizzle_migrations" (
+				id SERIAL PRIMARY KEY,
+				hash text NOT NULL,
+				created_at bigint
+			)`,
+    );
+
+    const journal = JSON.parse(
+      readFileSync(path.join(dir, "meta", "_journal.json"), "utf8"),
+    ) as { entries: JournalEntry[] };
+    const entries = [...journal.entries].sort((a, b) => a.idx - b.idx);
+    report.journalCount = entries.length;
+
+    const recorded = new Set(
+      (
+        await db.query<{ hash: string }>(
+          `SELECT hash FROM "drizzle"."__drizzle_migrations"`,
+        )
+      ).map((r) => r.hash),
+    );
+
+    for (const entry of entries) {
+      const sql = readFileSync(path.join(dir, `${entry.tag}.sql`), "utf8");
+      const hash = createHash("sha256").update(sql).digest("hex");
+      if (recorded.has(hash)) {
+        report.alreadyRecorded++;
+        continue;
+      }
+
+      const skipped = await applyMigration(db, entry.tag, sql);
+      report.skippedStatements += skipped;
+      await db.query(
+        `INSERT INTO "drizzle"."__drizzle_migrations" ("hash", "created_at") VALUES ($1, $2)`,
+        [hash, entry.when],
+      );
+      report.appliedNow.push(entry.tag);
+      console.log(
+        `[migrations] ✓ ${entry.tag}${skipped > 0 ? ` (${skipped} statement(s) already existed)` : ""}`,
+      );
+    }
+
+    report.ok = true;
+    console.log(
+      report.appliedNow.length > 0
+        ? `[migrations] ✅ Applied ${report.appliedNow.length} migration(s): ${report.appliedNow.join(", ")}`
+        : "[migrations] ✅ Schema is up to date",
+    );
     return true;
   } catch (err: any) {
+    report.error = String(err?.message ?? err);
     console.error(
       "[migrations] ❌ FAILED — schema may be behind the code:",
-      err?.message ?? err,
+      report.error,
     );
     return false;
   }
+}
+
+/**
+ * Run one migration's statements in a single transaction, with a savepoint
+ * around each statement so "already exists" failures can be skipped without
+ * aborting the rest. Returns the number of skipped statements.
+ */
+async function applyMigration(
+  db: PostgresService,
+  tag: string,
+  sql: string,
+): Promise<number> {
+  const statements = sql
+    .split("--> statement-breakpoint")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  let skipped = 0;
+  const client = await db.getClient();
+  try {
+    await client.query("BEGIN");
+    for (const statement of statements) {
+      await client.query("SAVEPOINT mig_stmt");
+      try {
+        await client.query(statement);
+      } catch (err: any) {
+        if (err?.code && ALREADY_EXISTS_CODES.has(err.code)) {
+          await client.query("ROLLBACK TO SAVEPOINT mig_stmt");
+          skipped++;
+          console.log(
+            `[migrations]   • ${tag}: skipped already-existing object (${err.code}): ${statement.slice(0, 80).replace(/\s+/g, " ")}…`,
+          );
+        } else {
+          throw err;
+        }
+      }
+      await client.query("RELEASE SAVEPOINT mig_stmt");
+    }
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+  return skipped;
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -35,7 +35,10 @@ import { startPendingSendCron } from "./cron/pendingSendCron.js";
 import { seedExtraBadges } from "./services/badgeService.js";
 import { seedExtraChallenges } from "./services/dailyChallengeService.js";
 import { PostgresService } from "./services/DbService.js";
-import { runPendingMigrations } from "./db/runMigrations.js";
+import {
+  runPendingMigrations,
+  getMigrationReport,
+} from "./db/runMigrations.js";
 import { webcrypto } from "node:crypto";
 
 (globalThis as any).crypto ??= webcrypto;
@@ -57,6 +60,46 @@ app.use("/uploads", express.static(path.join(process.cwd(), "uploads")));
 
 app.get("/status", (req, res) => {
   res.send("healthy");
+});
+
+// Public schema diagnostics: the startup-migration boot report plus live
+// probes for the marker objects recent code depends on. Contains only schema
+// booleans, migration tags, and counts — no user data. Exists because prod
+// has no shell/log access; this is how schema state gets diagnosed.
+app.get("/status/schema", async (req, res) => {
+  const probe = async (sql: string): Promise<boolean | string> => {
+    try {
+      const db = PostgresService.getInstance();
+      const rows = await db.query<{ ok: boolean }>(sql);
+      return rows[0]?.ok === true;
+    } catch (e: any) {
+      return `error: ${e?.message ?? e}`;
+    }
+  };
+  res.json({
+    migration_report: getMigrationReport(),
+    probes: {
+      posts_is_auto: await probe(
+        `SELECT EXISTS (SELECT 1 FROM information_schema.columns
+					WHERE table_name = 'posts' AND column_name = 'is_auto') AS ok`,
+      ),
+      workout_routes_table: await probe(
+        `SELECT EXISTS (SELECT 1 FROM information_schema.tables
+					WHERE table_name = 'workout_routes') AS ok`,
+      ),
+      share_route_maps: await probe(
+        `SELECT EXISTS (SELECT 1 FROM information_schema.columns
+					WHERE table_name = 'notification_settings' AND column_name = 'share_route_maps') AS ok`,
+      ),
+      error_log_table: await probe(
+        `SELECT EXISTS (SELECT 1 FROM information_schema.tables
+					WHERE table_name = 'error_log') AS ok`,
+      ),
+      journal_rows: await probe(
+        `SELECT EXISTS (SELECT 1 FROM "drizzle"."__drizzle_migrations") AS ok`,
+      ),
+    },
+  });
 });
 
 app.get("/test-signin.html", (req, res) => {

--- a/backend/src/services/DbService.ts
+++ b/backend/src/services/DbService.ts
@@ -1,80 +1,95 @@
-import { Pool, QueryResultRow, types } from 'pg';
-import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
-import * as schema from '../db/drizzle/schema.js';
+import { Pool, QueryResultRow, types } from "pg";
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import * as schema from "../db/drizzle/schema.js";
 
 // Return DATE columns (OID 1082) as 'YYYY-MM-DD' strings instead of JS Date objects.
 // JS Date is local-midnight and causes TZ confusion; the backend treats these columns as strings.
 types.setTypeParser(1082, (val: string) => val);
 
 type QueryConfig = {
-	query: string;
-	params?: any[];
+  query: string;
+  params?: any[];
 };
 
 export class PostgresService {
-	private static instance: PostgresService;
-	private pool: Pool;
-	private drizzleDb: NodePgDatabase<typeof schema>;
+  private static instance: PostgresService;
+  private pool: Pool;
+  private drizzleDb: NodePgDatabase<typeof schema>;
 
-	private constructor() {
-		this.pool = new Pool({
-			connectionString: process.env.DATABASE_URL,
-			max: 20,
-			idleTimeoutMillis: 30_000,
-			connectionTimeoutMillis: 5_000,
-			statement_timeout: 30_000,
-			query_timeout: 30_000
-		});
+  private constructor() {
+    this.pool = new Pool({
+      connectionString: process.env.DATABASE_URL,
+      max: 20,
+      idleTimeoutMillis: 30_000,
+      connectionTimeoutMillis: 5_000,
+      statement_timeout: 30_000,
+      query_timeout: 30_000,
+    });
 
-		this.pool.on('error', (err: any) => {
-			console.error('Unexpected error on idle client', err);
-			process.exit(1);
-		});
+    this.pool.on("error", (err: any) => {
+      console.error("Unexpected error on idle client", err);
+      process.exit(1);
+    });
 
-		// Drizzle ORM shares the SAME pool as the raw-SQL helpers below, so the
-		// ORM and existing `query()`/`transaction()` calls draw from one set of
-		// connections. Use `.orm` for new typed queries; raw SQL stays valid.
-		this.drizzleDb = drizzle({ client: this.pool, schema, casing: 'snake_case' });
-	}
+    // Drizzle ORM shares the SAME pool as the raw-SQL helpers below, so the
+    // ORM and existing `query()`/`transaction()` calls draw from one set of
+    // connections. Use `.orm` for new typed queries; raw SQL stays valid.
+    this.drizzleDb = drizzle({
+      client: this.pool,
+      schema,
+      casing: "snake_case",
+    });
+  }
 
-	/** Typed Drizzle ORM client backed by the shared pool. */
-	public get orm(): NodePgDatabase<typeof schema> {
-		return this.drizzleDb;
-	}
+  /** Typed Drizzle ORM client backed by the shared pool. */
+  public get orm(): NodePgDatabase<typeof schema> {
+    return this.drizzleDb;
+  }
 
-	public static getInstance(): PostgresService {
-		if (!PostgresService.instance) {
-			PostgresService.instance = new PostgresService();
-		}
-		return PostgresService.instance;
-	}
+  /**
+   * Check out a raw client for multi-statement work that needs manual
+   * transaction control (BEGIN/SAVEPOINT/...). Caller MUST release() it.
+   */
+  public async getClient() {
+    return this.pool.connect();
+  }
 
-	public async query<T extends QueryResultRow = any>(query: string, params?: any[]): Promise<T[]> {
-		const result = await this.pool.query<T>(query, params);
-		return result.rows;
-	}
+  public static getInstance(): PostgresService {
+    if (!PostgresService.instance) {
+      PostgresService.instance = new PostgresService();
+    }
+    return PostgresService.instance;
+  }
 
-	public async transaction(queries: QueryConfig[]): Promise<void> {
-		const client = await this.pool.connect();
-		try {
-			await client.query('BEGIN');
+  public async query<T extends QueryResultRow = any>(
+    query: string,
+    params?: any[],
+  ): Promise<T[]> {
+    const result = await this.pool.query<T>(query, params);
+    return result.rows;
+  }
 
-			for (const { query, params } of queries) {
-				await client.query(query, params);
-			}
+  public async transaction(queries: QueryConfig[]): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
 
-			await client.query('COMMIT');
-		} catch (err) {
-			await client.query('ROLLBACK');
-			throw err;
-		} finally {
-			client.release();
-		}
-	}
+      for (const { query, params } of queries) {
+        await client.query(query, params);
+      }
 
-	public async close(): Promise<void> {
-		await this.pool.end();
-	}
+      await client.query("COMMIT");
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  public async close(): Promise<void> {
+    await this.pool.end();
+  }
 }
 
 // Convenience handles for new ORM-based code:


### PR DESCRIPTION
# ⚠️ Merge ASAP — follow-up to #182; feed is still down because prod's migration bookkeeping was never initialized

**Why #182 wasn't enough:** its migrator assumed prod's `drizzle.__drizzle_migrations` table already recorded migrations `0000–0007`. But prod has never had any way to run migrations, so that bookkeeping is almost certainly empty (or partial) — in that state the strict migrator errors out, the server boots with the old schema, and the feed stays empty.

## Changes

### Idempotent catch-up migrator (replaces the strict one)
- Every journal migration not recorded in bookkeeping runs in a transaction with a **savepoint per statement**; a statement failing with an "already exists" error class (`42P07`/`42701`/`42710`/`42P06`/`42723`) is skipped — that object simply predates the bookkeeping. Any other error aborts and is reported.
- This converges **any** additive-schema state — empty, partial, or current bookkeeping — onto the journal, then records each migration byte-compatibly with `drizzle-kit migrate`.
- Migrations folder resolution tries both cwd- and module-relative paths.

### Public `GET /status/schema`
Returns the boot migration report (applied tags, skipped-statement count, error if any) plus live probes for the marker objects (`posts.is_auto`, `workout_routes`, `share_route_maps`, `error_log`). Schema booleans and migration tags only — no user data. This exists because prod has no shell or log access; it's how we diagnose from now on.

## Verification (scratch Postgres 16)
| Starting state | Result |
|---|---|
| Bookkeeping at `0007` | applies `0008–0010` |
| **Full `0007` schema, EMPTY bookkeeping** (suspected prod state) | 119 pre-existing statements skipped, all 11 migrations recorded, `0008–0010` genuinely applied |
| Re-run after either | clean no-op ("Schema is up to date") |

All new columns/tables verified present after each run; `npm run build` passes.

## After merge
Open **`https://mad.mindgoblin.tech/status/schema`** in a browser once the deploy finishes:
- `migration_report.ok: true` + all `probes` `true` → schema is fixed; the app feed recovers on next refresh with no new build.
- Anything else → paste the JSON into the Claude session and it pinpoints the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQh9bdXHFoZag7ehNxh4Ak

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQh9bdXHFoZag7ehNxh4Ak)_