### PR TITLE
Hotfix 3 (root cause): Docker entrypoint runs idempotent migrations — un-pins deploys, heals feed

### DIFF
--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -3,10 +3,17 @@
 # migration abort startup with a non-zero exit so the container never serves
 # against a half-migrated schema — Coolify then keeps the previous (healthy)
 # container running instead of switching traffic to a broken one.
+#
+# Migrations run through the statement-level idempotent applier (NOT strict
+# `drizzle-kit migrate`): production's bookkeeping predates drizzle in places,
+# and the strict migrator dies on objects that already exist — which quietly
+# pinned every deploy to the old container while the schema stayed behind the
+# code. The applier converges any additive-schema state and only exits
+# non-zero on a real failure.
 set -e
 
-echo "[entrypoint] Applying database migrations (drizzle-kit migrate)..."
-npm run db:migrate
+echo "[entrypoint] Applying database migrations (idempotent applier)..."
+node dist/db/migrateCli.js
 echo "[entrypoint] Migrations applied. Starting server..."
 
 # exec so node becomes PID 1 and receives SIGTERM/SIGINT directly for clean shutdown.

--- a/backend/src/db/migrateCli.ts
+++ b/backend/src/db/migrateCli.ts
@@ -1,0 +1,18 @@
+import "dotenv/config";
+import { runPendingMigrations, getMigrationReport } from "./runMigrations.js";
+import { PostgresService } from "../services/DbService.js";
+
+// Container-entrypoint migration step (replaces strict `drizzle-kit migrate`).
+// Uses the same statement-level idempotent applier as the in-server safety
+// net, so it converges ANY bookkeeping state instead of dying on objects that
+// already exist — a dead entrypoint means Coolify silently keeps the OLD
+// container serving, which is how a broken schema stayed live for hours.
+// Exit code still gates the deploy: 0 = schema converged, 1 = real failure
+// (Coolify then keeps the previous healthy container — the safe outcome).
+const ok = await runPendingMigrations();
+console.log(
+  "[migrate-cli] report:",
+  JSON.stringify(getMigrationReport(), null, 2),
+);
+await PostgresService.getInstance().close();
+process.exit(ok ? 0 : 1);

--- a/backend/src/db/runMigrations.ts
+++ b/backend/src/db/runMigrations.ts
@@ -1,80 +1,204 @@
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { migrate } from "drizzle-orm/node-postgres/migrator";
+import { fileURLToPath } from "node:url";
 import { PostgresService } from "../services/DbService.js";
 
 // Deploys are git-driven with no shell access to the host, so the server owns
-// its own schema migrations: any journal entry not yet recorded in
-// drizzle.__drizzle_migrations is applied at boot, before traffic is accepted.
-// Idempotent — an already-migrated database is a fast no-op.
-const MIGRATIONS_DIR = path.join(process.cwd(), "src", "db", "drizzle");
+// its own schema migrations: at boot, every journal entry not yet recorded in
+// drizzle.__drizzle_migrations is applied, before traffic is accepted.
+//
+// The applier is a statement-level idempotent catch-up, NOT drizzle's strict
+// migrator, because production's bookkeeping state is unknowable (it may be
+// empty, partial, or current — nobody has ever been able to run `db:migrate`
+// there). Each migration runs in a transaction with a savepoint per statement;
+// a statement failing with an "already exists" error class is skipped (that
+// object predates the bookkeeping), anything else aborts the migration. This
+// converges ANY additive-schema state onto the journal without ever touching
+// data it shouldn't.
+//
+// Bookkeeping stays byte-compatible with drizzle-kit migrate (same table, the
+// hash is sha256 of the .sql file, created_at is the journal `when`).
 
-/**
- * Mirror of scripts/drizzle-baseline.mjs, run automatically when the
- * bookkeeping table is empty: the `0000` migration is the introspection
- * snapshot of the schema that ALREADY exists in production — record it as
- * applied (never execute it) so the migrator starts from `0001`.
- */
-async function baselineIfNeeded(db: PostgresService): Promise<void> {
-  await db.query(`CREATE SCHEMA IF NOT EXISTS "drizzle"`);
-  await db.query(
-    `CREATE TABLE IF NOT EXISTS "drizzle"."__drizzle_migrations" (
-			id SERIAL PRIMARY KEY,
-			hash text NOT NULL,
-			created_at bigint
-		)`,
-  );
+// PG error codes meaning "this object already exists" — safe to treat the
+// statement as already applied. Anything else is a real failure.
+const ALREADY_EXISTS_CODES = new Set([
+  "42P07", // duplicate table / index
+  "42701", // duplicate column
+  "42710", // duplicate object (constraint, extension, ...)
+  "42P06", // duplicate schema
+  "42723", // duplicate function
+]);
 
-  const applied = await db.query<{ count: string }>(
-    `SELECT COUNT(*)::text AS count FROM "drizzle"."__drizzle_migrations"`,
-  );
-  if (parseInt(applied[0]?.count ?? "0", 10) > 0) return;
+interface JournalEntry {
+  idx: number;
+  when: number;
+  tag: string;
+}
 
-  const journal = JSON.parse(
-    readFileSync(path.join(MIGRATIONS_DIR, "meta", "_journal.json"), "utf8"),
-  ) as { entries: { idx: number; when: number; tag: string }[] };
-  const baseline = journal.entries.find((e) => e.idx === 0);
-  if (!baseline) return;
+/** Boot report, exposed via /status/schema so it can be read without host access. */
+export interface MigrationReport {
+  at: string;
+  ok: boolean;
+  migrationsDir: string | null;
+  journalCount: number;
+  alreadyRecorded: number;
+  appliedNow: string[];
+  skippedStatements: number;
+  error: string | null;
+}
 
-  const sql = readFileSync(
-    path.join(MIGRATIONS_DIR, `${baseline.tag}.sql`),
-    "utf8",
-  );
-  const hash = createHash("sha256").update(sql).digest("hex");
-  await db.query(
-    `INSERT INTO "drizzle"."__drizzle_migrations" ("hash", "created_at") VALUES ($1, $2)`,
-    [hash, baseline.when],
-  );
-  console.log(
-    `[migrations] Baselined ${baseline.tag} (recorded as applied, not executed)`,
-  );
+let lastReport: MigrationReport | null = null;
+export function getMigrationReport(): MigrationReport | null {
+  return lastReport;
+}
+
+function resolveMigrationsDir(): string | null {
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(process.cwd(), "src", "db", "drizzle"),
+    // dist/db/runMigrations.js → <backend root>/src/db/drizzle
+    path.join(moduleDir, "..", "..", "src", "db", "drizzle"),
+    path.join(moduleDir, "..", "..", "..", "src", "db", "drizzle"),
+  ];
+  for (const dir of candidates) {
+    if (existsSync(path.join(dir, "meta", "_journal.json"))) return dir;
+  }
+  return null;
 }
 
 /**
  * Apply pending migrations. Returns true when the schema is up to date.
- * Never throws — a failure is logged loudly and the server still boots
- * (endpoints not touching new columns keep working; crashing the process
- * would take those down too).
+ * Never throws — failures are logged loudly and captured in the boot report,
+ * and the server still starts (endpoints not touching new columns keep
+ * working; crashing the process would take those down too).
  */
 export async function runPendingMigrations(): Promise<boolean> {
+  const report: MigrationReport = {
+    at: new Date().toISOString(),
+    ok: false,
+    migrationsDir: null,
+    journalCount: 0,
+    alreadyRecorded: 0,
+    appliedNow: [],
+    skippedStatements: 0,
+    error: null,
+  };
+  lastReport = report;
+
   try {
-    if (!existsSync(MIGRATIONS_DIR)) {
-      console.error(
-        `[migrations] ❌ Migrations folder missing at ${MIGRATIONS_DIR} — deploy must include src/db/drizzle`,
-      );
+    const dir = resolveMigrationsDir();
+    if (!dir) {
+      report.error = "migrations folder not found (src/db/drizzle)";
+      console.error(`[migrations] ❌ ${report.error}`);
       return false;
     }
+    report.migrationsDir = dir;
+
     const db = PostgresService.getInstance();
-    await baselineIfNeeded(db);
-    await migrate(db.orm, { migrationsFolder: MIGRATIONS_DIR });
-    console.log("[migrations] ✅ Schema is up to date");
+
+    await db.query(`CREATE SCHEMA IF NOT EXISTS "drizzle"`);
+    await db.query(
+      `CREATE TABLE IF NOT EXISTS "drizzle"."__drizzle_migrations" (
+				id SERIAL PRIMARY KEY,
+				hash text NOT NULL,
+				created_at bigint
+			)`,
+    );
+
+    const journal = JSON.parse(
+      readFileSync(path.join(dir, "meta", "_journal.json"), "utf8"),
+    ) as { entries: JournalEntry[] };
+    const entries = [...journal.entries].sort((a, b) => a.idx - b.idx);
+    report.journalCount = entries.length;
+
+    const recorded = new Set(
+      (
+        await db.query<{ hash: string }>(
+          `SELECT hash FROM "drizzle"."__drizzle_migrations"`,
+        )
+      ).map((r) => r.hash),
+    );
+
+    for (const entry of entries) {
+      const sql = readFileSync(path.join(dir, `${entry.tag}.sql`), "utf8");
+      const hash = createHash("sha256").update(sql).digest("hex");
+      if (recorded.has(hash)) {
+        report.alreadyRecorded++;
+        continue;
+      }
+
+      const skipped = await applyMigration(db, entry.tag, sql);
+      report.skippedStatements += skipped;
+      await db.query(
+        `INSERT INTO "drizzle"."__drizzle_migrations" ("hash", "created_at") VALUES ($1, $2)`,
+        [hash, entry.when],
+      );
+      report.appliedNow.push(entry.tag);
+      console.log(
+        `[migrations] ✓ ${entry.tag}${skipped > 0 ? ` (${skipped} statement(s) already existed)` : ""}`,
+      );
+    }
+
+    report.ok = true;
+    console.log(
+      report.appliedNow.length > 0
+        ? `[migrations] ✅ Applied ${report.appliedNow.length} migration(s): ${report.appliedNow.join(", ")}`
+        : "[migrations] ✅ Schema is up to date",
+    );
     return true;
   } catch (err: any) {
+    report.error = String(err?.message ?? err);
     console.error(
       "[migrations] ❌ FAILED — schema may be behind the code:",
-      err?.message ?? err,
+      report.error,
     );
     return false;
   }
+}
+
+/**
+ * Run one migration's statements in a single transaction, with a savepoint
+ * around each statement so "already exists" failures can be skipped without
+ * aborting the rest. Returns the number of skipped statements.
+ */
+async function applyMigration(
+  db: PostgresService,
+  tag: string,
+  sql: string,
+): Promise<number> {
+  const statements = sql
+    .split("--> statement-breakpoint")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  let skipped = 0;
+  const client = await db.getClient();
+  try {
+    await client.query("BEGIN");
+    for (const statement of statements) {
+      await client.query("SAVEPOINT mig_stmt");
+      try {
+        await client.query(statement);
+      } catch (err: any) {
+        if (err?.code && ALREADY_EXISTS_CODES.has(err.code)) {
+          await client.query("ROLLBACK TO SAVEPOINT mig_stmt");
+          skipped++;
+          console.log(
+            `[migrations]   • ${tag}: skipped already-existing object (${err.code}): ${statement.slice(0, 80).replace(/\s+/g, " ")}…`,
+          );
+        } else {
+          throw err;
+        }
+      }
+      await client.query("RELEASE SAVEPOINT mig_stmt");
+    }
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+  return skipped;
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -35,7 +35,10 @@ import { startPendingSendCron } from "./cron/pendingSendCron.js";
 import { seedExtraBadges } from "./services/badgeService.js";
 import { seedExtraChallenges } from "./services/dailyChallengeService.js";
 import { PostgresService } from "./services/DbService.js";
-import { runPendingMigrations } from "./db/runMigrations.js";
+import {
+  runPendingMigrations,
+  getMigrationReport,
+} from "./db/runMigrations.js";
 import { webcrypto } from "node:crypto";
 
 (globalThis as any).crypto ??= webcrypto;
@@ -57,6 +60,46 @@ app.use("/uploads", express.static(path.join(process.cwd(), "uploads")));
 
 app.get("/status", (req, res) => {
   res.send("healthy");
+});
+
+// Public schema diagnostics: the startup-migration boot report plus live
+// probes for the marker objects recent code depends on. Contains only schema
+// booleans, migration tags, and counts — no user data. Exists because prod
+// has no shell/log access; this is how schema state gets diagnosed.
+app.get("/status/schema", async (req, res) => {
+  const probe = async (sql: string): Promise<boolean | string> => {
+    try {
+      const db = PostgresService.getInstance();
+      const rows = await db.query<{ ok: boolean }>(sql);
+      return rows[0]?.ok === true;
+    } catch (e: any) {
+      return `error: ${e?.message ?? e}`;
+    }
+  };
+  res.json({
+    migration_report: getMigrationReport(),
+    probes: {
+      posts_is_auto: await probe(
+        `SELECT EXISTS (SELECT 1 FROM information_schema.columns
+					WHERE table_name = 'posts' AND column_name = 'is_auto') AS ok`,
+      ),
+      workout_routes_table: await probe(
+        `SELECT EXISTS (SELECT 1 FROM information_schema.tables
+					WHERE table_name = 'workout_routes') AS ok`,
+      ),
+      share_route_maps: await probe(
+        `SELECT EXISTS (SELECT 1 FROM information_schema.columns
+					WHERE table_name = 'notification_settings' AND column_name = 'share_route_maps') AS ok`,
+      ),
+      error_log_table: await probe(
+        `SELECT EXISTS (SELECT 1 FROM information_schema.tables
+					WHERE table_name = 'error_log') AS ok`,
+      ),
+      journal_rows: await probe(
+        `SELECT EXISTS (SELECT 1 FROM "drizzle"."__drizzle_migrations") AS ok`,
+      ),
+    },
+  });
 });
 
 app.get("/test-signin.html", (req, res) => {

--- a/backend/src/services/DbService.ts
+++ b/backend/src/services/DbService.ts
@@ -1,80 +1,95 @@
-import { Pool, QueryResultRow, types } from 'pg';
-import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
-import * as schema from '../db/drizzle/schema.js';
+import { Pool, QueryResultRow, types } from "pg";
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import * as schema from "../db/drizzle/schema.js";
 
 // Return DATE columns (OID 1082) as 'YYYY-MM-DD' strings instead of JS Date objects.
 // JS Date is local-midnight and causes TZ confusion; the backend treats these columns as strings.
 types.setTypeParser(1082, (val: string) => val);
 
 type QueryConfig = {
-	query: string;
-	params?: any[];
+  query: string;
+  params?: any[];
 };
 
 export class PostgresService {
-	private static instance: PostgresService;
-	private pool: Pool;
-	private drizzleDb: NodePgDatabase<typeof schema>;
+  private static instance: PostgresService;
+  private pool: Pool;
+  private drizzleDb: NodePgDatabase<typeof schema>;
 
-	private constructor() {
-		this.pool = new Pool({
-			connectionString: process.env.DATABASE_URL,
-			max: 20,
-			idleTimeoutMillis: 30_000,
-			connectionTimeoutMillis: 5_000,
-			statement_timeout: 30_000,
-			query_timeout: 30_000
-		});
+  private constructor() {
+    this.pool = new Pool({
+      connectionString: process.env.DATABASE_URL,
+      max: 20,
+      idleTimeoutMillis: 30_000,
+      connectionTimeoutMillis: 5_000,
+      statement_timeout: 30_000,
+      query_timeout: 30_000,
+    });
 
-		this.pool.on('error', (err: any) => {
-			console.error('Unexpected error on idle client', err);
-			process.exit(1);
-		});
+    this.pool.on("error", (err: any) => {
+      console.error("Unexpected error on idle client", err);
+      process.exit(1);
+    });
 
-		// Drizzle ORM shares the SAME pool as the raw-SQL helpers below, so the
-		// ORM and existing `query()`/`transaction()` calls draw from one set of
-		// connections. Use `.orm` for new typed queries; raw SQL stays valid.
-		this.drizzleDb = drizzle({ client: this.pool, schema, casing: 'snake_case' });
-	}
+    // Drizzle ORM shares the SAME pool as the raw-SQL helpers below, so the
+    // ORM and existing `query()`/`transaction()` calls draw from one set of
+    // connections. Use `.orm` for new typed queries; raw SQL stays valid.
+    this.drizzleDb = drizzle({
+      client: this.pool,
+      schema,
+      casing: "snake_case",
+    });
+  }
 
-	/** Typed Drizzle ORM client backed by the shared pool. */
-	public get orm(): NodePgDatabase<typeof schema> {
-		return this.drizzleDb;
-	}
+  /** Typed Drizzle ORM client backed by the shared pool. */
+  public get orm(): NodePgDatabase<typeof schema> {
+    return this.drizzleDb;
+  }
 
-	public static getInstance(): PostgresService {
-		if (!PostgresService.instance) {
-			PostgresService.instance = new PostgresService();
-		}
-		return PostgresService.instance;
-	}
+  /**
+   * Check out a raw client for multi-statement work that needs manual
+   * transaction control (BEGIN/SAVEPOINT/...). Caller MUST release() it.
+   */
+  public async getClient() {
+    return this.pool.connect();
+  }
 
-	public async query<T extends QueryResultRow = any>(query: string, params?: any[]): Promise<T[]> {
-		const result = await this.pool.query<T>(query, params);
-		return result.rows;
-	}
+  public static getInstance(): PostgresService {
+    if (!PostgresService.instance) {
+      PostgresService.instance = new PostgresService();
+    }
+    return PostgresService.instance;
+  }
 
-	public async transaction(queries: QueryConfig[]): Promise<void> {
-		const client = await this.pool.connect();
-		try {
-			await client.query('BEGIN');
+  public async query<T extends QueryResultRow = any>(
+    query: string,
+    params?: any[],
+  ): Promise<T[]> {
+    const result = await this.pool.query<T>(query, params);
+    return result.rows;
+  }
 
-			for (const { query, params } of queries) {
-				await client.query(query, params);
-			}
+  public async transaction(queries: QueryConfig[]): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
 
-			await client.query('COMMIT');
-		} catch (err) {
-			await client.query('ROLLBACK');
-			throw err;
-		} finally {
-			client.release();
-		}
-	}
+      for (const { query, params } of queries) {
+        await client.query(query, params);
+      }
 
-	public async close(): Promise<void> {
-		await this.pool.end();
-	}
+      await client.query("COMMIT");
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  public async close(): Promise<void> {
+    await this.pool.end();
+  }
 }
 
 // Convenience handles for new ORM-based code:


### PR DESCRIPTION
# ⚠️ Merge ASAP — this is the actual root cause; feed has been down since #181's deploy

## What's really been happening
`{"error":"Access token required"}` from `/status/schema` proved prod is **still running #181's code** — no deploy since then has gone live. The mechanism, from `backend/Dockerfile` + `docker-entrypoint.sh` (added in v1.2.0):

1. The entrypoint runs **strict `drizzle-kit migrate` under `set -e`** before the server starts.
2. Prod's migration bookkeeping is in a state the strict migrator chokes on (it recorded the release's `error_log` migration under its pre-rename tag, and older entries predate drizzle bookkeeping in places) — so `drizzle-kit migrate` dies on "already exists".
3. The container exits, never turns healthy, and **Coolify silently keeps the OLD (#181, schema-behind) container serving.**

So: #182 and #183 both merged, both built, both died in the entrypoint, and prod never changed. Reverting #183 (#184) also changed nothing in prod — the revert was chasing the wrong suspect, which is why this PR re-lands it.

## The fix
- **`docker-entrypoint.sh` now runs `node dist/db/migrateCli.js`** — the statement-level idempotent applier — instead of `drizzle-kit migrate`. It skips statements whose objects already exist (that's what "bookkeeping is behind reality" looks like), records each migration hash-compatibly, and only exits non-zero on a real failure (Coolify then correctly keeps the old container).
- **Re-lands the reverted #183**: the applier module, the in-server safety net, and public `GET /status/schema` diagnostics (schema booleans + migration tags only — no user data).
- Nice property: `0010_common_nitro.sql` is byte-identical to the release's `0008_lethal_gambit.sql`, so a bookkeeping row recorded under the old tag matches `0010` by hash and is skipped cleanly.

## Verification (scratch Postgres 16)
| Simulated prod state | Result |
|---|---|
| **Bookkeeping `0000–0007` + `lethal_gambit`, `error_log` present, new columns missing** (the state all evidence points to) | CLI applies exactly `0008` + `0009`, reports 9 already recorded, **exit 0** |
| Full `0007` schema, empty bookkeeping | 119 pre-existing statements skipped, all recorded, `0008–0010` applied |
| Fully migrated | no-op, exit 0 |

`npm run build` passes; re-runs are always no-ops.

## After merge
1. Wait for the Coolify deploy (it should finally turn healthy and switch traffic).
2. Open `https://mad.mindgoblin.tech/status/schema` — expect `migration_report.ok: true` and all probes `true`. (If you still get "Access token required", the deploy hasn't switched yet — or check the Coolify dashboard for this app's deploy logs.)
3. Pull-to-refresh the feed in the app — it recovers with no new build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQh9bdXHFoZag7ehnxh4Ak

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQh9bdXHFoZag7ehNxh4Ak)_