### PR TITLE
Feed/social fixes: hype burst & who-hyped list, route pipeline, per-workout photos, mile-completion tolerance

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -4,6 +4,8 @@ globs: backend/**
 
 # Backend Conventions
 
+- Daily-mile completion checks must use `DAILY_GOAL_TOLERANCE` (0.95) from workoutService, never a raw `>= 1.0` — streaks/challenges count 0.95 days, and today_miles is displayed 2-decimal-rounded ("1.00" can be 0.996). iOS mirror: `ProgressCalculator.dailyGoalTolerance`.
+
 ## Architecture: Routes -> Controllers -> Services
 - `routes/` - Express Router definitions. Thin: just wire HTTP verbs to controller functions + middleware.
 - `controllers/` - Request/response handling. Parse params/body, call services, format responses.

--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -28,6 +28,8 @@ globs: backend/**
 - Existing prod schema was baselined via `scripts/drizzle-baseline.mjs` (records `0000` as applied without running it). Run it ONCE per environment before the first `db:migrate`.
 - `drizzle-kit pull` has introspection bugs to fix by hand after every pull: (1) some SQL-expression/empty-string defaults emit broken TS → fix with `.default(sql\`...\`)` / `.default('')`; (2) composite-index per-column opclasses get misaligned (text col tagged `timestamptz_ops` etc.) → these are all DEFAULT opclasses, so strip every `.op(...)` EXCEPT non-defaults like `gin_trgm_ops`; (3) `relations.ts` imports `./schema` without `.js` → add it. After fixing, regenerate the baseline (empty `meta/_journal.json` + `db:generate`) and confirm it says "No schema changes".
 
+- Never emit raw `timestamptz::text` in URL query params (pagination cursors): its `+00` offset decodes as a SPACE in Express's query parser and the `::timestamptz` cast 500s. Emit cursors via `URL_SAFE_CURSOR` (ISO `…Z`, postService.ts); iOS must percent-encode query values with a set that excludes `+` (`PostService.queryValueAllowed`).
+
 ## Auth Pattern
 - Public routes (`/auth/*`, `/dev/*`, `/status`) are mounted BEFORE `authenticateToken` middleware in server.ts.
 - Protected routes are mounted AFTER. `req.userId` is set by auth middleware (see `AuthenticatedRequest` type).

--- a/.claude/rules/ios.md
+++ b/.claude/rules/ios.md
@@ -24,6 +24,7 @@ globs: app/**
   - `+DataFetching.swift`, `+PersonalRecords.swift`, `+StreakCalculation.swift`, `+WorkoutIndex.swift`
 - Workout sync: HealthKit -> WorkoutProcessor -> WorkoutSyncService -> Backend API
 - HealthKit queries ERROR when the device is locked (protected data). Never treat a query error as "0 miles" — only a successful empty result is a real zero. Writing 0 on error randomly reset widgets.
+- Feed route maps are read from HKWorkoutRoute at sync time. In-app tracked workouts must write their GPS trace via `HKWorkoutRouteBuilder.finishRoute` after `finishWorkout` (and `HKSeriesType.workoutRoute()` must be in the SHARE auth set) — points buffered in InProgressWorkoutStore alone never reach the backend.
 - WidgetKit renders statically: `.onAppear`-driven `@State` animations never play in widget views — render entry values directly. `WidgetDataStore` data is day-stamped; `load()` returns zeros for a stale day, and saves skip no-op writes (widget reloads are budgeted per day).
 
 ## Key Patterns

--- a/app/Mile A Day/Core/Services/MADBackgroundService.swift
+++ b/app/Mile A Day/Core/Services/MADBackgroundService.swift
@@ -274,7 +274,7 @@ final class MADBackgroundService: NSObject, ObservableObject {
         let todaysDistance = healthManager.todaysDistance
         let goalMiles = currentUser.goalMiles
 
-        let isCompleted = todaysDistance >= goalMiles
+        let isCompleted = ProgressCalculator.isGoalCompleted(current: todaysDistance, goal: goalMiles)
 
         if isCompleted {
             // Send completion notification only if conditions are met

--- a/app/Mile A Day/Core/Services/MADNotificationService.swift
+++ b/app/Mile A Day/Core/Services/MADNotificationService.swift
@@ -195,7 +195,8 @@ final class MADNotificationService: NSObject, ObservableObject {
         // 2. Previous miles was below goal (just completed)
         // 3. Haven't sent notification today already
         
-        let justCompleted = currentMiles >= goalMiles && previousMiles < goalMiles
+        let justCompleted = ProgressCalculator.isGoalCompleted(current: currentMiles, goal: goalMiles)
+            && !ProgressCalculator.isGoalCompleted(current: previousMiles, goal: goalMiles)
         let alreadySentToday = lastCompletionNotificationDate != nil && 
                              Calendar.current.isDate(lastCompletionNotificationDate!, inSameDayAs: Date())
         

--- a/app/Mile A Day/Models/HealthKitManager.swift
+++ b/app/Mile A Day/Models/HealthKitManager.swift
@@ -628,11 +628,14 @@ class HealthKitManager: ObservableObject {
             HKSeriesType.workoutRoute()
         ]
 
-        // Define the types we want to write to HealthKit (for workout tracking)
+        // Define the types we want to write to HealthKit (for workout tracking).
+        // workoutRoute share access lets in-app GPS workouts save their route,
+        // which is what the feed's route maps are built from at sync time.
         let writeTypes: Set = [
             HKObjectType.workoutType(),
             HKObjectType.quantityType(forIdentifier: .distanceWalkingRunning)!,
-            HKObjectType.quantityType(forIdentifier: .activeEnergyBurned)!
+            HKObjectType.quantityType(forIdentifier: .activeEnergyBurned)!,
+            HKSeriesType.workoutRoute()
         ]
 
         healthStore.requestAuthorization(toShare: writeTypes, read: readTypes) { success, error in

--- a/app/Mile A Day/Services/HypeService.swift
+++ b/app/Mile A Day/Services/HypeService.swift
@@ -80,6 +80,52 @@ enum HypeService {
             responseType: [ReceivedHype].self
         )
     }
+
+    /// Everyone who hyped one specific post or daily mile, newest first — the
+    /// Instagram-style "who liked this" list behind a feed card's hype tally.
+    /// `contextId` is the post id for posts, or the workout id for miles (the
+    /// backend resolves it to the canonical composite key).
+    static func hypers(
+        contextType: String,
+        contextId: String,
+        targetUserId: String
+    ) async throws -> [Hyper] {
+        struct HypersResponse: Decodable {
+            let hypers: [Hyper]
+            let count: Int
+        }
+        var components = URLComponents()
+        components.queryItems = [
+            URLQueryItem(name: "context_type", value: contextType),
+            URLQueryItem(name: "context_id", value: contextId),
+            URLQueryItem(name: "target_user_id", value: targetUserId)
+        ]
+        let query = components.percentEncodedQuery ?? ""
+        return try await APIClient.fancyFetch(
+            endpoint: "/hype/hypers?\(query)",
+            responseType: HypersResponse.self
+        ).hypers
+    }
+}
+
+/// One person who hyped a post/mile, for the "who hyped this" list.
+struct Hyper: Decodable, Identifiable {
+    let user_id: String
+    let username: String?
+    let first_name: String?
+    let last_name: String?
+    let profile_image_url: String?
+    let created_at: String
+
+    var id: String { user_id }
+
+    var displayName: String {
+        if let username, !username.isEmpty { return username }
+        if let first_name, !first_name.isEmpty { return first_name }
+        return "Someone"
+    }
+
+    var relativeTime: String { RelativeTime.short(from: created_at) }
 }
 
 /// A hype someone sent to the current user.

--- a/app/Mile A Day/Services/LeaderboardService.swift
+++ b/app/Mile A Day/Services/LeaderboardService.swift
@@ -131,17 +131,36 @@ enum LeaderboardService {
         metric: LeaderboardMetric,
         period: LeaderboardPeriod,
         limit: Int = defaultPageSize,
-        offset: Int = 0
+        offset: Int = 0,
+        attempt: Int = 0
     ) async throws -> LeaderboardPage {
         // Build the query string by hand — enum raw values + ints, so no
         // URL-encoding required. Avoids URLComponents quirks with path-only URLs.
         let endpoint = "/leaderboard?metric=\(metric.rawValue)&period=\(period.rawValue)&limit=\(limit)&offset=\(offset)"
 
-        return try await APIClient.fancyFetch(
-            endpoint: endpoint,
-            method: .GET,
-            body: nil,
-            responseType: LeaderboardPage.self
-        )
+        do {
+            return try await APIClient.fancyFetch(
+                endpoint: endpoint,
+                method: .GET,
+                body: nil,
+                responseType: LeaderboardPage.self
+            )
+        } catch {
+            // Transient network failures (timeout, flaky cellular) get two
+            // quiet retries with backoff before the error state surfaces —
+            // same policy as RemoteChallengeService. Real API/decode errors
+            // throw immediately.
+            let isTransient: Bool = {
+                if error is URLError { return true }
+                if case APIError.networkError = error { return true }
+                return false
+            }()
+            guard isTransient, attempt < 2, !Task.isCancelled else { throw error }
+            try await Task.sleep(nanoseconds: UInt64(attempt + 1) * 1_500_000_000)
+            return try await fetch(
+                metric: metric, period: period,
+                limit: limit, offset: offset, attempt: attempt + 1
+            )
+        }
     }
 }

--- a/app/Mile A Day/Services/PostService.swift
+++ b/app/Mile A Day/Services/PostService.swift
@@ -257,6 +257,26 @@ enum PostError: LocalizedError {
 /// APIClient.fancyFetch (auto token refresh); the photo upload hand-rolls
 /// multipart like ProfileImageService.
 enum PostService {
+    /// Percent-encoding for query-string VALUES (pagination cursors).
+    /// `.urlQueryAllowed` leaves '+' literal, and the backend's query parser
+    /// decodes a literal '+' as a SPACE — which corrupted the old
+    /// "…12:34:56.123456+00" timestamp cursors and silently froze feed
+    /// pagination after the first page. Encoding the reserved characters
+    /// guarantees the cursor arrives byte-identical.
+    private static let queryValueAllowed: CharacterSet = {
+        var set = CharacterSet.urlQueryAllowed
+        set.remove(charactersIn: "+&=?")
+        return set
+    }()
+
+    /// A `before=` query suffix for the given cursor, safely encoded.
+    fileprivate static func beforeSuffix(_ before: String?) -> String {
+        guard let before,
+              let encoded = before.addingPercentEncoding(withAllowedCharacters: queryValueAllowed)
+        else { return "" }
+        return "&before=\(encoded)"
+    }
+
     /// Upload a flattened post photo (overlay already composited). Returns the
     /// server `media_url` to reference when creating the post.
     static func uploadMedia(_ image: UIImage) async throws -> String {
@@ -386,28 +406,19 @@ enum PostService {
 
     /// One page of the feed. Pass the previous page's `next_before` to paginate.
     static func fetchFeed(before: String? = nil) async throws -> FeedResponse {
-        var endpoint = "/posts/feed?limit=20"
-        if let before, let encoded = before.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
-            endpoint += "&before=\(encoded)"
-        }
+        let endpoint = "/posts/feed?limit=20" + beforeSuffix(before)
         return try await APIClient.fancyFetch(endpoint: endpoint, responseType: FeedResponse.self)
     }
 
     /// The unified feed: photo posts + workout activity interleaved, paginated.
     static func fetchUnifiedFeed(before: String? = nil) async throws -> UnifiedFeedResponse {
-        var endpoint = "/posts/feed/unified?limit=20"
-        if let before, let encoded = before.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
-            endpoint += "&before=\(encoded)"
-        }
+        let endpoint = "/posts/feed/unified?limit=20" + beforeSuffix(before)
         return try await APIClient.fancyFetch(endpoint: endpoint, responseType: UnifiedFeedResponse.self)
     }
 
     /// A user's permanent posts for the Instagram-style profile grid.
     static func fetchUserPosts(userId: String, before: String? = nil) async throws -> FeedResponse {
-        var endpoint = "/posts/user/\(userId)?limit=24"
-        if let before, let encoded = before.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
-            endpoint += "&before=\(encoded)"
-        }
+        let endpoint = "/posts/user/\(userId)?limit=24" + beforeSuffix(before)
         return try await APIClient.fancyFetch(endpoint: endpoint, responseType: FeedResponse.self)
     }
 

--- a/app/Mile A Day/Services/PostService.swift
+++ b/app/Mile A Day/Services/PostService.swift
@@ -133,6 +133,9 @@ struct FeedEntry: Codable, Identifiable {
     let story_photo_url: String?
     /// post-only: system-generated route/stats card (vs a deliberate post).
     let is_auto: Bool?
+    /// The entry's workout: the linked workout for posts (nil when unlinked
+    /// or from an older backend), the workout itself for workout entries.
+    let workout_id: String?
     // workout columns (workout_type is also set for posts via their run)
     let workout_type: String?
     let distance: Double?
@@ -151,7 +154,7 @@ struct FeedEntry: Codable, Identifiable {
         case entryId = "id"
         case sort_ts, user_id, username, first_name, last_name, profile_image_url
         case media_url, caption, stats_snapshot, story_photo_url, is_auto
-        case workout_type, distance, total_duration, calories, steps, route
+        case workout_id, workout_type, distance, total_duration, calories, steps, route
         case is_self, is_hyped, hype_count
     }
 
@@ -181,7 +184,7 @@ struct FeedEntry: Codable, Identifiable {
             post_id: entryId, user_id: user_id, username: username,
             first_name: first_name, last_name: last_name,
             profile_image_url: profile_image_url, media_url: media, caption: caption,
-            workout_id: nil, stats_snapshot: stats_snapshot, local_date: nil,
+            workout_id: workout_id, stats_snapshot: stats_snapshot, local_date: nil,
             share_to_feed: true, share_to_story: nil, story_expires_at: nil,
             created_at: sort_ts, is_auto: is_auto, workout_type: workout_type,
             route: route, story_photo_url: story_photo_url,

--- a/app/Mile A Day/Utils/Extensions.swift
+++ b/app/Mile A Day/Utils/Extensions.swift
@@ -234,7 +234,14 @@ extension HKWorkout {
 /// Unified progress calculation system to ensure 1-to-1 synchronization
 /// between Apple Fitness tracking and MAD tracking
 struct ProgressCalculator {
-    
+
+    /// Canonical "daily mile done" tolerance, matching the backend
+    /// (`DAILY_GOAL_TOLERANCE` in workoutService.ts): streaks, challenges,
+    /// nudge status, and the posting gate all count >= 95% of the goal as
+    /// complete (GPS under-measure allowance). Completion checks here must
+    /// match, or the app shows "locked" states the server would allow.
+    static let dailyGoalTolerance = 0.95
+
     /// Calculates progress percentage, ensuring it never exceeds 100%
     /// - Parameters:
     ///   - current: Current distance completed
@@ -249,9 +256,9 @@ struct ProgressCalculator {
     /// - Parameters:
     ///   - current: Current distance completed
     ///   - goal: Goal distance
-    /// - Returns: True if goal is completed (current >= goal)
+    /// - Returns: True if goal is completed (within the daily-goal tolerance)
     static func isGoalCompleted(current: Double, goal: Double) -> Bool {
-        return current >= goal
+        return current + 1e-9 >= goal * dailyGoalTolerance
     }
     
     /// Calculates remaining distance to goal

--- a/app/Mile A Day/Views/Auth/HealthAccessView.swift
+++ b/app/Mile A Day/Views/Auth/HealthAccessView.swift
@@ -168,7 +168,10 @@ struct HealthAccessView: View {
         let writeTypes: Set<HKSampleType> = [
             HKObjectType.workoutType(),
             HKObjectType.quantityType(forIdentifier: .distanceWalkingRunning)!,
-            HKObjectType.quantityType(forIdentifier: .activeEnergyBurned)!
+            HKObjectType.quantityType(forIdentifier: .activeEnergyBurned)!,
+            // Lets in-app GPS workouts save their route — the source of the
+            // feed's route maps at sync time.
+            HKSeriesType.workoutRoute()
         ]
 
         healthStore.requestAuthorization(toShare: writeTypes, read: readTypes) { success, error in

--- a/app/Mile A Day/Views/Components/HypersListSheet.swift
+++ b/app/Mile A Day/Views/Components/HypersListSheet.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+
+/// Identifies one hypeable piece of content (a post or a daily mile) so the
+/// feed can open the "who hyped this" list for it.
+struct HypersListContext: Identifiable {
+    /// "post" | "mile"
+    let contextType: String
+    /// Post id, or the mile's workout id (backend canonicalizes).
+    let contextId: String
+    /// The content author's user id.
+    let targetUserId: String
+
+    var id: String { "\(contextType)-\(contextId)" }
+}
+
+/// Instagram's "Likes" sheet, in Mile A Day's language: tap a card's hype
+/// tally to see everyone who hyped it, newest first.
+struct HypersListSheet: View {
+    let context: HypersListContext
+    /// Tap a row to open that person's profile (dismisses this sheet first).
+    var onSelectUser: ((Hyper) -> Void)? = nil
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var hypers: [Hyper] = []
+    @State private var isLoading = true
+    @State private var failed = false
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                MADTheme.Colors.appBackgroundGradient.ignoresSafeArea()
+
+                if isLoading {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: MADTheme.Colors.madRed))
+                } else if failed {
+                    stateMessage(icon: "wifi.slash", text: "Couldn't load hypes")
+                } else if hypers.isEmpty {
+                    stateMessage(icon: "hands.clap", text: "No hypes yet")
+                } else {
+                    ScrollView {
+                        LazyVStack(spacing: 0) {
+                            ForEach(hypers) { hyper in
+                                row(hyper)
+                                if hyper.id != hypers.last?.id {
+                                    Divider().overlay(Color.white.opacity(0.06))
+                                        .padding(.leading, 62)
+                                }
+                            }
+                        }
+                        .padding(.vertical, MADTheme.Spacing.sm)
+                    }
+                    .scrollIndicators(.hidden)
+                }
+            }
+            .navigationTitle("Hypes")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundColor(MADTheme.Colors.madRed)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        .task { await load() }
+    }
+
+    private func row(_ hyper: Hyper) -> some View {
+        Button {
+            if let onSelectUser {
+                dismiss()
+                onSelectUser(hyper)
+            }
+        } label: {
+            HStack(spacing: 12) {
+                AvatarView(name: hyper.displayName, imageURL: hyper.profile_image_url, size: 42)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(hyper.displayName)
+                        .font(.system(size: 15, weight: .bold, design: .rounded))
+                        .foregroundColor(.white)
+                        .lineLimit(1)
+                    Text(hyper.relativeTime)
+                        .font(.system(size: 12, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.5))
+                }
+                Spacer()
+                Image(systemName: "hands.clap.fill")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundColor(.orange)
+            }
+            .padding(.horizontal, MADTheme.Spacing.md)
+            .padding(.vertical, 9)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(onSelectUser == nil)
+    }
+
+    private func stateMessage(icon: String, text: String) -> some View {
+        VStack(spacing: MADTheme.Spacing.sm) {
+            Image(systemName: icon)
+                .font(.system(size: 28))
+                .foregroundColor(.white.opacity(0.3))
+            Text(text)
+                .font(.system(size: 14, weight: .semibold, design: .rounded))
+                .foregroundColor(.white.opacity(0.5))
+        }
+    }
+
+    private func load() async {
+        do {
+            let result = try await HypeService.hypers(
+                contextType: context.contextType,
+                contextId: context.contextId,
+                targetUserId: context.targetUserId
+            )
+            await MainActor.run {
+                hypers = result
+                isLoading = false
+            }
+        } catch {
+            await MainActor.run {
+                failed = true
+                isLoading = false
+            }
+        }
+    }
+}

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -330,6 +330,15 @@ struct DashboardView: View {
         // see yourself climb with the added miles, then the extra-mile hype.
         celebrationManager.addCelebration(.leaderboardMoveUp(stats: stats))
         celebrationManager.addCelebration(.postGoalWorkout(stats: stats))
+
+        // Every walk/run gets its own photo moment, not just the goal-crossing
+        // one — same finale as the goal path. The celebration id is keyed by
+        // workout uuid, so each new workout prompts exactly once.
+        if autoShareRunsToFeed, let uuid = healthManager.workoutIndex?.latestWorkoutUUID {
+            let hk = healthManager.todaysWorkouts.first { $0.uuid.uuidString == uuid }
+            let wtype = hk?.workoutActivityType == .walking ? "walking" : "running"
+            celebrationManager.addCelebration(.postRunPhotoPrompt(workoutId: uuid, workoutType: wtype))
+        }
     }
 
     // Simplified state calculation

--- a/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
@@ -916,6 +916,14 @@ struct WorkoutTrackingView: View {
         // Flush any buffered route points
         InProgressWorkoutStore.flushRoutePoints()
 
+        // Capture the GPS trace NOW — finishCleanup() clears the store, and the
+        // HealthKit route write below happens after that. Without this route,
+        // in-app workouts never got an HKWorkoutRoute, so the sync (which reads
+        // routes back from HealthKit) uploaded them route-less and the feed
+        // could never draw their maps.
+        let routeLocations = (InProgressWorkoutStore.load()?.routePoints ?? [])
+            .map { $0.toCLLocation() }
+
         // Stop timer and location tracking
         timer?.invalidate()
         timer = nil
@@ -940,16 +948,44 @@ struct WorkoutTrackingView: View {
 
         let endDate = Date()
 
-        // Async chain: add distance sample → end collection → finish workout → cleanup.
-        // Every step proceeds regardless of whether the previous step failed.
+        // Async chain: add distance sample → end collection → finish workout →
+        // attach GPS route → cleanup. Every step proceeds regardless of whether
+        // the previous step failed.
         let addCompletion: (Bool, Error?) -> Void = { _, _ in
             builder.endCollection(withEnd: endDate) { _, _ in
                 builder.finishWorkout { workout, error in
                     let saved = (workout != nil && error == nil)
-                    DispatchQueue.main.async {
-                        self.finishCleanup(workoutSaved: saved)
-                        if saved {
-                            self.healthManager.fetchAllWorkoutData()
+                    let finalize = {
+                        DispatchQueue.main.async {
+                            self.finishCleanup(workoutSaved: saved)
+                            if saved {
+                                self.healthManager.fetchAllWorkoutData()
+                            }
+                        }
+                    }
+                    // Write the tracked GPS trace as the workout's
+                    // HKWorkoutRoute BEFORE finalizing — fetchAllWorkoutData
+                    // kicks off the backend sync, which reads the route back
+                    // from HealthKit to draw feed maps. Best-effort: a failed
+                    // route write still finalizes the workout itself.
+                    guard let workout, saved, routeLocations.count >= 2 else {
+                        finalize()
+                        return
+                    }
+                    let routeBuilder = HKWorkoutRouteBuilder(
+                        healthStore: HKHealthStore(), device: .local()
+                    )
+                    routeBuilder.insertRouteData(routeLocations) { inserted, insertError in
+                        guard inserted else {
+                            print("[WorkoutTracking] ⚠️ Route insert failed: \(String(describing: insertError))")
+                            finalize()
+                            return
+                        }
+                        routeBuilder.finishRoute(with: workout, metadata: nil) { route, finishError in
+                            if route == nil {
+                                print("[WorkoutTracking] ⚠️ Route finish failed: \(String(describing: finishError))")
+                            }
+                            finalize()
                         }
                     }
                 }

--- a/app/Mile A Day/Views/Feed/ActivityCardView.swift
+++ b/app/Mile A Day/Views/Feed/ActivityCardView.swift
@@ -17,7 +17,7 @@ struct ActivityCardView: View {
     @State private var hypeBurst = 0
 
     private var distance: Double { entry.distance ?? 0 }
-    private var completedMile: Bool { distance >= 1.0 }
+    private var completedMile: Bool { distance >= ProgressCalculator.dailyGoalTolerance }
     private var accent: Color { Self.color(entry.workout_type) }
 
     var body: some View {

--- a/app/Mile A Day/Views/Feed/ActivityCardView.swift
+++ b/app/Mile A Day/Views/Feed/ActivityCardView.swift
@@ -11,6 +11,8 @@ struct ActivityCardView: View {
     let onHype: () -> Void
     /// Tap the author's avatar or name to open their profile.
     var onTapAuthor: (() -> Void)? = nil
+    /// Tap the hype tally to see who hyped (Instagram-likes style).
+    var onTapHypeCount: (() -> Void)? = nil
 
     @State private var hypeBurst = 0
 
@@ -147,7 +149,12 @@ struct ActivityCardView: View {
     private var footer: some View {
         HStack(spacing: 10) {
             if let count = entry.hype_count, count > 0 {
-                HypeTally(count: count)
+                Button { onTapHypeCount?() } label: {
+                    HypeTally(count: count)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(onTapHypeCount == nil)
             }
             Spacer()
             if !entry.is_self {

--- a/app/Mile A Day/Views/Feed/FeedMediaViews.swift
+++ b/app/Mile A Day/Views/Feed/FeedMediaViews.swift
@@ -378,8 +378,19 @@ struct FeedWorkoutCard: View {
 /// Instagram's big-heart moment, in Mile A Day's language: a huge clap bursts
 /// from the center of the photo with a spring, mini claps radiate outward,
 /// then everything floats up and fades. Fire it by incrementing `trigger`.
+///
+/// Fully invisible at rest — every element's opacity is gated on `playing`,
+/// not just animation phase. (The particles used to key opacity solely off
+/// `particlesOut`, which is false at rest too, so six claps sat permanently
+/// on every card that had never been double-tapped.)
 struct HypeBurstView: View {
     let trigger: Int
+
+    /// True only while a burst is on screen. Also generation-guards the
+    /// delayed cleanup so a rapid re-double-tap isn't cut short by the
+    /// previous burst's teardown.
+    @State private var playing = false
+    @State private var generation = 0
 
     @State private var mainScale: CGFloat = 0
     @State private var mainRotation: Double = -14
@@ -398,7 +409,7 @@ struct HypeBurstView: View {
                     .foregroundColor(.orange.opacity(0.9))
                     .rotationEffect(.degrees(Double(index.isMultiple(of: 2) ? -18 : 14)))
                     .offset(particleOffset(angle: angle, distance: particlesOut ? 84 : 12))
-                    .opacity(particlesOut ? 0 : 0.9)
+                    .opacity(playing && !particlesOut ? 0.9 : 0)
                     .scaleEffect(particlesOut ? 0.6 : 1)
             }
 
@@ -415,7 +426,7 @@ struct HypeBurstView: View {
                 .shadow(color: .black.opacity(0.35), radius: 8, y: 4)
                 .scaleEffect(mainScale)
                 .rotationEffect(.degrees(mainRotation))
-                .opacity(mainOpacity)
+                .opacity(playing ? mainOpacity : 0)
                 .offset(y: rise)
         }
         .allowsHitTesting(false)
@@ -428,13 +439,22 @@ struct HypeBurstView: View {
     }
 
     private func play() {
-        // Reset instantly (a rapid re-double-tap replays from the start).
-        mainScale = 0.2
-        mainRotation = -14
-        mainOpacity = 0
-        rise = 0
-        particlesOut = false
+        generation += 1
+        let gen = generation
 
+        // Reset instantly (a rapid re-double-tap replays from the start).
+        var reset = Transaction()
+        reset.disablesAnimations = true
+        withTransaction(reset) {
+            playing = true
+            mainScale = 0.2
+            mainRotation = -14
+            mainOpacity = 0
+            rise = 0
+            particlesOut = false
+        }
+
+        // Pop in with an Instagram-style overshoot spring…
         withAnimation(.spring(response: 0.32, dampingFraction: 0.55)) {
             mainScale = 1.12
             mainRotation = 0
@@ -443,12 +463,18 @@ struct HypeBurstView: View {
         withAnimation(.easeOut(duration: 0.7).delay(0.05)) {
             particlesOut = true
         }
+        // …hold a beat, then float up and fade out.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.55) {
+            guard gen == generation else { return }
             withAnimation(.easeIn(duration: 0.35)) {
                 mainOpacity = 0
                 rise = -60
                 mainScale = 0.8
             }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.95) {
+            guard gen == generation else { return }
+            playing = false
         }
     }
 }

--- a/app/Mile A Day/Views/Feed/Memories.swift
+++ b/app/Mile A Day/Views/Feed/Memories.swift
@@ -104,49 +104,40 @@ enum MemoriesService {
 }
 
 /// Compact "On this day" card shown at the top of the feed when memories exist.
+/// Scales from one memory to many: stacked photo thumbnails when photos exist,
+/// and a summary line that says how many there are instead of a bare "+N".
 struct MemoriesCardView: View {
     let memories: [MemoryItem]
     let onTap: () -> Void
 
+    private var photoURLs: [URL] {
+        memories.compactMap(\.photoURL)
+    }
+
+    private var subtitle: String {
+        guard let top = memories.first else { return "" }
+        if memories.count == 1 {
+            return "\(top.yearsAgoText) · \(String(format: "%.2f", top.miles)) mi \(ActivityCardView.verb(top.workoutType).lowercased())"
+        }
+        return "\(memories.count) memories · \(top.yearsAgoText) and more"
+    }
+
     var body: some View {
         Button(action: onTap) {
             HStack(spacing: MADTheme.Spacing.md) {
-                if let photoURL = memories.first(where: { $0.photoURL != nil })?.photoURL {
-                    AsyncImage(url: photoURL) { phase in
-                        if case .success(let image) = phase {
-                            image.resizable().scaledToFill()
-                        } else {
-                            Color.white.opacity(0.06)
-                        }
-                    }
-                    .frame(width: 44, height: 44)
-                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-                } else {
-                    Image(systemName: "clock.arrow.circlepath")
-                        .font(.system(size: 22, weight: .bold))
-                        .foregroundColor(.white)
-                        .frame(width: 44, height: 44)
-                        .background(Circle().fill(MADTheme.Colors.redGradient))
-                }
+                leadingThumbnails
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text("On this day")
                         .font(.system(size: 11, weight: .heavy, design: .rounded))
                         .tracking(1.2)
                         .foregroundColor(.white.opacity(0.6))
-                    if let top = memories.first {
-                        Text("\(top.yearsAgoText) · \(String(format: "%.2f", top.miles)) mi \(ActivityCardView.verb(top.workoutType).lowercased())")
-                            .font(.system(size: 15, weight: .bold, design: .rounded))
-                            .foregroundColor(.white)
-                            .lineLimit(1)
-                    }
+                    Text(subtitle)
+                        .font(.system(size: 15, weight: .bold, design: .rounded))
+                        .foregroundColor(.white)
+                        .lineLimit(1)
                 }
                 Spacer()
-                if memories.count > 1 {
-                    Text("+\(memories.count - 1)")
-                        .font(.system(size: 13, weight: .heavy, design: .rounded))
-                        .foregroundColor(.white.opacity(0.6))
-                }
                 Image(systemName: "chevron.right")
                     .font(.system(size: 13, weight: .bold))
                     .foregroundColor(.white.opacity(0.4))
@@ -163,9 +154,48 @@ struct MemoriesCardView: View {
         }
         .buttonStyle(.plain)
     }
+
+    /// Up to three overlapping photo thumbnails, or the clock badge when the
+    /// memories have no photos.
+    @ViewBuilder
+    private var leadingThumbnails: some View {
+        let urls = Array(photoURLs.prefix(3))
+        if urls.isEmpty {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 22, weight: .bold))
+                .foregroundColor(.white)
+                .frame(width: 44, height: 44)
+                .background(Circle().fill(MADTheme.Colors.redGradient))
+        } else {
+            ZStack {
+                ForEach(Array(urls.enumerated().reversed()), id: \.offset) { index, url in
+                    AsyncImage(url: url) { phase in
+                        if case .success(let image) = phase {
+                            image.resizable().scaledToFill()
+                        } else {
+                            Color.white.opacity(0.06)
+                        }
+                    }
+                    .frame(width: 44, height: 44)
+                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .strokeBorder(Color(red: 0.09, green: 0.07, blue: 0.08), lineWidth: 1.5)
+                    )
+                    .offset(x: CGFloat(index) * 10)
+                }
+            }
+            // Reserve the stack's real footprint so the text column doesn't
+            // overlap the offset thumbnails.
+            .frame(width: 44 + CGFloat(max(0, urls.count - 1)) * 10, height: 44, alignment: .leading)
+        }
+    }
 }
 
-/// Full list of today's memories across past years.
+/// Today's memories across past years, presented as full feed-style cards:
+/// a header ("2 years ago · June 4, 2024"), the day's photo when one exists
+/// (or a branded distance hero when not), and a stat chip strip — the same
+/// visual language as the main feed.
 struct MemoriesDetailView: View {
     let memories: [MemoryItem]
     @Environment(\.dismiss) private var dismiss
@@ -180,74 +210,179 @@ struct MemoriesDetailView: View {
         NavigationStack {
             ZStack {
                 MADTheme.Colors.appBackgroundGradient.ignoresSafeArea()
-                ScrollView {
-                    VStack(spacing: MADTheme.Spacing.md) {
-                        ForEach(memories) { memory in
-                            row(memory)
+                if memories.isEmpty {
+                    emptyState
+                } else {
+                    ScrollView {
+                        LazyVStack(spacing: MADTheme.Spacing.md) {
+                            ForEach(memories) { memory in
+                                memoryCard(memory)
+                            }
                         }
+                        .padding(MADTheme.Spacing.md)
+                        .padding(.bottom, MADTheme.Spacing.xl)
                     }
-                    .padding(MADTheme.Spacing.md)
+                    .scrollIndicators(.hidden)
                 }
             }
             .navigationTitle("On this day")
             .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }
+                        .foregroundColor(MADTheme.Colors.madRed)
                 }
             }
         }
     }
 
-    private func row(_ memory: MemoryItem) -> some View {
-        HStack(spacing: MADTheme.Spacing.md) {
-            if let photoURL = memory.photoURL {
-                AsyncImage(url: photoURL) { phase in
-                    if case .success(let image) = phase {
-                        image.resizable().scaledToFill()
-                    } else {
-                        ZStack {
-                            Color.white.opacity(0.06)
-                            Image(systemName: "photo").foregroundColor(.white.opacity(0.3))
-                        }
-                    }
+    private var emptyState: some View {
+        VStack(spacing: MADTheme.Spacing.sm) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 32))
+                .foregroundColor(.white.opacity(0.3))
+            Text("No memories today")
+                .font(.system(size: 15, weight: .bold, design: .rounded))
+                .foregroundColor(.white)
+        }
+    }
+
+    // MARK: - Feed-style memory card
+
+    private func memoryCard(_ memory: MemoryItem) -> some View {
+        let accent = ActivityCardView.color(memory.workoutType)
+        return VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+            // Header — mirrors the feed card's author row, with the memory's
+            // age standing in for the author.
+            HStack(spacing: 10) {
+                Image(systemName: "clock.arrow.circlepath")
+                    .font(.system(size: 17, weight: .bold))
+                    .foregroundColor(.white)
+                    .frame(width: 40, height: 40)
+                    .background(Circle().fill(MADTheme.Colors.redGradient))
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(memory.yearsAgoText)
+                        .font(.system(size: 15, weight: .bold, design: .rounded))
+                        .foregroundColor(.white)
+                    Text(Self.dateFormatter.string(from: memory.date))
+                        .font(.system(size: 12, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.5))
                 }
-                .frame(width: 56, height: 70)
-                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-            } else {
+                Spacer()
                 Image(systemName: ActivityCardView.icon(memory.workoutType))
-                    .font(.system(size: 20, weight: .bold))
-                    .foregroundColor(ActivityCardView.color(memory.workoutType))
-                    .frame(width: 44, height: 44)
-                    .background(Circle().fill(Color.white.opacity(0.06)))
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundColor(accent)
+                    .frame(width: 30, height: 30)
+                    .background(Circle().fill(accent.opacity(0.15)))
             }
 
-            VStack(alignment: .leading, spacing: 3) {
-                Text(memory.yearsAgoText)
-                    .font(.system(size: 16, weight: .bold, design: .rounded))
-                    .foregroundColor(.white)
-                Text(Self.dateFormatter.string(from: memory.date))
-                    .font(.system(size: 12, weight: .medium, design: .rounded))
-                    .foregroundColor(.white.opacity(0.5))
+            if let photoURL = memory.photoURL {
+                photoSlide(photoURL)
+            } else if memory.miles > 0 {
+                distanceHero(memory, accent: accent)
             }
-            Spacer()
-            VStack(alignment: .trailing, spacing: 2) {
-                Text("\(String(format: "%.2f", memory.miles)) mi")
-                    .font(.system(size: 16, weight: .heavy, design: .rounded))
-                    .foregroundColor(.white)
-                    .monospacedDigit()
-                if memory.durationSeconds > 0 {
-                    Text(RunStatsStickerView.durationText(memory.durationSeconds))
-                        .font(.system(size: 12, weight: .semibold, design: .rounded))
-                        .foregroundColor(.white.opacity(0.5))
-                        .monospacedDigit()
+
+            statStrip(memory)
+        }
+        .padding(MADTheme.Spacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
+                .fill(Color.white.opacity(0.04))
+        )
+    }
+
+    /// The day's photo, full-width 4:5 like a feed post slide.
+    private func photoSlide(_ url: URL) -> some View {
+        AsyncImage(url: url) { phase in
+            switch phase {
+            case .success(let image):
+                image.resizable().scaledToFill()
+            case .failure:
+                ZStack {
+                    Color.white.opacity(0.05)
+                    Image(systemName: "photo").foregroundColor(.white.opacity(0.3))
+                }
+            default:
+                ZStack {
+                    Color.white.opacity(0.05)
+                    ProgressView().tint(.white)
                 }
             }
         }
-        .padding(MADTheme.Spacing.md)
-        .background(
-            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
-                .fill(Color.white.opacity(0.04))
-        )
+        .frame(maxWidth: .infinity)
+        .aspectRatio(4.0 / 5.0, contentMode: .fit)
+        .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
+    }
+
+    /// Photo-less memories get a compact branded hero — the distance as the
+    /// moment, in the same gradient language as the feed's workout card.
+    private func distanceHero(_ memory: MemoryItem, accent: Color) -> some View {
+        ZStack {
+            LinearGradient(
+                colors: [Color(red: 0.09, green: 0.09, blue: 0.12), .black],
+                startPoint: .top, endPoint: .bottom
+            )
+            RadialGradient(
+                colors: [accent.opacity(0.35), .clear],
+                center: .init(x: 0.5, y: 0.4), startRadius: 8, endRadius: 180
+            )
+            VStack(spacing: 2) {
+                Text(String(format: "%.2f", memory.miles))
+                    .font(.system(size: 46, weight: .black, design: .rounded))
+                    .foregroundColor(.white)
+                    .monospacedDigit()
+                    .shadow(color: .black.opacity(0.4), radius: 5, y: 2)
+                Text("MILES \(ActivityCardView.verb(memory.workoutType).uppercased())")
+                    .font(.system(size: 11, weight: .heavy, design: .rounded))
+                    .tracking(4)
+                    .foregroundColor(.white.opacity(0.6))
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .aspectRatio(16.0 / 9.0, contentMode: .fit)
+        .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
+    }
+
+    /// Miles / time / pace chips, same grammar as the feed's activity card.
+    @ViewBuilder
+    private func statStrip(_ memory: MemoryItem) -> some View {
+        let items = statItems(memory)
+        if !items.isEmpty {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(items, id: \.0) { item in
+                        HStack(spacing: 5) {
+                            Image(systemName: item.1)
+                                .font(.system(size: 11, weight: .bold))
+                                .foregroundColor(.orange)
+                            Text(item.2)
+                                .font(.system(size: 13, weight: .heavy, design: .rounded))
+                                .monospacedDigit()
+                                .foregroundColor(.white.opacity(0.9))
+                        }
+                        .padding(.horizontal, 10).padding(.vertical, 6)
+                        .background(Capsule().fill(Color.white.opacity(0.07)))
+                    }
+                }
+                .padding(.horizontal, 2)
+            }
+        }
+    }
+
+    private func statItems(_ memory: MemoryItem) -> [(String, String, String)] {
+        var out: [(String, String, String)] = []
+        if memory.miles > 0 {
+            out.append(("miles", ActivityCardView.icon(memory.workoutType),
+                        String(format: "%.2f mi", memory.miles)))
+        }
+        if memory.durationSeconds > 0 {
+            out.append(("time", "clock.fill", RunStatsStickerView.durationText(memory.durationSeconds)))
+            if memory.miles > 0 {
+                out.append(("pace", "speedometer",
+                            "\(RunStatsStickerView.paceText(memory.durationSeconds / memory.miles)) /mi"))
+            }
+        }
+        return out
     }
 }

--- a/app/Mile A Day/Views/Feed/PostCardView.swift
+++ b/app/Mile A Day/Views/Feed/PostCardView.swift
@@ -21,6 +21,8 @@ struct PostCardView: View {
     let onDelete: () -> Void
     /// Tap the author's avatar or name to open their profile.
     var onTapAuthor: (() -> Void)? = nil
+    /// Tap the hype tally to see who hyped (Instagram-likes style).
+    var onTapHypeCount: (() -> Void)? = nil
 
     @State private var hypeBurst = 0
 
@@ -226,7 +228,12 @@ struct PostCardView: View {
     private var footer: some View {
         HStack(spacing: 10) {
             if let count = post.hype_count, count > 0 {
-                HypeTally(count: count)
+                Button { onTapHypeCount?() } label: {
+                    HypeTally(count: count)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(onTapHypeCount == nil)
             }
             Spacer()
             if !post.is_self {

--- a/app/Mile A Day/Views/Feed/ProfilePostsGridView.swift
+++ b/app/Mile A Day/Views/Feed/ProfilePostsGridView.swift
@@ -152,6 +152,8 @@ struct ProfilePostsFeedSheet: View {
     let initialPostId: String
     let onNeedMore: () -> Void
     @Environment(\.dismiss) private var dismiss
+    /// Tapped hype tally — presents the "who hyped this" sheet.
+    @State private var hypersContext: HypersListContext?
 
     var body: some View {
         NavigationStack {
@@ -196,6 +198,9 @@ struct ProfilePostsFeedSheet: View {
             .toolbarBackground(.black, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbarColorScheme(.dark, for: .navigationBar)
+            .sheet(item: $hypersContext) { context in
+                HypersListSheet(context: context)
+            }
         }
     }
 
@@ -255,7 +260,17 @@ struct ProfilePostsFeedSheet: View {
                     .padding(.horizontal, 2)
             }
             if let count = post.hype_count, count > 0 {
-                HypeTally(count: count).padding(.horizontal, 2)
+                Button {
+                    hypersContext = HypersListContext(
+                        contextType: "post",
+                        contextId: post.post_id,
+                        targetUserId: post.user_id
+                    )
+                } label: {
+                    HypeTally(count: count).contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 2)
             }
         }
         .padding(MADTheme.Spacing.sm)

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -18,6 +18,9 @@ struct SocialFeedView: View {
     @State private var nextBefore: String?
     @State private var isLoading = false
     @State private var isLoadingMore = false
+    /// A load-more request failed (offline, server error). Shows a tappable
+    /// retry row — the stalled last card never re-fires onAppear on its own.
+    @State private var loadMoreFailed = false
     @State private var loadedOnce = false
 
     @State private var hypingIds: Set<String> = []
@@ -165,11 +168,20 @@ struct SocialFeedView: View {
                     } else {
                         ForEach(feed) { entry in
                             feedCard(entry)
-                                .onAppear { if entry.id == feed.last?.id { Task { await loadMore() } } }
+                                // Prefetch a few cards early (not just on the
+                                // very last row) so the next page is usually
+                                // there before the user reaches the bottom.
+                                .onAppear {
+                                    if feed.suffix(3).contains(where: { $0.id == entry.id }) {
+                                        Task { await loadMore() }
+                                    }
+                                }
                                 .padding(.horizontal, MADTheme.Spacing.md)
                         }
                         if isLoadingMore {
                             ProgressView().tint(.white).padding(.vertical, MADTheme.Spacing.md)
+                        } else if loadMoreFailed, nextBefore != nil {
+                            loadMoreRetryRow
                         }
                     }
                 }
@@ -449,6 +461,7 @@ struct SocialFeedView: View {
             if let feedResponse {
                 feed = feedResponse.items
                 nextBefore = feedResponse.next_before
+                loadMoreFailed = false
             }
             if let storyGroups {
                 stories = storyGroups
@@ -467,18 +480,54 @@ struct SocialFeedView: View {
         }
     }
 
+    /// Instagram-style infinite scroll: pages keep coming until the server
+    /// says there's nothing older (`next_before == nil`). A page whose rows
+    /// ALL dedupe away (fresh posts shifted the keyset boundary between
+    /// requests) advances the cursor and immediately fetches again — an
+    /// unchanged last row never re-fires onAppear, so stopping there would
+    /// stall the feed with history still unloaded. A failed request surfaces
+    /// the retry row instead of dying silently.
     private func loadMore() async {
-        guard let before = nextBefore, !isLoadingMore else { return }
-        await MainActor.run { isLoadingMore = true }
-        let response = try? await PostService.fetchUnifiedFeed(before: before)
+        guard nextBefore != nil, !isLoadingMore else { return }
         await MainActor.run {
-            if let response {
-                let existing = Set(feed.map(\.id))
-                feed.append(contentsOf: response.items.filter { !existing.contains($0.id) })
-                nextBefore = response.next_before
-            }
-            isLoadingMore = false
+            isLoadingMore = true
+            loadMoreFailed = false
         }
+        while let before = nextBefore {
+            guard let response = try? await PostService.fetchUnifiedFeed(before: before) else {
+                await MainActor.run {
+                    loadMoreFailed = true
+                    isLoadingMore = false
+                }
+                return
+            }
+            let gotFresh: Bool = await MainActor.run {
+                let existing = Set(feed.map(\.id))
+                let fresh = response.items.filter { !existing.contains($0.id) }
+                feed.append(contentsOf: fresh)
+                nextBefore = response.next_before
+                return !fresh.isEmpty
+            }
+            if gotFresh || nextBefore == nil { break }
+        }
+        await MainActor.run { isLoadingMore = false }
+    }
+
+    private var loadMoreRetryRow: some View {
+        Button {
+            Task { await loadMore() }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 12, weight: .bold))
+                Text("Couldn't load more — tap to retry")
+                    .font(.system(size: 13, weight: .bold, design: .rounded))
+            }
+            .foregroundColor(.white.opacity(0.7))
+            .padding(.vertical, MADTheme.Spacing.md)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 
     // MARK: - Actions

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -7,6 +7,10 @@ import SwiftUI
 struct SocialFeedView: View {
     @StateObject private var healthManager = HealthKitManager.shared
     @StateObject private var userManager = UserManager.shared
+    /// One stable service for profiles opened from the feed. Creating a fresh
+    /// FriendService inside the sheet closure re-instantiated it on every feed
+    /// state change, wiping the loaded friends list mid-view.
+    @StateObject private var profileFriendService = FriendService()
 
     @State private var feed: [FeedEntry] = []
     @State private var stories: [StoryGroup] = []
@@ -35,6 +39,11 @@ struct SocialFeedView: View {
     @State private var showMemories = false
     @State private var showWeeklyRecap = false
     @State private var profileUser: BackendUser?
+    /// Tapped hype tally — presents the "who hyped this" sheet.
+    @State private var hypersContext: HypersListContext?
+    /// Profile tapped INSIDE the hypers sheet — presented after that sheet
+    /// fully dismisses (sheet-over-sheet races drop the second presentation).
+    @State private var pendingProfileUser: BackendUser?
 
     private var currentUserId: String? { UserDefaults.standard.string(forKey: "backendUserId") }
     /// Completing the daily mile unlocks posting AND viewing friends' stories.
@@ -183,7 +192,29 @@ struct SocialFeedView: View {
         }
         .sheet(item: $profileUser) { user in
             NavigationStack {
-                UserProfileDetailView(user: user, friendService: FriendService())
+                UserProfileDetailView(user: user, friendService: profileFriendService)
+            }
+        }
+        .sheet(item: $hypersContext, onDismiss: {
+            if let pending = pendingProfileUser {
+                pendingProfileUser = nil
+                profileUser = pending
+            }
+        }) { context in
+            HypersListSheet(context: context) { hyper in
+                guard hyper.user_id != currentUserId else { return }
+                pendingProfileUser = BackendUser(
+                    user_id: hyper.user_id,
+                    username: hyper.username,
+                    email: nil,
+                    first_name: hyper.first_name,
+                    last_name: hyper.last_name,
+                    bio: nil,
+                    profile_image_url: hyper.profile_image_url,
+                    apple_id: nil,
+                    auth_provider: nil,
+                    role: nil
+                )
             }
         }
         .alert("Finish today's mile first", isPresented: $showMileHint) {
@@ -262,6 +293,13 @@ struct SocialFeedView: View {
                 role: nil
             )
         }
+        let openHypers = {
+            hypersContext = HypersListContext(
+                contextType: entry.isPost ? "post" : "mile",
+                contextId: entry.entryId,
+                targetUserId: entry.user_id
+            )
+        }
         if entry.isPost, let post = entry.asPostItem() {
             PostCardView(
                 post: post,
@@ -271,14 +309,16 @@ struct SocialFeedView: View {
                 onReport: { reportingPost = post },
                 onBlock: { Task { await block(entry) } },
                 onDelete: { Task { await deletePost(entry) } },
-                onTapAuthor: openProfile
+                onTapAuthor: openProfile,
+                onTapHypeCount: openHypers
             )
         } else {
             ActivityCardView(
                 entry: entry,
                 isHyping: hypingIds.contains(entry.id),
                 onHype: { Task { await hype(entry) } },
-                onTapAuthor: openProfile
+                onTapAuthor: openProfile,
+                onTapHypeCount: openHypers
             )
         }
     }

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -47,20 +47,55 @@ struct SocialFeedView: View {
 
     private var currentUserId: String? { UserDefaults.standard.string(forKey: "backendUserId") }
     /// Completing the daily mile unlocks posting AND viewing friends' stories.
-    private var mileDone: Bool { healthManager.todaysDistance >= userManager.currentUser.goalMiles }
+    private var mileDone: Bool {
+        ProgressCalculator.isGoalCompleted(
+            current: healthManager.todaysDistance,
+            goal: userManager.currentUser.goalMiles
+        )
+    }
 
-    /// True once the user has already made a DELIBERATE share for today's mile —
-    /// a photo post on the feed or an active story of their own. One share per
-    /// walk/run is the reward, so the compose affordances hide until they delete
-    /// it (feed/story refreshes it away) or a new day's mile comes around. The
-    /// auto route/stats card doesn't count — a photo can still replace it.
+    /// Workout ids of the user's own stories (fetched when the rail shows an
+    /// own-story group) — a story share counts as that workout's one share.
+    @State private var myStoryWorkoutIds: Set<String> = []
+
+    /// Workout ids of today's walks/runs that already carry the user's
+    /// DELIBERATE share — a photo post on the feed or a story. The auto
+    /// route/stats card doesn't count (a photo can still replace it).
+    private var mySharedWorkoutIds: Set<String> {
+        var ids = Set(feed.compactMap { entry -> String? in
+            guard entry.is_self, entry.isPost, entry.is_auto != true else { return nil }
+            return entry.workout_id
+        })
+        ids.formUnion(myStoryWorkoutIds)
+        return ids
+    }
+
+    /// The workout the composer should attach to: the LATEST of today's
+    /// walks/runs without a deliberate share yet. One share per walk/run is
+    /// the reward — every new workout unlocks another photo.
+    private var nextShareableWorkoutId: String? {
+        let shared = mySharedWorkoutIds
+        return healthManager.todaysWorkouts
+            .sorted { $0.startDate > $1.startDate }
+            .first { !shared.contains($0.uuid.uuidString) }?
+            .uuid.uuidString
+    }
+
+    /// True when there's nothing left to share right now: every one of today's
+    /// walks/runs already has its photo post or story. Compose affordances
+    /// hide until the user deletes a share or finishes another workout.
     private var alreadySharedWorkout: Bool {
         guard let uid = currentUserId else { return false }
-        let hasStoryToday = stories.contains { $0.user_id == uid && Self.isToday($0.latest_at) }
-        let hasFeedPostToday = feed.contains {
-            $0.is_self && $0.isPost && $0.is_auto != true && Self.isToday($0.sort_ts)
+        if healthManager.todaysWorkouts.isEmpty {
+            // Mile met via non-workout distance — no per-workout key to dedupe
+            // on, so keep the legacy one-share-per-day rule.
+            let hasStoryToday = stories.contains { $0.user_id == uid && Self.isToday($0.latest_at) }
+            let hasFeedPostToday = feed.contains {
+                $0.is_self && $0.isPost && $0.is_auto != true && Self.isToday($0.sort_ts)
+            }
+            return hasStoryToday || hasFeedPostToday
         }
-        return hasStoryToday || hasFeedPostToday
+        return nextShareableWorkoutId == nil
     }
 
     private static func isToday(_ iso: String) -> Bool {
@@ -82,9 +117,10 @@ struct SocialFeedView: View {
             streak: user.streak,
             calories: calories > 0 ? calories : nil,
             steps: steps > 0 ? steps : nil,
-            // Link to the daily-mile workout so this post upserts into the same
-            // feed item as the auto route/stats post — one post per run.
-            workoutId: mileDone ? RunPostService.dailyMileWorkoutId() : nil,
+            // Link to the newest not-yet-shared workout so this post upserts
+            // into that run's feed item — one post per run, and every new
+            // walk/run in the day unlocks another photo.
+            workoutId: mileDone ? (nextShareableWorkoutId ?? RunPostService.dailyMileWorkoutId()) : nil,
             dateText: Self.todayText()
         )
     }
@@ -225,7 +261,7 @@ struct SocialFeedView: View {
         .alert("You've already shared this one", isPresented: $showAlreadySharedHint) {
             Button("Got it", role: .cancel) {}
         } message: {
-            Text("One post per walk or run — that's the reward. Delete your current post or story if you'd rather share a different shot.")
+            Text("One post per walk or run — that's the reward. Do another walk or run to share again, or delete a post or story to swap the shot.")
         }
     }
 
@@ -401,12 +437,23 @@ struct SocialFeedView: View {
         await MainActor.run { isLoading = feed.isEmpty }
         let feedResponse = try? await PostService.fetchUnifiedFeed(before: nil)
         let storyGroups = try? await PostService.fetchStoriesRail()
+        // Own active stories carry their workout ids — needed to know which
+        // of today's workouts are already "spent" on a story share.
+        var storyWorkoutIds: Set<String> = []
+        if let uid = currentUserId,
+           storyGroups?.contains(where: { $0.user_id == uid }) == true,
+           let ownStories = try? await PostService.fetchUserStories(userId: uid) {
+            storyWorkoutIds = Set(ownStories.compactMap(\.workout_id))
+        }
         await MainActor.run {
             if let feedResponse {
                 feed = feedResponse.items
                 nextBefore = feedResponse.next_before
             }
-            if let storyGroups { stories = storyGroups }
+            if let storyGroups {
+                stories = storyGroups
+                myStoryWorkoutIds = storyWorkoutIds
+            }
             isLoading = false
             loadedOnce = true
         }

--- a/app/Mile A Day/Views/Friends/FriendsListView.swift
+++ b/app/Mile A Day/Views/Friends/FriendsListView.swift
@@ -340,7 +340,7 @@ struct FriendsListView: View {
 
     private func feedRow(_ item: FeedWorkoutItem) -> some View {
         let expanded = expandedWorkoutIds.contains(item.workout_id)
-        let completedMile = item.distance >= 1.0
+        let completedMile = item.distance >= ProgressCalculator.dailyGoalTolerance
 
         return VStack(spacing: 0) {
             HStack(spacing: 12) {

--- a/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
+++ b/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
@@ -3,7 +3,13 @@ import SwiftUI
 /// Detailed view for displaying a user's profile information
 struct UserProfileDetailView: View {
     let user: BackendUser
-    let friendService: FriendService
+    // Observed, not a plain `let`: the friendship gates below (today's
+    // progress card, nudge/compete row, close-friend star) read
+    // `friendService.isFriend(...)`, and when the profile opens from a
+    // surface that passes a freshly-created service (the feed), the friends
+    // list arrives AFTER first render — without observation the view never
+    // re-evaluates and today's distance stays blank.
+    @ObservedObject var friendService: FriendService
     @ObservedObject private var userManager = UserManager.shared
     @ObservedObject private var closeFriends = CloseFriendsService.shared
     @Environment(\.dismiss) private var dismiss
@@ -138,7 +144,6 @@ struct UserProfileDetailView: View {
         }
         .onAppear {
             loadUserData()
-            refreshFriendshipStatus()
         }
         .task {
             await loadFriendTodayChallenge()
@@ -147,6 +152,12 @@ struct UserProfileDetailView: View {
             await loadBadges()
         }
         .task {
+            // Friendship data FIRST, nudge status second — loadNudgeStatus is
+            // gated on isFriend, and a service passed in fresh (e.g. from the
+            // feed) hasn't loaded its friends list yet. Running them in
+            // parallel made the gate misread friends as strangers, so today's
+            // distance never loaded.
+            await friendService.refreshAllData()
             await loadNudgeStatus()
         }
         .task {
@@ -937,12 +948,6 @@ struct UserProfileDetailView: View {
                     isLoadingStats = false
                 }
             }
-        }
-    }
-
-    private func refreshFriendshipStatus() {
-        Task {
-            await friendService.refreshAllData()
         }
     }
 

--- a/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
+++ b/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
@@ -926,7 +926,8 @@ struct UserProfileDetailView: View {
 
                     let goalMiles = stats.goalMiles ?? 1.0
                     let todayMiles = stats.todayMiles ?? 0.0
-                    let hasCompletedGoalToday = todayMiles >= goalMiles && goalMiles > 0
+                    let hasCompletedGoalToday = goalMiles > 0
+                        && ProgressCalculator.isGoalCompleted(current: todayMiles, goal: goalMiles)
 
                     userStats = UserStats(
                         streak: stats.streak,

--- a/app/Mile A Day/Views/MainTabView.swift
+++ b/app/Mile A Day/Views/MainTabView.swift
@@ -183,7 +183,8 @@ struct MainTabView: View {
             }
         }
         .onChange(of: healthManager.todaysDistance) { _, newDistance in
-            let isCompleted = newDistance >= userManager.currentUser.goalMiles
+            let isCompleted = ProgressCalculator.isGoalCompleted(
+                current: newDistance, goal: userManager.currentUser.goalMiles)
             notificationService.updateDailyReminder(
                 isCompleted: isCompleted,
                 currentMiles: newDistance,
@@ -258,7 +259,8 @@ struct MainTabView: View {
             await notificationService.requestAuthorization()
 
             // Use smart daily reminder with completion status
-            let isCompleted = healthManager.todaysDistance >= userManager.currentUser.goalMiles
+            let isCompleted = ProgressCalculator.isGoalCompleted(
+                current: healthManager.todaysDistance, goal: userManager.currentUser.goalMiles)
             notificationService.updateDailyReminder(
                 isCompleted: isCompleted,
                 currentMiles: healthManager.todaysDistance,

--- a/backend/src/controllers/friendNudgeController.ts
+++ b/backend/src/controllers/friendNudgeController.ts
@@ -8,7 +8,10 @@ import {
   logFriendNudge,
 } from "../services/pushNotificationService.js";
 import { shouldSendNotification } from "../services/notificationSettingsService.js";
-import { getTodayMiles } from "../services/workoutService.js";
+import {
+  getTodayMiles,
+  DAILY_GOAL_TOLERANCE,
+} from "../services/workoutService.js";
 import { evaluateSocialBadgesForUser } from "../services/badgeService.js";
 import { PostgresService } from "../services/DbService.js";
 
@@ -59,9 +62,11 @@ export async function nudgeFriend(req: AuthenticatedRequest, res: Response) {
       return res.status(400).json({ error: "You can only nudge friends" });
     }
 
-    // Check if friend has already completed their mile today
+    // Check if friend has already completed their mile today — same 0.95
+    // tolerance as streak counting, so a day the streak credits can't be
+    // nudged as "incomplete".
     const friendTodayMiles = await getTodayMiles(friendId);
-    if (friendTodayMiles >= 1.0) {
+    if (friendTodayMiles >= DAILY_GOAL_TOLERANCE) {
       return res
         .status(400)
         .json({ error: "This friend has already completed their mile today" });
@@ -122,7 +127,7 @@ export async function checkNudgeStatus(
       fetchStreaks([friendId]),
     ]);
 
-    const hasCompletedMile = friendTodayMiles >= 1.0;
+    const hasCompletedMile = friendTodayMiles >= DAILY_GOAL_TOLERANCE;
 
     res.status(200).json({
       can_nudge: canNudge && !hasCompletedMile,
@@ -173,7 +178,7 @@ export async function checkNudgeStatusBatch(
           getTodayMiles(friendId),
         ]);
 
-        const hasCompletedMile = friendTodayMiles >= 1.0;
+        const hasCompletedMile = friendTodayMiles >= DAILY_GOAL_TOLERANCE;
         statuses[friendId] = {
           can_nudge: canNudge && !hasCompletedMile,
           has_completed_mile: hasCompletedMile,

--- a/backend/src/controllers/hypeController.ts
+++ b/backend/src/controllers/hypeController.ts
@@ -17,6 +17,7 @@ import {
   HYPE_DAILY_LIMIT,
   HypeContext,
   getReceivedHypes,
+  getContextHypers,
 } from "../services/hypeService.js";
 
 const db = PostgresService.getInstance();
@@ -270,6 +271,68 @@ export async function getReceivedHypesController(
   } catch (error: any) {
     console.error("Error getting received hypes:", error.message);
     res.status(500).json({ error: "Error getting received hypes" });
+  }
+}
+
+/**
+ * Who hyped a specific post or daily mile — the Instagram-style "who liked
+ * this" list behind a hype tally. Query params: `context_type` ('post'|'mile'),
+ * `context_id` (post id, or the mile's workout id / user:date composite), and
+ * `target_user_id` (the content's author). Viewer must be the author, a
+ * friend, or an active-competition co-participant — the same audience that can
+ * see the tally on the feed.
+ */
+export async function getContextHypersController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  const viewerId = req.userId!;
+  const contextType = String(req.query.context_type ?? "");
+  const rawContextId = String(req.query.context_id ?? "");
+  const targetUserId = String(req.query.target_user_id ?? "");
+
+  try {
+    if (!["post", "mile"].includes(contextType)) {
+      return res
+        .status(400)
+        .json({ error: "context_type must be 'post' or 'mile'" });
+    }
+    if (!rawContextId || !targetUserId) {
+      return res
+        .status(400)
+        .json({ error: "context_id and target_user_id are required" });
+    }
+
+    if (viewerId !== targetUserId) {
+      const allowed = await isFriendOrCoParticipant(viewerId, targetUserId);
+      if (!allowed) {
+        return res
+          .status(403)
+          .json({ error: "You can only view hypes on content you can see" });
+      }
+    }
+
+    // Mile hypes are stored under the canonical `<userId>:<localDate>`
+    // composite — resolve a raw workout id to it, same as the send path.
+    let contextId = rawContextId;
+    if (contextType === "mile") {
+      try {
+        const canonical = await canonicalizeMileContext(targetUserId, {
+          contextType: "mile",
+          contextId: rawContextId,
+          contextLabel: "",
+        });
+        contextId = canonical.contextId;
+      } catch {
+        return res.status(400).json({ error: "Invalid mile context" });
+      }
+    }
+
+    const hypers = await getContextHypers(targetUserId, contextType, contextId);
+    res.status(200).json({ hypers, count: hypers.length });
+  } catch (error: any) {
+    console.error("Error getting context hypers:", error.message);
+    res.status(500).json({ error: "Error getting context hypers" });
   }
 }
 

--- a/backend/src/controllers/postsController.ts
+++ b/backend/src/controllers/postsController.ts
@@ -341,6 +341,22 @@ export async function getPostMemoriesController(
   }
 }
 
+/**
+ * Repair a keyset cursor whose timezone '+' was decoded as a space. Shipped
+ * clients percent-encode cursors with a set that leaves '+' literal, and
+ * Express's query parser turns a literal '+' into ' ' — so the old
+ * "2026-07-04 12:34:56.123456+00" cursor arrived as "…123456 00" and its
+ * `::timestamptz` cast threw, silently killing pagination after page one.
+ * New cursors are emitted URL-safe (ISO-8601 "…Z"), but cursors already in
+ * the field (and older app builds) still need this rewrite. A valid cursor
+ * never legitimately ends in <space><offset-digits>, so the rewrite is safe.
+ */
+function repairBeforeCursor(req: AuthenticatedRequest): string | null {
+  const raw = typeof req.query.before === "string" ? req.query.before : null;
+  if (!raw) return null;
+  return raw.replace(/ (\d{2}(:?\d{2})?)$/, "+$1");
+}
+
 export async function getFeedController(
   req: AuthenticatedRequest,
   res: Response,
@@ -350,10 +366,9 @@ export async function getFeedController(
     const limit = Number.isFinite(rawLimit)
       ? Math.min(Math.max(rawLimit, 1), MAX_FEED_LIMIT)
       : DEFAULT_FEED_LIMIT;
-    const before =
-      typeof req.query.before === "string" ? req.query.before : null;
+    const before = repairBeforeCursor(req);
     const items = await getFeed(req.userId!, limit, before);
-    // `cursor` is the microsecond-precise Postgres text timestamp; created_at
+    // `cursor` is the microsecond-precise URL-safe timestamp; created_at
     // (a ms-truncated JS Date) would skip same-millisecond rows at boundaries.
     const last = items[items.length - 1];
     const nextBefore =
@@ -377,8 +392,7 @@ export async function getUnifiedFeedController(
     const limit = Number.isFinite(rawLimit)
       ? Math.min(Math.max(rawLimit, 1), MAX_FEED_LIMIT)
       : DEFAULT_FEED_LIMIT;
-    const before =
-      typeof req.query.before === "string" ? req.query.before : null;
+    const before = repairBeforeCursor(req);
     const items = await getUnifiedFeed(req.userId!, limit, before);
     const last = items[items.length - 1];
     const nextBefore =
@@ -408,8 +422,7 @@ export async function getUserPostsController(
     const limit = Number.isFinite(rawLimit)
       ? Math.min(Math.max(rawLimit, 1), MAX_FEED_LIMIT)
       : DEFAULT_FEED_LIMIT;
-    const before =
-      typeof req.query.before === "string" ? req.query.before : null;
+    const before = repairBeforeCursor(req);
     const items = await getUserPosts(
       req.userId!,
       req.params.userId,

--- a/backend/src/controllers/workoutController.ts
+++ b/backend/src/controllers/workoutController.ts
@@ -11,6 +11,7 @@ import {
   getBestMilesDay,
   getBestSplit,
   getTodayMiles,
+  DAILY_GOAL_TOLERANCE,
   updateWorkout as updateWorkoutDb,
   computePersonalRecords,
   getUserLocalToday,
@@ -109,7 +110,9 @@ export async function uploadWorkouts(req: Request, res: Response) {
     if (!isFullSync && hasRecentWorkout) {
       try {
         const todayMiles = await getTodayMiles(userId);
-        if (todayMiles >= 1.0) {
+        // Same 0.95 tolerance as streak counting — a GPS 0.98-mile day that
+        // extends the streak must also fire the mile-completed notification.
+        if (todayMiles >= DAILY_GOAL_TOLERANCE) {
           const milestoneFired = await notifyFriendsOfMileCompletion(
             userId,
           ).catch((err) => {

--- a/backend/src/routes/hypeRoutes.ts
+++ b/backend/src/routes/hypeRoutes.ts
@@ -1,10 +1,16 @@
-import { Router } from 'express';
-import { sendHype, getHypeStatus, getReceivedHypesController } from '../controllers/hypeController.js';
+import { Router } from "express";
+import {
+  sendHype,
+  getHypeStatus,
+  getReceivedHypesController,
+  getContextHypersController,
+} from "../controllers/hypeController.js";
 
 const router = Router();
 
-router.post('/', sendHype);
-router.get('/status', getHypeStatus);
-router.get('/received', getReceivedHypesController);
+router.post("/", sendHype);
+router.get("/status", getHypeStatus);
+router.get("/received", getReceivedHypesController);
+router.get("/hypers", getContextHypersController);
 
 export default router;

--- a/backend/src/services/hypeService.ts
+++ b/backend/src/services/hypeService.ts
@@ -71,6 +71,44 @@ export async function getReceivedHypes(
   return rows;
 }
 
+export interface ContextHyper {
+  user_id: string;
+  username: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  profile_image_url: string | null;
+  created_at: string;
+}
+
+/**
+ * Everyone who hyped one specific context (a post, or a user's daily mile),
+ * newest first — powers the Instagram-style "who liked this" list behind the
+ * hype tally. DISTINCT ON sender so pre-migration dual-keyed mile rows from
+ * one person appear once, matching the feed's COUNT(DISTINCT sender_id).
+ */
+export async function getContextHypers(
+  targetId: string,
+  contextType: string,
+  contextId: string,
+  limit: number = 100,
+): Promise<ContextHyper[]> {
+  const rows = await db.query<ContextHyper>(
+    `SELECT h.sender_id AS user_id, u.username, u.first_name, u.last_name,
+			u.profile_image_url, h.created_at
+		FROM (
+			SELECT DISTINCT ON (sender_id) sender_id, created_at
+			FROM hype_log
+			WHERE target_id = $1 AND context_type = $2 AND context_id = $3
+			ORDER BY sender_id, created_at DESC
+		) h
+		JOIN users u ON u.user_id = h.sender_id
+		ORDER BY h.created_at DESC
+		LIMIT $4`,
+    [targetId, contextType, contextId, limit],
+  );
+  return rows;
+}
+
 /**
  * Atomically insert a hype_log row only if the sender is still under the
  * daily limit. Optional context describes what was hyped (mile/badge/pr) and

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -605,6 +605,10 @@ export interface FeedEntryRow {
   story_photo_url: string | null;
   // post-only: system-generated route/stats card vs deliberate user post.
   is_auto: boolean | null;
+  // The entry's workout: the linked workout for posts (null when unlinked),
+  // the workout itself for workout entries. Lets the client know which of
+  // today's runs already carry a deliberate post.
+  workout_id: string | null;
   // workout columns (also populated for posts via their linked workout)
   workout_type: string | null;
   distance: number | null;
@@ -659,6 +663,7 @@ export async function getUnifiedFeed(
 					LIMIT 1
 				) AS story_photo_url,
 				p.is_auto,
+				p.workout_id,
 				(SELECT w2.workout_type FROM workouts w2 WHERE w2.workout_id = p.workout_id) AS workout_type,
 				NULL::double precision AS distance,
 				NULL::double precision AS total_duration,
@@ -699,6 +704,7 @@ export async function getUnifiedFeed(
 				NULL::text AS media_url, NULL::text AS caption, NULL::jsonb AS stats_snapshot,
 				NULL::text AS story_photo_url,
 				NULL::boolean AS is_auto,
+				w.workout_id,
 				w.workout_type,
 				w.distance::double precision,
 				w.total_duration::double precision,

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -77,6 +77,18 @@ export interface StoryGroup {
   latest_at: string;
 }
 
+/**
+ * Keyset-pagination cursor as URL-safe ISO-8601 UTC with microseconds
+ * ("2026-07-04T12:34:56.123456Z"). The raw `::text` of a timestamptz renders
+ * as "2026-07-04 12:34:56.123456+00" — and a literal '+' in a query string is
+ * decoded as a SPACE by Express's query parser, which made the returned
+ * cursor fail its `::timestamptz` cast on the next page ("the feed stops
+ * loading"). Microsecond precision is kept so same-millisecond rows at page
+ * boundaries are neither skipped nor repeated.
+ */
+const URL_SAFE_CURSOR = (col: string) =>
+  `to_char((${col}) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US') || 'Z'`;
+
 // Base post columns shared by every post-shaped read (viewer-independent).
 // Routes are deliberately NOT here — only the unified feed ships them (the
 // story viewer / memories / profile grid never render a route map, and the
@@ -569,7 +581,7 @@ export async function getFeed(
     `
 		${CIRCLE_CTE}
 		SELECT ${POST_SELECT},
-			p.created_at::text AS cursor
+			${URL_SAFE_CURSOR("p.created_at")} AS cursor
 		FROM posts p
 		JOIN circle c ON c.uid = p.user_id
 		JOIN users u ON u.user_id = p.user_id
@@ -641,7 +653,7 @@ export async function getUnifiedFeed(
   const rows = await db.query<FeedEntryRow>(
     `
 		${CIRCLE_CTE}
-		SELECT feed.*, feed.sort_ts::text AS cursor FROM (
+		SELECT feed.*, ${URL_SAFE_CURSOR("feed.sort_ts")} AS cursor FROM (
 			SELECT
 				'post' AS kind,
 				p.post_id::text AS id,
@@ -766,7 +778,7 @@ export async function getUserPosts(
     `
 		${CIRCLE_CTE}
 		SELECT ${POST_SELECT},
-			p.created_at::text AS cursor,
+			${URL_SAFE_CURSOR("p.created_at")} AS cursor,
 			-- The run's story photo, so the profile grid + detail cards lead
 			-- with the real picture (workout card second), matching the feed.
 			-- Owner's decision: story expiry does NOT remove the photo from

--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -423,6 +423,17 @@ export async function getUserLocalDate(userId: string): Promise<string> {
   return rows[0].local_date;
 }
 
+/**
+ * Canonical "daily mile done" tolerance, as a fraction of the goal. Streak
+ * counting (leaderboardService), daily challenges, and the weekly recap all
+ * treat >= 0.95 mi as a completed day (GPS under-measure allowance). Every
+ * completion check against today's miles must apply this — a raw `>= 1.0`
+ * check lets a 0.98-mile day extend the streak and display as "1.00 mi ·
+ * 100%" (2-decimal rounding) while still reading "incomplete" for nudges,
+ * friend notifications, and posting.
+ */
+export const DAILY_GOAL_TOLERANCE = 0.95;
+
 export async function getTodayMiles(userId: string) {
   // Use the user's timezone offset from their most recent workout to determine
   // what "today" is in their local time (local_date is stored in user's timezone)
@@ -486,8 +497,9 @@ export async function getDailyGoalStatus(
     ),
   ]);
   const goalMiles = Number(goalRows[0]?.goal_miles ?? 1);
-  // Small epsilon so a goal stored as 1.0 isn't missed by 1.0 reading 0.9999.
-  const completed = miles + 1e-9 >= goalMiles;
+  // Same tolerance as streaks/challenges — a day the streak counts as done
+  // must also unlock posting.
+  const completed = miles + 1e-9 >= goalMiles * DAILY_GOAL_TOLERANCE;
   return { completed, miles, goalMiles, localDate };
 }
 


### PR DESCRIPTION
## What & Why

Nine feed/social fixes and features from user-reported issues, in three rounds.

## Round 1

### 1. Clap icons showing on every card (double-tap hype burst)
`HypeBurstView`'s six mini claps keyed their opacity solely off the animation phase (`particlesOut`), which is also false **at rest** — so every card permanently showed claps near its center, double-tapped or not. All burst elements are now gated on a `playing` flag (nothing renders until a double-tap), and a generation counter keeps a rapid re-double-tap from being truncated by the previous burst's teardown.

### 2. Routes never appearing on feed cards
Root cause: **in-app tracked workouts never wrote an `HKWorkoutRoute`**. The tracker buffered GPS points for crash recovery only and finished the workout with just a distance sample; the sync pipeline reads routes back *from HealthKit* to upload them — so in-app workouts always synced route-less. Fix: `workoutRoute` added to the HealthKit **share** authorization sets (iOS prompts on next workout start), and on stop the tracked trace is written via `HKWorkoutRouteBuilder.finishRoute` before the sync kicks off.

### 3. Tap the hype count to see who hyped (like Instagram likes)
New `GET /hype/hypers` endpoint (author/friend/co-participant gated, mile ids canonicalized like the send path) + `HypersListSheet`; hype tallies on feed and profile post cards are tappable, rows open profiles.

### 4. "On this day" memories polish
Detail view renders full feed-style cards (header, 4:5 photo or branded distance hero, stat chips); the compact card scales to any count with stacked thumbnails and a summary line.

### 5. Profile opened from feed never loaded today's distance
The feed passed a freshly-created, unobserved `FriendService`, so the `isFriend` gate ran before friends loaded and the today card never populated. The service is now `@ObservedObject`, friendship data loads before the gated nudge-status fetch, and the feed reuses one stable `@StateObject` instance.

## Round 2

### 6. A photo for every walk/run of the day
The BeReal-style photo prompt only fired from the once-a-day goal celebration, so a second workout never prompted — and the feed compose button hid for the whole day after one share. The prompt now also queues after every post-goal workout (deduped per workout uuid); the unified feed ships each post's `workout_id` (additive), the client tracks which of today's workouts already carry a deliberate post or story, and the composer targets the newest unshared workout. The backend's one-post-per-workout rule is unchanged; only the client's one-share-per-*day* gate is gone (kept solely for goal-met-without-workouts days).

### 7. Friend at "1.00 / 1 mi · 100%" still nudgeable and not marked complete
Nudge status, the nudge send gate, and the friend mile-completed notification used raw `>= 1.0` miles, while streaks/challenges/weekly recap count `>= 0.95` and `today_miles` is 2-decimal rounded — so a GPS-measured 0.996-mile day **displayed** as "1.00 / 100%" and kept the streak, yet read incomplete for nudges. All daily-mile completion checks now share `DAILY_GOAL_TOLERANCE` (0.95) on the backend and `ProgressCalculator.dailyGoalTolerance` on iOS.

### 8. Leaderboard didn't load
No logic bug — the screen has a real error state with retry; this was transient connectivity. Added two quiet client-side retries with backoff for transient network errors, matching RemoteChallengeService policy.

## Round 3

### 9. Feed stops loading older posts after the first page
Root cause, **verified end-to-end** (wire-format simulation + Postgres 16): `next_before` cursors were raw Postgres timestamptz text (`2026-07-04 12:34:56.123456+00`). iOS percent-encodes with `.urlQueryAllowed`, which leaves `+` literal; Express's query parser decodes a literal `+` as a **space**; the mangled `…123456 00` fails the `::timestamptz` cast (`invalid input syntax`, 500); the client's `try?` swallows it — so the scroll silently froze at the first page boundary, permanently.

- **Backend (repairs all shipped clients on deploy):** cursors are now emitted URL-safe (ISO-8601 UTC with microseconds, `…T12:34:56.123456Z`) via a shared `URL_SAFE_CURSOR` SQL helper on all three paginated reads, and incoming `before` values are repaired (trailing <code>&nbsp;NN</code> → `+NN`) so mangled cursors from apps in the field parse again. Verified: old format fails the cast, repaired + new formats round-trip exactly (microseconds intact), negative/half-hour offsets unaffected.
- **iOS:** cursor values are percent-encoded with a set that excludes `+&=?`; `loadMore` prefetches when any of the last 3 cards appears, auto-continues when a page fully dedupes (keyset boundary shift), and shows a tap-to-retry row on failure instead of dying silently — proper Instagram-style infinite scroll.

## Compatibility / App Review notes
- Backend changes are **additive** (new GET endpoint, new feed field, new cursor format for an opaque token, input repair) — no endpoint/field removals or type changes; old clients are unaffected and the cursor fix actively *repairs* them.
- HealthKit `workoutRoute` share access serves a shipping feature (feed route maps) with user-controllable sharing (5.1.3-compliant); no new purpose strings needed.

## Testing
- `backend`: `npm run build` (tsc) passes on all commits.
- Cursor bug reproduced and fix verified against a scratch PostgreSQL 16 + the exact Express query-parser behavior (see commit `cdb2b1b` message).
- iOS builds via Xcode only (not possible in this environment). On-device checks: double-tap burst, route prompt + map after an outdoor in-app walk, hype-count tap, memories sheet, profile today card from feed, photo prompt + compose after a second workout, friend at ~0.99 mi reading complete, and **scrolling the feed well past 20 items**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xp6ZThP8xHvbfRe7eKsUvj