### PR TITLE
Show stats overlay on every route slide; yearly-only memories

### DIFF
--- a/app/Mile A Day/Services/PostService.swift
+++ b/app/Mile A Day/Services/PostService.swift
@@ -394,8 +394,8 @@ enum PostService {
         )
     }
 
-    /// The caller's own post photos from this day in past years / a week ago /
-    /// a month ago — fuel for the "On this day" memories surface.
+    /// The caller's own post photos from this day in past years — fuel for
+    /// the "On this day" memories surface.
     static func fetchPostMemories() async throws -> [PostItem] {
         struct MemoriesResponse: Decodable { let items: [PostItem] }
         return try await APIClient.fancyFetch(

--- a/app/Mile A Day/Views/Feed/Memories.swift
+++ b/app/Mile A Day/Views/Feed/Memories.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// A walk/run the user did on today's calendar day in a previous year — or a
-/// past post photo (a week / a month / years ago) resurfaced from the server.
+/// past post photo from this day in a previous year resurfaced from the server.
 struct MemoryItem: Identifiable {
     let id = UUID()
     let date: Date
@@ -12,12 +12,9 @@ struct MemoryItem: Identifiable {
     /// The story/feed photo from that day, when one exists. Expired stories
     /// live on here — the photo outlasts its 24 hours.
     var photoURL: URL? = nil
-    /// Overrides the "N years ago" label for sub-year memories ("1 week ago").
-    var agoOverride: String? = nil
 
     var yearsAgoText: String {
-        if let agoOverride { return agoOverride }
-        return yearsAgo == 1 ? "1 year ago" : "\(yearsAgo) years ago"
+        yearsAgo == 1 ? "1 year ago" : "\(yearsAgo) years ago"
     }
 }
 
@@ -51,9 +48,9 @@ enum MemoriesService {
         return out.sorted { $0.yearsAgo < $1.yearsAgo }
     }
 
-    /// Blend the server's photo memories (this day in past years, a week ago,
-    /// a month ago) into the local HealthKit ones: matching days get the photo
-    /// attached; days we have no workout record for become photo-only items.
+    /// Blend the server's photo memories (this day in past years) into the
+    /// local HealthKit ones: matching days get the photo attached; days we
+    /// have no workout record for become photo-only items.
     static func mergingPostMemories(_ posts: [PostItem], into items: [MemoryItem]) -> [MemoryItem] {
         var merged = items
         let cal = Calendar.current
@@ -67,39 +64,26 @@ enum MemoriesService {
         for post in posts {
             guard let localDate = post.local_date, let date = parser.date(from: localDate),
                   let photoURL = post.mediaURL else { continue }
-            let days = cal.dateComponents([.day], from: cal.startOfDay(for: date), to: today).day ?? 0
-            guard days > 0 else { continue }
-
-            // Bucket by RANGE, not exact day counts — the server computes "a
-            // week/month ago" against its own date, and timezone or midnight
-            // drift makes the client's day math land on 6/8 or 29/31.
-            let ago: String? = {
-                if (5...9).contains(days) { return "1 week ago" }
-                if (25...45).contains(days) { return "1 month ago" }
-                return nil // exact-year memories use the standard label
-            }()
+            // Yearly memories only — a server that predates this rule also
+            // sends week/month-ago photos; anything under a year old is too
+            // recent to be a memory.
             let years = cal.dateComponents([.year], from: date, to: today).year ?? 0
+            guard years >= 1 else { continue }
 
             if let idx = merged.firstIndex(where: { cal.isDate($0.date, inSameDayAs: date) }) {
                 if merged[idx].photoURL == nil { merged[idx].photoURL = photoURL }
-                if merged[idx].agoOverride == nil, let ago { merged[idx].agoOverride = ago }
             } else {
                 merged.append(MemoryItem(
                     date: date,
-                    yearsAgo: max(years, 0),
+                    yearsAgo: years,
                     miles: post.stats_snapshot?.distance ?? 0,
                     workoutType: "running",
                     durationSeconds: post.stats_snapshot?.duration ?? 0,
-                    photoURL: photoURL,
-                    agoOverride: ago
+                    photoURL: photoURL
                 ))
             }
         }
-        // Freshest memories first: sub-year (week/month) photos, then by years.
-        return merged.sorted {
-            if ($0.agoOverride != nil) != ($1.agoOverride != nil) { return $0.agoOverride != nil }
-            return $0.yearsAgo < $1.yearsAgo
-        }
+        return merged.sorted { $0.yearsAgo < $1.yearsAgo }
     }
 }
 

--- a/app/Mile A Day/Views/Feed/PostCardView.swift
+++ b/app/Mile A Day/Views/Feed/PostCardView.swift
@@ -210,6 +210,24 @@ struct PostCardView: View {
             .aspectRatio(4.0 / 5.0, contentMode: .fit)
     }
 
+    /// Stats to overlay on the live route slide — same band the auto post
+    /// bakes into its image, so a route NEVER shows as a bare map when the
+    /// post carries numbers.
+    private var routeOverlayStats: RunStatsInput? {
+        guard let stats = post.stats_snapshot, let distance = stats.distance, distance > 0
+        else { return nil }
+        return RunStatsInput(
+            distance: distance,
+            paceSecondsPerMile: stats.pace,
+            durationSeconds: stats.duration,
+            streak: stats.streak,
+            calories: stats.calories,
+            steps: stats.steps,
+            workoutId: nil,
+            dateText: stats.date
+        )
+    }
+
     private func routeSlide(_ coords: [CLLocationCoordinate2D]) -> some View {
         WorkoutRouteMapView(
             coordinates: coords,
@@ -217,9 +235,26 @@ struct PostCardView: View {
         )
         .frame(maxWidth: .infinity)
         .aspectRatio(4.0 / 5.0, contentMode: .fit)
+        .overlay {
+            if let stats = routeOverlayStats {
+                // The overlay lays out at the baked card's 360×450 design
+                // size; the slide is the same 4:5, so scaling by width alone
+                // reproduces the auto post's look pixel-for-pixel.
+                GeometryReader { geo in
+                    RouteStatsOverlayView(stats: stats, workoutType: post.workout_type ?? "running")
+                        .scaleEffect(geo.size.width / RunStatsCardView.designSize.width,
+                                     anchor: .topLeading)
+                }
+                .allowsHitTesting(false)
+            }
+        }
         .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
         .overlay(alignment: .topLeading) {
-            slideBadge("Route", icon: "map.fill")
+            // The stats band carries its own activity chip up top; only badge
+            // the bare-map fallback (posts without a stats snapshot).
+            if routeOverlayStats == nil {
+                slideBadge("Route", icon: "map.fill")
+            }
         }
     }
 

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -472,7 +472,7 @@ struct SocialFeedView: View {
 
     private func loadMemories() {
         // Local HealthKit memories show instantly; past post photos (this day
-        // in past years, a week ago, a month ago) blend in when they arrive.
+        // in past years) blend in when they arrive.
         memories = MemoriesService.onThisDay(using: healthManager)
         Task {
             if let posts = try? await PostService.fetchPostMemories(), !posts.isEmpty {

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -542,9 +542,9 @@ export async function reactToStory(
 
 /**
  * The caller's own past post photos for the "On this day" memories surface:
- * same calendar day in previous years, plus exactly one week and one month
- * ago. Story-only photos count — expiry hides them from the rail, not from
- * the author's memories.
+ * same calendar day in previous years only — sub-year lookbacks (a week/month
+ * ago) felt too recent to be a "memory". Story-only photos count — expiry
+ * hides them from the rail, not from the author's memories.
  */
 export async function getOwnPostMemories(
   userId: string,
@@ -558,12 +558,8 @@ export async function getOwnPostMemories(
 		WHERE p.user_id = $1
 			AND p.deleted_at IS NULL
 			AND p.local_date < $2::date
-			AND (
-				(EXTRACT(MONTH FROM p.local_date) = EXTRACT(MONTH FROM $2::date)
-					AND EXTRACT(DAY FROM p.local_date) = EXTRACT(DAY FROM $2::date))
-				OR p.local_date = ($2::date - INTERVAL '1 month')::date
-				OR p.local_date = ($2::date - INTERVAL '7 days')::date
-			)
+			AND EXTRACT(MONTH FROM p.local_date) = EXTRACT(MONTH FROM $2::date)
+			AND EXTRACT(DAY FROM p.local_date) = EXTRACT(DAY FROM $2::date)
 		ORDER BY p.local_date DESC
 		LIMIT 12
 		`,


### PR DESCRIPTION
## What

Two feed fixes:

**1. Route maps now carry stats every time**

Auto posts bake `RouteStatsOverlayView` (big distance, pace/time chips, streak, brand row) into their route image — but photo posts with a GPS route rendered the live route slide as a bare map with just a "Route" badge. That's why stats showed on routes "only sometimes."

`PostCardView.routeSlide` now overlays the same stats band live whenever the post has a `stats_snapshot` with distance. The overlay lays out at the baked card's 360×450 design space and is scaled to the slide width (same 4:5 aspect), so it matches the auto-post look pixel-for-pixel. The "Route" badge remains only on the fallback bare map for old posts with no stats snapshot.

**2. "On this day" memories are yearly only**

"1 week ago" / "1 month ago" felt way too recent for a memory. Changes:
- Backend `getOwnPostMemories` now returns only same-calendar-day posts from previous years (dropped the `- INTERVAL '7 days'` / `- INTERVAL '1 month'` branches).
- iOS `MemoriesService.mergingPostMemories` skips any post under a year old (so the fix holds even against a not-yet-deployed server) and the week/month label bucketing + `agoOverride` are removed.

## Compatibility

- Backend change is read-path only and additive-safe: shipped clients just receive fewer rows from `/posts/memories`, and their week/month label code simply never triggers. Backend can deploy before the iOS release.
- No schema, migration, or endpoint shape changes.

## Verification

- `backend`: `npm run build` (tsc) passes.
- iOS changes are SwiftUI-only; build via Xcode (per repo rules, no CLI build available here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRVKEocwYC2nqExK8gNksH

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRVKEocwYC2nqExK8gNksH)_