### PR TITLE
Add race PR tracking (best times per standard distance)

### DIFF
--- a/app/Mile A Day/Models/UserManager.swift
+++ b/app/Mile A Day/Models/UserManager.swift
@@ -64,12 +64,14 @@ class UserManager: ObservableObject {
             guard let self else { return }
             guard let userId = self.currentUser.backendUserId else { return }
             let freshCompletions = note.userInfo?["newChallengeCompletions"] as? [[String: String]] ?? []
+            let freshRacePRs = note.userInfo?["newRaceRecords"] as? [[String: String]] ?? []
             Task {
                 await self.refreshBadgesFromServer()
                 await ChallengeService.refresh(userId: userId)
                 // After state is fresh, celebrate any challenge completed by this upload.
                 await MainActor.run {
                     self.celebrateChallengeCompletions(freshCompletions)
+                    self.celebrateRacePRs(freshRacePRs)
                 }
             }
         }
@@ -565,6 +567,26 @@ class UserManager: ObservableObject {
                 challengeStreak: streak
             )
             CelebrationManager.shared.addCelebration(.challengeCompleted(info: info))
+        }
+    }
+
+    /// Celebrate any race-distance PR (best time for 5K, 10K, half, etc.) set by
+    /// the latest upload — the "you got a new PR!" moment. Reuses the generic
+    /// milestone celebration. Silent during the initial historical sync, same as
+    /// challenges, so a first-time backfill doesn't fire a wall of celebrations.
+    func celebrateRacePRs(_ prs: [[String: String]]) {
+        guard hasCompletedInitialBadgeSync, !prs.isEmpty else { return }
+        for pr in prs {
+            guard let key = pr["distanceKey"] else { continue }
+            let name = RaceCatalog.name(for: key)
+            let timeStr = pr["durationSec"].flatMap { Double($0) }.map { RaceCatalog.formatTime($0) }
+            CelebrationManager.shared.addCelebration(
+                .milestone(
+                    title: "New \(name) PR!",
+                    description: timeStr.map { "\($0) — your fastest yet 🏃" } ?? "Your fastest yet 🏃",
+                    icon: "stopwatch.fill"
+                )
+            )
         }
     }
 

--- a/app/Mile A Day/Services/RaceRecordsService.swift
+++ b/app/Mile A Day/Services/RaceRecordsService.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// One race-distance personal record (best time), from the backend
+/// `/workouts/:id/race-records` endpoints. Keys are already camelCase.
+struct RaceRecord: Codable, Identifiable, Equatable {
+    let distanceKey: String
+    let durationSec: Double
+    let distanceMiles: Double
+    let workoutId: String
+    let achievedDate: String  // "YYYY-MM-DD" in the user's local timezone
+
+    var id: String { distanceKey + "-" + workoutId }
+}
+
+/// Display metadata for the standard race distances, in presentation order.
+/// Mirrors `RACE_DISTANCES` in the backend workoutService — keep in sync.
+struct RaceDistance: Identifiable, Equatable {
+    let key: String
+    let name: String
+    var id: String { key }
+}
+
+enum RaceCatalog {
+    static let distances: [RaceDistance] = [
+        .init(key: "1mi", name: "1 Mile"),
+        .init(key: "2mi", name: "2 Miles"),
+        .init(key: "5k", name: "5K"),
+        .init(key: "5mi", name: "5 Miles"),
+        .init(key: "10k", name: "10K"),
+        .init(key: "15k", name: "15K"),
+        .init(key: "half", name: "Half Marathon"),
+        .init(key: "marathon", name: "Marathon"),
+    ]
+
+    static func name(for key: String) -> String {
+        distances.first { $0.key == key }?.name ?? key
+    }
+
+    /// mm:ss, or h:mm:ss once a time reaches an hour.
+    static func formatTime(_ seconds: Double) -> String {
+        let s = Int(seconds.rounded())
+        let h = s / 3600, m = (s % 3600) / 60, sec = s % 60
+        return h > 0
+            ? String(format: "%d:%02d:%02d", h, m, sec)
+            : String(format: "%d:%02d", m, sec)
+    }
+}
+
+/// Read-only fetches for race PRs. All records are derived server-side from the
+/// user's existing workouts — no separate PR store — so a full history counts.
+enum RaceRecordsService {
+    /// Best time per distance (distances with no qualifying run are absent).
+    static func fetchRecords(userId: String) async throws -> [RaceRecord] {
+        struct Resp: Decodable { let records: [RaceRecord] }
+        let resp: Resp = try await APIClient.fancyFetch(
+            endpoint: "/workouts/\(userId)/race-records",
+            responseType: Resp.self
+        )
+        return resp.records
+    }
+
+    /// Full progression history (every qualifying run, newest first) for one distance.
+    static func fetchHistory(userId: String, distanceKey: String) async throws -> [RaceRecord] {
+        struct Resp: Decodable { let history: [RaceRecord] }
+        let resp: Resp = try await APIClient.fancyFetch(
+            endpoint: "/workouts/\(userId)/race-records/\(distanceKey)",
+            responseType: Resp.self
+        )
+        return resp.history
+    }
+}

--- a/app/Mile A Day/Services/WorkoutSyncService.swift
+++ b/app/Mile A Day/Services/WorkoutSyncService.swift
@@ -527,10 +527,15 @@ class WorkoutSyncService: ObservableObject {
             let challengeKey: String
             let challengeTitle: String
         }
+        struct UploadedRacePR: Codable {
+            let distanceKey: String
+            let durationSec: Double
+        }
         struct UploadResponse: Codable {
             let message: String?
             let newlyEarnedBadges: [UploadedBadge]?
             let newChallengeCompletions: [UploadedChallengeCompletion]?
+            let newRaceRecords: [UploadedRacePR]?
         }
 
         do {
@@ -553,6 +558,11 @@ class WorkoutSyncService: ObservableObject {
             let completionPayload: [[String: String]] = (response.newChallengeCompletions ?? []).map {
                 ["challengeKey": $0.challengeKey, "challengeTitle": $0.challengeTitle, "localDate": $0.localDate]
             }
+            // Race PRs set by this upload (best time for 5K, 10K, etc.) so the
+            // celebration layer can tell the user they just set a new PR.
+            let racePRPayload: [[String: String]] = (response.newRaceRecords ?? []).map {
+                ["distanceKey": $0.distanceKey, "durationSec": String($0.durationSec)]
+            }
             await MainActor.run {
                 NotificationCenter.default.post(
                     name: Notification.Name("MAD_WorkoutsUploaded"),
@@ -560,7 +570,8 @@ class WorkoutSyncService: ObservableObject {
                     userInfo: [
                         "newBadgeCount": badgeCount,
                         "newChallengeCompletionCount": completionCount,
-                        "newChallengeCompletions": completionPayload
+                        "newChallengeCompletions": completionPayload,
+                        "newRaceRecords": racePRPayload
                     ]
                 )
             }

--- a/app/Mile A Day/Views/Profile/ProfileView.swift
+++ b/app/Mile A Day/Views/Profile/ProfileView.swift
@@ -329,6 +329,7 @@ struct ProfileView: View {
     private var ownStatsTabContent: some View {
         VStack(spacing: MADTheme.Spacing.lg) {
             performanceSection
+            RacePRsSection(userId: userManager.currentUser.backendUserId)
             routeHeatmapCard
         }
     }

--- a/app/Mile A Day/Views/Profile/RaceRecordsView.swift
+++ b/app/Mile A Day/Views/Profile/RaceRecordsView.swift
@@ -1,0 +1,200 @@
+import SwiftUI
+
+/// Race PR grid for the Stats tab: best time per standard distance. Tap a card
+/// that has a record to open its full history. Self-contained — owns its own
+/// fetch + state, so the parent just drops it in with a user id.
+struct RacePRsSection: View {
+    let userId: String?
+
+    @State private var records: [String: RaceRecord] = [:]  // keyed by distanceKey
+    @State private var selected: RaceDistance?
+
+    var body: some View {
+        VStack(spacing: MADTheme.Spacing.md) {
+            HStack(spacing: MADTheme.Spacing.sm) {
+                Image(systemName: "stopwatch.fill")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(MADTheme.Colors.redGradient)
+                Text("Race PRs")
+                    .font(MADTheme.Typography.headline)
+                    .foregroundColor(.primary)
+                Spacer()
+            }
+
+            LazyVGrid(
+                columns: [GridItem(.flexible()), GridItem(.flexible())],
+                spacing: MADTheme.Spacing.md
+            ) {
+                ForEach(RaceCatalog.distances) { dist in
+                    let rec = records[dist.key]
+                    let hasRecord = rec != nil
+                    Button {
+                        if hasRecord { selected = dist }
+                    } label: {
+                        MADStatCard(
+                            title: dist.name,
+                            value: rec.map { RaceCatalog.formatTime($0.durationSec) } ?? "—",
+                            icon: "stopwatch",
+                            iconColor: hasRecord ? MADTheme.Colors.madRed : .gray,
+                            backgroundColor: (hasRecord ? MADTheme.Colors.madRed : Color.gray).opacity(0.1)
+                        )
+                        .opacity(hasRecord ? 1 : 0.55)
+                    }
+                    .buttonStyle(ScaleButtonStyle())
+                    .disabled(!hasRecord)
+                }
+            }
+        }
+        .padding(MADTheme.Spacing.md)
+        .madLiquidGlass()
+        .task(id: userId) { await load() }
+        .sheet(item: $selected) { dist in
+            RaceHistoryView(userId: userId ?? "", distance: dist)
+        }
+    }
+
+    private func load() async {
+        guard let userId else { return }
+        do {
+            let recs = try await RaceRecordsService.fetchRecords(userId: userId)
+            records = Dictionary(recs.map { ($0.distanceKey, $0) }, uniquingKeysWith: { a, _ in a })
+        } catch {
+            print("[RacePRs] load failed: \(error)")
+        }
+    }
+}
+
+/// Every qualifying run for one distance, newest first. The fastest run is the
+/// PR (highlighted at the top); the list below is the full progression.
+struct RaceHistoryView: View {
+    let userId: String
+    let distance: RaceDistance
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var history: [RaceRecord] = []
+    @State private var isLoading = true
+
+    private var best: RaceRecord? {
+        history.min(by: { $0.durationSec < $1.durationSec })
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: MADTheme.Spacing.lg) {
+                    if let best {
+                        prHeader(best)
+                        historyList
+                    } else if isLoading {
+                        ProgressView().padding(.top, 60)
+                    } else {
+                        emptyState
+                    }
+                }
+                .padding(MADTheme.Spacing.md)
+            }
+            .scrollContentBackground(.hidden)
+            .background(MADTheme.Colors.appBackgroundGradient)
+            .navigationTitle(distance.name)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .task { await load() }
+    }
+
+    private func prHeader(_ rec: RaceRecord) -> some View {
+        VStack(spacing: MADTheme.Spacing.sm) {
+            Image(systemName: "trophy.fill")
+                .font(.system(size: 28, weight: .bold))
+                .foregroundStyle(MADTheme.Colors.redGradient)
+            Text(RaceCatalog.formatTime(rec.durationSec))
+                .font(.system(size: 44, weight: .bold, design: .rounded))
+                .foregroundColor(.primary)
+            Text("Personal record · \(formatDate(rec.achievedDate))")
+                .font(MADTheme.Typography.caption)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(MADTheme.Spacing.lg)
+        .madLiquidGlass()
+    }
+
+    private var historyList: some View {
+        VStack(spacing: MADTheme.Spacing.sm) {
+            HStack {
+                Text("History")
+                    .font(MADTheme.Typography.headline)
+                    .foregroundColor(.primary)
+                Spacer()
+                Text("\(history.count) run\(history.count == 1 ? "" : "s")")
+                    .font(MADTheme.Typography.caption)
+                    .foregroundColor(.secondary)
+            }
+            ForEach(history) { rec in
+                HStack {
+                    Text(formatDate(rec.achievedDate))
+                        .font(.system(size: 15, weight: .medium, design: .rounded))
+                        .foregroundColor(.primary)
+                    if rec.id == best?.id {
+                        Image(systemName: "trophy.fill")
+                            .font(.system(size: 12, weight: .bold))
+                            .foregroundColor(MADTheme.Colors.madRed)
+                    }
+                    Spacer()
+                    Text(String(format: "%.2f mi", rec.distanceMiles))
+                        .font(MADTheme.Typography.caption)
+                        .foregroundColor(.secondary)
+                    Text(RaceCatalog.formatTime(rec.durationSec))
+                        .font(.system(size: 16, weight: .semibold, design: .rounded))
+                        .foregroundColor(rec.id == best?.id ? MADTheme.Colors.madRed : .primary)
+                        .frame(minWidth: 68, alignment: .trailing)
+                }
+                .padding(.vertical, MADTheme.Spacing.sm)
+                .padding(.horizontal, MADTheme.Spacing.md)
+                .background(RoundedRectangle(cornerRadius: 12).fill(Color.white.opacity(0.03)))
+            }
+        }
+        .padding(MADTheme.Spacing.md)
+        .madLiquidGlass()
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: MADTheme.Spacing.sm) {
+            Image(systemName: "stopwatch")
+                .font(.system(size: 32, weight: .medium))
+                .foregroundColor(.secondary)
+            Text("No \(distance.name) runs yet")
+                .font(MADTheme.Typography.headline)
+                .foregroundColor(.primary)
+            Text("Run this distance to set your first PR.")
+                .font(MADTheme.Typography.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(.top, 60)
+    }
+
+    private func load() async {
+        defer { isLoading = false }
+        do {
+            history = try await RaceRecordsService.fetchHistory(userId: userId, distanceKey: distance.key)
+        } catch {
+            print("[RaceHistory] load failed: \(error)")
+        }
+    }
+
+    /// "YYYY-MM-DD" → "Mar 3, 2026". Falls back to the raw string on parse failure.
+    private func formatDate(_ ymd: String) -> String {
+        let inFmt = DateFormatter()
+        inFmt.dateFormat = "yyyy-MM-dd"
+        inFmt.timeZone = TimeZone(identifier: "UTC")
+        guard let date = inFmt.date(from: ymd) else { return ymd }
+        let outFmt = DateFormatter()
+        outFmt.dateStyle = .medium
+        outFmt.timeZone = TimeZone(identifier: "UTC")
+        return outFmt.string(from: date)
+    }
+}

--- a/backend/src/controllers/workoutController.ts
+++ b/backend/src/controllers/workoutController.ts
@@ -14,6 +14,10 @@ import {
   DAILY_GOAL_TOLERANCE,
   updateWorkout as updateWorkoutDb,
   computePersonalRecords,
+  computeRaceRecords,
+  getRaceHistory,
+  RACE_DISTANCES,
+  type RaceDistanceKey,
   getUserLocalToday,
   getUserRoutes,
 } from "../services/workoutService.js";
@@ -32,6 +36,7 @@ import {
   fanOutFriendBadgePush,
   fanOutFriendChallengePush,
   fanOutFriendPersonalBestPush,
+  fanOutFriendRacePrPush,
 } from "../services/pushNotificationService.js";
 import { refreshCurrentStreak } from "../services/leaderboardService.js";
 
@@ -76,6 +81,14 @@ export async function uploadWorkouts(req: Request, res: Response) {
     if (!user) {
       return res.status(400).send({ error: `No user found with ID ${userId}` });
     }
+
+    // Snapshot race PRs BEFORE the upsert so a retried/idempotent re-upload
+    // doesn't re-fire a PR that was already recorded. The upsert is idempotent
+    // and the client retries, so comparing post-upsert state with the batch
+    // excluded would treat an already-persisted workout as "new" on every retry
+    // (duplicate celebration + friend push). A true pre-upsert snapshot already
+    // contains that workout, so it won't look improved. Skipped on full syncs.
+    const preRaceRecords = isFullSync ? [] : await computeRaceRecords(userId);
 
     const uploadedWorkoutIds = await uploadWorkoutsDb(userId, req.body);
 
@@ -257,10 +270,51 @@ export async function uploadWorkouts(req: Request, res: Response) {
         }
       })();
 
+    // Race-distance PR detection, computed SYNCHRONOUSLY so the improved records
+    // ride back in the response (`newRaceRecords`) for an immediate in-app "New
+    // PR!" celebration. `preRaceRecords` was snapshotted before the upsert (see
+    // above) so retries don't double-fire. The today-guard (achievedDate ===
+    // userToday) prevents a historical backfill from celebrating old runs; full
+    // syncs skip entirely. Errors here never fail the upload — PRs are a
+    // garnish, not the payload.
+    let newRaceRecords: { distanceKey: string; durationSec: number }[] = [];
+    if (!isFullSync) {
+      try {
+        const [postRace, userToday] = await Promise.all([
+          computeRaceRecords(userId),
+          getUserLocalToday(userId),
+        ]);
+        const prevByKey = new Map(
+          preRaceRecords.map((r) => [r.distanceKey, r.durationSec]),
+        );
+        for (const rec of postRace) {
+          const prev = prevByKey.get(rec.distanceKey);
+          const improved = prev === undefined || rec.durationSec < prev;
+          if (improved && rec.achievedDate === userToday) {
+            newRaceRecords.push({
+              distanceKey: rec.distanceKey,
+              durationSec: rec.durationSec,
+            });
+            fanOutFriendRacePrPush(
+              userId,
+              rec.distanceKey,
+              rec.durationSec,
+              rec.workoutId,
+            ).catch((err) =>
+              console.error("Error fanning out friend_race_pr:", err.message),
+            );
+          }
+        }
+      } catch (err: any) {
+        console.error("Error detecting race PRs:", err.message);
+      }
+    }
+
     res.status(200).json({
       message: "Successfully uploaded workouts.",
       newlyEarnedBadges: rewards.newlyEarnedBadges,
       newChallengeCompletions: rewards.newChallengeCompletions,
+      newRaceRecords,
     });
   } catch (error: any) {
     console.error("Error uploading workouts:", error.message);
@@ -287,6 +341,51 @@ export async function getStreak(req: Request, res: Response) {
   } catch (error: any) {
     console.error("Error getting streak:", error.message);
     res.status(500).json({ error: "Error getting streak: " + error.message });
+  }
+}
+
+/**
+ * Best time per race distance (1mi, 5K, 10K, half, marathon, ...), derived live
+ * from the user's workouts. Readable by any authenticated user, like /stats —
+ * friend profiles show PRs. Distances with no qualifying workout are absent.
+ */
+export async function getRaceRecords(req: Request, res: Response) {
+  if (!hasRequiredKeys(["userId"], req, res)) return;
+
+  try {
+    const records = await computeRaceRecords(req.params.userId);
+    return res.status(200).json({ records });
+  } catch (error: any) {
+    console.error("Error getting race records:", error.message);
+    res
+      .status(500)
+      .json({ error: "Error getting race records: " + error.message });
+  }
+}
+
+/**
+ * Full progression history (every qualifying run, newest first) for one race
+ * distance. `:distance` must be a known race key.
+ */
+export async function getRaceHistoryController(req: Request, res: Response) {
+  if (!hasRequiredKeys(["userId", "distance"], req, res)) return;
+
+  const distance = req.params.distance;
+  if (!RACE_DISTANCES.some((d) => d.key === distance)) {
+    return res.status(400).json({ error: `Unknown race distance: ${distance}` });
+  }
+
+  try {
+    const history = await getRaceHistory(
+      req.params.userId,
+      distance as RaceDistanceKey,
+    );
+    return res.status(200).json({ distance, history });
+  } catch (error: any) {
+    console.error("Error getting race history:", error.message);
+    res
+      .status(500)
+      .json({ error: "Error getting race history: " + error.message });
   }
 }
 

--- a/backend/src/routes/workoutRoutes.ts
+++ b/backend/src/routes/workoutRoutes.ts
@@ -9,6 +9,8 @@ import {
   recalibrateStreak,
   deleteWorkout,
   getUserRoutesController,
+  getRaceRecords,
+  getRaceHistoryController,
 } from "../controllers/workoutController.js";
 import { requireSelfAccess } from "../middleware/auth.js";
 
@@ -41,5 +43,10 @@ router.get("/:userId/streak", getStreak);
 router.get("/:userId/range", getWorkoutRange);
 router.get("/:userId/recent", getRecentWorkouts);
 router.get("/:userId/stats", getUserStats);
+// Race PRs are readable by any authenticated user (like /stats) so friend
+// profiles can display them. Specific `/race-records/:distance` first so it
+// isn't shadowed.
+router.get("/:userId/race-records/:distance", getRaceHistoryController);
+router.get("/:userId/race-records", getRaceRecords);
 
 export default router;

--- a/backend/src/services/pushNotificationService.ts
+++ b/backend/src/services/pushNotificationService.ts
@@ -961,6 +961,76 @@ export async function fanOutFriendPersonalBestPush(
   }
 }
 
+const RACE_DISPLAY_NAMES: Record<string, string> = {
+  "1mi": "1 mile",
+  "2mi": "2 mile",
+  "5k": "5K",
+  "5mi": "5 mile",
+  "10k": "10K",
+  "15k": "15K",
+  half: "half marathon",
+  marathon: "marathon",
+};
+
+function formatRaceDuration(sec: number): string {
+  const s = Math.round(sec);
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const ss = s % 60;
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return h > 0 ? `${h}:${pad(m)}:${pad(ss)}` : `${m}:${pad(ss)}`;
+}
+
+/**
+ * Fan out a race-distance PR (best time for 5K, 10K, half, etc.) to every
+ * accepted friend. Reuses the friend_personal_best notification category so it
+ * inherits the existing user-facing on/off toggle and audience gating — no new
+ * settings surface. pr_type is `race_<key>` so clients can distinguish it.
+ */
+export async function fanOutFriendRacePrPush(
+  senderId: string,
+  distanceKey: string,
+  durationSec: number,
+  workoutId: string,
+): Promise<void> {
+  const sender = await getSenderDisplayName(senderId);
+  const name = RACE_DISPLAY_NAMES[distanceKey] ?? distanceKey;
+  const timeStr = formatRaceDuration(durationSec);
+  const payload: PushPayload = {
+    title: `${sender} set a new ${name} PR`,
+    body: `${timeStr} — new personal record 🏃`,
+    type: "friend_personal_best",
+    data: {
+      sender_id: senderId,
+      pr_type: `race_${distanceKey}`,
+      pr_label: `${name} PR (${timeStr})`,
+      new_value: String(durationSec),
+      workout_id: workoutId,
+    },
+  };
+
+  const friendIds = await resolveFriendFanOutRecipients(
+    senderId,
+    "personal_best",
+    payload,
+    workoutId,
+  );
+  if (!friendIds || friendIds.length === 0) return;
+
+  for (const friendId of friendIds) {
+    const allowed = await shouldSendNotification(
+      friendId,
+      senderId,
+      "friend_personal_best",
+    );
+    if (!allowed) continue;
+
+    sendPush(friendId, payload).catch((err) =>
+      console.error("[Push] friend_race_pr send failed:", err.message),
+    );
+  }
+}
+
 /**
  * Fan out a daily-challenge completion to every accepted friend.
  */

--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -844,3 +844,139 @@ export async function computePersonalRecords(
     bestDayDate: bestDayRow[0]?.best_day_date ?? null,
   };
 }
+
+/**
+ * Standard race distances tracked for personal records, in miles. A workout
+ * sets the PR for the distance whose band its TOTAL distance falls in.
+ * ponytail: whole-workout match (not best-effort segments inside longer runs).
+ * The bands don't overlap, so a workout matches at most one distance. Only
+ * running/walking workouts ever reach the workouts table, so no activity-type
+ * filter is needed — the exclusion_reason/deleted_at guards (same as daily-mile
+ * counting) keep out flagged/deleted rows. Widen RACE_BAND_LO/HI if real GPS
+ * runs routinely miss their bucket.
+ */
+export const RACE_DISTANCES = [
+  { key: "1mi", miles: 1 },
+  { key: "2mi", miles: 2 },
+  { key: "5k", miles: 3.106856 },
+  { key: "5mi", miles: 5 },
+  { key: "10k", miles: 6.213712 },
+  { key: "15k", miles: 9.320568 },
+  { key: "half", miles: 13.109375 },
+  { key: "marathon", miles: 26.21875 },
+] as const;
+
+export type RaceDistanceKey = (typeof RACE_DISTANCES)[number]["key"];
+
+const RACE_BAND_LO = 0.98;
+const RACE_BAND_HI = 1.1;
+
+// SQL CASE mapping workouts.distance -> race bucket key (NULL if it fits none).
+// Built once from RACE_DISTANCES so bands stay DRY with the constant above.
+const RACE_BUCKET_CASE = `CASE ${RACE_DISTANCES.map(
+  (d) =>
+    `WHEN w.distance BETWEEN ${d.miles * RACE_BAND_LO} AND ${d.miles * RACE_BAND_HI} THEN '${d.key}'`,
+).join(" ")} END`;
+
+export interface RaceRecord {
+  distanceKey: RaceDistanceKey;
+  durationSec: number;
+  distanceMiles: number;
+  workoutId: string;
+  achievedDate: string; // YYYY-MM-DD in the user's local timezone
+}
+
+function mapRaceRow(r: {
+  bucket: RaceDistanceKey;
+  duration: string;
+  distance: string;
+  workout_id: string;
+  achieved_date: string;
+}): RaceRecord {
+  return {
+    distanceKey: r.bucket,
+    durationSec: parseFloat(r.duration),
+    distanceMiles: parseFloat(r.distance),
+    workoutId: r.workout_id,
+    achievedDate: r.achieved_date,
+  };
+}
+
+/**
+ * Fastest (MIN total_duration) qualifying workout per race distance, derived
+ * live from the workouts table — there is no stored PR table, so a user's whole
+ * history counts with zero migration/backfill. Optionally excludes a set of
+ * workout IDs to compute a "pre-upload" baseline for same-day PR detection
+ * (mirrors computePersonalRecords).
+ * ponytail: full scan of the user's run/walk workouts per call; indexed on
+ * user_id, hundreds–low-thousands of rows = ms. Add a cached table only if a
+ * profiler says this is hot.
+ */
+export async function computeRaceRecords(
+  userId: string,
+  excludeWorkoutIds: string[] = [],
+): Promise<RaceRecord[]> {
+  const exclude = excludeWorkoutIds.length > 0;
+  const excludeClause = exclude
+    ? `AND NOT (w.workout_id = ANY($2::text[]))`
+    : "";
+  const query = `
+    SELECT DISTINCT ON (bucket)
+      bucket,
+      total_duration::text AS duration,
+      distance::text AS distance,
+      workout_id,
+      to_char(local_date, 'YYYY-MM-DD') AS achieved_date
+    FROM (
+      SELECT w.workout_id, w.total_duration, w.distance, w.local_date,
+             ${RACE_BUCKET_CASE} AS bucket
+      FROM workouts w
+      WHERE w.user_id = $1
+        AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL
+        AND w.total_duration > 0
+        ${excludeClause}
+    ) b
+    WHERE bucket IS NOT NULL
+    ORDER BY bucket, total_duration ASC, local_date DESC`;
+  const params: any[] = exclude ? [userId, excludeWorkoutIds] : [userId];
+  const rows = await db.query<{
+    bucket: RaceDistanceKey;
+    duration: string;
+    distance: string;
+    workout_id: string;
+    achieved_date: string;
+  }>(query, params);
+  return rows.map(mapRaceRow);
+}
+
+/**
+ * Every qualifying workout for ONE race distance, newest first — the user's
+ * progression history for that distance. Same band logic as computeRaceRecords,
+ * single bucket, no aggregate.
+ */
+export async function getRaceHistory(
+  userId: string,
+  distanceKey: RaceDistanceKey,
+): Promise<RaceRecord[]> {
+  const dist = RACE_DISTANCES.find((d) => d.key === distanceKey);
+  if (!dist) return [];
+  const rows = await db.query<{
+    duration: string;
+    distance: string;
+    workout_id: string;
+    achieved_date: string;
+  }>(
+    `SELECT total_duration::text AS duration,
+            distance::text AS distance,
+            workout_id,
+            to_char(local_date, 'YYYY-MM-DD') AS achieved_date
+       FROM workouts w
+      WHERE w.user_id = $1
+        AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL
+        AND w.total_duration > 0
+        AND w.distance BETWEEN $2 AND $3
+      ORDER BY w.device_end_date DESC`,
+    [userId, dist.miles * RACE_BAND_LO, dist.miles * RACE_BAND_HI],
+  );
+  return rows.map((r) => mapRaceRow({ ...r, bucket: distanceKey }));
+}


### PR DESCRIPTION
Track personal-record times for 1mi, 2mi, 5k, 5mi, 10k, 15k, half, and full marathon. Records and full per-distance history are derived live from existing workouts (no new table, no migration), so all past runs count.

Backend:
- computeRaceRecords / getRaceHistory in workoutService (whole-workout distance-band match; only run/walk reach the table)
- GET /workouts/:userId/race-records and /race-records/:distance
- Same-day PR detection in the upload flow returns newRaceRecords and fans a friend push (reuses friend_personal_best category). Pre-upsert snapshot so idempotent retries don't double-fire.

iOS:
- RaceRecordsService + RaceRecord model
- Race PRs grid in Profile > Stats, tap-through history view
- "New PR!" milestone celebration from the sync response