### PR TITLE
Picture-first posts everywhere + feed diagnostics

### DIFF
--- a/app/Mile A Day/Services/PostService.swift
+++ b/app/Mile A Day/Services/PostService.swift
@@ -41,6 +41,9 @@ struct PostItem: Codable, Identifiable {
     var workout_type: String?
     /// Simplified GPS trace [[lat, lng], ...] when synced + shared.
     var route: [[Double]]?
+    /// The run's ACTIVE story photo (profile posts responses) — the real
+    /// picture leads wherever it exists; the workout card is secondary.
+    var story_photo_url: String?
     let is_self: Bool
     var is_hyped: Bool
     var hype_count: Int?
@@ -58,6 +61,12 @@ struct PostItem: Codable, Identifiable {
     }
 
     var mediaURL: URL? { ProfileImageService.fullImageURL(for: media_url) }
+
+    /// The run's story photo when present and distinct from the post media.
+    var storyPhotoURL: URL? {
+        guard let story_photo_url, story_photo_url != media_url else { return nil }
+        return ProfileImageService.fullImageURL(for: story_photo_url)
+    }
 
     /// Short "2h", "5m", "now" relative time from created_at.
     var relativeTime: String { RelativeTime.short(from: created_at) }
@@ -172,7 +181,8 @@ struct FeedEntry: Codable, Identifiable {
             workout_id: nil, stats_snapshot: stats_snapshot, local_date: nil,
             share_to_feed: true, share_to_story: nil, story_expires_at: nil,
             created_at: sort_ts, is_auto: is_auto, workout_type: workout_type,
-            route: route, is_self: is_self, is_hyped: is_hyped,
+            route: route, story_photo_url: story_photo_url,
+            is_self: is_self, is_hyped: is_hyped,
             hype_count: hype_count, is_viewed: nil
         )
     }

--- a/app/Mile A Day/Views/Feed/ProfilePostsGridView.swift
+++ b/app/Mile A Day/Views/Feed/ProfilePostsGridView.swift
@@ -55,7 +55,9 @@ struct ProfilePostsGridView: View {
         Color.clear
             .aspectRatio(1, contentMode: .fit)
             .overlay(
-                AsyncImage(url: post.mediaURL) { phase in
+                // The real picture leads when the run has one; the workout
+                // card is only the face of the post when no photo exists.
+                AsyncImage(url: post.storyPhotoURL ?? post.mediaURL) { phase in
                     switch phase {
                     case .success(let image): image.resizable().scaledToFill()
                     case .failure:
@@ -149,7 +151,13 @@ struct ProfilePostsFeedSheet: View {
     let initialPostId: String
     let onNeedMore: () -> Void
     @Environment(\.dismiss) private var dismiss
-    @State private var lightboxPost: PostItem?
+
+    /// The tapped slide's image, presented in the zoom lightbox.
+    private struct LightboxItem: Identifiable {
+        let url: URL
+        var id: String { url.absoluteString }
+    }
+    @State private var lightboxItem: LightboxItem?
 
     var body: some View {
         NavigationStack {
@@ -195,8 +203,62 @@ struct ProfilePostsFeedSheet: View {
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbarColorScheme(.dark, for: .navigationBar)
         }
-        .fullScreenCover(item: $lightboxPost) { post in
-            PhotoLightboxView(url: ProfileImageService.fullImageURL(for: post.media_url))
+        .fullScreenCover(item: $lightboxItem) { item in
+            PhotoLightboxView(url: item.url)
+        }
+    }
+
+    /// Same media treatment as the feed card: the real photo leads, the
+    /// workout card is the second slide (badged "Stats"), page dots when
+    /// there's more than one.
+    @ViewBuilder
+    private func media(_ post: PostItem) -> some View {
+        if let storyPhoto = post.storyPhotoURL {
+            TabView {
+                photoSlide(storyPhoto)
+                photoSlide(post.mediaURL, badge: post.is_auto == true ? "Stats" : nil)
+            }
+            .tabViewStyle(.page(indexDisplayMode: .always))
+            .indexViewStyle(.page(backgroundDisplayMode: .interactive))
+            .frame(maxWidth: .infinity)
+            .aspectRatio(4.0 / 5.0, contentMode: .fit)
+        } else {
+            photoSlide(post.mediaURL)
+        }
+    }
+
+    private func photoSlide(_ url: URL?, badge: String? = nil) -> some View {
+        AsyncImage(url: url) { phase in
+            switch phase {
+            case .success(let image):
+                image.resizable().scaledToFill()
+            case .failure:
+                ZStack { Color.white.opacity(0.05); Image(systemName: "photo").foregroundColor(.white.opacity(0.3)) }
+            default:
+                ZStack { Color.white.opacity(0.05); ProgressView().tint(.white) }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .aspectRatio(4.0 / 5.0, contentMode: .fit)
+        .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
+        .contentShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
+        .onTapGesture {
+            if let url { lightboxItem = LightboxItem(url: url) }
+        }
+        .overlay(alignment: .topLeading) {
+            if let badge {
+                HStack(spacing: 5) {
+                    Image(systemName: "chart.bar.fill")
+                        .font(.system(size: 11, weight: .bold))
+                    Text(badge)
+                        .font(.system(size: 12, weight: .bold, design: .rounded))
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(Capsule().fill(Color.black.opacity(0.55)))
+                .padding(10)
+            }
         }
     }
 
@@ -221,21 +283,7 @@ struct ProfilePostsFeedSheet: View {
                 }
             }
 
-            AsyncImage(url: post.mediaURL) { phase in
-                switch phase {
-                case .success(let image):
-                    image.resizable().scaledToFill()
-                case .failure:
-                    ZStack { Color.white.opacity(0.05); Image(systemName: "photo").foregroundColor(.white.opacity(0.3)) }
-                default:
-                    ZStack { Color.white.opacity(0.05); ProgressView().tint(.white) }
-                }
-            }
-            .frame(maxWidth: .infinity)
-            .aspectRatio(4.0 / 5.0, contentMode: .fit)
-            .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
-            .contentShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
-            .onTapGesture { lightboxPost = post }
+            media(post)
 
             if let stats = post.stats_snapshot {
                 PostStatStrip(stats: stats).padding(.horizontal, 2)

--- a/backend/src/controllers/postsController.ts
+++ b/backend/src/controllers/postsController.ts
@@ -33,6 +33,7 @@ import {
 import { getDailyGoalStatus } from "../services/workoutService.js";
 import { hasUnlimitedActions } from "../services/privilegedUsers.js";
 import { evaluateSocialBadgesForUser } from "../services/badgeService.js";
+import { logError } from "../services/errorLogService.js";
 
 // Friend "new post" push notifications stay OFF until the Feed/Stories feature
 // ships in the App Store build. The backend is already live, but the feed UI is
@@ -223,6 +224,10 @@ export async function getStoriesRailController(
     res.status(200).json(await getStoriesRail(req.userId!));
   } catch (error: any) {
     console.error("Error fetching stories rail:", error.message);
+    logError("api", `stories rail failed: ${error.message}`, {
+      userId: req.userId ?? null,
+      context: { path: "/posts/stories" },
+    });
     res.status(500).json({ error: "Error fetching stories" });
   }
 }
@@ -366,6 +371,12 @@ export async function getUnifiedFeedController(
     res.status(200).json({ items, next_before: nextBefore });
   } catch (error: any) {
     console.error("Error fetching unified feed:", error.message);
+    // Surface in the error dashboard — the app swallows feed failures
+    // silently ("No activity yet"), so this must never be invisible.
+    logError("api", `unified feed failed: ${error.message}`, {
+      userId: req.userId ?? null,
+      context: { path: "/posts/feed/unified" },
+    });
     res.status(500).json({ error: "Error fetching feed" });
   }
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -39,6 +39,7 @@ import {
   runPendingMigrations,
   getMigrationReport,
 } from "./db/runMigrations.js";
+import { getUnifiedFeed, getStoriesRail } from "./services/postService.js";
 import { webcrypto } from "node:crypto";
 
 (globalThis as any).crypto ??= webcrypto;
@@ -99,6 +100,27 @@ app.get("/status/schema", async (req, res) => {
         `SELECT EXISTS (SELECT 1 FROM "drizzle"."__drizzle_migrations") AS ok`,
       ),
     },
+    // Execute the REAL feed queries as the most recently active user and
+    // report only row counts (or the SQL error text) — proves end-to-end
+    // whether the feed works in production without exposing any content.
+    feed_probe: await (async () => {
+      try {
+        const db = PostgresService.getInstance();
+        const rows = await db.query<{ user_id: string }>(
+          `SELECT user_id FROM workouts WHERE deleted_at IS NULL
+					ORDER BY device_end_date DESC LIMIT 1`,
+        );
+        const uid = rows[0]?.user_id;
+        if (!uid) return "no workouts in db";
+        const [feed, rail] = await Promise.all([
+          getUnifiedFeed(uid, 5, null),
+          getStoriesRail(uid),
+        ]);
+        return { unified_feed_rows: feed.length, story_groups: rail.length };
+      } catch (e: any) {
+        return `error: ${e?.message ?? e}`;
+      }
+    })(),
   });
 });
 

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -630,8 +630,9 @@ export async function getUnifiedFeed(
 				p.created_at AS sort_ts,
 				p.user_id, u.username, u.first_name, u.last_name, u.profile_image_url,
 				p.media_url, p.caption, p.stats_snapshot,
-				-- Story photos are a 24h moment: once expired they must stop
-				-- riding along on the permanent feed card.
+				-- Owner's decision: the 24h expiry only ends the STORY (rail/viewer).
+				-- A photo riding on the run's feed card stays permanently — only
+				-- deleting the story removes it.
 				(
 					SELECT p3.media_url FROM posts p3
 					WHERE p.workout_id IS NOT NULL
@@ -640,7 +641,6 @@ export async function getUnifiedFeed(
 						AND p3.post_id <> p.post_id
 						AND p3.deleted_at IS NULL
 						AND p3.share_to_story AND NOT p3.share_to_feed
-						AND p3.story_expires_at > NOW()
 					ORDER BY p3.created_at DESC
 					LIMIT 1
 				) AS story_photo_url,
@@ -747,9 +747,10 @@ export async function getUserPosts(
 		${CIRCLE_CTE}
 		SELECT ${POST_SELECT},
 			p.created_at::text AS cursor,
-			-- The run's ACTIVE story photo, so the profile grid + detail cards
-			-- can lead with the real picture (workout card second), matching
-			-- the feed. Expired stories drop off here just like on feed cards.
+			-- The run's story photo, so the profile grid + detail cards lead
+			-- with the real picture (workout card second), matching the feed.
+			-- Owner's decision: story expiry does NOT remove the photo from
+			-- feed/profile surfaces — only deleting the story does.
 			(
 				SELECT p3.media_url FROM posts p3
 				WHERE p.workout_id IS NOT NULL
@@ -758,7 +759,6 @@ export async function getUserPosts(
 					AND p3.post_id <> p.post_id
 					AND p3.deleted_at IS NULL
 					AND p3.share_to_story AND NOT p3.share_to_feed
-					AND p3.story_expires_at > NOW()
 				ORDER BY p3.created_at DESC
 				LIMIT 1
 			) AS story_photo_url

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -55,6 +55,9 @@ export interface PostRow {
   // node-pg parses timestamptz to a ms-truncated JS Date, and a truncated
   // `before` cursor silently skips same-millisecond rows at page boundaries.
   cursor?: string;
+  // The run's active story photo (getUserPosts only) — lets profile surfaces
+  // lead with the real picture like the feed does.
+  story_photo_url?: string | null;
 }
 
 export interface StoryGroup {
@@ -743,7 +746,22 @@ export async function getUserPosts(
     `
 		${CIRCLE_CTE}
 		SELECT ${POST_SELECT},
-			p.created_at::text AS cursor
+			p.created_at::text AS cursor,
+			-- The run's ACTIVE story photo, so the profile grid + detail cards
+			-- can lead with the real picture (workout card second), matching
+			-- the feed. Expired stories drop off here just like on feed cards.
+			(
+				SELECT p3.media_url FROM posts p3
+				WHERE p.workout_id IS NOT NULL
+					AND p3.workout_id = p.workout_id
+					AND p3.user_id = p.user_id
+					AND p3.post_id <> p.post_id
+					AND p3.deleted_at IS NULL
+					AND p3.share_to_story AND NOT p3.share_to_feed
+					AND p3.story_expires_at > NOW()
+				ORDER BY p3.created_at DESC
+				LIMIT 1
+			) AS story_photo_url
 		FROM posts p
 		JOIN users u ON u.user_id = p.user_id
 		WHERE p.user_id = $2


### PR DESCRIPTION
# Summary

## Picture leads everywhere (feed ↔ profile consistency)
The profile Posts tab only surfaced the permanent feed post, so a run whose photo went to the story showed just the stats card — different from the feed card, which already leads with the photo.

- `getUserPosts` now ships each post's story photo alongside it (same subquery as the unified feed).
- **Grid thumbnails** lead with the picture when one exists; the workout card is only the face of a post with no photo.
- **Posts detail cards** use the same photo-first carousel as the feed: photo → stats card (badged "Stats"), page dots, pinch-zoom lightbox per slide.

## Story expiry semantics (owner decision)
The 24h expiry ends the **story** (rail/viewer) only. A photo riding on the run's feed card and profile posts stays **permanently** — deleting the story is the way to remove it. The `story_expires_at` condition is dropped from both feed-side photo lookups.

## Feed diagnostics (from the outage hunt — worth keeping)
- `/status/schema` gains `feed_probe`: executes the real `getUnifiedFeed` + `getStoriesRail` as the most recently active user and reports only row counts or the SQL error text.
- Unified feed + stories rail failures now log to `error_log` (visible in the admin dashboard) — the app renders these as a silent "No activity yet", so the server must never lose them.

## Verification
- `npm run build` (tsc) passes.
- Feed queries verified end-to-end earlier against a migrated, seeded scratch Postgres (rows, routes, rail all correct).
- iOS changes are additive decodes (`story_photo_url` optional) — older responses render exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQh9bdXHFoZag7ehNxh4Ak