### PR TITLE
Fix streak/widget desync: index holes, reload-budget exhaustion, locked-phone zeroing

### DIFF
--- a/.claude/rules/ios.md
+++ b/.claude/rules/ios.md
@@ -28,6 +28,7 @@ globs: app/**
 - WidgetKit renders statically: `.onAppear`-driven `@State` animations never play in widget views — render entry values directly. `WidgetDataStore` data is day-stamped; `load()` returns zeros for a stale day, and saves skip no-op writes (widget reloads are budgeted per day).
 - Widget timeline policies are fallbacks (the app reloads on every data write). Never request sub-15-min refreshes: a 60s policy drained the ~40-70/day budget by morning and iOS then silently dropped ALL reloads — widgets froze on stale data while the app was correct.
 - Background HealthKit reads must gate on `hasLoadedInitialData`, not a fixed sleep — on a locked device queries error, `retroactiveStreak` reads 0, and `updateFromHealthKit` persists it unconditionally (streak 0 stuck in widgets).
+- WorkoutIndex incremental updates need the 48h lookback + record-id dedup: querying strictly from `lastUpdated` permanently drops workouts that reached HealthKit late (Watch sync), leaving a `qualifyingDays` hole — `activeStreak()` stops there and the dashboard flashes a tiny streak until the backend rescue lands. Backend-streak ≫ local triggers a debounced rebuild (`repairWorkoutIndexIfStale`).
 
 ## Key Patterns
 - Use `@Observable` (iOS 17+ Observation framework) for new view models.

--- a/.claude/rules/ios.md
+++ b/.claude/rules/ios.md
@@ -26,6 +26,8 @@ globs: app/**
 - HealthKit queries ERROR when the device is locked (protected data). Never treat a query error as "0 miles" — only a successful empty result is a real zero. Writing 0 on error randomly reset widgets.
 - Feed route maps are read from HKWorkoutRoute at sync time. In-app tracked workouts must write their GPS trace via `HKWorkoutRouteBuilder.finishRoute` after `finishWorkout` (and `HKSeriesType.workoutRoute()` must be in the SHARE auth set) — points buffered in InProgressWorkoutStore alone never reach the backend.
 - WidgetKit renders statically: `.onAppear`-driven `@State` animations never play in widget views — render entry values directly. `WidgetDataStore` data is day-stamped; `load()` returns zeros for a stale day, and saves skip no-op writes (widget reloads are budgeted per day).
+- Widget timeline policies are fallbacks (the app reloads on every data write). Never request sub-15-min refreshes: a 60s policy drained the ~40-70/day budget by morning and iOS then silently dropped ALL reloads — widgets froze on stale data while the app was correct.
+- Background HealthKit reads must gate on `hasLoadedInitialData`, not a fixed sleep — on a locked device queries error, `retroactiveStreak` reads 0, and `updateFromHealthKit` persists it unconditionally (streak 0 stuck in widgets).
 
 ## Key Patterns
 - Use `@Observable` (iOS 17+ Observation framework) for new view models.

--- a/app/Mile A Day/Core/Services/MADBackgroundService.swift
+++ b/app/Mile A Day/Core/Services/MADBackgroundService.swift
@@ -244,14 +244,26 @@ final class MADBackgroundService: NSObject, ObservableObject {
     @MainActor
     private static func fetchLatestWorkoutDataStatic() async -> Bool {
         let service = shared
-        
+
         // Fetch all workout data
         service.healthManager.fetchAllWorkoutData()
-        
-        // Give HealthKit queries more time to complete (increased from 2.0 to 3.0 seconds)
-        // This ensures the retroactiveStreak calculation finishes before we read it
-        try? await Task.sleep(nanoseconds: 3_000_000_000) // 3 seconds
-        
+
+        // Wait (bounded) for HealthKit to actually finish loading instead of a
+        // blind sleep. On a locked phone the queries error out (protected
+        // data) and retroactiveStreak can still be 0 when read — writing that
+        // through UserManager persisted streak=0 and pushed it into the
+        // widget store, so widgets showed a 0 streak while the app (which
+        // recomputes after unlock) was correct.
+        var waited = 0
+        while !service.healthManager.hasLoadedInitialData && waited < 10 {
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            waited += 1
+        }
+        guard service.healthManager.hasLoadedInitialData else {
+            service.log("[Background] HealthKit data not ready (device likely locked) — skipping user/widget update")
+            return false
+        }
+
         service.log("[Background] Updating user with HealthKit data - Streak: \(service.healthManager.retroactiveStreak), Miles: \(service.healthManager.todaysDistance)")
         
         // Update user data with new HealthKit data

--- a/app/Mile A Day/Models/HealthKitManager+WorkoutIndex.swift
+++ b/app/Mile A Day/Models/HealthKitManager+WorkoutIndex.swift
@@ -135,7 +135,15 @@ extension HealthKitManager {
         guard isAuthorized else { return }
 
         let lastUpdate = currentIndex.lastUpdated
-        print("[WorkoutIndex] 🔄 Checking for workouts since \(lastUpdate)...")
+        // Look back 48h behind the last update stamp: a workout that ENDED
+        // before the stamp but reached HealthKit after it (Watch sync latency,
+        // an in-app save finishing late) was otherwise missed FOREVER. The
+        // resulting hole in qualifyingDays made activeStreak() stop at that
+        // day — the dashboard flashed a tiny local streak on every refresh
+        // until the backend value rescued it. Re-fetched known workouts are
+        // deduped by record id below.
+        let queryStart = Calendar.current.date(byAdding: .hour, value: -48, to: lastUpdate) ?? lastUpdate
+        print("[WorkoutIndex] 🔄 Checking for workouts since \(queryStart) (48h lookback)...")
 
         // Query for workouts after last update
         let newWorkouts = await withCheckedContinuation { (continuation: CheckedContinuation<[HKWorkout], Never>) in
@@ -143,7 +151,7 @@ extension HealthKitManager {
             let walkingPredicate = HKQuery.predicateForWorkouts(with: .walking)
             let workoutTypePredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [runningPredicate, walkingPredicate])
 
-            let datePredicate = HKQuery.predicateForSamples(withStart: lastUpdate, end: Date(), options: .strictEndDate)
+            let datePredicate = HKQuery.predicateForSamples(withStart: queryStart, end: Date(), options: .strictEndDate)
             let compoundPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [workoutTypePredicate, datePredicate])
 
             let query = HKSampleQuery(
@@ -184,10 +192,34 @@ extension HealthKitManager {
             return
         }
 
-        print("[WorkoutIndex] 🆕 Found \(newWorkouts.count) new workouts, updating index...")
+        // The 48h lookback re-fetches workouts that may already be indexed —
+        // drop those so a day's distance isn't double-counted.
+        let existingIds = Set(currentIndex.workoutsByDate.values.flatMap { $0 }.map { $0.id })
+        let trulyNewWorkouts = newWorkouts.filter { !existingIds.contains($0.uuid.uuidString) }
+
+        guard !trulyNewWorkouts.isEmpty else {
+            print("[WorkoutIndex] ✅ No new workouts after lookback dedup")
+            // Same bookkeeping as the empty-fetch branch above: dailyMileGoals
+            // isn't persisted and the displayed streak must be derived as of NOW.
+            await MainActor.run {
+                var goals: [Date: Bool] = [:]
+                for (dateKey, records) in currentIndex.workoutsByDate {
+                    if let date = dateFromKey(dateKey) {
+                        let totalMiles = records.reduce(0) { $0 + $1.distance }
+                        goals[date] = totalMiles >= 0.95
+                    }
+                }
+                self.dailyMileGoals = goals
+                self.retroactiveStreak = currentIndex.activeStreak()
+                self.saveCachedData()
+            }
+            return
+        }
+
+        print("[WorkoutIndex] 🆕 Found \(trulyNewWorkouts.count) new workouts, updating index...")
 
         // Process new workouts
-        let newRecords = workoutProcessor.processWorkouts(newWorkouts)
+        let newRecords = workoutProcessor.processWorkouts(trulyNewWorkouts)
 
         // Update index
         var updatedIndex = currentIndex

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -729,6 +729,7 @@ struct DashboardView: View {
                     // updateStreakFromBackend only raises the value, so it can't clobber a
                     // higher HealthKit-computed streak from a later refresh.
                     userManager.updateStreakFromBackend(stats.streak)
+                    repairWorkoutIndexIfStale(backendStreak: stats.streak)
                     if let bestSplitSeconds = stats.bestSplitTimeSeconds, bestSplitSeconds > 0 {
                         let paceMinutesPerMile = bestSplitSeconds / 60.0
                         print("[Dashboard] ✅ Updating fastest pace from backend → \(paceMinutesPerMile) min/mi")
@@ -739,6 +740,24 @@ struct DashboardView: View {
                 print("[Dashboard] ⚠️ Failed to fetch stats from backend: \(error)")
             }
         }
+    }
+
+    /// A backend streak ≥2 days ahead of the local HealthKit-derived one is the
+    /// signature of a hole in the WorkoutIndex: a workout that reached HealthKit
+    /// after the index's lastUpdated stamp was never indexed, so activeStreak()
+    /// stops at that day. Every refresh then flashes the tiny local value (via
+    /// applyHealthDataToUserManager's unconditional overwrite) before the backend
+    /// rescue lands — "1 day streak" for a second, then the real number. Rebuild
+    /// the index from full history to repair the hole; debounced to once per
+    /// calendar day, and buildWorkoutIndex() itself no-ops while a build runs.
+    private func repairWorkoutIndexIfStale(backendStreak: Int) {
+        guard backendStreak > healthManager.retroactiveStreak + 1 else { return }
+        let debounceKey = "lastStreakMismatchIndexRebuild"
+        if let last = UserDefaults.standard.object(forKey: debounceKey) as? Date,
+           Calendar.current.isDateInToday(last) { return }
+        UserDefaults.standard.set(Date(), forKey: debounceKey)
+        print("[Dashboard] 🔧 Backend streak \(backendStreak) ≫ local \(healthManager.retroactiveStreak) — rebuilding workout index to repair missed workouts")
+        Task { await healthManager.buildWorkoutIndex() }
     }
 
     /// Pull the current streak from the backend (the authoritative source the manual

--- a/app/Mile A Day/Widgets/TodayProgressWidget.swift
+++ b/app/Mile A Day/Widgets/TodayProgressWidget.swift
@@ -139,8 +139,13 @@ struct TodayProgressProvider: TimelineProvider {
             streak: WidgetDataStore.loadStreak()
         )
         
-        // Refresh every minute for incomplete goals, every 15 minutes for completed goals
-        let refreshInterval: TimeInterval = data.streakCompleted ? 900 : 60 // 1min incomplete, 15min completed
+        // The timeline policy is only a FALLBACK (plus the midnight reset
+        // below) — the app force-reloads this widget on every real data write.
+        // The old 1-minute policy drained WidgetKit's daily refresh budget
+        // (~40-70 reloads) within the first hour of each day, after which iOS
+        // silently dropped ALL reloads — including the app's post-run writes —
+        // freezing the widget on stale morning zeros while the app was correct.
+        let refreshInterval: TimeInterval = data.streakCompleted ? 3600 : 1800 // 30min incomplete, 1h completed
 
         // Never sleep past midnight: WidgetDataStore.load() zeroes out data
         // from a previous day, so rebuilding right at the day boundary makes


### PR DESCRIPTION
## Problem

Two user-visible symptoms, one tangled root system — all app-side (the July 12 backend deploy is unrelated; it shipped only daily-challenge selection code, which nothing widget- or streak-related consumes):

1. **Dashboard flashes "1 day streak" for a second on every refresh**, then snaps to the correct value (426).
2. **Widgets stuck showing 0/stale streak and miles** while the app is correct.

## Root causes (three, compounding)

**A. The WorkoutIndex has a permanent hole (`HealthKitManager+WorkoutIndex.swift`).** Incremental updates query HealthKit strictly from `index.lastUpdated` (wall clock). A workout that *ended* before that stamp but *arrived* in HealthKit after it — Watch sync latency, an in-app save completing late — is never indexed, and nothing ever backfills it. `activeStreak()` walks `qualifyingDays` back from today and stops at the hole → the local streak computes as 1. Every index code path publishes that value, `applyHealthDataToUserManager` unconditionally overwrites the displayed streak with it, and ~a second later the backend stats fetch (raise-only) rescues the real number. Hence the flash on every refresh, forever — and each flap writes both values to the widget store, double-reloading the streak widget.

**B. Widget reload budget exhaustion (`TodayProgressWidget.swift`).** The provider requested a timeline refresh every 60 seconds while the goal was incomplete; WidgetKit budgets ~40–70 refreshes/day, so by mid-morning iOS silently drops **all** reloads — including the app's corrective writes. Whatever bogus value (A) or (C) last rendered stays frozen on the home screen.

**C. Locked-phone background zeroing (`MADBackgroundService.swift`).** Background HealthKit wakes read `retroactiveStreak` a fixed 3 s after kicking off async queries. On a locked device the queries error and the read is 0, which gets persisted and pushed to the widget store.

## Fixes

- **Index lookback + dedup:** incremental updates now query with a 48 h lookback behind `lastUpdated` and dedupe re-fetched workouts by record id (`workout.uuid.uuidString`), so late arrivals are picked up without double-counting. The dedup-empty path keeps the same `dailyMileGoals`/streak bookkeeping as the existing empty-fetch branch.
- **Self-heal existing holes:** when the backend streak is ≥2 days ahead of the local one (the signature of a hole older than the lookback), the dashboard triggers a full index rebuild — debounced to once per calendar day; `buildWorkoutIndex()` already no-ops while a build is running.
- **Timeline policy → 30 min / 1 h** (fallback only; the app force-reloads on every real write; midnight reset preserved).
- **Background write gated on `hasLoadedInitialData`** (bounded 10 s wait) instead of a blind sleep — skipped entirely when HealthKit never loaded.
- All four gotchas recorded in `.claude/rules/ios.md`.

## Verification / testing notes

- iOS-only change — please build the main target + widget extension in Xcode (no CLI build available in this environment). Backend/website CI is unaffected.
- Expected behavior after install: first dashboard visit detects backend streak ≫ local, rebuilds the index once (log: `🔧 Backend streak … rebuilding workout index`), and the 1-day flash disappears from that point on. Widgets recover on the next app open and keep updating through the evening.
- Diagnostic that confirms the hole theory on the current build: the flash number grows by one each day (it's "days since the missed workout", not a constant 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qv3qehuTGaV3V8RtsxsTzU