### PR TITLE
Default the Apple web client ID in code — admin login works without env setup

### DIFF
--- a/backend/src/controllers/adminController.ts
+++ b/backend/src/controllers/adminController.ts
@@ -32,11 +32,11 @@ export async function verifyAppleWeb(req: Request, res: Response) {
     return res.status(400).json({ error: "id_token required" });
   }
 
-  const audience = process.env.APPLE_WEB_CLIENT_ID;
-  if (!audience) {
-    console.error("APPLE_WEB_CLIENT_ID not configured");
-    return res.status(500).json({ error: "Admin auth not configured" });
-  }
+  // Default to the registered Services ID (team NS237SS5KD) — the client id
+  // is public by design (it travels in every SIWA request), so a code default
+  // is safe and removes the host-env dependency. Env var wins when set.
+  const audience =
+    process.env.APPLE_WEB_CLIENT_ID || "org.robertwiscount.Mile-A-Day.web";
 
   try {
     const { payload } = await jwtVerify(idToken, appleJwks, {

--- a/website/app/admin/login.tsx
+++ b/website/app/admin/login.tsx
@@ -3,7 +3,13 @@
 import Script from "next/script";
 import { useState } from "react";
 
-const CLIENT_ID = process.env.NEXT_PUBLIC_APPLE_WEB_CLIENT_ID;
+// The Services ID registered in the Apple Developer portal (team NS237SS5KD).
+// NOT a secret — Apple client IDs travel in every sign-in request by design,
+// so a code default is safe and spares the hosting-dashboard env-var dance.
+// An env var still wins when set (e.g. a staging Services ID).
+const CLIENT_ID =
+  process.env.NEXT_PUBLIC_APPLE_WEB_CLIENT_ID ||
+  "org.robertwiscount.Mile-A-Day.web";
 const REDIRECT_URI =
   process.env.NEXT_PUBLIC_APPLE_WEB_REDIRECT_URI ||
   "https://mileaday.run/admin";


### PR DESCRIPTION
## What & Why

The admin dashboard's Sign in with Apple was dead on both ends: `NEXT_PUBLIC_APPLE_WEB_CLIENT_ID` (website build) and `APPLE_WEB_CLIENT_ID` (backend) were never set on the hosts, and setting them requires hosting-dashboard access the owner doesn't have handy.

The Apple client ID is **not a secret** — it travels in plaintext in every Sign-in-with-Apple request by design. So both sides now default to the registered Services ID (`org.robertwiscount.Mile-A-Day.web`, team `NS237SS5KD`), with the env vars still taking precedence when set (e.g. for a staging Services ID). Merging to `main` is the entire deploy — no host configuration needed.

## Testing
- `backend`: tsc passes. `website`: `next build` passes.
- After deploy: https://mileaday.run/admin → Sign in with Apple should open Apple's popup instead of "Apple web client ID not configured".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xp6ZThP8xHvbfRe7eKsUvj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xp6ZThP8xHvbfRe7eKsUvj)_