### PR TITLE
Review fixes: Add-to-feed vs auto card, dot clearance, off-main JPEG encode

### DIFF
--- a/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
@@ -345,14 +345,22 @@ struct WorkoutTrackingView: View {
         .onChange(of: midRunImage) { _, newImage in
             guard let image = newImage else { return }
             midRunImage = nil
-            guard MidRunPhotoStash.add(image) else { return }
-            midRunSnapCount = MidRunPhotoStash.count
-            UINotificationFeedbackGenerator().notificationOccurred(.success)
-            withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
-                showSnapSavedToast = true
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.8) {
-                withAnimation(.easeOut(duration: 0.25)) { showSnapSavedToast = false }
+            // Downscale + JPEG-encode off the main thread — doing it inline
+            // stutters the camera dismissal animation on big sensor images.
+            Task.detached(priority: .utility) {
+                let saved = MidRunPhotoStash.add(image)
+                let count = MidRunPhotoStash.count
+                guard saved else { return }
+                await MainActor.run {
+                    midRunSnapCount = count
+                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                    withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                        showSnapSavedToast = true
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.8) {
+                        withAnimation(.easeOut(duration: 0.25)) { showSnapSavedToast = false }
+                    }
+                }
             }
         }
     }

--- a/app/Mile A Day/Views/Feed/FeedMediaViews.swift
+++ b/app/Mile A Day/Views/Feed/FeedMediaViews.swift
@@ -320,6 +320,9 @@ struct FeedWorkoutCard: View {
                 .padding(.top, 14)
             }
             .padding(18)
+            // This card renders inside the paging carousel, whose page dots
+            // occupy the slide's bottom edge — keep the brand row above them.
+            .padding(.bottom, 16)
         }
         .aspectRatio(4.0 / 5.0, contentMode: .fit)
         .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))

--- a/app/Mile A Day/Views/Feed/StoryViewerView.swift
+++ b/app/Mile A Day/Views/Feed/StoryViewerView.swift
@@ -326,9 +326,10 @@ struct StoryViewerView: View {
 
     /// A story photo can be promoted into the permanent feed — it replaces the
     /// run's auto route/stats card in place (upsert by workout). Hidden when the
-    /// story is itself on the feed OR its workout already has a separate feed
-    /// post (server-computed `workout_on_feed`) — otherwise "Add to feed" would
-    /// be offered only to 409 on tap.
+    /// story is itself on the feed OR its workout already has a separate
+    /// DELIBERATE feed post (server-computed `workout_on_feed`; the auto card
+    /// doesn't count — replacing it is the point) — otherwise "Add to feed"
+    /// would be offered only to 409 on tap.
     private func canPromote(_ post: PostItem) -> Bool {
         post.share_to_feed != true
             && post.workout_on_feed != true

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -58,9 +58,11 @@ export interface PostRow {
   // The run's active story photo (getUserPosts only) — lets profile surfaces
   // lead with the real picture like the feed does.
   story_photo_url?: string | null;
-  // getUserActiveStories only: does this story's workout ALREADY have a live
-  // feed post? Drives hiding the story viewer's "Add to feed" button so it
-  // isn't offered (then 409'd) when the run is already on the feed.
+  // getUserActiveStories only: does this story's workout already have a live
+  // DELIBERATE feed post? Drives hiding the story viewer's "Add to feed"
+  // button so it isn't offered (then 409'd) when the run is already on the
+  // feed. The auto route/stats card does NOT count — promoting a story photo
+  // replaces the auto card in place, which is the button's whole point.
   workout_on_feed?: boolean;
 }
 
@@ -334,6 +336,7 @@ export async function getUserActiveStories(
 					AND pf.workout_id IS NOT NULL
 					AND pf.deleted_at IS NULL
 					AND pf.share_to_feed
+					AND NOT pf.is_auto
 			) AS workout_on_feed
 		FROM posts p
 		JOIN circle c ON c.uid = p.user_id


### PR DESCRIPTION
Post-merge review of #187's last two commits found **one real bug** and two polish items.

## 🔴 The bug: "Add to feed" was about to disappear from almost every story

`workout_on_feed` (added in #187 to hide the story viewer's dead "Add to feed" button) counted **any** live feed post for the story's workout — including the **auto route/stats card** that every completed mile gets. But promoting a story photo is *designed to replace the auto card in place* — that's the button's primary use case. So once your auto card landed on the feed (i.e. almost always), the button would have vanished everywhere.

Fixed by counting only **deliberate** feed posts (`AND NOT pf.is_auto`). Verified on a scratch Postgres:
- story + auto card only → `workout_on_feed = false` → button shows, promote replaces the card ✅
- story + deliberate feed post → `workout_on_feed = true` → button hidden ✅

The original #187 test only seeded deliberate posts, which is why this slipped through.

## 🟡 Polish

- **FeedWorkoutCard** (the new photo→workout second slide): added bottom padding so the "Mile A Day" brand row sits clear of the carousel's page dots instead of colliding with them.
- **Mid-run snaps**: the downscale + JPEG encode now runs off the main thread — encoding a large sensor image inline could stutter the camera dismissal animation.

## Verification
- Backend `tsc` + `drizzle-kit check` clean; seeded feed smoke test passes
- Both `workout_on_feed` cases exercised on scratch DB (above)
- iOS changes need an Xcode build: check a photo post's second slide (dots shouldn't touch the brand row) and take a mid-run snap (camera should dismiss smoothly, toast + badge still appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQh9bdXHFoZag7ehNxh4Ak

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQh9bdXHFoZag7ehNxh4Ak)_