### PR TITLE
Sweep matches stored media paths; forensics exposes bare filename

### DIFF
--- a/backend/src/cron/storiesCron.ts
+++ b/backend/src/cron/storiesCron.ts
@@ -44,8 +44,14 @@ async function sweepOrphanedMedia(): Promise<void> {
     }
     if (mtimeMs > cutoff) continue;
     const mediaUrl = `/uploads/posts/${file}`;
+    // Compare against the stored value's PATH — rows written before the
+    // query-stripping landed (or through any future gap) may carry a
+    // ?e=&s= signature, and an exact-equality check would misread their
+    // files as orphans and delete user photos.
     const referenced = await db.query<{ exists: boolean }>(
-      `SELECT EXISTS (SELECT 1 FROM posts WHERE media_url = $1) AS exists`,
+      `SELECT EXISTS (
+				SELECT 1 FROM posts WHERE split_part(media_url, '?', 1) = $1
+			) AS exists`,
       [mediaUrl],
     );
     if (referenced[0]?.exists) continue;

--- a/backend/src/services/adminService.ts
+++ b/backend/src/services/adminService.ts
@@ -124,12 +124,23 @@ export async function getPostForensics(
 
   const fs = await import("fs");
   const path = await import("path");
-  return rows.map((r) => ({
-    ...r,
-    media_file_exists: r.media_url.startsWith("/uploads/")
-      ? fs.existsSync(path.join(process.cwd(), r.media_url.replace(/^\//, "")))
-      : null,
-  }));
+  return rows.map((r) => {
+    // Stored values MAY carry a legacy ?e=&s= signature — always work on the
+    // bare path for disk checks, and expose the bare FILENAME so recovery
+    // (host snapshots, device caches) knows exactly what to look for. The
+    // filename passes through the response signer untouched (it only rewrites
+    // strings starting with /uploads/posts/).
+    const barePath = r.media_url.split("?")[0];
+    return {
+      ...r,
+      media_file: barePath.startsWith("/uploads/posts/")
+        ? barePath.slice("/uploads/posts/".length)
+        : null,
+      media_file_exists: barePath.startsWith("/uploads/")
+        ? fs.existsSync(path.join(process.cwd(), barePath.replace(/^\//, "")))
+        : null,
+    };
+  });
 }
 
 /**
@@ -138,7 +149,9 @@ export async function getPostForensics(
  * violate the partial unique index). Restoring the ROW only helps if the
  * media file survived — check media_file_exists in getPostForensics first.
  */
-export async function restoreDeletedPost(postId: string): Promise<
+export async function restoreDeletedPost(
+  postId: string,
+): Promise<
   | { status: "not_found" | "already_live" }
   | { status: "slot_taken"; by: string }
   | { status: "restored" }

--- a/website/app/admin/dashboard.tsx
+++ b/website/app/admin/dashboard.tsx
@@ -244,6 +244,7 @@ type ForensicsPost = {
   deleted_at: string | null;
   workout_type: string | null;
   workout_distance: number | null;
+  media_file: string | null;
   media_file_exists: boolean | null;
 };
 
@@ -403,6 +404,11 @@ function PhotoForensics() {
                 {p.caption && (
                   <p className="mt-1 truncate text-xs text-white/50">
                     “{p.caption}”
+                  </p>
+                )}
+                {p.media_file && (
+                  <p className="mt-1 select-all font-mono text-[11px] text-white/35">
+                    {p.media_file}
                   </p>
                 )}
                 {p.deleted_at && (


### PR DESCRIPTION
## What & Why

The Jul 2 lost-photo forensics showed a **LIVE story row with its file gone** — the orphan sweep should never delete a referenced file. Either the stored `media_url` mismatched the disk path (a legacy `?e=&s=` signature stored in the window before query-stripping shipped in `7a49b3f`), or the file was lost another way. This closes the mismatch class and makes the investigation decisive:

- **storiesCron**: the reference check now compares `split_part(media_url, '?', 1)` — rows carrying a legacy signed URL still protect their files from tonight's 3:30 AM run onward.
- **Admin forensics**: the disk-existence check runs on the bare path, and each row returns `media_file` (the bare filename — deliberately shaped so the response signer passes it through untouched). The dashboard renders it as selectable mono text, giving host-snapshot or device-cache recovery the exact file to hunt.

## Testing
- `backend`: tsc passes. `website`: `next build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xp6ZThP8xHvbfRe7eKsUvj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xp6ZThP8xHvbfRe7eKsUvj)_