### PR TITLE
Photo safety: sweep + clobber fixes, delete clarity, camera-roll auto-save

### DIFF
--- a/app/Mile A Day/Views/Components/ImagePicker.swift
+++ b/app/Mile A Day/Views/Components/ImagePicker.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import PhotosUI
+import Photos
 
 struct ImagePicker: UIViewControllerRepresentable {
     @Binding var selectedImage: UIImage?
@@ -45,10 +46,35 @@ struct ImagePicker: UIViewControllerRepresentable {
     }
 }
 
+// MARK: - Camera-roll auto-save
+
+/// Saves in-app camera captures to the user's photo library (add-only
+/// access), so the app is never the only holder of a photo — posts and
+/// stories can be deleted, but the user always keeps their own copy in the
+/// camera roll. Best-effort: a denied permission or save failure never
+/// interrupts the capture flow.
+enum PhotoRollSaver {
+    static func save(_ image: UIImage) {
+        PHPhotoLibrary.requestAuthorization(for: .addOnly) { status in
+            guard status == .authorized || status == .limited else { return }
+            PHPhotoLibrary.shared().performChanges {
+                PHAssetChangeRequest.creationRequestForAsset(from: image)
+            } completionHandler: { _, error in
+                if let error {
+                    print("[PhotoRollSaver] Save failed: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+}
+
 // MARK: - Camera Capture
 
-/// Camera-only capture (no photo library). Used by the post composer so shared
-/// walks/runs are captured in the moment rather than uploaded from the roll.
+/// Camera-only capture (no photo library picking). Used by the post composer
+/// and the mid-run snap button so shared walks/runs are captured in the
+/// moment rather than uploaded from the roll. Every capture is ALSO saved to
+/// the camera roll (see PhotoRollSaver) — the user's own copy, independent of
+/// what happens to the post.
 struct CameraPicker: UIViewControllerRepresentable {
     @Binding var image: UIImage?
     @Environment(\.presentationMode) var presentationMode
@@ -85,6 +111,8 @@ struct CameraPicker: UIViewControllerRepresentable {
         ) {
             if let img = info[.originalImage] as? UIImage {
                 parent.image = img
+                // Every in-app capture also lands in the camera roll.
+                PhotoRollSaver.save(img)
             }
             parent.presentationMode.wrappedValue.dismiss()
         }

--- a/app/Mile A Day/Views/Feed/StoryViewerView.swift
+++ b/app/Mile A Day/Views/Feed/StoryViewerView.swift
@@ -116,7 +116,7 @@ struct StoryViewerView: View {
         .confirmationDialog("Story options", isPresented: $showOptions, titleVisibility: .hidden) {
             if let post = optionsPost {
                 if post.is_self {
-                    Button("Delete story", role: .destructive) {
+                    Button("Delete story & photo", role: .destructive) {
                         Task { await deleteOwn(post) }
                     }
                 } else {
@@ -125,6 +125,13 @@ struct StoryViewerView: View {
                         Task { await block(post) }
                     }
                 }
+            }
+        } message: {
+            // The story's photo also fronts the run's card on the feed and
+            // profile — deleting it removes the photo EVERYWHERE, which
+            // surprised users who thought they were only ending the 24h story.
+            if optionsPost?.is_self == true {
+                Text("This also removes the photo from your run's card on the feed and your profile.")
             }
         }
         .onChange(of: showOptions) { _, open in

--- a/app/Mile-A-Day-Info.plist
+++ b/app/Mile-A-Day-Info.plist
@@ -21,6 +21,8 @@
 	</array>
 	<key>NSCameraUsageDescription</key>
 	<string>Mile A Day uses the camera to take photos for your walk and run posts and stories, and to scan a friend's profile QR code so you can add each other quickly.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Photos you take in Mile A Day are also saved to your photo library so you always keep your own copy.</string>
 	<key>NSHealthShareUsageDescription</key>
 	<string>Mile A Day reads your workouts, walking and running distance, active energy, step count, and workout routes to track your daily mile, calculate streaks, and show your progress. This data is synced to Mile A Day's servers so you can compete with friends and view your history across devices.</string>
 	<key>NSHealthUpdateUsageDescription</key>

--- a/backend/src/controllers/adminController.ts
+++ b/backend/src/controllers/adminController.ts
@@ -8,7 +8,10 @@ import {
   getMilesByDay,
   getErrors,
   getErrorSummary,
+  getPostForensics,
+  restoreDeletedPost,
 } from "../services/adminService.js";
+import { signMediaUrlsDeep } from "../services/mediaSigningService.js";
 
 const APPLE_ISS = "https://appleid.apple.com";
 const appleJwks = createRemoteJWKSet(
@@ -84,4 +87,72 @@ export async function errors(req: Request, res: Response) {
 
 export async function errorSummary(_req: Request, res: Response) {
   res.json(await getErrorSummary());
+}
+
+/**
+ * GET /admin/posts/:userId/forensics?from=YYYY-MM-DD&to=YYYY-MM-DD
+ * Every posts row (INCLUDING soft-deleted) for the user in the window, with
+ * whether each media file still exists on disk and signed URLs so the photos
+ * are viewable in a browser. Support tooling for "my photo disappeared".
+ */
+export async function postForensics(req: Request, res: Response) {
+  const userId = req.params.userId;
+  const from =
+    typeof req.query.from === "string" &&
+    /^\d{4}-\d{2}-\d{2}$/.test(req.query.from)
+      ? req.query.from
+      : null;
+  const to =
+    typeof req.query.to === "string" && /^\d{4}-\d{2}-\d{2}$/.test(req.query.to)
+      ? req.query.to
+      : null;
+  if (!from || !to) {
+    return res
+      .status(400)
+      .json({ error: "from and to (YYYY-MM-DD) are required" });
+  }
+  try {
+    const rows = await getPostForensics(userId, from, to);
+    res.json({ posts: signMediaUrlsDeep(rows) });
+  } catch (error: any) {
+    console.error("Error in post forensics:", error.message);
+    res.status(500).json({ error: "Error fetching post forensics" });
+  }
+}
+
+/**
+ * POST /admin/posts/:postId/restore — clear a soft-deleted post's deleted_at.
+ * 404 unknown id, 409 already live or the slot is now occupied by a live
+ * post. Restoring only brings the photo back if the media file survived the
+ * orphan sweep (see media_file_exists in the forensics response).
+ */
+export async function restorePost(req: Request, res: Response) {
+  const postId = req.params.postId;
+  // Non-uuid ids would blow up the ::uuid cast as a 500 — 404 them instead.
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      postId,
+    )
+  ) {
+    return res.status(404).json({ error: "Post not found" });
+  }
+  try {
+    const result = await restoreDeletedPost(postId);
+    switch (result.status) {
+      case "not_found":
+        return res.status(404).json({ error: "Post not found" });
+      case "already_live":
+        return res.status(409).json({ error: "Post is not deleted" });
+      case "slot_taken":
+        return res.status(409).json({
+          error: "A live post now occupies this workout's slot",
+          occupied_by: result.by,
+        });
+      case "restored":
+        return res.json({ ok: true });
+    }
+  } catch (error: any) {
+    console.error("Error restoring post:", error.message);
+    res.status(500).json({ error: "Error restoring post" });
+  }
 }

--- a/backend/src/cron/storiesCron.ts
+++ b/backend/src/cron/storiesCron.ts
@@ -15,8 +15,14 @@ const db = PostgresService.getInstance();
  */
 
 /**
- * Delete /uploads/posts files older than 24h that no live post references —
+ * Delete /uploads/posts files older than 72h that NO posts row references —
  * catches orphans from uploads that never completed a POST /posts.
+ *
+ * The reference check deliberately includes SOFT-DELETED posts: deleted_at is
+ * the undo path, and a photo is often the only copy the user has. The old
+ * live-rows-only check made every soft delete silently irreversible — delete
+ * a story (whose photo also fronts the run's feed card), and by the next
+ * 3:30 AM sweep the photo file was gone from disk forever.
  */
 async function sweepOrphanedMedia(): Promise<void> {
   const dir = path.join(process.cwd(), "uploads", "posts");
@@ -26,7 +32,7 @@ async function sweepOrphanedMedia(): Promise<void> {
   } catch {
     return; // dir not created yet
   }
-  const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+  const cutoff = Date.now() - 72 * 60 * 60 * 1000;
   let removed = 0;
   for (const file of files) {
     const full = path.join(dir, file);
@@ -39,7 +45,7 @@ async function sweepOrphanedMedia(): Promise<void> {
     if (mtimeMs > cutoff) continue;
     const mediaUrl = `/uploads/posts/${file}`;
     const referenced = await db.query<{ exists: boolean }>(
-      `SELECT EXISTS (SELECT 1 FROM posts WHERE media_url = $1 AND deleted_at IS NULL) AS exists`,
+      `SELECT EXISTS (SELECT 1 FROM posts WHERE media_url = $1) AS exists`,
       [mediaUrl],
     );
     if (referenced[0]?.exists) continue;

--- a/backend/src/routes/adminRoutes.ts
+++ b/backend/src/routes/adminRoutes.ts
@@ -5,6 +5,8 @@ import {
   milesByDay,
   errors,
   errorSummary,
+  postForensics,
+  restorePost,
 } from "../controllers/adminController.js";
 
 // Public: Sign in with Apple (web) exchange -> admin access token.
@@ -18,5 +20,9 @@ adminRouter.get("/overview", overview);
 adminRouter.get("/miles-by-day", milesByDay);
 adminRouter.get("/errors", errors);
 adminRouter.get("/errors/summary", errorSummary);
+// Support tooling: post rows incl. soft-deleted + on-disk file checks, and
+// soft-delete undo — for "my photo disappeared" investigations.
+adminRouter.get("/posts/:userId/forensics", postForensics);
+adminRouter.post("/posts/:postId/restore", restorePost);
 
 export default adminRouter;

--- a/backend/src/services/adminService.ts
+++ b/backend/src/services/adminService.ts
@@ -79,3 +79,104 @@ export async function getErrorSummary() {
   );
   return { total, byCategory };
 }
+
+// ─── Post forensics + restore (support tooling) ─────────────────────
+
+/**
+ * Every posts row for a user in a local-date window — INCLUDING soft-deleted
+ * rows — with the linked workout and whether each media file still exists on
+ * disk. Built for "my photo disappeared" investigations: the row shapes +
+ * deleted_at timestamps show whether a photo post was deleted, replaced by an
+ * auto card, or never existed, and file_exists says if a restore can still
+ * bring the pixels back.
+ */
+export async function getPostForensics(
+  userId: string,
+  from: string,
+  to: string,
+) {
+  const rows = await db.query<{
+    post_id: string;
+    workout_id: string | null;
+    media_url: string;
+    caption: string | null;
+    is_auto: boolean;
+    share_to_feed: boolean;
+    share_to_story: boolean;
+    local_date: string;
+    story_expires_at: string | null;
+    created_at: string;
+    deleted_at: string | null;
+    workout_type: string | null;
+    workout_distance: number | null;
+  }>(
+    `SELECT p.post_id::text AS post_id, p.workout_id, p.media_url, p.caption,
+			p.is_auto, p.share_to_feed, p.share_to_story,
+			p.local_date::text AS local_date, p.story_expires_at, p.created_at,
+			p.deleted_at,
+			w.workout_type, w.distance::float AS workout_distance
+		FROM posts p
+		LEFT JOIN workouts w ON w.workout_id = p.workout_id
+		WHERE p.user_id = $1 AND p.local_date BETWEEN $2::date AND $3::date
+		ORDER BY p.created_at`,
+    [userId, from, to],
+  );
+
+  const fs = await import("fs");
+  const path = await import("path");
+  return rows.map((r) => ({
+    ...r,
+    media_file_exists: r.media_url.startsWith("/uploads/")
+      ? fs.existsSync(path.join(process.cwd(), r.media_url.replace(/^\//, "")))
+      : null,
+  }));
+}
+
+/**
+ * Clear a soft-deleted post's deleted_at so it surfaces again. Refuses when a
+ * LIVE post now occupies the same one-per-workout slot (restoring would
+ * violate the partial unique index). Restoring the ROW only helps if the
+ * media file survived — check media_file_exists in getPostForensics first.
+ */
+export async function restoreDeletedPost(postId: string): Promise<
+  | { status: "not_found" | "already_live" }
+  | { status: "slot_taken"; by: string }
+  | { status: "restored" }
+> {
+  const rows = await db.query<{
+    post_id: string;
+    user_id: string;
+    workout_id: string | null;
+    share_to_feed: boolean;
+    share_to_story: boolean;
+    deleted_at: string | null;
+  }>(
+    `SELECT post_id::text AS post_id, user_id, workout_id,
+			share_to_feed, share_to_story, deleted_at
+		FROM posts WHERE post_id = $1::uuid`,
+    [postId],
+  );
+  const row = rows[0];
+  if (!row) return { status: "not_found" };
+  if (!row.deleted_at) return { status: "already_live" };
+
+  if (row.workout_id) {
+    const slotPredicate = row.share_to_feed
+      ? "share_to_feed"
+      : "(share_to_story AND NOT share_to_feed)";
+    const occupied = await db.query<{ post_id: string }>(
+      `SELECT post_id::text AS post_id FROM posts
+			WHERE workout_id = $1 AND user_id = $2 AND deleted_at IS NULL
+				AND ${slotPredicate}
+			LIMIT 1`,
+      [row.workout_id, row.user_id],
+    );
+    if (occupied[0]) return { status: "slot_taken", by: occupied[0].post_id };
+  }
+
+  await db.query(
+    `UPDATE posts SET deleted_at = NULL WHERE post_id = $1::uuid`,
+    [postId],
+  );
+  return { status: "restored" };
+}

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -186,12 +186,13 @@ export async function createPost(input: CreatePostInput): Promise<PostRow> {
     !input.shareToStory;
   const isAutoValue =
     input.isAuto === undefined ? legacyLooksAuto : input.isAuto === true;
-  // Legacy requests may overwrite anything the caller owns; flagged requests
-  // may only overwrite the slot's AUTO post.
-  const updateGuard =
-    input.isAuto === undefined
-      ? `WHERE posts.user_id = $1`
-      : `WHERE posts.user_id = $1 AND posts.is_auto`;
+  // Only the slot's AUTO post may be overwritten in place — for legacy
+  // requests too. Legacy upserts used to overwrite ANYTHING the caller owned,
+  // which let an old build's background auto-card post silently DESTROY a
+  // deliberate photo post's media (the old media_url is recorded nowhere, and
+  // the orphan sweep then removed the photo file from disk). A blocked legacy
+  // write now falls through to the yield/409 handling below instead.
+  const updateGuard = `WHERE posts.user_id = $1 AND posts.is_auto`;
   // Legacy clients never sent the flags, so their upserts must not clobber a
   // stored is_auto/include_route (e.g. resetting a route opt-out to true).
   const flagUpdates =
@@ -244,9 +245,10 @@ export async function createPost(input: CreatePostInput): Promise<PostRow> {
   if (rows[0]) return rows[0];
 
   // Zero rows — the slot is taken and the update guard skipped it. An auto
-  // post quietly yields to the caller's existing user post; anything else
-  // (another user's post, or a second deliberate post) is rejected.
-  if (input.isAuto === true && input.workoutId) {
+  // post (flagged, or a legacy insert that classifies as auto) quietly yields
+  // to the caller's existing user post; anything else (another user's post,
+  // or a second deliberate post) is rejected.
+  if ((input.isAuto === true || legacyLooksAuto) && input.workoutId) {
     const existing = await db.query<PostRow>(
       `
 			${CREATED_POST_SELECT}


### PR DESCRIPTION
## What & Why

Investigating a user report: a photo attached to a Jul 2 workout's feed post vanished, leaving only the auto stats card. Code audit found **two paths that can eat a photo**, both funneling into the same permanent-loss mechanism. This PR closes all of them, adds a camera-roll safety net, and ships the admin tooling to diagnose + recover the specific lost photo.

### The loss mechanism (fixed)
The nightly 3:30 AM orphan sweep deleted `/uploads/posts` files not referenced by a **live** (`deleted_at IS NULL`) post. But soft-delete is supposed to be the undo path — the moment a story was soft-deleted (and a story's photo also fronts the run's feed/profile card), its photo file became "unreferenced" and was erased from disk within a day, silently and irreversibly. The sweep now protects files referenced by **any** posts row (deleted included) and only touches files older than 72h.

### Path A: story delete surprise (fixed with clarity)
A run's photo often lives on a **story** post while the feed slot holds the auto card; the card leads with the story's photo permanently, by design. The story viewer's delete gave no hint the photo also leaves the feed card. Now labeled **"Delete story & photo"** with an explicit dialog message.

### Path B: legacy upsert clobber (fixed)
`createPost` let **legacy clients** (pre-`is_auto` builds) overwrite *any* post they owned for a workout — an old build's background auto-card post could silently replace a photo post's media in place, unrecorded. The update guard now permits in-place replacement of **auto rows only** for everyone; blocked legacy auto-looking inserts quietly yield; blocked deliberate re-posts get `workout_already_posted`.

### Camera-roll auto-save (new safety net)
Photos taken in-app (composer camera + mid-run snaps) existed only in the app. Every `CameraPicker` capture is now also saved to the photo library via **add-only** `PHPhotoLibrary` access, best-effort. Library picks untouched. Adds `NSPhotoLibraryAddUsageDescription`; the add-only prompt appears on first capture, in context (5.1.1-compliant).

### Admin forensics + restore (find & recover the lost photo)
Diagnosing a vanished photo required raw DB access; undoing a soft delete had no tool at all. Two `requireAdmin` endpoints:
- `GET /admin/posts/:userId/forensics?from=YYYY-MM-DD&to=YYYY-MM-DD` — every posts row in the window **including soft-deleted**, joined with the linked workout, plus `media_file_exists` (is the upload still on disk → can a restore still bring the pixels back) and signed media URLs so each row's image is viewable in a browser.
- `POST /admin/posts/:postId/restore` — clears `deleted_at`; 409s if the post is live or a live post now occupies the same one-per-workout slot (partial unique index protection).

## Compatibility / App Review
- Server changes are additive or bug-tightening; no API shape changes. Legacy clients lose only the ability to clobber non-auto posts — which was the data-loss bug.
- Photo-library access is add-only with a clear purpose string (5.1.1).

## Testing
- `backend`: `npm run build` (tsc) passes.
- iOS builds via Xcode only. On-device: in-app captures appear in Photos (after the one-time add-only prompt); library picks don't duplicate; story delete dialog warns about the feed photo.
- After deploy, run the forensics call for the Jul 2 window to identify what happened to the reported photo (steps in chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xp6ZThP8xHvbfRe7eKsUvj