### PR TITLE
Go-live: fail-closed dev gates, strip dev tooling from Release, kill the 1-day streak flash

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -31,7 +31,7 @@ globs: backend/**
 - Never emit raw `timestamptz::text` in URL query params (pagination cursors): its `+00` offset decodes as a SPACE in Express's query parser and the `::timestamptz` cast 500s. Emit cursors via `URL_SAFE_CURSOR` (ISO `…Z`, postService.ts); iOS must percent-encode query values with a set that excludes `+` (`PostService.queryValueAllowed`).
 
 ## Auth Pattern
-- Public routes (`/auth/*`, `/dev/*`, `/status`) are mounted BEFORE `authenticateToken` middleware in server.ts.
+- Public routes (`/auth/*`, `/dev/*`, `/status`) are mounted BEFORE `authenticateToken` middleware in server.ts. `/dev/*` endpoints are fail-closed: 403 unless `NODE_ENV=development` (`npm run dev` sets it; testing them via plain `tsx watch` won't work without it).
 - Protected routes are mounted AFTER. `req.userId` is set by auth middleware (see `AuthenticatedRequest` type).
 - Use `requireSelfAccess('paramName')` middleware when a route should only allow users to access their own resources.
 

--- a/.claude/rules/ios.md
+++ b/.claude/rules/ios.md
@@ -29,6 +29,7 @@ globs: app/**
 - Widget timeline policies are fallbacks (the app reloads on every data write). Never request sub-15-min refreshes: a 60s policy drained the ~40-70/day budget by morning and iOS then silently dropped ALL reloads — widgets froze on stale data while the app was correct.
 - Background HealthKit reads must gate on `hasLoadedInitialData`, not a fixed sleep — on a locked device queries error, `retroactiveStreak` reads 0, and `updateFromHealthKit` persists it unconditionally (streak 0 stuck in widgets).
 - WorkoutIndex incremental updates need the 48h lookback + record-id dedup: querying strictly from `lastUpdated` permanently drops workouts that reached HealthKit late (Watch sync), leaving a `qualifyingDays` hole — `activeStreak()` stops there and the dashboard flashes a tiny streak until the backend rescue lands. Backend-streak ≫ local triggers a debounced rebuild (`repairWorkoutIndexIfStale`).
+- The displayed streak (`currentUser.streak`) is quarantine-gated: `UserManager.vettedHealthKitStreak` refuses 2+ day drops from local recomputes unless the backend (48h-fresh, recomputed server-side every `getUserStats`) agrees or a same-day full index rebuild confirms. Never write `hk.retroactiveStreak` raw to UI/widgets/watch — it flaps on index holes; route through `updateUserWithHealthKitData` / push `max(hk, user.streak)`.
 
 ## Key Patterns
 - Use `@Observable` (iOS 17+ Observation framework) for new view models.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,16 @@
 
 Gamified fitness app: run a mile every day, build streaks, compete with friends.
 
+## PRODUCTION — App is LIVE on the App Store
+
+Real users, real data. `main` auto-deploys the backend to production via Coolify.
+- API backwards compatibility: additive changes only; never remove/rename endpoints or response fields shipped clients consume.
+- User data is sacred: no destructive SQL without explicit confirmation and a rollback plan.
+- Every change must be App Store Review Guidelines-compliant (see `.claude/rules/ios.md`).
+- When an iOS change depends on a backend change, the backend deploys first.
+
+See `CLAUDE.md` for the full, authoritative version of these rules — if this file and CLAUDE.md disagree, CLAUDE.md wins.
+
 ## Project Structure
 
 - `app/` - iOS app (Swift/SwiftUI, targets iOS + watchOS + Widgets)
@@ -18,8 +28,8 @@ Gamified fitness app: run a mile every day, build streaks, compete with friends.
 
 ### Website (`cd website`)
 - Dev: `npm run dev`
-- Build: `npm run build`
-- Lint: `npm run lint`
+- Build: `npm run build` (also type-checks — this is the pre-merge gate)
+- The `lint` script is broken: eslint is not a dependency and there is no config. Don't run it; don't add it to CI.
 
 ### iOS (`app/`)
 - Build via Xcode only. Do not attempt `xcodebuild` from CLI.
@@ -36,20 +46,20 @@ Gamified fitness app: run a mile every day, build streaks, compete with friends.
 1. **Backend is ESM** - `"type": "module"` in package.json. All local imports MUST use `.js` extension (e.g., `import foo from './foo.js'`), even though source is `.ts`.
 2. **Express 5.1** - Async errors propagate automatically. Controllers currently use explicit try/catch but it's not strictly required.
 3. **JWT uses `jose`** - Auth middleware uses `jwtVerify` from `jose`, NOT `jsonwebtoken`. The `jsonwebtoken` package is also installed but only used for token signing in some auth flows.
-4. **No migrations system** - Database schema changes are done manually against PostgreSQL. No ORM.
-5. **No CI/CD** - No automated tests or deployment pipeline. Be extra careful with changes.
+4. **Migrations via Drizzle** - Schema changes go through drizzle-kit (`backend/src/db/drizzle/`, see `.claude/rules/backend.md`). Drizzle ORM and raw SQL coexist on one pool. Existing schema is baselined; never recreate live tables.
+5. **CI is the only merge gate** - `.github/workflows/ci.yml` runs on PRs + main: backend tsc build, `drizzle-kit check`, the real migrator twice against throwaway Postgres, a feed smoke test, and the website build. Merging to `main` auto-deploys the backend via Coolify.
 6. **No shared package manager** - Backend and website both use npm. No monorepo tooling.
 7. **`.claudeignore` excludes `project.pbxproj`** - This is intentional. Never ask to read it.
 
 ## Code Style
 
 - No linter/formatter configured for backend. Follow existing patterns.
-- Website has ESLint (`pnpm lint`).
+- Website has NO working ESLint (the `lint` script references an uninstalled eslint). `next build` is the check.
 - iOS: follow existing SwiftUI patterns, no SwiftLint.
 
 ## Codex Skills & Agents
 
-This repo includes custom Codex skills and agents in `.Codex/`:
+This repo includes custom Codex skills and agents in `.claude/`:
 
 ### Skills (invoke with `/skill-name`)
 - `/new-endpoint` — Scaffold a backend endpoint (route + controller + service)
@@ -73,7 +83,7 @@ Available on top of the project skills above:
 
 - `/spec <feature>` — Spec-Driven Development entry point
 - `/ship` — final gate (Codex review + tests + UI polish + criteria check)
-- `/learn` — sweep session corrections into `.Codex/references/gotchas.md`
+- `/learn` — sweep session corrections into `.claude/references/gotchas.md`
 - `/remember "rule"` — capture a single rule mid-session
 - `/maintain` — periodic sweep (re-tune perms, regenerate INSTALLED.md, audit cost)
 - `/batch <files>` — fan-out migration orchestrator (one implementer agent per slice)
@@ -85,15 +95,15 @@ Available on top of the project skills above:
 
 ## References
 
-- **`.Codex/rules/{backend,ios,website}.md`** — area-specific conventions (existing, kept under 60 lines each)
-- **`.Codex/references/conventions.md`** — cross-cutting conventions (package manager, secrets, cross-area changes)
-- **`.Codex/references/gotchas.md`** — learned mistakes (grows via `/learn` and `/remember`)
-- **`.Codex/references/decisions.md`** — ADR-style architectural records
-- **`~/.Codex/references/{behavior,workflow-overrides,security,skill-catalog}.md`** — workflow-wide rules from cc-optimize (loaded at SessionStart and after PostCompact)
+- **`.claude/rules/{backend,ios,website}.md`** — area-specific conventions (existing, kept under 60 lines each)
+- **`.claude/references/conventions.md`** — cross-cutting conventions (package manager, secrets, cross-area changes)
+- **`.claude/references/gotchas.md`** — learned mistakes (grows via `/learn` and `/remember`)
+- **`.claude/references/decisions.md`** — ADR-style architectural records
+- **`~/.claude/references/{behavior,workflow-overrides,security,skill-catalog}.md`** — workflow-wide rules from cc-optimize (loaded at SessionStart and after PostCompact)
 
 ## Self-Maintenance
 
-These Codex files (AGENTS.md and .Codex/rules/*.md) are living documents. Update them as you work:
+These Codex files (AGENTS.md and .claude/rules/*.md) are living documents. Update them as you work:
 
 **When to add an entry:**
 - You hit a bug or build error caused by a non-obvious project quirk
@@ -106,7 +116,7 @@ These Codex files (AGENTS.md and .Codex/rules/*.md) are living documents. Update
 - Information is redundant with what you can derive from reading the code
 
 **Rules for edits:**
-- Add to the relevant rules file (.Codex/rules/backend.md, ios.md, website.md) not AGENTS.md, unless it's cross-cutting
+- Add to the relevant rules file (.claude/rules/backend.md, ios.md, website.md) not AGENTS.md, unless it's cross-cutting
 - Keep entries specific and actionable — "Use X, not Y" not "be careful with X"
 - Each file must stay under 60 lines. If a file is getting long, remove the least useful entries first
 - Never add obvious language conventions, code that speaks for itself, or vague advice

--- a/app/Mile A Day/Models/HealthKitManager+WorkoutIndex.swift
+++ b/app/Mile A Day/Models/HealthKitManager+WorkoutIndex.swift
@@ -109,6 +109,11 @@ extension HealthKitManager {
             print("  - Current streak: \(finalStreak) days")
             print("  - Most miles in one day: \(finalIndex.mostMilesInOneDay)")
 
+            // Full-history rebuild completed: from now until midnight,
+            // UserManager.vettedHealthKitStreak may accept a 2+ day streak drop
+            // as verified (unless a fresh backend value contradicts it).
+            UserDefaults.standard.set(Date(), forKey: "lastFullIndexRebuildCompletedAt")
+
             // CRITICAL: Post notification that index is ready
             NotificationCenter.default.post(name: NSNotification.Name("WorkoutIndexReady"), object: nil)
 

--- a/app/Mile A Day/Models/HealthKitManager.swift
+++ b/app/Mile A Day/Models/HealthKitManager.swift
@@ -487,7 +487,11 @@ class HealthKitManager: ObservableObject {
         if cachedTotalLifetimeMiles > 0 {
             totalLifetimeMiles = cachedTotalLifetimeMiles
         }
-        if cachedRetroactiveStreak > 0 {
+        // Raise-only: on iOS, init already derived retroactiveStreak from the
+        // workout index (activeStreak() as of now), which is fresher truth than
+        // this snapshot — the cache may hold a transient low value saved while
+        // the index had a hole (see UserManager.vettedHealthKitStreak).
+        if cachedRetroactiveStreak > retroactiveStreak {
             retroactiveStreak = cachedRetroactiveStreak
         }
             }
@@ -1454,7 +1458,11 @@ final class MADWatchBridge: NSObject {
         let user = UserManager.shared.currentUser
 
         var payload: [String: Any] = [
-            "streak": hk.retroactiveStreak,
+            // Display-grade streak: hk.retroactiveStreak can transiently hold an
+            // unverified low value mid-recompute (WorkoutIndex hole). The user
+            // model's streak is quarantine-protected (vettedHealthKitStreak), so
+            // never push below it — the watch renders this number directly.
+            "streak": max(hk.retroactiveStreak, user.streak),
             "todayMiles": hk.todaysDistance,
             "goalMiles": user.goalMiles > 0 ? user.goalMiles : 1.0,
             "firstName": user.firstName ?? "",

--- a/app/Mile A Day/Models/UserManager.swift
+++ b/app/Mile A Day/Models/UserManager.swift
@@ -285,20 +285,76 @@ class UserManager: ObservableObject {
         mostMilesInDay: Double
     ) {
         currentUser.updateFromHealthKit(
-            streak: retroactiveStreak,
+            streak: vettedHealthKitStreak(retroactiveStreak),
             miles: currentMiles,
             totalMiles: totalMiles,
             fastestPace: fastestPace,
             mostMilesInDay: mostMilesInDay,
             date: Date()
         )
-        
+
         // Check for retroactive badges after updating stats
         checkForRetroactiveBadges()
-        
+
         // CRITICAL FIX: Save data to persist streak update
         // Without this, streak updates are only in memory and revert when app reopens
         saveUserData()
+    }
+
+    // MARK: - Streak trust & verification
+
+    // A HealthKit-derived streak that collapses by 2+ days in one recompute is
+    // almost always a WorkoutIndex artifact (a day whose workout reached
+    // HealthKit late, was deleted there, or never synced locally) — not a real
+    // break. Applying it unconditionally made the dashboard, widgets, and watch
+    // flash "1 day" on every launch until the backend rescue raised it back,
+    // and persisted/pushed the bad number everywhere in between.
+    private static let backendStreakKey = "lastKnownBackendStreak"
+    private static let backendStreakAtKey = "lastKnownBackendStreakAt"
+    /// Stamped by HealthKitManager.buildWorkoutIndex() when a full rebuild completes.
+    private static let indexRebuildCompletedKey = "lastFullIndexRebuildCompletedAt"
+    /// Shared with DashboardView.repairWorkoutIndexIfStale — max one rebuild per day.
+    private static let indexRebuildTriggerKey = "lastStreakMismatchIndexRebuild"
+
+    /// Gate for lowering the displayed streak: equal/higher values and 1-day
+    /// corrections always apply; a 2+ day collapse applies only when verified —
+    /// the backend (which recomputes from its own workout rows on every stats
+    /// fetch, within 48h) agrees it broke, or a full-history index rebuild
+    /// completed today and the backend doesn't contradict it. Otherwise the
+    /// currently displayed value is kept and a rebuild is scheduled to either
+    /// repair the index hole or confirm the break.
+    private func vettedHealthKitStreak(_ localStreak: Int) -> Int {
+        let displayed = currentUser.streak
+        guard localStreak < displayed - 1 else { return localStreak }
+
+        let defaults = UserDefaults.standard
+        let backendAt = defaults.object(forKey: Self.backendStreakAtKey) as? Date
+        let backendFresh = backendAt.map { Date().timeIntervalSince($0) < 48 * 3600 } ?? false
+        let backendStreak = defaults.integer(forKey: Self.backendStreakKey)
+
+        if backendFresh && backendStreak <= localStreak + 1 {
+            return localStreak
+        }
+        if let rebuiltAt = defaults.object(forKey: Self.indexRebuildCompletedKey) as? Date,
+           Calendar.current.isDateInToday(rebuiltAt),
+           !(backendFresh && backendStreak > localStreak + 1) {
+            return localStreak
+        }
+        scheduleWorkoutIndexRepair()
+        return displayed
+    }
+
+    /// Kick a full WorkoutIndex rebuild (max once per calendar day) so a held
+    /// streak either gets its hole repaired or its break confirmed.
+    private func scheduleWorkoutIndexRepair() {
+        #if !os(watchOS)
+        let defaults = UserDefaults.standard
+        if let last = defaults.object(forKey: Self.indexRebuildTriggerKey) as? Date,
+           Calendar.current.isDateInToday(last) { return }
+        defaults.set(Date(), forKey: Self.indexRebuildTriggerKey)
+        print("[UserManager] 🔧 Unverified streak collapse — rebuilding workout index to verify")
+        Task { await HealthKitManager.shared.buildWorkoutIndex() }
+        #endif
     }
     
     // Set fastest mile pace from backend. The backend's workout_splits table is the
@@ -317,6 +373,11 @@ class UserManager: ObservableObject {
     // for users whose history lives in the backend. HealthKit's notification path
     // will still overwrite via updateUserWithHealthKitData() once it computes.
     func updateStreakFromBackend(_ streak: Int) {
+        // Record every backend answer (with freshness) even when it doesn't
+        // raise anything — vettedHealthKitStreak uses it to decide whether a
+        // local streak collapse is real or a WorkoutIndex hole.
+        UserDefaults.standard.set(streak, forKey: Self.backendStreakKey)
+        UserDefaults.standard.set(Date(), forKey: Self.backendStreakAtKey)
         guard streak > currentUser.streak else { return }
         currentUser.streak = streak
         #if !os(watchOS)

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -113,30 +113,6 @@ struct DashboardView: View {
         )
     }
 
-    /// Build test stats for admin testing — uses real data if available, otherwise realistic placeholders
-    private func buildTestGoalCompletionStats() -> GoalCompletionStats {
-        let real = buildGoalCompletionStats()
-        if real.todaysDistance > 0 { return real }
-        return GoalCompletionStats(
-            todaysDistance: 1.75,
-            goalDistance: userManager.currentUser.goalMiles,
-            currentStreak: max(userManager.currentUser.streak, 7),
-            totalLifetimeMiles: max(healthManager.totalLifetimeMiles, 150),
-            bestDayMiles: max(healthManager.cachedMostMilesInOneDay, 3.2),
-            todaysAveragePace: 9.15,
-            todaysFastestPace: 8.32,
-            personalBestPace: 7.8,
-            todaysTotalDuration: 1050,
-            todaysCalories: 215,
-            todaysWorkoutCount: 2,
-            workoutBreakdowns: [
-                WorkoutBreakdown(type: "running", distance: 1.25, duration: 750, displayName: "Run", icon: "figure.run"),
-                WorkoutBreakdown(type: "walking", distance: 0.50, duration: 300, displayName: "Walk", icon: "figure.walk")
-            ],
-            latestWorkout: WorkoutBreakdown(type: "running", distance: 1.25, duration: 750, displayName: "Run", icon: "figure.run")
-        )
-    }
-
     /// Re-play today's celebration so the user can re-watch and re-share at any time.
     /// Picks the right animation for the day: yearly milestone if the streak crossed a
     /// year boundary, otherwise the standard goal-completed celebration (which itself
@@ -157,20 +133,6 @@ struct DashboardView: View {
             let stats = buildGoalCompletionStats()
             celebrationManager.replayCelebration(.goalCompleted(stats: stats))
         }
-    }
-
-    /// Build a yearly milestone test payload using realistic-ish stats from the user.
-    private func triggerYearlyTest(years: Int) {
-        celebrationManager.clearAll()
-        let totalDays = years * 365
-        let lifetimeMiles = max(userManager.currentUser.totalMiles, Double(totalDays) * 1.15)
-        let info = YearlyMilestoneInfo(
-            years: years,
-            totalMiles: lifetimeMiles,
-            totalStreakDays: max(userManager.currentUser.streak, totalDays),
-            streakStartDate: Calendar.current.date(byAdding: .day, value: -totalDays, to: Date())
-        )
-        celebrationManager.addCelebration(.yearMilestone(info: info))
     }
 
     /// Group today's workouts by activity type into breakdowns

--- a/app/Mile A Day/Views/Profile/ProfileSettingsView.swift
+++ b/app/Mile A Day/Views/Profile/ProfileSettingsView.swift
@@ -18,9 +18,11 @@ struct ProfileSettingsView: View {
         ScrollView {
             VStack(spacing: MADTheme.Spacing.lg) {
                 settingsSection
+                #if DEBUG
                 if showsDevelopmentSection {
                     developmentSection
                 }
+                #endif
             }
             .padding(.horizontal, MADTheme.Spacing.md)
             .padding(.vertical, MADTheme.Spacing.md)
@@ -144,6 +146,8 @@ struct ProfileSettingsView: View {
 
     // MARK: - Development
 
+    // DEBUG builds only — compiled out of Release so no dev tooling ships.
+    #if DEBUG
     private var showsDevelopmentSection: Bool {
         AppEnvironment.isDevelopment && userManager.currentUser.role == "admin"
     }
@@ -195,4 +199,5 @@ struct ProfileSettingsView: View {
                 )
         )
     }
+    #endif
 }

--- a/app/Mile A Day/Views/Settings/DeveloperSettingsView.swift
+++ b/app/Mile A Day/Views/Settings/DeveloperSettingsView.swift
@@ -5,6 +5,11 @@
 //  Developer tools for testing and debugging
 //  Includes cache clearing, sync reset, and testing utilities
 //
+//  DEBUG builds only: the entire file is compiled out of Release/App Store
+//  builds so no dev tooling (or its strings) ships in the production binary.
+//
+
+#if DEBUG
 
 import SwiftUI
 import HealthKit
@@ -678,3 +683,5 @@ struct DeveloperSettingsView_Previews: PreviewProvider {
         }
     }
 }
+
+#endif

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
 	"description": "",
 	"main": "index.js",
 	"scripts": {
-		"dev": "tsx watch src/server.ts",
+		"dev": "NODE_ENV=development tsx watch src/server.ts",
 		"build": "tsc",
 		"start": "node dist/server.js",
 		"db:pull": "drizzle-kit pull",

--- a/backend/src/controllers/devController.ts
+++ b/backend/src/controllers/devController.ts
@@ -1,122 +1,142 @@
-import { Request, Response } from 'express';
-import { SignJWT } from 'jose';
-import { resolveExpiredCompetitions } from '../services/competitionService.js';
-import { sendPush, sendSilentPushToUser } from '../services/pushNotificationService.js';
-import { runSilentSyncPushFanout } from '../cron/silentSyncCron.js';
+import { Request, Response } from "express";
+import { SignJWT } from "jose";
+import { resolveExpiredCompetitions } from "../services/competitionService.js";
+import {
+  sendPush,
+  sendSilentPushToUser,
+} from "../services/pushNotificationService.js";
+import { runSilentSyncPushFanout } from "../cron/silentSyncCron.js";
+
+// Fail-closed gate for every /dev endpoint: these run ONLY when NODE_ENV is
+// explicitly 'development'. The old check (`=== 'production'` → 403) was
+// fail-open — an unset/typo'd NODE_ENV on a deploy would have exposed
+// test-token minting (a full auth bypass) to the public internet.
+function devEndpointsEnabled(): boolean {
+  return process.env.NODE_ENV === "development";
+}
 
 export async function generateTestToken(req: Request, res: Response) {
-	const env = process.env.NODE_ENV;
+  if (!devEndpointsEnabled()) {
+    return res.status(403).json({
+      error:
+        "Test token generation is only available when NODE_ENV=development",
+    });
+  }
 
-	if (env === 'production') {
-		return res.status(403).json({
-			error: 'Test token generation is not available in production'
-		});
-	}
+  const { userId } = req.body;
 
-	const { userId } = req.body;
+  if (!userId) {
+    return res.status(400).json({
+      error: "userId is required in request body",
+    });
+  }
 
-	if (!userId) {
-		return res.status(400).json({
-			error: 'userId is required in request body'
-		});
-	}
+  const appJwtSecret = process.env.APP_JWT_SECRET;
 
-	const appJwtSecret = process.env.APP_JWT_SECRET;
+  if (!appJwtSecret) {
+    return res.status(500).json({
+      error: "APP_JWT_SECRET is not configured",
+    });
+  }
 
-	if (!appJwtSecret) {
-		return res.status(500).json({
-			error: 'APP_JWT_SECRET is not configured'
-		});
-	}
+  try {
+    const token = await new SignJWT({ provider: "test" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setSubject(userId)
+      .setIssuedAt()
+      .setExpirationTime("30d")
+      .sign(new TextEncoder().encode(appJwtSecret));
 
-	try {
-		const token = await new SignJWT({ provider: 'test' })
-			.setProtectedHeader({ alg: 'HS256' })
-			.setSubject(userId)
-			.setIssuedAt()
-			.setExpirationTime('30d')
-			.sign(new TextEncoder().encode(appJwtSecret));
+    const expiresAt = Date.now() + 30 * 24 * 60 * 60 * 1000;
 
-		const expiresAt = Date.now() + 30 * 24 * 60 * 60 * 1000;
-
-		return res.json({
-			token,
-			userId,
-			expiresIn: '30d',
-			expiresAt,
-			environment: env
-		});
-	} catch (err) {
-		console.error('Error generating test token:', err);
-		return res.status(500).json({
-			error: 'Failed to generate test token'
-		});
-	}
+    return res.json({
+      token,
+      userId,
+      expiresIn: "30d",
+      expiresAt,
+      environment: process.env.NODE_ENV,
+    });
+  } catch (err) {
+    console.error("Error generating test token:", err);
+    return res.status(500).json({
+      error: "Failed to generate test token",
+    });
+  }
 }
 
 export async function sendTestNotification(req: Request, res: Response) {
-	if (process.env.NODE_ENV === 'production') {
-		return res.status(403).json({ error: 'Not available in production' });
-	}
+  if (!devEndpointsEnabled()) {
+    return res
+      .status(403)
+      .json({ error: "Only available when NODE_ENV=development" });
+  }
 
-	const { userId, message } = req.body;
-	if (!userId || !message) {
-		return res.status(400).json({ error: 'userId and message are required' });
-	}
+  const { userId, message } = req.body;
+  if (!userId || !message) {
+    return res.status(400).json({ error: "userId and message are required" });
+  }
 
-	try {
-		await sendPush(userId, {
-			title: 'Test Notification',
-			body: message,
-			type: 'friend_request',
-			data: {}
-		});
-		return res.json({ success: true });
-	} catch (err: any) {
-		return res.status(500).json({ error: err.message });
-	}
+  try {
+    await sendPush(userId, {
+      title: "Test Notification",
+      body: message,
+      type: "friend_request",
+      data: {},
+    });
+    return res.json({ success: true });
+  } catch (err: any) {
+    return res.status(500).json({ error: err.message });
+  }
 }
 
 export async function triggerCompetitionCron(_req: Request, res: Response) {
-	if (process.env.NODE_ENV === 'production') {
-		return res.status(403).json({ error: 'Not available in production' });
-	}
+  if (!devEndpointsEnabled()) {
+    return res
+      .status(403)
+      .json({ error: "Only available when NODE_ENV=development" });
+  }
 
-	try {
-		await resolveExpiredCompetitions();
-		return res.json({ success: true });
-	} catch (err: any) {
-		return res.status(500).json({ error: err.message });
-	}
+  try {
+    await resolveExpiredCompetitions();
+    return res.json({ success: true });
+  } catch (err: any) {
+    return res.status(500).json({ error: err.message });
+  }
 }
 
-export async function triggerSilentSyncFanout(req: Request, res: Response): Promise<void> {
-	if (process.env.NODE_ENV === 'production') {
-		res.status(403).json({ error: 'Not available in production' });
-		return;
-	}
-	try {
-		const result = await runSilentSyncPushFanout();
-		res.json({ success: true, ...result });
-	} catch (err: any) {
-		res.status(500).json({ success: false, error: err.message });
-	}
+export async function triggerSilentSyncFanout(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  if (!devEndpointsEnabled()) {
+    res.status(403).json({ error: "Only available when NODE_ENV=development" });
+    return;
+  }
+  try {
+    const result = await runSilentSyncPushFanout();
+    res.json({ success: true, ...result });
+  } catch (err: any) {
+    res.status(500).json({ success: false, error: err.message });
+  }
 }
 
-export async function triggerSilentSyncForUser(req: Request, res: Response): Promise<void> {
-	if (process.env.NODE_ENV === 'production') {
-		res.status(403).json({ error: 'Not available in production' });
-		return;
-	}
-	const userId = req.params.userId;
-	if (!userId) {
-		res.status(400).json({ success: false, error: 'userId required' });
-		return;
-	}
-	try {
-		const pushes = await sendSilentPushToUser(userId, 'background_sync');
-		res.json({ success: true, userId, pushes });
-	} catch (err: any) {
-		res.status(500).json({ success: false, error: err.message });
-	}
+export async function triggerSilentSyncForUser(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  if (!devEndpointsEnabled()) {
+    res.status(403).json({ error: "Only available when NODE_ENV=development" });
+    return;
+  }
+  const userId = req.params.userId;
+  if (!userId) {
+    res.status(400).json({ success: false, error: "userId required" });
+    return;
+  }
+  try {
+    const pushes = await sendSilentPushToUser(userId, "background_sync");
+    res.json({ success: true, userId, pushes });
+  } catch (err: any) {
+    res.status(500).json({ success: false, error: err.message });
+  }
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -130,10 +130,6 @@ app.get("/status/schema", async (req, res) => {
   });
 });
 
-app.get("/test-signin.html", (req, res) => {
-  res.sendFile(path.join(process.cwd(), "test-signin.html"));
-});
-
 // Public endpoint: get profile image URL by username
 app.get(
   "/public/profile-image/:username",
@@ -214,9 +210,12 @@ app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
     },
   });
 
+  // Generic body only: raw err.message can carry SQL fragments or file paths.
+  // The full message + stack already went to error_log above (admin dashboard).
+  // `message` field kept for response-shape compatibility with shipped clients.
   res.status(500).json({
     error: "Internal Server Error",
-    message: err.message,
+    message: "Something went wrong. Please try again.",
   });
 });
 

--- a/website/README.md
+++ b/website/README.md
@@ -22,7 +22,7 @@ Mile A Day was born from a bet between two competitive friends — Rob Wiscount 
 - Apple Watch + HealthKit integration
 - 100% free
 
-[![Download on the App Store](https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg)](https://apps.apple.com/app/mile-a-day/id6744917105)
+[![Download on the App Store](https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg)](https://apps.apple.com/app/mile-a-day/id6746970905)
 
 ---
 

--- a/website/components/navbar.tsx
+++ b/website/components/navbar.tsx
@@ -1,43 +1,46 @@
-"use client"
+"use client";
 
-import { useState, useEffect } from "react"
-import Image from "next/image"
-import { Menu, X } from "lucide-react"
+import { useState, useEffect } from "react";
+import Image from "next/image";
+import { Menu, X } from "lucide-react";
 
 const navLinks = [
   { label: "Features", href: "#features" },
   { label: "Competitions", href: "#competitions" },
   { label: "Our Story", href: "#story" },
-]
+];
 
 export function Navbar() {
-  const [scrolled, setScrolled] = useState(false)
-  const [mobileOpen, setMobileOpen] = useState(false)
+  const [scrolled, setScrolled] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   useEffect(() => {
-    let ticking = false
+    let ticking = false;
     const handleScroll = () => {
       if (!ticking) {
         requestAnimationFrame(() => {
-          setScrolled(window.scrollY > 20)
-          ticking = false
-        })
-        ticking = true
+          setScrolled(window.scrollY > 20);
+          ticking = false;
+        });
+        ticking = true;
       }
-    }
-    window.addEventListener("scroll", handleScroll, { passive: true })
-    return () => window.removeEventListener("scroll", handleScroll)
-  }, [])
+    };
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
 
   return (
     <nav
       className={`fixed top-0 left-0 right-0 z-50 transition-all duration-500 ${
         scrolled ? "glass-nav py-3" : "py-5 bg-transparent"
       }`}
-      style={{ transition: "opacity 0.6s ease, transform 0.6s ease, padding 0.5s ease, background 0.5s ease" }}
+      style={{
+        transition:
+          "opacity 0.6s ease, transform 0.6s ease, padding 0.5s ease, background 0.5s ease",
+      }}
     >
       <div className="mx-auto flex max-w-6xl items-center justify-between px-6">
-        <a href="#" className="flex items-center gap-3">
+        <a href="/" className="flex items-center gap-3">
           <Image
             src="/images/mad-circle-icon.png"
             alt="Mile A Day logo"
@@ -46,7 +49,9 @@ export function Navbar() {
             className="rounded-full"
             loading="lazy"
           />
-          <span className="font-heading text-[22px] tracking-[2px] text-[#f5f5f5]">MILE A DAY</span>
+          <span className="font-heading text-[22px] tracking-[2px] text-[#f5f5f5]">
+            MILE A DAY
+          </span>
         </a>
 
         {/* Desktop nav */}
@@ -79,7 +84,11 @@ export function Navbar() {
           className="text-[#f5f5f5] md:hidden"
           aria-label="Toggle navigation menu"
         >
-          {mobileOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+          {mobileOpen ? (
+            <X className="h-6 w-6" />
+          ) : (
+            <Menu className="h-6 w-6" />
+          )}
         </button>
       </div>
 
@@ -112,5 +121,5 @@ export function Navbar() {
         </div>
       )}
     </nav>
-  )
+  );
 }


### PR DESCRIPTION
# Summary

Pre-release pass for the 2.0 (feed) version: every dev-only surface is off by construction, and the launch-time "1 day streak" flash is fixed at its root.

## Streak flash fix (`f5ce5ff`)

On launch the dashboard/widgets briefly showed "1 day" before snapping back to the real streak. Chain: a WorkoutIndex hole (a day whose workout reached HealthKit late, was deleted there, or never synced) → `activeStreak()` stops at that day → `updateUserWithHealthKitData` overwrote `currentUser.streak` unconditionally → widgets + watch got the bad value (each flap double-reloads widgets, burning the daily WidgetKit reload budget) → backend fetch rescued the display but never fixed `retroactiveStreak`'s persisted cache, re-arming the flash every launch.

Fix: display-grade streak drops now require verification. `UserManager.vettedHealthKitStreak` allows a 2+ day drop only when the backend (recorded on every `getUserStats`, which recomputes server-side; 48h freshness) agrees the streak broke, or a same-day full index rebuild confirms it without backend contradiction. Unverified drops hold the trusted value and schedule a rebuild (shared daily debounce with `repairWorkoutIndexIfStale`) that repairs the hole or confirms the break. The watch bridge now pushes `max(hk.retroactiveStreak, user.streak)`, and the init-time cache load is raise-only. All display surfaces (dashboard hero, widgets, watch, celebrations) read `currentUser.streak`, so one choke point covers them. Backend data was never at risk — `users.current_streak` is computed server-side only.

## Backend hardening
- **`/dev/*` endpoints are now fail-closed** — 403 unless `NODE_ENV=development`. Previously they were open unless `NODE_ENV` was exactly `production`, so an unset/typo'd value on a future deploy would have exposed `POST /dev/test-token` (mints a valid 30-day JWT for **any** userId) publicly. Production behavior unchanged (Dockerfile sets `NODE_ENV=production`); `npm run dev` now sets `NODE_ENV=development` for local work.
- **Removed dead `GET /test-signin.html`** — file doesn't exist; the route only 500'd and leaked the server path.
- **500 responses no longer echo `err.message`** (SQL fragments / paths). Response shape unchanged; full detail still lands in `error_log`.

## iOS dev tooling stripped from Release
- `DeveloperSettingsView` (+ its hardcoded test user id and `/dev` endpoint call) compiled out via `#if DEBUG`; `ProfileSettingsView` dev section likewise.
- Removed dead test scaffolding in `DashboardView`.

## Website / docs
- Navbar logo links to `/` instead of `#`; README App Store badge fixed to the live app id `6746970905`.
- `AGENTS.md` corrected (claimed "No CI/CD" / "no migrations" and pointed at a nonexistent `.Codex/`); CLAUDE.md made authoritative. `.claude/rules/{backend,ios}.md` updated with the new gotchas.

## Verification
- Backend `npm run build` (tsc): ✅  Website `npm run build`: ✅
- iOS changes are `#if DEBUG` wraps, dead-code removal, and the quarantine logic — Xcode Cloud PR Build compiles the scheme on this PR.

## Compatibility
- No endpoint/response-field changes shipped clients consume. `/dev/*` was 403 in prod before and after. No schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01As47P3oiGe1Q8f8eksd1L8