### PR TITLE
Instagram-style double-tap + synced hype tallies + unlimited hype/nudge role UI

### DIFF
--- a/app/Mile A Day/Core/Services/MADNotificationService.swift
+++ b/app/Mile A Day/Core/Services/MADNotificationService.swift
@@ -463,10 +463,14 @@ extension MADNotificationService: UNUserNotificationCenterDelegate {
             let response = try await HypeService.sendHype(targetUserId: targetUserId)
             let remaining = response.hypes_remaining
             let body: String
-            switch remaining {
-            case 0:  body = "Hype sent! That was your last one today."
-            case 1:  body = "Hype sent! 1 left today."
-            default: body = "Hype sent! \(remaining) left today."
+            if response.unlimited == true {
+                body = "Hype sent!"
+            } else {
+                switch remaining {
+                case 0:  body = "Hype sent! That was your last one today."
+                case 1:  body = "Hype sent! 1 left today."
+                default: body = "Hype sent! \(remaining) left today."
+                }
             }
             await postLocalToast(title: "🔥 Hype sent", body: body)
         } catch let error as APIError where error.isRateLimited {

--- a/app/Mile A Day/Models/Competition.swift
+++ b/app/Mile A Day/Models/Competition.swift
@@ -835,11 +835,22 @@ struct FriendNudgeResponse: Codable {
 struct NudgeStatusResponse: Codable, Equatable {
     let can_nudge: Bool
     let has_completed_mile: Bool
+    /// Legacy: derived from can_nudge server-side, so unlimited (admin)
+    /// nudgers read false here even after nudging. Prefer `nudgedToday`.
     let already_nudged_today: Bool
     let today_miles: Double?
     /// Friend's current streak (in days). Optional for backward compatibility
     /// with pre-leaderboard backend deploys.
     let current_streak: Int?
+    /// Log truth: the sender HAS nudged this friend today — set even for
+    /// unlimited nudgers, who may still nudge again. Absent on old backends.
+    var has_nudged_today: Bool? = nil
+    /// The sender's role bypasses the once-per-friend-per-day nudge limit.
+    var unlimited_nudges: Bool? = nil
+
+    /// Display truth for "already nudged today" across backend versions.
+    var nudgedToday: Bool { has_nudged_today ?? already_nudged_today }
+    var unlimitedNudges: Bool { unlimited_nudges ?? false }
 }
 
 struct NudgeStatusBatchResponse: Codable {
@@ -891,6 +902,10 @@ struct InAppNotification: Codable, Identifiable {
     let hype_context_id: String?
     let hype_context_label: String?
     let is_hyped: Bool?
+    /// Total hypes this event has received (all senders), computed with the
+    /// SAME canonical context keys as the feed so both surfaces agree.
+    /// Absent on older backends / non-hypeable rows.
+    var hype_count: Int?
 }
 
 struct InAppNotificationResponse: Codable {

--- a/app/Mile A Day/Services/HypeService.swift
+++ b/app/Mile A Day/Services/HypeService.swift
@@ -3,11 +3,15 @@ import Foundation
 struct HypeResponse: Decodable {
     let message: String
     let hypes_remaining: Int
+    /// Admin/founder roles bypass the daily cap. Absent on older backends.
+    var unlimited: Bool?
 }
 
 struct HypeStatusResponse: Decodable {
     let hypes_remaining: Int
     let resets_at: String?
+    /// Admin/founder roles bypass the daily cap. Absent on older backends.
+    var unlimited: Bool?
 }
 
 /// Optional context describing what was hyped. When provided, the backend uses

--- a/app/Mile A Day/Views/Components/HypeControls.swift
+++ b/app/Mile A Day/Views/Components/HypeControls.swift
@@ -73,19 +73,31 @@ struct HypeButton: View {
 // MARK: - Hype Tally
 
 /// Social-proof badge: how many hypes a single workout/event has received.
-/// Reads "👏 N". Hidden by callers when the count is zero.
+/// Compact form reads "👏 N" (tight rows); labeled form reads "👏 3 hypes"
+/// — the Instagram-likes-style line used on feed cards, where it's also the
+/// tap target for "who hyped this".
 struct HypeTally: View {
     let count: Int
+    /// Render the spelled-out "N hypes" form (feed cards).
+    var showsLabel: Bool = false
 
     var body: some View {
-        HStack(spacing: 3) {
+        HStack(spacing: showsLabel ? 5 : 3) {
             Image(systemName: "hands.clap.fill")
-                .font(.system(size: 10, weight: .bold))
-            Text("\(count)")
-                .font(.system(size: 12, weight: .heavy, design: .rounded))
-                .monospacedDigit()
+                .font(.system(size: showsLabel ? 12 : 10, weight: .bold))
+                .foregroundColor(.orange)
+            if showsLabel {
+                Text("\(count) hype\(count == 1 ? "" : "s")")
+                    .font(.system(size: 13, weight: .heavy, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundColor(.white.opacity(0.9))
+            } else {
+                Text("\(count)")
+                    .font(.system(size: 12, weight: .heavy, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundColor(.orange)
+            }
         }
-        .foregroundColor(.orange)
     }
 }
 
@@ -93,15 +105,19 @@ struct HypeTally: View {
 
 /// Shows how many hypes the user has left today. `compact` ("N left") fits the
 /// navigation toolbar; the default descriptive form suits inline placement.
-/// Dims to grey once the daily allowance is spent.
+/// Dims to grey once the daily allowance is spent. Unlimited (admin/founder)
+/// users get an "∞" pill that never depletes.
 struct HypePill: View {
     let remaining: Int
     var compact: Bool = false
+    /// The user's role bypasses the daily hype cap.
+    var unlimited: Bool = false
 
-    private var depleted: Bool { remaining <= 0 }
+    private var depleted: Bool { !unlimited && remaining <= 0 }
     private var tint: Color { depleted ? .white.opacity(0.55) : .orange }
 
     private var label: String {
+        if unlimited { return compact ? "∞" : "Unlimited hypes" }
         if compact { return "\(remaining) left" }
         return "\(remaining) hype\(remaining == 1 ? "" : "s") left today"
     }

--- a/app/Mile A Day/Views/Feed/ActivityCardView.swift
+++ b/app/Mile A Day/Views/Feed/ActivityCardView.swift
@@ -157,7 +157,7 @@ struct ActivityCardView: View {
         HStack(spacing: 10) {
             if let count = entry.hype_count, count > 0 {
                 Button { onTapHypeCount?() } label: {
-                    HypeTally(count: count)
+                    HypeTally(count: count, showsLabel: true)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)

--- a/app/Mile A Day/Views/Feed/ActivityCardView.swift
+++ b/app/Mile A Day/Views/Feed/ActivityCardView.swift
@@ -3,8 +3,8 @@ import SwiftUI
 /// A raw walk/run in the unified feed (no photo) — the auto activity card.
 /// Shares the visual language of PostCardView: author header, a big
 /// distance hero line, the GPS route map when the workout has one, a stat
-/// strip, and a hype affordance. Double-tapping the map (or the hero) hypes,
-/// same as photos.
+/// strip, and a hype affordance. Double-tapping anywhere on the card body
+/// hypes, same as photo posts.
 struct ActivityCardView: View {
     let entry: FeedEntry
     var isHyping: Bool = false
@@ -15,6 +15,9 @@ struct ActivityCardView: View {
     var onTapHypeCount: (() -> Void)? = nil
 
     @State private var hypeBurst = 0
+    /// Collapses duplicate reports of one physical double-tap (see
+    /// PostCardView.lastDoubleTapAt).
+    @State private var lastDoubleTapAt = Date.distantPast
 
     private var distance: Double { entry.distance ?? 0 }
     private var completedMile: Bool { distance >= ProgressCalculator.dailyGoalTolerance }
@@ -23,25 +26,29 @@ struct ActivityCardView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
             header
-            heroLine
-            if let coords = entry.routeCoordinates {
-                WorkoutRouteMapView(coordinates: coords, routeColor: accent)
-                    .frame(maxWidth: .infinity)
-                    // Proportional, not a fixed 160pt: the map scales with the
-                    // card on every screen size instead of shrinking to a strip.
-                    .aspectRatio(16.0 / 10.0, contentMode: .fit)
-                    .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
-                            .strokeBorder(Color.white.opacity(0.08), lineWidth: 1)
-                    )
-                    .overlay(
-                        Color.clear
-                            .contentShape(Rectangle())
-                            .onTapGesture(count: 2) { doubleTapHype() }
-                    )
+            // Instagram behavior: double-tap ANYWHERE on the card body (hero
+            // line, map, stat chips, spacing) hypes. Header/footer buttons
+            // stay out so double-tapping them can't hype by accident.
+            VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+                heroLine
+                if let coords = entry.routeCoordinates {
+                    WorkoutRouteMapView(coordinates: coords, routeColor: accent)
+                        .frame(maxWidth: .infinity)
+                        // Proportional, not a fixed 160pt: the map scales with the
+                        // card on every screen size instead of shrinking to a strip.
+                        .aspectRatio(16.0 / 10.0, contentMode: .fit)
+                        .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
+                                .strokeBorder(Color.white.opacity(0.08), lineWidth: 1)
+                        )
+                }
+                statStrip
             }
-            statStrip
+            .contentShape(Rectangle())
+            .simultaneousGesture(
+                TapGesture(count: 2).onEnded { doubleTapHype() }
+            )
             footer
         }
         .padding(MADTheme.Spacing.sm)
@@ -49,13 +56,15 @@ struct ActivityCardView: View {
             RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
                 .fill(Color.white.opacity(0.04))
         )
-        // Card-level so the burst plays for route-less cards too (double-tap
-        // on the hero line).
+        // Card-level so the burst plays centered over the whole card.
         .overlay(HypeBurstView(trigger: hypeBurst))
     }
 
     private func doubleTapHype() {
         guard !entry.is_self else { return }
+        let now = Date()
+        guard now.timeIntervalSince(lastDoubleTapAt) > 0.35 else { return }
+        lastDoubleTapAt = now
         hypeBurst += 1
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
         if !entry.is_hyped {
@@ -115,8 +124,6 @@ struct ActivityCardView: View {
                 .foregroundColor(.white.opacity(0.7))
         }
         .padding(.horizontal, 2)
-        .contentShape(Rectangle())
-        .onTapGesture(count: 2) { doubleTapHype() }
     }
 
     @ViewBuilder

--- a/app/Mile A Day/Views/Feed/FeedMediaViews.swift
+++ b/app/Mile A Day/Views/Feed/FeedMediaViews.swift
@@ -135,12 +135,15 @@ private struct ZoomGestureHost: UIViewRepresentable {
         pinch.delegate = context.coordinator
         view.addGestureRecognizer(pinch)
 
-        if onDoubleTap != nil {
-            let doubleTap = UITapGestureRecognizer(
-                target: context.coordinator, action: #selector(Coordinator.handleDoubleTap(_:)))
-            doubleTap.numberOfTapsRequired = 2
-            view.addGestureRecognizer(doubleTap)
-        }
+        // Always installed — the callback is resolved at fire time via the
+        // coordinator's current `parent`. Gating installation on the closure
+        // captured at CREATION time left slides created without a handler
+        // (or recycled across identities) permanently deaf to double-taps.
+        let doubleTap = UITapGestureRecognizer(
+            target: context.coordinator, action: #selector(Coordinator.handleDoubleTap(_:)))
+        doubleTap.numberOfTapsRequired = 2
+        doubleTap.delegate = context.coordinator
+        view.addGestureRecognizer(doubleTap)
         return view
     }
 

--- a/app/Mile A Day/Views/Feed/PostCardView.swift
+++ b/app/Mile A Day/Views/Feed/PostCardView.swift
@@ -239,7 +239,7 @@ struct PostCardView: View {
         HStack(spacing: 10) {
             if let count = post.hype_count, count > 0 {
                 Button { onTapHypeCount?() } label: {
-                    HypeTally(count: count)
+                    HypeTally(count: count, showsLabel: true)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)

--- a/app/Mile A Day/Views/Feed/PostCardView.swift
+++ b/app/Mile A Day/Views/Feed/PostCardView.swift
@@ -25,20 +25,35 @@ struct PostCardView: View {
     var onTapHypeCount: (() -> Void)? = nil
 
     @State private var hypeBurst = 0
+    /// Collapses the same physical double-tap arriving from two recognizers
+    /// (the card-level SwiftUI gesture AND the zoom host's UIKit one) into a
+    /// single burst + hype.
+    @State private var lastDoubleTapAt = Date.distantPast
 
     var body: some View {
         VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
             header
-            media
-            if let stats = post.stats_snapshot {
-                PostStatStrip(stats: stats).padding(.horizontal, 2)
+            // Instagram behavior: double-tap ANYWHERE on the post body —
+            // photo, route map, stats, caption, or the space between — hypes.
+            // `simultaneousGesture` so single taps (paging dots, horizontal
+            // swipes, pinch zoom) are untouched. The header and footer stay
+            // out so double-tapping a button can't hype by accident.
+            VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+                media
+                if let stats = post.stats_snapshot {
+                    PostStatStrip(stats: stats).padding(.horizontal, 2)
+                }
+                if let caption = post.caption, !caption.isEmpty {
+                    Text(caption)
+                        .font(.system(size: 14, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.9))
+                        .padding(.horizontal, 2)
+                }
             }
-            if let caption = post.caption, !caption.isEmpty {
-                Text(caption)
-                    .font(.system(size: 14, weight: .medium, design: .rounded))
-                    .foregroundColor(.white.opacity(0.9))
-                    .padding(.horizontal, 2)
-            }
+            .contentShape(Rectangle())
+            .simultaneousGesture(
+                TapGesture(count: 2).onEnded { doubleTapHype() }
+            )
             footer
         }
         .padding(MADTheme.Spacing.sm)
@@ -128,10 +143,14 @@ struct PostCardView: View {
         return stats
     }
 
-    /// Double-tap on any media slide: clap burst + hype (friends' posts only,
-    /// once — a re-double-tap replays the burst without double-counting).
+    /// Double-tap anywhere on the post body: clap burst + hype (friends'
+    /// posts only, once — a re-double-tap replays the burst without
+    /// double-counting).
     private func doubleTapHype() {
         guard !post.is_self else { return }
+        let now = Date()
+        guard now.timeIntervalSince(lastDoubleTapAt) > 0.35 else { return }
+        lastDoubleTapAt = now
         hypeBurst += 1
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
         if !post.is_hyped {
@@ -181,13 +200,11 @@ struct PostCardView: View {
     }
 
     /// The run itself as a branded stats card — the second slide when a photo
-    /// post has no GPS route to show. Double-tap hypes, matching the photo.
+    /// post has no GPS route to show. The card-level double-tap covers it.
     private func workoutCardSlide(_ stats: PostStats) -> some View {
         FeedWorkoutCard(stats: stats, workoutType: post.workout_type)
             .frame(maxWidth: .infinity)
             .aspectRatio(4.0 / 5.0, contentMode: .fit)
-            .contentShape(Rectangle())
-            .onTapGesture(count: 2) { if !post.is_self { doubleTapHype() } }
     }
 
     private func routeSlide(_ coords: [CLLocationCoordinate2D]) -> some View {
@@ -198,13 +215,6 @@ struct PostCardView: View {
         .frame(maxWidth: .infinity)
         .aspectRatio(4.0 / 5.0, contentMode: .fit)
         .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
-        .overlay(
-            // The map is display-only, so a clear layer can own the
-            // double-tap without stealing anything the map needs.
-            Color.clear
-                .contentShape(Rectangle())
-                .onTapGesture(count: 2) { doubleTapHype() }
-        )
         .overlay(alignment: .topLeading) {
             slideBadge("Route", icon: "map.fill")
         }

--- a/app/Mile A Day/Views/Feed/ProfilePostsGridView.swift
+++ b/app/Mile A Day/Views/Feed/ProfilePostsGridView.swift
@@ -267,7 +267,7 @@ struct ProfilePostsFeedSheet: View {
                         targetUserId: post.user_id
                     )
                 } label: {
-                    HypeTally(count: count).contentShape(Rectangle())
+                    HypeTally(count: count, showsLabel: true).contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .padding(.horizontal, 2)

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -534,8 +534,25 @@ struct SocialFeedView: View {
 
     private func hype(_ entry: FeedEntry) async {
         guard !entry.is_self, !entry.is_hyped, !hypingIds.contains(entry.id) else { return }
-        await MainActor.run { _ = hypingIds.insert(entry.id) }
+        // Optimistic, Instagram-style: the card flips to "Hyped" and the tally
+        // bumps the instant the user acts — the network round-trip happens
+        // behind it and only a rejection walks it back.
+        await MainActor.run {
+            _ = hypingIds.insert(entry.id)
+            updateEntry(entry.id) { e in
+                guard !e.is_hyped else { return }
+                e.is_hyped = true
+                e.hype_count = (e.hype_count ?? 0) + 1
+            }
+        }
         defer { Task { @MainActor in hypingIds.remove(entry.id) } }
+        let revert: @MainActor () -> Void = {
+            updateEntry(entry.id) { e in
+                guard e.is_hyped else { return }
+                e.is_hyped = false
+                e.hype_count = max(0, (e.hype_count ?? 1) - 1)
+            }
+        }
         let ctxType = entry.isPost ? "post" : "mile"
         let label = entry.isPost
             ? (entry.caption ?? entry.displayName)
@@ -546,19 +563,13 @@ struct SocialFeedView: View {
                 context: HypeContext(contextType: ctxType, contextId: entry.entryId, contextLabel: label)
             )
             await MainActor.run {
-                updateEntry(entry.id) { e in
-                    // A refresh may have landed mid-request and already carry
-                    // this hype — don't count it twice.
-                    guard !e.is_hyped else { return }
-                    e.is_hyped = true
-                    e.hype_count = (e.hype_count ?? 0) + 1
-                }
                 UINotificationFeedbackGenerator().notificationOccurred(.success)
             }
         } catch APIError.rateLimited {
-            // Out of hypes for today — say so instead of silently doing
-            // nothing after the double-tap burst played.
+            // Out of hypes for today — walk the optimistic state back and say
+            // so instead of silently doing nothing after the burst played.
             await MainActor.run {
+                revert()
                 UINotificationFeedbackGenerator().notificationOccurred(.warning)
                 withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
                     showHypeLimitBanner = true
@@ -568,8 +579,11 @@ struct SocialFeedView: View {
             await MainActor.run {
                 withAnimation(.easeOut(duration: 0.25)) { showHypeLimitBanner = false }
             }
+        } catch APIError.conflict {
+            // Already hyped server-side — the optimistic state is the truth.
         } catch {
-            // conflict (already hyped) — leave as-is.
+            // Network/server failure — undo quietly; the user can re-tap.
+            await MainActor.run { revert() }
         }
     }
 

--- a/app/Mile A Day/Views/Friends/FriendsListView.swift
+++ b/app/Mile A Day/Views/Friends/FriendsListView.swift
@@ -50,6 +50,8 @@ struct FriendsListView: View {
     @State private var isLoadingFeed = false
     @State private var hasLoadedFeed = false
     @State private var hypesRemaining: Int?
+    /// Admin/founder roles bypass the daily hype cap — pill shows ∞.
+    @State private var hypesUnlimited = false
     @State private var hypingWorkoutIds: Set<String> = []
     // Rows the user has tapped open to reveal the duration/pace/calories/steps strip.
     @State private var expandedWorkoutIds: Set<String> = []
@@ -320,7 +322,7 @@ struct FriendsListView: View {
     private var hypesRemainingChip: some View {
         HStack {
             Spacer()
-            HypePill(remaining: hypesRemaining ?? HypeService.dailyLimit)
+            HypePill(remaining: hypesRemaining ?? HypeService.dailyLimit, unlimited: hypesUnlimited)
             Spacer()
         }
         .padding(.top, 2)
@@ -403,7 +405,9 @@ struct FriendsListView: View {
                         HypeButton(
                             isHyped: item.is_hyped,
                             isBusy: hypingWorkoutIds.contains(item.workout_id),
-                            isOutOfHypes: (hypesRemaining ?? HypeService.dailyLimit) <= 0 && !item.is_hyped
+                            isOutOfHypes: !hypesUnlimited
+                                && (hypesRemaining ?? HypeService.dailyLimit) <= 0
+                                && !item.is_hyped
                         ) {
                             Task { await sendHype(for: item) }
                         }
@@ -571,6 +575,7 @@ struct FriendsListView: View {
             // New hype landed — reflect it and bump the social-proof tally.
             markHyped(item.workout_id, bumpCount: true)
             hypesRemaining = response.hypes_remaining
+            hypesUnlimited = response.unlimited ?? hypesUnlimited
             UINotificationFeedbackGenerator().notificationOccurred(.success)
         } catch let error as APIError {
             switch error {
@@ -607,6 +612,7 @@ struct FriendsListView: View {
         }
         if let status = try? await HypeService.status() {
             hypesRemaining = status.hypes_remaining
+            hypesUnlimited = status.unlimited ?? false
         }
         isLoadingFeed = false
         hasLoadedFeed = true
@@ -893,7 +899,8 @@ struct FriendsListView: View {
     /// green when done, accent when in-progress.
     private func friendRowCompact(friend: BackendUser, isCompleted: Bool) -> some View {
         let status = nudgeStatuses[friend.user_id]
-        let alreadyNudged = status?.already_nudged_today ?? false
+        let alreadyNudged = status?.nudgedToday ?? false
+        let canRenudge = status?.unlimitedNudges ?? false
         let todayMiles = status?.today_miles ?? 0
         let goalMiles: Double = 1.0
         let progress = min(todayMiles / goalMiles, 1.0)
@@ -920,7 +927,7 @@ struct FriendsListView: View {
             .buttonStyle(.plain)
 
             if !isCompleted {
-                nudgeButton(friend: friend, alreadyNudged: alreadyNudged)
+                nudgeButton(friend: friend, alreadyNudged: alreadyNudged, canRenudge: canRenudge)
                     .padding(.trailing, MADTheme.Spacing.md)
             }
         }
@@ -1017,9 +1024,42 @@ struct FriendsListView: View {
     }
 
     // MARK: - Nudge Button (only shown when friend hasn't completed goal)
-    private func nudgeButton(friend: BackendUser, alreadyNudged: Bool) -> some View {
+    /// `canRenudge` (unlimited-nudge roles): an already-nudged friend shows an
+    /// ENABLED "Nudge again" pill — visibly different from the fresh "Nudge",
+    /// so the sender knows one already went out today before sending another.
+    private func nudgeButton(friend: BackendUser, alreadyNudged: Bool, canRenudge: Bool = false) -> some View {
         Group {
-            if alreadyNudged {
+            if alreadyNudged && canRenudge {
+                Button {
+                    handleNudge(friend)
+                } label: {
+                    HStack(spacing: 4) {
+                        if nudgingFriendId == friend.user_id {
+                            ProgressView()
+                                .scaleEffect(0.6)
+                                .tint(.orange)
+                        } else {
+                            Image(systemName: "bell.and.waves.left.and.right.fill")
+                                .font(.system(size: 10, weight: .semibold))
+                            Text("Nudge again")
+                                .font(.system(size: 10, weight: .semibold, design: .rounded))
+                        }
+                    }
+                    .foregroundColor(.orange.opacity(0.75))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(
+                        Capsule()
+                            .fill(Color.white.opacity(0.05))
+                            .overlay(
+                                Capsule()
+                                    .strokeBorder(Color.orange.opacity(0.35), style: StrokeStyle(lineWidth: 1, dash: [3, 2.5]))
+                            )
+                    )
+                }
+                .buttonStyle(ScaleButtonStyle())
+                .disabled(nudgingFriendId != nil)
+            } else if alreadyNudged {
                 HStack(spacing: 4) {
                     Image(systemName: "bell.slash.fill")
                         .font(.system(size: 10))
@@ -1230,14 +1270,18 @@ struct FriendsListView: View {
                 await MainActor.run {
                     nudgingFriendId = nil
                     FlexNudgeTracker.markFriendNudgeSent(friendId: friend.user_id)
-                    // Optimistic update on the shared service state — preserve existing miles/completion
+                    // Optimistic update on the shared service state — preserve existing miles/completion.
+                    // Unlimited nudgers keep can_nudge so "Nudge again" stays available.
                     let existing = friendService.nudgeStatuses[friend.user_id]
+                    let unlimited = existing?.unlimitedNudges ?? false
                     friendService.nudgeStatuses[friend.user_id] = NudgeStatusResponse(
-                        can_nudge: false,
+                        can_nudge: unlimited,
                         has_completed_mile: existing?.has_completed_mile ?? false,
-                        already_nudged_today: true,
+                        already_nudged_today: !unlimited,
                         today_miles: existing?.today_miles,
-                        current_streak: existing?.current_streak
+                        current_streak: existing?.current_streak,
+                        has_nudged_today: true,
+                        unlimited_nudges: existing?.unlimited_nudges
                     )
                     UINotificationFeedbackGenerator().notificationOccurred(.success)
                     showNudgeFeedback(NudgeFeedback(

--- a/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
+++ b/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
@@ -686,7 +686,44 @@ struct UserProfileDetailView: View {
            friendService.isFriend(user),
            let status = nudgeStatus,
            !status.has_completed_mile {
-            if status.already_nudged_today {
+            if status.nudgedToday && status.unlimitedNudges {
+                // Unlimited-nudge roles: one already went out today, but they
+                // may send another — the distinct "Nudge again" pill IS the
+                // awareness that this isn't the first.
+                Button {
+                    handleProfileNudge()
+                } label: {
+                    HStack(spacing: 5) {
+                        if isNudging {
+                            ProgressView()
+                                .scaleEffect(0.6)
+                                .tint(.orange)
+                        } else {
+                            Image(systemName: "bell.and.waves.left.and.right.fill")
+                                .font(.system(size: 11, weight: .bold))
+                            Text("Nudge again")
+                                .font(.system(size: 12, weight: .bold, design: .rounded))
+                                .lineLimit(1)
+                        }
+                    }
+                    .foregroundColor(.orange.opacity(0.75))
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 9)
+                    .frame(maxWidth: .infinity)
+                    .background(
+                        Capsule()
+                            .fill(Color.white.opacity(0.05))
+                            .overlay(
+                                Capsule().strokeBorder(
+                                    Color.orange.opacity(0.35),
+                                    style: StrokeStyle(lineWidth: 1, dash: [3, 2.5])
+                                )
+                            )
+                    )
+                }
+                .buttonStyle(.plain)
+                .disabled(isNudging)
+            } else if status.nudgedToday {
                 HStack(spacing: 5) {
                     Image(systemName: "bell.slash.fill")
                         .font(.system(size: 11, weight: .bold))
@@ -749,12 +786,16 @@ struct UserProfileDetailView: View {
                     isNudging = false
                     FlexNudgeTracker.markFriendNudgeSent(friendId: user.user_id)
                     // Preserve existing miles/completion in the optimistic update.
+                    // Unlimited nudgers keep "Nudge again" available.
+                    let unlimited = nudgeStatus?.unlimitedNudges ?? false
                     nudgeStatus = NudgeStatusResponse(
-                        can_nudge: false,
+                        can_nudge: unlimited,
                         has_completed_mile: nudgeStatus?.has_completed_mile ?? false,
-                        already_nudged_today: true,
+                        already_nudged_today: !unlimited,
                         today_miles: nudgeStatus?.today_miles,
-                        current_streak: nudgeStatus?.current_streak
+                        current_streak: nudgeStatus?.current_streak,
+                        has_nudged_today: true,
+                        unlimited_nudges: nudgeStatus?.unlimited_nudges
                     )
                     UINotificationFeedbackGenerator().notificationOccurred(.success)
                     showProfileNudgeFeedback(NudgeFeedback(

--- a/app/Mile A Day/Views/NotificationInboxView.swift
+++ b/app/Mile A Day/Views/NotificationInboxView.swift
@@ -13,6 +13,8 @@ struct NotificationInboxView: View {
     @State private var hypedRowIds: Set<String> = []
     @State private var hypeToast: String?
     @State private var hypesRemaining: Int?
+    /// Admin/founder roles bypass the daily hype cap — pill shows ∞.
+    @State private var hypesUnlimited = false
 
     /// Active category filter. `all` shows everything; the others narrow
     /// the feed to a related cluster of notification types so users can
@@ -85,12 +87,12 @@ struct NotificationInboxView: View {
                 // stops the orange pill from rendering inside a second system pill.
                 if #available(iOS 26.0, *) {
                     ToolbarItem(placement: .navigationBarLeading) {
-                        HypePill(remaining: remaining, compact: true)
+                        HypePill(remaining: remaining, compact: true, unlimited: hypesUnlimited)
                     }
                     .sharedBackgroundVisibility(.hidden)
                 } else {
                     ToolbarItem(placement: .navigationBarLeading) {
-                        HypePill(remaining: remaining, compact: true)
+                        HypePill(remaining: remaining, compact: true, unlimited: hypesUnlimited)
                     }
                 }
             }
@@ -473,6 +475,15 @@ struct NotificationInboxView: View {
         notification.is_hyped == true || hypedRowIds.contains(notification.id)
     }
 
+    /// The event's total hype count for display: the server figure (computed
+    /// with the same canonical context keys as the feed) plus one while the
+    /// viewer's own optimistic hype is in flight but not yet reflected.
+    private func displayedHypeCount(_ notification: InAppNotification) -> Int {
+        let base = notification.hype_count ?? 0
+        let optimisticBump = hypedRowIds.contains(notification.id) && notification.is_hyped != true
+        return base + (optimisticBump ? 1 : 0)
+    }
+
     private func performHype(_ notification: InAppNotification) {
         guard
             let targetId = hypeTargetUserId(for: notification),
@@ -485,7 +496,10 @@ struct NotificationInboxView: View {
         Task {
             do {
                 let response = try await HypeService.sendHype(targetUserId: targetId, context: context)
-                await MainActor.run { hypesRemaining = response.hypes_remaining }
+                await MainActor.run {
+                    hypesRemaining = response.hypes_remaining
+                    hypesUnlimited = response.unlimited ?? hypesUnlimited
+                }
             } catch APIError.conflict {
                 // Already hyped server-side; stay greyed out, no toast.
             } catch APIError.rateLimited(let msg) {
@@ -518,7 +532,10 @@ struct NotificationInboxView: View {
     private func fallbackHype(_ notification: InAppNotification, targetId: String) async {
         do {
             let response = try await HypeService.sendHype(targetUserId: targetId)
-            await MainActor.run { hypesRemaining = response.hypes_remaining }
+            await MainActor.run {
+                hypesRemaining = response.hypes_remaining
+                hypesUnlimited = response.unlimited ?? hypesUnlimited
+            }
         } catch APIError.rateLimited(let msg) {
             await MainActor.run {
                 hypedRowIds.remove(notification.id)
@@ -628,8 +645,17 @@ struct NotificationInboxView: View {
 
                     if canShowHypeButton(notification) {
                         let hyped = isAlreadyHyped(notification)
-                        HypeButton(isHyped: hyped) {
-                            performHype(notification)
+                        HStack(spacing: 10) {
+                            HypeButton(isHyped: hyped) {
+                                performHype(notification)
+                            }
+                            // Same tally the feed shows for this event — the
+                            // server computes both from the same canonical
+                            // hype context, so the numbers always agree.
+                            let count = displayedHypeCount(notification)
+                            if count > 0 {
+                                HypeTally(count: count)
+                            }
                         }
                         .padding(.top, 4)
                     }
@@ -782,7 +808,10 @@ struct NotificationInboxView: View {
     private func loadHypeStatus() async {
         do {
             let status = try await HypeService.status()
-            await MainActor.run { hypesRemaining = status.hypes_remaining }
+            await MainActor.run {
+                hypesRemaining = status.hypes_remaining
+                hypesUnlimited = status.unlimited ?? false
+            }
         } catch {
             // Non-fatal — pill just stays hidden.
         }

--- a/backend/src/controllers/friendNudgeController.ts
+++ b/backend/src/controllers/friendNudgeController.ts
@@ -5,8 +5,10 @@ import { getFriendship } from "../services/friendshipService.js";
 import {
   sendPush,
   canFriendNudge,
+  hasNudgedFriendToday,
   logFriendNudge,
 } from "../services/pushNotificationService.js";
+import { hasUnlimitedActions } from "../services/privilegedUsers.js";
 import { shouldSendNotification } from "../services/notificationSettingsService.js";
 import {
   getTodayMiles,
@@ -121,18 +123,27 @@ export async function checkNudgeStatus(
   const senderId = req.userId!;
 
   try {
-    const [canNudge, friendTodayMiles, streaks] = await Promise.all([
-      canFriendNudge(senderId, friendId),
-      getTodayMiles(friendId),
-      fetchStreaks([friendId]),
-    ]);
+    const [nudgedToday, unlimited, friendTodayMiles, streaks] =
+      await Promise.all([
+        hasNudgedFriendToday(senderId, friendId),
+        hasUnlimitedActions(senderId),
+        getTodayMiles(friendId),
+        fetchStreaks([friendId]),
+      ]);
+    const canNudge = unlimited || !nudgedToday;
 
     const hasCompletedMile = friendTodayMiles >= DAILY_GOAL_TOLERANCE;
 
     res.status(200).json({
       can_nudge: canNudge && !hasCompletedMile,
       has_completed_mile: hasCompletedMile,
+      // Legacy field: derived from can_nudge, so unlimited nudgers read
+      // false here and old builds keep their re-nudge ability.
       already_nudged_today: !canNudge,
+      // Log truth + role, so new builds can show "already nudged, nudge
+      // again?" for unlimited senders.
+      has_nudged_today: nudgedToday,
+      unlimited_nudges: unlimited,
       today_miles: Math.round(friendTodayMiles * 100) / 100,
       current_streak: streaks[friendId] ?? 0,
     });
@@ -163,26 +174,36 @@ export async function checkNudgeStatusBatch(
         can_nudge: boolean;
         has_completed_mile: boolean;
         already_nudged_today: boolean;
+        has_nudged_today: boolean;
+        unlimited_nudges: boolean;
         today_miles: number;
         current_streak: number;
       }
     > = {};
 
-    // One DB roundtrip for all streaks rather than N per-friend queries.
-    const streaks = await fetchStreaks(friendIds);
+    // One DB roundtrip for all streaks rather than N per-friend queries;
+    // the role bypass is per-sender, so look it up once.
+    const [streaks, unlimited] = await Promise.all([
+      fetchStreaks(friendIds),
+      hasUnlimitedActions(senderId),
+    ]);
 
     await Promise.all(
       friendIds.map(async (friendId: string) => {
-        const [canNudge, friendTodayMiles] = await Promise.all([
-          canFriendNudge(senderId, friendId),
+        const [nudgedToday, friendTodayMiles] = await Promise.all([
+          hasNudgedFriendToday(senderId, friendId),
           getTodayMiles(friendId),
         ]);
+        const canNudge = unlimited || !nudgedToday;
 
         const hasCompletedMile = friendTodayMiles >= DAILY_GOAL_TOLERANCE;
         statuses[friendId] = {
           can_nudge: canNudge && !hasCompletedMile,
           has_completed_mile: hasCompletedMile,
+          // Legacy: derived, so unlimited nudgers keep re-nudge on old builds.
           already_nudged_today: !canNudge,
+          has_nudged_today: nudgedToday,
+          unlimited_nudges: unlimited,
           today_miles: Math.round(friendTodayMiles * 100) / 100,
           current_streak: streaks[friendId] ?? 0,
         };

--- a/backend/src/controllers/hypeController.ts
+++ b/backend/src/controllers/hypeController.ts
@@ -6,6 +6,7 @@ import { getUser } from "../services/userService.js";
 import { sendPush } from "../services/pushNotificationService.js";
 import { shouldSendNotification } from "../services/notificationSettingsService.js";
 import { getPostAuthor } from "../services/postService.js";
+import { hasUnlimitedHypes } from "../services/privilegedUsers.js";
 import { evaluateSocialBadgesForUser } from "../services/badgeService.js";
 import {
   logHypeIfUnderLimit,
@@ -226,7 +227,10 @@ export async function sendHype(req: AuthenticatedRequest, res: Response) {
     // Re-evaluate hype badges (first hype, X hypes) in the background.
     evaluateSocialBadgesForUser(senderId).catch(() => {});
 
-    const countAfter = await getDailyHypeCount(senderId);
+    const [countAfter, unlimited] = await Promise.all([
+      getDailyHypeCount(senderId),
+      hasUnlimitedHypes(senderId),
+    ]);
 
     const shouldSend = await shouldSendNotification(
       targetUserId,
@@ -250,9 +254,16 @@ export async function sendHype(req: AuthenticatedRequest, res: Response) {
       });
     }
 
+    // Unlimited (admin/founder) senders never report a depleted allowance:
+    // old builds read hypes_remaining directly for their "N left" pill and
+    // disable hyping at 0, so pin it at the cap; new builds show ∞ via the
+    // explicit flag.
     res.status(200).json({
       message: "Hype sent",
-      hypes_remaining: Math.max(0, HYPE_DAILY_LIMIT - countAfter),
+      hypes_remaining: unlimited
+        ? HYPE_DAILY_LIMIT
+        : Math.max(0, HYPE_DAILY_LIMIT - countAfter),
+      unlimited,
     });
   } catch (error: any) {
     console.error("Error sending hype:", error.message);
@@ -339,13 +350,19 @@ export async function getContextHypersController(
 export async function getHypeStatus(req: AuthenticatedRequest, res: Response) {
   const senderId = req.userId!;
   try {
-    const [count, resetsAt] = await Promise.all([
+    const [count, resetsAt, unlimited] = await Promise.all([
       getDailyHypeCount(senderId),
       getHypeResetsAt(senderId),
+      hasUnlimitedHypes(senderId),
     ]);
+    // See sendHype: unlimited senders pin hypes_remaining at the cap so old
+    // builds never render a depleted/disabled hype UI for them.
     res.status(200).json({
-      hypes_remaining: Math.max(0, HYPE_DAILY_LIMIT - count),
+      hypes_remaining: unlimited
+        ? HYPE_DAILY_LIMIT
+        : Math.max(0, HYPE_DAILY_LIMIT - count),
       resets_at: resetsAt,
+      unlimited,
     });
   } catch (error: any) {
     console.error("Error getting hype status:", error.message);

--- a/backend/src/controllers/inAppNotificationController.ts
+++ b/backend/src/controllers/inAppNotificationController.ts
@@ -138,7 +138,7 @@ export async function getInAppNotifications(req: Request, res: Response) {
     const types = ctxKeys.map((k) => k.type);
     const ids = ctxKeys.map((k) => k.id);
 
-    const [hyped, unreadCount] = await Promise.all([
+    const [hyped, counts, unreadCount] = await Promise.all([
       ctxKeys.length > 0
         ? db.query<{
             target_id: string;
@@ -154,6 +154,26 @@ export async function getInAppNotifications(req: Request, res: Response) {
             [userId, targetIds, types, ids],
           )
         : Promise.resolve([]),
+      // Total hypes per context across ALL senders — the same DISTINCT-sender
+      // count the feed shows, keyed by the same canonical context (mile
+      // composites, post ids), so the inbox and feed tallies always agree.
+      ctxKeys.length > 0
+        ? db.query<{
+            target_id: string;
+            context_type: string;
+            context_id: string;
+            cnt: number;
+          }>(
+            `SELECT target_id, context_type, context_id,
+						COUNT(DISTINCT sender_id)::int AS cnt
+					FROM hype_log
+					WHERE (target_id, context_type, context_id) IN (
+							SELECT * FROM UNNEST($1::text[], $2::text[], $3::text[])
+						)
+					GROUP BY target_id, context_type, context_id`,
+            [targetIds, types, ids],
+          )
+        : Promise.resolve([]),
       db.query(
         `SELECT COUNT(*) as count FROM in_app_notifications
 			WHERE user_id = $1 AND is_read = FALSE`,
@@ -164,6 +184,13 @@ export async function getInAppNotifications(req: Request, res: Response) {
     const hypedSet = new Set<string>();
     for (const h of hyped) {
       hypedSet.add(`${h.target_id}|${h.context_type}|${h.context_id}`);
+    }
+    const countByKey = new Map<string, number>();
+    for (const c of counts) {
+      countByKey.set(
+        `${c.target_id}|${c.context_type}|${c.context_id}`,
+        Number(c.cnt) || 0,
+      );
     }
 
     const notifications = derived.map(({ row, hype }) => {
@@ -187,6 +214,7 @@ export async function getInAppNotifications(req: Request, res: Response) {
         hype_context_id: hype.hype_context_id,
         hype_context_label: hype.hype_context_label,
         is_hyped: isHyped,
+        hype_count: key !== null ? (countByKey.get(key) ?? 0) : null,
       };
     });
 

--- a/backend/src/services/pushNotificationService.ts
+++ b/backend/src/services/pushNotificationService.ts
@@ -714,11 +714,13 @@ export async function logNudge(
 
 // ─── Friend Nudge Rate Limiting ─────────────────────────────────────
 
-export async function canFriendNudge(
+/** Log truth: has the sender already nudged this friend today (ET day)?
+ * Independent of any rate-limit bypass — unlimited (admin) nudgers still
+ * want to SEE that they've nudged, even though they may nudge again. */
+export async function hasNudgedFriendToday(
   senderId: string,
   targetId: string,
 ): Promise<boolean> {
-  if (await hasUnlimitedActions(senderId)) return true;
   const result = await db.query(
     `SELECT id FROM friend_nudge_log
 		WHERE sender_id = $1 AND target_id = $2
@@ -726,7 +728,15 @@ export async function canFriendNudge(
 		LIMIT 1`,
     [senderId, targetId],
   );
-  return result.length === 0;
+  return result.length > 0;
+}
+
+export async function canFriendNudge(
+  senderId: string,
+  targetId: string,
+): Promise<boolean> {
+  if (await hasUnlimitedActions(senderId)) return true;
+  return !(await hasNudgedFriendToday(senderId, targetId));
 }
 
 export async function logFriendNudge(


### PR DESCRIPTION
## What & Why

Follow-up to #189, two rounds of feed/social polish.

## Round 1 — double-tap hype that actually works, everywhere

Double-tapping a friend's feed post could do nothing. The wiring was fragmented and fragile:
- On **photo slides** the only handler was a UIKit recognizer inside the pinch-zoom host, installed **only if the slide was created with a handler** — slides created without one (or recycled) were permanently deaf. `updateUIView` refreshed the callback but never installed the recognizer.
- Every other surface had its own separate gesture patch (route slide, stats slide, hero line, map), with dead zones between them.

Fix:
- **One card-body double-tap** (`simultaneousGesture(TapGesture(count: 2))`) on both card types covering media + stats + caption / hero + map + chips. Double-tap anywhere on the body → clap burst + hype. Single taps, carousel swipes, pinch-zoom untouched; header/footer buttons excluded so double-tapping them can't hype by accident.
- Zoom host's UIKit recognizer now always installed (callback resolved at fire time) as redundancy; 0.35s debounce collapses duplicate reports of one physical tap.
- **Optimistic hype**: "Hyped" chip + tally flip instantly; rate-limit walks back with the banner, conflict keeps it, network failure reverts quietly.

## Round 2 — tallies in sync across surfaces + unlimited-role UI

### Hype tally placement & sync
- Feed/profile post cards render the tally as a labeled **"N hypes"** line (Instagram-likes style) in the footer — still the tap target for the who-hyped sheet.
- **Notifications inbox now shows the same tally** beside each row's Hype button. The backend batch-computes per-context `COUNT(DISTINCT sender_id)` using the **same canonical context keys** (mile `user:date` composites, post ids) already used by the unified feed and the Friends "Today" feed — so all three surfaces always show the same number. Optimistic +1 while the viewer's own hype is in flight.

### Unlimited hypes (admin/founder roles)
- `/hype` and `/hype/status` now return `unlimited`, and pin `hypes_remaining` at the cap for these roles — so **old builds** never render "0 left" or disabled hype buttons for them (they used to read depleted while still being able to hype).
- New builds show an "∞ Unlimited hypes" pill and skip the out-of-hypes disable; the push-action toast drops the "N left" suffix.

### Unlimited nudges (admin role)
- Previously `already_nudged_today` was derived from the bypass, so admins **never saw** that they'd nudged someone. Nudge-status endpoints now also return log-truth `has_nudged_today` + `unlimited_nudges` (legacy field unchanged → old builds keep re-nudge ability).
- New builds: after nudging, unlimited nudgers get a distinct dashed **"Nudge again"** pill (friends list + profile) — visibly different from the fresh "Nudge", so they know one already went out today but can deliberately send another. Everyone else keeps the disabled "Nudged" chip. Optimistic post-nudge state preserves the affordance.

## Compatibility
- Backend changes are additive (`unlimited`, `has_nudged_today`, `unlimited_nudges`, `hype_count` on inbox rows) plus the old-build-friendly `hypes_remaining` pinning; no removals or type changes.

## Testing
- `backend`: `npm run build` (tsc) passes.
- iOS builds via Xcode only. On-device: double-tap everywhere on friend cards (burst + instant Hyped), tally reads "N hypes" and matches the inbox tally for the same mile, admin/founder account shows ∞ pill and never disables, admin sees "Nudge again" after nudging and can re-send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xp6ZThP8xHvbfRe7eKsUvj