### PR TITLE
Website: live community stats, feed showcase, real Android waitlist + miles-today ET fix

### DIFF
--- a/backend/src/controllers/publicController.ts
+++ b/backend/src/controllers/publicController.ts
@@ -1,0 +1,38 @@
+import { Request, Response } from "express";
+import { getPublicStats } from "../services/publicStatsService.js";
+import {
+  addToAndroidWaitlist,
+  normalizeWaitlistEmail,
+} from "../services/waitlistService.js";
+
+/** Global community counters for the marketing site. Aggregates only — the
+ *  service layer is the gate for what may ever appear in this payload. */
+export async function getPublicStatsController(_req: Request, res: Response) {
+  try {
+    const stats = await getPublicStats();
+    res.json(stats);
+  } catch (error) {
+    console.error("Failed to fetch public stats:", error);
+    res.status(500).json({ error: "Failed to fetch stats" });
+  }
+}
+
+/** Android-launch waitlist signup from the marketing site. Responds the same
+ *  for new and already-subscribed emails so addresses can't be enumerated. */
+export async function joinAndroidWaitlistController(
+  req: Request,
+  res: Response,
+) {
+  const email = normalizeWaitlistEmail(req.body?.email);
+  if (!email) {
+    return res.status(400).json({ error: "A valid email is required" });
+  }
+
+  try {
+    await addToAndroidWaitlist(email, "website");
+    res.json({ ok: true });
+  } catch (error) {
+    console.error("Failed to save waitlist signup:", error);
+    res.status(500).json({ error: "Failed to save signup" });
+  }
+}

--- a/backend/src/db/drizzle/0014_lyrical_shatterstar.sql
+++ b/backend/src/db/drizzle/0014_lyrical_shatterstar.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "android_waitlist" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"email" text NOT NULL,
+	"source" text DEFAULT 'website' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now(),
+	CONSTRAINT "android_waitlist_email_unique" UNIQUE("email")
+);

--- a/backend/src/db/drizzle/meta/0014_snapshot.json
+++ b/backend/src/db/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,3833 @@
+{
+  "id": "7bf4e971-6d9a-406e-a5f3-6eda4f28d916",
+  "prevId": "dfda8860-620a-4a94-9474-fac4394413d2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.android_waitlist": {
+      "name": "android_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'website'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "android_waitlist_email_unique": {
+          "name": "android_waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_badges_category": {
+          "name": "idx_badges_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "badges_rarity_check": {
+          "name": "badges_rarity_check",
+          "value": "rarity = ANY (ARRAY['common'::text, 'rare'::text, 'legendary'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.close_friends": {
+      "name": "close_friends",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_friend_id": {
+          "name": "close_friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_close_friends_friend": {
+          "name": "idx_close_friends_friend",
+          "columns": [
+            {
+              "expression": "close_friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "close_friends_pkey": {
+          "name": "close_friends_pkey",
+          "columns": [
+            "user_id",
+            "close_friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_users": {
+      "name": "competition_users",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_rank": {
+          "name": "last_known_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_score": {
+          "name": "last_known_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rank_updated_at": {
+          "name": "last_rank_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_competition_users_comp": {
+          "name": "idx_competition_users_comp",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_competition": {
+          "name": "idx_competition_users_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_rank_cache": {
+          "name": "idx_competition_users_rank_cache",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_known_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((invite_status)::text = 'accepted'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user": {
+          "name": "idx_competition_users_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user_status": {
+          "name": "idx_competition_users_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invite_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_users_user_id_fkey": {
+          "name": "competition_users_user_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_users_competition_id_fkey": {
+          "name": "competition_users_competition_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_users_pkey": {
+          "name": "competition_users_pkey",
+          "columns": [
+            "competition_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_users_invite_status_check": {
+          "name": "competition_users_invite_status_check",
+          "value": "(invite_status)::text = ANY ((ARRAY['pending'::character varying, 'accepted'::character varying, 'declined'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workouts": {
+          "name": "workouts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_winner": {
+          "name": "idx_competitions_winner",
+          "columns": [
+            {
+              "expression": "winner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(winner IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_winner_fkey": {
+          "name": "competitions_winner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "competitions_owner_fkey": {
+          "name": "competitions_owner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitions_type_check": {
+          "name": "competitions_type_check",
+          "value": "(type)::text = ANY ((ARRAY['streaks'::character varying, 'apex'::character varying, 'clash'::character varying, 'targets'::character varying, 'race'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_challenges": {
+      "name": "daily_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_template": {
+          "name": "description_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_start": {
+          "name": "gradient_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_end": {
+          "name": "gradient_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rotation_index": {
+          "name": "rotation_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_challenges_rotation_index_key": {
+          "name": "daily_challenges_rotation_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rotation_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daily_challenges_type_check": {
+          "name": "daily_challenges_type_check",
+          "value": "type = ANY (ARRAY['pace'::text, 'distance'::text, 'time'::text, 'activity'::text, 'steps'::text, 'social'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_steps": {
+      "name": "daily_steps",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_steps_user_date": {
+          "name": "idx_daily_steps_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_steps_user_id_fkey": {
+          "name": "daily_steps_user_id_fkey",
+          "tableFrom": "daily_steps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_steps_pkey": {
+          "name": "daily_steps_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "daily_steps_steps_check": {
+          "name": "daily_steps_steps_check",
+          "value": "steps >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token": {
+          "name": "device_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_tokens_user_id": {
+          "name": "idx_device_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_user_id_fkey": {
+          "name": "device_tokens_user_id_fkey",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_user_id_device_token_key": {
+          "name": "device_tokens_user_id_device_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_log": {
+      "name": "error_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_error_log_created_at": {
+          "name": "idx_error_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_error_log_category": {
+          "name": "idx_error_log_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flex_log": {
+      "name": "flex_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flex_log_lookup": {
+          "name": "idx_flex_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_notification_settings": {
+      "name": "friend_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted": {
+          "name": "muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nudges_muted": {
+          "name": "nudges_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "activity_muted": {
+          "name": "activity_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "friend_notification_settings_pkey": {
+          "name": "friend_notification_settings_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_nudge_log": {
+      "name": "friend_nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_nudge_log_lookup": {
+          "name": "idx_friend_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_friendships_friend_status": {
+          "name": "idx_friendships_friend_status",
+          "columns": [
+            {
+              "expression": "friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_friendships_user_status": {
+          "name": "idx_friendships_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_user_id_fkey": {
+          "name": "friendships_user_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_friend_id_fkey": {
+          "name": "friendships_friend_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendships_pkey": {
+          "name": "friendships_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_friendship_pair": {
+          "name": "unique_friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hype_log": {
+      "name": "hype_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_label": {
+          "name": "context_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hype_log_context_dedupe_idx": {
+          "name": "hype_log_context_dedupe_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_lookup": {
+          "name": "idx_hype_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_app_notifications": {
+      "name": "in_app_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_in_app_notifications_unread": {
+          "name": "idx_in_app_notifications_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_read = false)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_app_notifications_user": {
+          "name": "idx_in_app_notifications_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_app_notifications_user_id_fkey": {
+          "name": "in_app_notifications_user_id_fkey",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_notifications": {
+      "name": "milestone_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_key": {
+          "name": "milestone_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_notifications_milestone_key_key": {
+          "name": "milestone_notifications_milestone_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_audience_settings": {
+      "name": "notification_audience_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_audience_settings_pkey": {
+          "name": "notification_audience_settings_pkey",
+          "columns": [
+            "user_id",
+            "direction",
+            "event_type",
+            "activity_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_audience_settings_direction_check": {
+          "name": "notification_audience_settings_direction_check",
+          "value": "direction = ANY (ARRAY['outgoing'::text, 'incoming'::text])"
+        },
+        "notification_audience_settings_audience_check": {
+          "name": "notification_audience_settings_audience_check",
+          "value": "audience = ANY (ARRAY['none'::text, 'close'::text, 'all'::text, 'ask'::text, 'match_run'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_user_date": {
+          "name": "idx_notification_log_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nudges_enabled": {
+          "name": "nudges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "flexes_enabled": {
+          "name": "flexes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_activity_enabled": {
+          "name": "friend_activity_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_invites_enabled": {
+          "name": "competition_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_updates_enabled": {
+          "name": "competition_updates_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_milestones_enabled": {
+          "name": "competition_milestones_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "hypes_enabled": {
+          "name": "hypes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "step_goal_enabled": {
+          "name": "step_goal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "friend_personal_best_enabled": {
+          "name": "friend_personal_best_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_enabled": {
+          "name": "daily_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_hour": {
+          "name": "daily_reminder_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 18
+        },
+        "timezone_offset_minutes": {
+          "name": "timezone_offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_workouts_to_feed": {
+          "name": "share_workouts_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_posts_enabled": {
+          "name": "friend_posts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "share_route_maps": {
+          "name": "share_route_maps",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "weekly_recap_enabled": {
+          "name": "weekly_recap_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nudge_log": {
+      "name": "nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_nudge_log_lookup": {
+          "name": "idx_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nudge_log_rate_limit": {
+          "name": "idx_nudge_log_rate_limit",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_friend_notifications": {
+      "name": "pending_friend_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "send_after_at": {
+          "name": "send_after_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_friend_notif_user": {
+          "name": "idx_pending_friend_notif_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_pending_friend_notif_workout": {
+          "name": "uq_pending_friend_notif_workout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((workout_id IS NOT NULL) AND (status = 'pending'::text))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pending_friend_notifications_status_check": {
+          "name": "pending_friend_notifications_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'sent'::text, 'dismissed'::text, 'expired'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_notifications": {
+      "name": "pending_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_notifications_unsent": {
+          "name": "idx_pending_notifications_unsent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(sent_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_notifications_user_id_fkey": {
+          "name": "pending_notifications_user_id_fkey",
+          "tableFrom": "pending_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_reports": {
+      "name": "post_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_reports_dedupe_idx": {
+          "name": "post_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_reports_status": {
+          "name": "idx_post_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_reports_post_id_fkey": {
+          "name": "post_reports_post_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_reports_reporter_id_fkey": {
+          "name": "post_reports_reporter_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_reports_reason_check": {
+          "name": "post_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_snapshot": {
+          "name": "stats_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_to_feed": {
+          "name": "share_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_to_story": {
+          "name": "share_to_story",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "story_expires_at": {
+          "name": "story_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto": {
+          "name": "is_auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_route": {
+          "name": "include_route",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_posts_user_created": {
+          "name": "idx_posts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_feed": {
+          "name": "idx_posts_feed",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_story_active": {
+          "name": "idx_posts_story_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "story_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_story)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_active": {
+          "name": "uq_posts_workout_active",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_story": {
+          "name": "uq_posts_workout_story",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_story AND NOT share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_fkey": {
+          "name": "posts_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_workout_id_fkey": {
+          "name": "posts_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_family_id": {
+          "name": "token_family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_hash": {
+          "name": "replaced_by_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "token_family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_revoked_at": {
+          "name": "idx_refresh_tokens_revoked_at",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(revoked_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_token_hash": {
+          "name": "idx_refresh_tokens_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_fkey": {
+          "name": "refresh_tokens_user_id_fkey",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_key": {
+          "name": "refresh_tokens_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_reactions": {
+      "name": "story_reactions",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_reactions_post_id_fkey": {
+          "name": "story_reactions_post_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_reactions_user_id_fkey": {
+          "name": "story_reactions_user_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_reactions_pkey": {
+          "name": "story_reactions_pkey",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_views": {
+      "name": "story_views",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_views_post_id_fkey": {
+          "name": "story_views_post_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_views_viewer_id_fkey": {
+          "name": "story_views_viewer_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_views_pkey": {
+          "name": "story_views_pkey",
+          "columns": [
+            "post_id",
+            "viewer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggering_workout_id": {
+          "name": "triggering_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_snapshot": {
+          "name": "progress_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_slot": {
+          "name": "pin_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_badges_user": {
+          "name": "idx_user_badges_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_new": {
+          "name": "idx_user_badges_user_new",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_new = true)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_pin_slot": {
+          "name": "idx_user_badges_user_pin_slot",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(pin_slot IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_workout": {
+          "name": "idx_user_badges_workout",
+          "columns": [
+            {
+              "expression": "triggering_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_badges_user_id_fkey": {
+          "name": "user_badges_user_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_fkey": {
+          "name": "user_badges_badge_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "badge_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_triggering_workout_id_fkey": {
+          "name": "user_badges_triggering_workout_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "triggering_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_badges_user_id_badge_id_key": {
+          "name": "user_badges_user_id_badge_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "badge_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_badges_pin_slot_range": {
+          "name": "user_badges_pin_slot_range",
+          "value": "(pin_slot IS NULL) OR ((pin_slot >= 0) AND (pin_slot <= 2))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_blocks_blocked": {
+          "name": "idx_user_blocks_blocked",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_fkey": {
+          "name": "user_blocks_blocker_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_blocks_blocked_id_fkey": {
+          "name": "user_blocks_blocked_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_pkey": {
+          "name": "user_blocks_pkey",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenge_completions": {
+      "name": "user_challenge_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completing_workout_id": {
+          "name": "completing_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ucc_user": {
+          "name": "idx_ucc_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ucc_user_date": {
+          "name": "idx_ucc_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenge_completions_user_id_fkey": {
+          "name": "user_challenge_completions_user_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_challenge_key_fkey": {
+          "name": "user_challenge_completions_challenge_key_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "daily_challenges",
+          "columnsFrom": [
+            "challenge_key"
+          ],
+          "columnsTo": [
+            "challenge_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_completing_workout_id_fkey": {
+          "name": "user_challenge_completions_completing_workout_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "completing_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_challenge_completions_user_id_local_date_key": {
+          "name": "user_challenge_completions_user_id_local_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_sub": {
+          "name": "apple_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "goal_miles": {
+          "name": "goal_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_current_streak_desc": {
+          "name": "idx_users_current_streak_desc",
+          "columns": [
+            {
+              "expression": "current_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email_trgm": {
+          "name": "idx_users_email_trgm",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_username_trgm": {
+          "name": "idx_users_username_trgm",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_apple_id_key": {
+          "name": "users_apple_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_apple_sub_key": {
+          "name": "users_apple_sub_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "apple_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_recap_log": {
+      "name": "weekly_recap_log",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "weekly_recap_log_pkey": {
+          "name": "weekly_recap_log_pkey",
+          "columns": [
+            "user_id",
+            "week_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_completion_notifications": {
+      "name": "workout_completion_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_date": {
+          "name": "notified_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_completion_notifications_user_id_notified_date_key": {
+          "name": "workout_completion_notifications_user_id_notified_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "notified_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_routes": {
+      "name": "workout_routes",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "point_count": {
+          "name": "point_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workout_routes_workout_id_fkey": {
+          "name": "workout_routes_workout_id_fkey",
+          "tableFrom": "workout_routes",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_splits": {
+      "name": "workout_splits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_number": {
+          "name": "split_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_duration": {
+          "name": "split_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_distance": {
+          "name": "split_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_pace": {
+          "name": "split_pace",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_splits_time": {
+          "name": "idx_splits_time",
+          "columns": [
+            {
+              "expression": "split_duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_splits_workout": {
+          "name": "idx_splits_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_splits_workout_id_fkey": {
+          "name": "workout_splits_workout_id_fkey",
+          "tableFrom": "workout_splits",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_splits_workout_id_split_number_key": {
+          "name": "workout_splits_workout_id_split_number_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "split_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workouts": {
+      "name": "workouts",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_end_date": {
+          "name": "device_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthkit'"
+        },
+        "original_distance": {
+          "name": "original_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_duration": {
+          "name": "original_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_flagged": {
+          "name": "speed_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_workouts_local_date_user_id": {
+          "name": "idx_workouts_local_date_user_id",
+          "columns": [
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_device_end": {
+          "name": "idx_workouts_user_device_end",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_local_date": {
+          "name": "idx_workouts_user_local_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workouts_user_workout_unique": {
+          "name": "workouts_user_workout_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/drizzle/meta/_journal.json
+++ b/backend/src/db/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1783532891538,
       "tag": "0013_flashy_psylocke",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1783903836569,
+      "tag": "0014_lyrical_shatterstar",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/drizzle/schema.ts
+++ b/backend/src/db/drizzle/schema.ts
@@ -1242,3 +1242,20 @@ export const errorLog = pgTable(
     ),
   ],
 );
+
+export const androidWaitlist = pgTable(
+  "android_waitlist",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    // Stored normalized (trimmed + lowercased by waitlistService); the UNIQUE
+    // constraint makes signups idempotent so the endpoint can't be used to
+    // probe whether an address is already on the list.
+    email: text().notNull(),
+    source: text().default("website").notNull(),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+  },
+  (table) => [unique("android_waitlist_email_unique").on(table.email)],
+);

--- a/backend/src/routes/publicRoutes.ts
+++ b/backend/src/routes/publicRoutes.ts
@@ -1,25 +1,43 @@
-import { Router } from 'express';
-import { getPublicUserCount, getPublicUserStreak } from '../controllers/usersController.js';
+import { Router } from "express";
+import {
+  getPublicUserCount,
+  getPublicUserStreak,
+} from "../controllers/usersController.js";
+import {
+  getPublicStatsController,
+  joinAndroidWaitlistController,
+} from "../controllers/publicController.js";
 
 const router = Router();
 
 // Public routes — mounted before authenticateToken. CORS open so the
 // marketing site (mileaday.run) can fetch directly from the browser.
-router.use((_req, res, next) => {
-	res.setHeader('Access-Control-Allow-Origin', '*');
-	next();
+// The JSON waitlist POST triggers a browser preflight, so OPTIONS must be
+// answered here too (with the allowed methods/headers), not fall to a 404.
+router.use((req, res, next) => {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  if (req.method === "OPTIONS") {
+    return res.sendStatus(204);
+  }
+  next();
 });
 
-router.get('/user-count', getPublicUserCount);
+router.get("/user-count", getPublicUserCount);
 // Alias — same count payload. Exposes NO per-user data.
-router.get('/users', getPublicUserCount);
+router.get("/users", getPublicUserCount);
 // Streaks are public only for allowlisted usernames (see PUBLIC_STREAK_USERNAMES)
-router.get('/streak/:username', getPublicUserStreak);
+router.get("/streak/:username", getPublicUserStreak);
+// Community-wide counters for the site's live stats band. Aggregates only.
+router.get("/stats", getPublicStatsController);
+// Android launch waitlist signups from the site footer form.
+router.post("/android-waitlist", joinAndroidWaitlistController);
 
 // Unknown /public/* paths should 404 here, not fall through to the auth
 // middleware (which confusingly answers "access token required").
 router.use((_req, res) => {
-	res.status(404).json({ error: 'Not found' });
+  res.status(404).json({ error: "Not found" });
 });
 
 export default router;

--- a/backend/src/services/adminService.ts
+++ b/backend/src/services/adminService.ts
@@ -1,5 +1,5 @@
 import { PostgresService } from "./DbService.js";
-import { START_OF_TODAY_ET_SQL } from "./dailyResetTime.js";
+import { START_OF_TODAY_ET_SQL, TODAY_ET_DATE_SQL } from "./dailyResetTime.js";
 
 const db = PostgresService.getInstance();
 
@@ -26,11 +26,14 @@ export async function getOverview() {
       (SELECT COUNT(*) FROM users)::int AS total_users,
       (SELECT COALESCE(SUM(distance), 0) FROM workouts
          WHERE deleted_at IS NULL AND exclusion_reason IS NULL)::float AS total_miles,
+      -- "Today" must be the ET calendar day like every other daily counter:
+      -- CURRENT_DATE is the DB server's UTC date, which flips at 8pm ET and
+      -- zeroed miles_today every evening.
       (SELECT COALESCE(SUM(distance), 0) FROM workouts
-         WHERE local_date = CURRENT_DATE
+         WHERE local_date = ${TODAY_ET_DATE_SQL}
            AND deleted_at IS NULL AND exclusion_reason IS NULL)::float AS miles_today,
       (SELECT COUNT(DISTINCT user_id) FROM workouts
-         WHERE local_date >= CURRENT_DATE - INTERVAL '7 days'
+         WHERE local_date >= ${TODAY_ET_DATE_SQL} - 7
            AND deleted_at IS NULL AND exclusion_reason IS NULL)::int AS active_users_7d,
       (SELECT COUNT(*) FROM hype_log)::int AS total_hypes,
       (SELECT COUNT(*) FROM hype_log
@@ -54,7 +57,7 @@ export async function getOverview() {
 export async function getMilesByDay() {
   return db.query(`
     SELECT d::date::text AS date, COALESCE(SUM(w.distance), 0)::float AS miles
-    FROM generate_series(CURRENT_DATE - INTERVAL '29 days', CURRENT_DATE, INTERVAL '1 day') d
+    FROM generate_series(${TODAY_ET_DATE_SQL} - 29, ${TODAY_ET_DATE_SQL}, INTERVAL '1 day') d
     LEFT JOIN workouts w
       ON w.local_date = d::date
       AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL

--- a/backend/src/services/dailyResetTime.ts
+++ b/backend/src/services/dailyResetTime.ts
@@ -15,3 +15,11 @@ export const START_OF_TODAY_ET_SQL = `(date_trunc('day', NOW() AT TIME ZONE 'Ame
  * Used to report when a rate-limited user can act again.
  */
 export const START_OF_TOMORROW_ET_SQL = `((date_trunc('day', NOW() AT TIME ZONE 'America/New_York') + INTERVAL '1 day') AT TIME ZONE 'America/New_York')`;
+
+/**
+ * SQL fragment for "today" as a DATE in the app's canonical timezone (ET).
+ * Use against DATE columns like workouts.local_date. Plain CURRENT_DATE is the
+ * DB server's (UTC) date — from 8pm ET onward it reads as tomorrow, which
+ * zeroed the "miles today" counters every evening.
+ */
+export const TODAY_ET_DATE_SQL = `((NOW() AT TIME ZONE 'America/New_York')::date)`;

--- a/backend/src/services/publicStatsService.ts
+++ b/backend/src/services/publicStatsService.ts
@@ -1,0 +1,64 @@
+import { PostgresService } from "./DbService.js";
+import { TODAY_ET_DATE_SQL } from "./dailyResetTime.js";
+
+const db = PostgresService.getInstance();
+
+/**
+ * Community-wide counters for the marketing site's live stats band.
+ *
+ * PUBLIC + UNAUTHENTICATED. Only global aggregates may ever go in here —
+ * no user ids, usernames, emails, per-user numbers, or anything that could
+ * identify or enumerate a person. Values are rounded so the endpoint can't
+ * be used to fingerprint individual workouts as they land.
+ */
+export interface PublicStats {
+  total_users: number;
+  total_miles: number;
+  miles_today: number;
+  total_hypes: number;
+  total_nudges: number;
+}
+
+// The endpoint is public and uncached queries hit five aggregate scans, so a
+// short in-memory cache keeps a traffic spike (or someone hammering it) from
+// turning into DB load. One minute matches the site's poll interval.
+const CACHE_TTL_MS = 60_000;
+let cache: { data: PublicStats; at: number } | null = null;
+
+export async function getPublicStats(): Promise<PublicStats> {
+  if (cache && Date.now() - cache.at < CACHE_TTL_MS) {
+    return cache.data;
+  }
+
+  // Mile counts mirror the app/admin: soft-deleted and auto-excluded
+  // (e.g. vehicle-speed) workouts don't count. "Today" is the ET calendar
+  // day — the app's canonical daily-reset timezone.
+  const [row] = await db.query<{
+    total_users: number;
+    total_miles: number;
+    miles_today: number;
+    total_hypes: number;
+    total_nudges: number;
+  }>(`
+    SELECT
+      (SELECT COUNT(*) FROM users)::int AS total_users,
+      (SELECT COALESCE(SUM(distance), 0) FROM workouts
+         WHERE deleted_at IS NULL AND exclusion_reason IS NULL)::float AS total_miles,
+      (SELECT COALESCE(SUM(distance), 0) FROM workouts
+         WHERE local_date = ${TODAY_ET_DATE_SQL}
+           AND deleted_at IS NULL AND exclusion_reason IS NULL)::float AS miles_today,
+      (SELECT COUNT(*) FROM hype_log)::int AS total_hypes,
+      ((SELECT COUNT(*) FROM nudge_log)
+        + (SELECT COUNT(*) FROM friend_nudge_log))::int AS total_nudges
+  `);
+
+  const data: PublicStats = {
+    total_users: row?.total_users ?? 0,
+    total_miles: Math.round(row?.total_miles ?? 0),
+    miles_today: Math.round((row?.miles_today ?? 0) * 10) / 10,
+    total_hypes: row?.total_hypes ?? 0,
+    total_nudges: row?.total_nudges ?? 0,
+  };
+  cache = { data, at: Date.now() };
+  return data;
+}

--- a/backend/src/services/waitlistService.ts
+++ b/backend/src/services/waitlistService.ts
@@ -1,0 +1,35 @@
+import { PostgresService } from "./DbService.js";
+
+const db = PostgresService.getInstance();
+
+// Practical upper bound from RFC 5321; anything longer is garbage or abuse.
+const MAX_EMAIL_LENGTH = 254;
+// Deliberately loose shape check — real validation happens when we actually
+// email the list. This just keeps obvious junk out of the table.
+const EMAIL_SHAPE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+
+/** Normalize and validate a submitted email. Returns null when unusable. */
+export function normalizeWaitlistEmail(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const email = raw.trim().toLowerCase();
+  if (email.length === 0 || email.length > MAX_EMAIL_LENGTH) return null;
+  if (!EMAIL_SHAPE.test(email)) return null;
+  return email;
+}
+
+/**
+ * Add an email to the Android launch waitlist. Idempotent: duplicates are
+ * silently absorbed (ON CONFLICT DO NOTHING) so the endpoint never reveals
+ * whether an address was already subscribed.
+ */
+export async function addToAndroidWaitlist(
+  email: string,
+  source: string,
+): Promise<void> {
+  await db.query(
+    `INSERT INTO android_waitlist (email, source)
+     VALUES ($1, $2)
+     ON CONFLICT (email) DO NOTHING`,
+    [email, source],
+  );
+}

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -1,16 +1,19 @@
-import { Navbar } from "@/components/navbar"
-import { HeroSection } from "@/components/hero-section"
-import { MarqueeSection } from "@/components/marquee-section"
-import { FeaturesSection } from "@/components/features-section"
-import { BadgeShowcaseSection } from "@/components/badge-showcase-section"
-import { HabitSection } from "@/components/habit-section"
-import { CompetitionsSection } from "@/components/competitions-section"
-import { SocialSection } from "@/components/social-section"
-import { HowItWorksSection } from "@/components/how-it-works-section"
-import { StorySection } from "@/components/story-section"
-import { CtaSection } from "@/components/cta-section"
-import { Footer } from "@/components/footer"
-import { ScrollReveal } from "@/components/scroll-reveal"
+import { Navbar } from "@/components/navbar";
+import { HeroSection } from "@/components/hero-section";
+import { MarqueeSection } from "@/components/marquee-section";
+import { LiveStatsBand } from "@/components/live-stats-band";
+import { FeedSection } from "@/components/feed-section";
+import { WhatsNewSection } from "@/components/whats-new-section";
+import { FeaturesSection } from "@/components/features-section";
+import { BadgeShowcaseSection } from "@/components/badge-showcase-section";
+import { HabitSection } from "@/components/habit-section";
+import { CompetitionsSection } from "@/components/competitions-section";
+import { SocialSection } from "@/components/social-section";
+import { HowItWorksSection } from "@/components/how-it-works-section";
+import { StorySection } from "@/components/story-section";
+import { CtaSection } from "@/components/cta-section";
+import { Footer } from "@/components/footer";
+import { ScrollReveal } from "@/components/scroll-reveal";
 
 export default function Home() {
   return (
@@ -19,6 +22,9 @@ export default function Home() {
       <Navbar />
       <HeroSection />
       <MarqueeSection />
+      <LiveStatsBand />
+      <FeedSection />
+      <WhatsNewSection />
       <FeaturesSection />
       <BadgeShowcaseSection />
       <HabitSection />
@@ -29,5 +35,5 @@ export default function Home() {
       <CtaSection />
       <Footer />
     </main>
-  )
+  );
 }

--- a/website/components/cta-section.tsx
+++ b/website/components/cta-section.tsx
@@ -1,24 +1,42 @@
-"use client"
+"use client";
 
-import { useState } from "react"
-import { LiveCommunityCount } from "./live-community-count"
+import { useState } from "react";
+import { LiveCommunityCount } from "./live-community-count";
+
+const API_URL =
+  process.env.NEXT_PUBLIC_API_URL || "https://mad.mindgoblin.tech";
 
 export function CtaSection() {
-  const [email, setEmail] = useState("")
-  const [submitted, setSubmitted] = useState(false)
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<"idle" | "sending" | "done" | "error">(
+    "idle",
+  );
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    if (email) {
-      setSubmitted(true)
-      setEmail("")
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email || status === "sending") return;
+    setStatus("sending");
+    try {
+      const res = await fetch(`${API_URL}/public/android-waitlist`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setStatus("done");
+      setEmail("");
+    } catch {
+      setStatus("error");
     }
-  }
+  };
 
   return (
     <section
       className="section-lazy relative px-6 py-24"
-      style={{ background: "radial-gradient(ellipse 600px 600px at 50% 100%, rgba(199,37,84,0.08) 0%, transparent 70%)" }}
+      style={{
+        background:
+          "radial-gradient(ellipse 600px 600px at 50% 100%, rgba(199,37,84,0.08) 0%, transparent 70%)",
+      }}
     >
       <div className="relative mx-auto max-w-3xl text-center">
         <span className="reveal mb-4 inline-block text-sm font-semibold uppercase tracking-widest text-[#c72554]">
@@ -28,11 +46,13 @@ export function CtaSection() {
           <LiveCommunityCount />
         </div>
         <h2 className="reveal-scale reveal-delay-1 font-heading text-[clamp(48px,8vw,96px)] leading-[0.95] tracking-[-1px] text-[#f5f5f5]">
-          YOUR STREAK<br />STARTS <span className="text-[#c72554]">TODAY</span>
+          YOUR STREAK
+          <br />
+          STARTS <span className="text-[#c72554]">TODAY</span>
         </h2>
         <p className="reveal reveal-delay-2 mt-6 text-lg leading-relaxed text-[#a0a0a0]">
-          One mile. Every day. That&apos;s all it takes to build a habit that lasts a lifetime.
-          Download Mile A Day and never look back.
+          One mile. Every day. That&apos;s all it takes to build a habit that
+          lasts a lifetime. Download Mile A Day and never look back.
         </p>
         <div className="reveal reveal-delay-3 mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
           <a
@@ -45,7 +65,9 @@ export function CtaSection() {
               <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
             </svg>
             <div className="text-left">
-              <div className="text-[10px] text-[#a0a0a0] tracking-wide">Download on the</div>
+              <div className="text-[10px] text-[#a0a0a0] tracking-wide">
+                Download on the
+              </div>
               <div className="text-base font-semibold">App Store</div>
             </div>
           </a>
@@ -56,30 +78,40 @@ export function CtaSection() {
           <p className="mb-3 text-sm text-[#a0a0a0]/80">
             On Android? Get notified when we launch.
           </p>
-          {submitted ? (
+          {status === "done" ? (
             <div className="glass-card-highlight rounded-xl px-6 py-3 text-sm font-medium text-[#c72554]">
-              You&apos;re on the list! We&apos;ll let you know when Android is ready.
+              You&apos;re on the list! We&apos;ll let you know when Android is
+              ready.
             </div>
           ) : (
-            <form onSubmit={handleSubmit} className="flex gap-2">
-              <input
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="your@email.com"
-                required
-                className="flex-1 rounded-xl border border-[#333333] bg-[#1a1a1a] px-4 py-3 text-sm text-[#f5f5f5] placeholder-[#606060] outline-none transition-colors focus:border-[#c72554]/50"
-              />
-              <button
-                type="submit"
-                className="glass-button rounded-xl px-5 py-3 text-sm font-semibold text-[#ffffff] whitespace-nowrap"
-              >
-                Notify Me
-              </button>
-            </form>
+            <>
+              <form onSubmit={handleSubmit} className="flex gap-2">
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="your@email.com"
+                  required
+                  disabled={status === "sending"}
+                  className="flex-1 rounded-xl border border-[#333333] bg-[#1a1a1a] px-4 py-3 text-sm text-[#f5f5f5] placeholder-[#606060] outline-none transition-colors focus:border-[#c72554]/50 disabled:opacity-60"
+                />
+                <button
+                  type="submit"
+                  disabled={status === "sending"}
+                  className="glass-button rounded-xl px-5 py-3 text-sm font-semibold text-[#ffffff] whitespace-nowrap disabled:opacity-60"
+                >
+                  {status === "sending" ? "Adding…" : "Notify Me"}
+                </button>
+              </form>
+              {status === "error" && (
+                <p className="mt-2 text-xs text-[#ff6b6b]">
+                  Something went wrong — please try again in a moment.
+                </p>
+              )}
+            </>
           )}
         </div>
       </div>
     </section>
-  )
+  );
 }

--- a/website/components/features-section.tsx
+++ b/website/components/features-section.tsx
@@ -1,4 +1,4 @@
-import { Flame, Smartphone, Users, Watch, Activity, Award } from "lucide-react"
+import { Flame, Smartphone, Users, Watch, Activity, Award } from "lucide-react";
 
 const topFeatures = [
   {
@@ -19,10 +19,10 @@ const topFeatures = [
     icon: Users,
     title: "Social & Friends",
     description:
-      "Add friends, see their streaks, and keep each other accountable. Nudge slackers, flex your wins, and compete head-to-head.",
+      "Share your runs to the feed, post stories, and hype your friends' miles. Nudge slackers, flex your wins, and compete head-to-head.",
     color: "#D94059",
   },
-]
+];
 
 const bottomFeatures = [
   {
@@ -39,14 +39,17 @@ const bottomFeatures = [
       "Unlock 63 medals as you hit milestones. Track your fastest mile, longest streak, and personal bests.",
     color: "#FF6B6B",
   },
-]
+];
 
 export function FeaturesSection() {
   return (
     <section
       id="features"
       className="section-lazy relative px-6 py-24"
-      style={{ background: "radial-gradient(ellipse 400px 400px at 90% 0%, rgba(139,21,56,0.04) 0%, transparent 70%)" }}
+      style={{
+        background:
+          "radial-gradient(ellipse 400px 400px at 90% 0%, rgba(139,21,56,0.04) 0%, transparent 70%)",
+      }}
     >
       <div className="relative mx-auto max-w-6xl">
         <div className="mx-auto mb-16 max-w-2xl text-center">
@@ -54,7 +57,9 @@ export function FeaturesSection() {
             Features
           </span>
           <h2 className="reveal reveal-delay-1 font-heading text-[clamp(40px,6vw,72px)] leading-none tracking-[-1px] text-[#f5f5f5]">
-            EVERYTHING YOU NEED.<br />NOTHING YOU DON&apos;T.
+            EVERYTHING YOU NEED.
+            <br />
+            NOTHING YOU DON&apos;T.
           </h2>
           <p className="reveal reveal-delay-2 mt-4 text-base leading-relaxed text-[#a0a0a0]">
             Simple by design. Powerful where it counts.
@@ -71,12 +76,21 @@ export function FeaturesSection() {
             >
               <div
                 className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl"
-                style={{ background: `linear-gradient(135deg, ${feature.color}20, ${feature.color}08)` }}
+                style={{
+                  background: `linear-gradient(135deg, ${feature.color}20, ${feature.color}08)`,
+                }}
               >
-                <feature.icon className="h-6 w-6" style={{ color: feature.color }} />
+                <feature.icon
+                  className="h-6 w-6"
+                  style={{ color: feature.color }}
+                />
               </div>
-              <h3 className="font-heading mb-2 text-[22px] tracking-[1px] text-[#f5f5f5] uppercase">{feature.title}</h3>
-              <p className="text-sm leading-relaxed text-[#a0a0a0]">{feature.description}</p>
+              <h3 className="font-heading mb-2 text-[22px] tracking-[1px] text-[#f5f5f5] uppercase">
+                {feature.title}
+              </h3>
+              <p className="text-sm leading-relaxed text-[#a0a0a0]">
+                {feature.description}
+              </p>
             </div>
           ))}
         </div>
@@ -91,7 +105,9 @@ export function FeaturesSection() {
             <div className="flex items-start gap-4 mb-4">
               <div
                 className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl"
-                style={{ background: "linear-gradient(135deg, #8b153820, #8b153808)" }}
+                style={{
+                  background: "linear-gradient(135deg, #8b153820, #8b153808)",
+                }}
               >
                 <Watch className="h-6 w-6 text-[#8b1538]" />
               </div>
@@ -100,7 +116,9 @@ export function FeaturesSection() {
                   Watch, Widgets & Live Activities
                 </h3>
                 <p className="text-sm leading-relaxed text-[#a0a0a0]">
-                  Your mile is everywhere. Start runs from your wrist, check your streak from the home screen, and track progress in the Dynamic Island.
+                  Your mile is everywhere. Start runs from your wrist, check
+                  your streak from the home screen, and track progress in the
+                  Dynamic Island.
                 </p>
               </div>
             </div>
@@ -110,20 +128,43 @@ export function FeaturesSection() {
               {/* Home screen widget mockup — the app's actual streak widget is
                   a progress ring with the day count in orange (StreakCountWidget) */}
               <div className="flex flex-col items-center gap-2">
-                <div className="h-[88px] w-[88px] rounded-[18px] border border-white/[0.08] flex items-center justify-center" style={{ background: "linear-gradient(180deg, #1a1a1a 0%, #0d0d0d 100%)" }}>
+                <div
+                  className="h-[88px] w-[88px] rounded-[18px] border border-white/[0.08] flex items-center justify-center"
+                  style={{
+                    background:
+                      "linear-gradient(180deg, #1a1a1a 0%, #0d0d0d 100%)",
+                  }}
+                >
                   <div className="relative h-[68px] w-[68px]">
                     <svg viewBox="0 0 68 68" className="h-[68px] w-[68px]">
-                      <circle cx="34" cy="34" r="30" fill="rgba(255,153,0,0.10)" stroke="rgba(128,128,128,0.2)" strokeWidth="4" />
                       <circle
-                        cx="34" cy="34" r="30" fill="none" stroke="#FF9900" strokeWidth="4" strokeLinecap="round"
+                        cx="34"
+                        cy="34"
+                        r="30"
+                        fill="rgba(255,153,0,0.10)"
+                        stroke="rgba(128,128,128,0.2)"
+                        strokeWidth="4"
+                      />
+                      <circle
+                        cx="34"
+                        cy="34"
+                        r="30"
+                        fill="none"
+                        stroke="#FF9900"
+                        strokeWidth="4"
+                        strokeLinecap="round"
                         strokeDasharray={`${2 * Math.PI * 30}`}
                         strokeDashoffset={`${2 * Math.PI * 30 * 0.25}`}
                         transform="rotate(-90 34 34)"
                       />
                     </svg>
                     <div className="absolute inset-0 flex flex-col items-center justify-center">
-                      <span className="font-heading text-[22px] leading-none text-[#FF9900]">288</span>
-                      <span className="text-[8px] font-medium text-[#FF9900]/80">days</span>
+                      <span className="font-heading text-[22px] leading-none text-[#FF9900]">
+                        288
+                      </span>
+                      <span className="text-[8px] font-medium text-[#FF9900]/80">
+                        days
+                      </span>
                     </div>
                   </div>
                 </div>
@@ -132,27 +173,55 @@ export function FeaturesSection() {
 
               {/* Watch mockup — matches app's watchOS progress ring */}
               <div className="flex flex-col items-center gap-2">
-                <div className="relative h-[100px] w-[84px] rounded-[20px] border-2 border-white/[0.08] p-2 flex flex-col items-center justify-center" style={{ background: "linear-gradient(180deg, #1a1a1a 0%, #0a0a0a 100%)" }}>
+                <div
+                  className="relative h-[100px] w-[84px] rounded-[20px] border-2 border-white/[0.08] p-2 flex flex-col items-center justify-center"
+                  style={{
+                    background:
+                      "linear-gradient(180deg, #1a1a1a 0%, #0a0a0a 100%)",
+                  }}
+                >
                   <div className="relative h-14 w-14 mb-1">
                     <svg viewBox="0 0 56 56" className="h-14 w-14">
-                      <circle cx="28" cy="28" r="23" fill="none" stroke="rgba(255,255,255,0.06)" strokeWidth="5" />
                       <circle
-                        cx="28" cy="28" r="23" fill="none" strokeWidth="5" strokeLinecap="round"
+                        cx="28"
+                        cy="28"
+                        r="23"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.06)"
+                        strokeWidth="5"
+                      />
+                      <circle
+                        cx="28"
+                        cy="28"
+                        r="23"
+                        fill="none"
+                        strokeWidth="5"
+                        strokeLinecap="round"
                         stroke="url(#watchProgress)"
                         strokeDasharray={`${2 * Math.PI * 23}`}
                         strokeDashoffset={`${2 * Math.PI * 23 * 0.25}`}
                         transform="rotate(-90 28 28)"
                       />
                       <defs>
-                        <linearGradient id="watchProgress" x1="0%" y1="0%" x2="100%" y2="0%">
+                        <linearGradient
+                          id="watchProgress"
+                          x1="0%"
+                          y1="0%"
+                          x2="100%"
+                          y2="0%"
+                        >
                           <stop offset="0%" stopColor="#D94059" />
                           <stop offset="100%" stopColor="#FF8E53" />
                         </linearGradient>
                       </defs>
                     </svg>
-                    <span className="absolute inset-0 flex items-center justify-center font-heading text-[15px] text-white">75%</span>
+                    <span className="absolute inset-0 flex items-center justify-center font-heading text-[15px] text-white">
+                      75%
+                    </span>
                   </div>
-                  <span className="text-[7px] font-medium text-white/40">0.75 / 1.0 mi</span>
+                  <span className="text-[7px] font-medium text-white/40">
+                    0.75 / 1.0 mi
+                  </span>
                 </div>
                 <span className="text-[10px] text-[#555]">Apple Watch</span>
               </div>
@@ -160,18 +229,41 @@ export function FeaturesSection() {
               {/* Dynamic Island mockup */}
               <div className="flex flex-col items-center gap-2">
                 <div className="flex items-center gap-2.5 rounded-[22px] bg-black border border-white/[0.08] px-4 py-2.5">
-                  <div className="h-7 w-7 rounded-full flex items-center justify-center" style={{ background: "linear-gradient(135deg, #D9405930, #D9405910)" }}>
+                  <div
+                    className="h-7 w-7 rounded-full flex items-center justify-center"
+                    style={{
+                      background:
+                        "linear-gradient(135deg, #D9405930, #D9405910)",
+                    }}
+                  >
                     <Activity className="h-3.5 w-3.5 text-[#D94059]" />
                   </div>
                   <div className="flex flex-col">
-                    <span className="text-[11px] font-semibold text-white leading-tight">0.75 mi</span>
-                    <span className="text-[8px] text-white/40 leading-tight">7:42 /mi</span>
+                    <span className="text-[11px] font-semibold text-white leading-tight">
+                      0.75 mi
+                    </span>
+                    <span className="text-[8px] text-white/40 leading-tight">
+                      7:42 /mi
+                    </span>
                   </div>
                   <div className="h-5 w-5 rounded-full flex items-center justify-center ml-1">
                     <svg viewBox="0 0 20 20" className="h-5 w-5">
-                      <circle cx="10" cy="10" r="8" fill="none" stroke="rgba(255,255,255,0.08)" strokeWidth="2" />
                       <circle
-                        cx="10" cy="10" r="8" fill="none" stroke="#D94059" strokeWidth="2" strokeLinecap="round"
+                        cx="10"
+                        cy="10"
+                        r="8"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.08)"
+                        strokeWidth="2"
+                      />
+                      <circle
+                        cx="10"
+                        cy="10"
+                        r="8"
+                        fill="none"
+                        stroke="#D94059"
+                        strokeWidth="2"
+                        strokeLinecap="round"
                         strokeDasharray={`${2 * Math.PI * 8}`}
                         strokeDashoffset={`${2 * Math.PI * 8 * 0.25}`}
                         transform="rotate(-90 10 10)"
@@ -194,17 +286,26 @@ export function FeaturesSection() {
               >
                 <div
                   className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl"
-                  style={{ background: `linear-gradient(135deg, ${feature.color}20, ${feature.color}08)` }}
+                  style={{
+                    background: `linear-gradient(135deg, ${feature.color}20, ${feature.color}08)`,
+                  }}
                 >
-                  <feature.icon className="h-6 w-6" style={{ color: feature.color }} />
+                  <feature.icon
+                    className="h-6 w-6"
+                    style={{ color: feature.color }}
+                  />
                 </div>
-                <h3 className="font-heading mb-2 text-[22px] tracking-[1px] text-[#f5f5f5] uppercase">{feature.title}</h3>
-                <p className="text-sm leading-relaxed text-[#a0a0a0]">{feature.description}</p>
+                <h3 className="font-heading mb-2 text-[22px] tracking-[1px] text-[#f5f5f5] uppercase">
+                  {feature.title}
+                </h3>
+                <p className="text-sm leading-relaxed text-[#a0a0a0]">
+                  {feature.description}
+                </p>
               </div>
             ))}
           </div>
         </div>
       </div>
     </section>
-  )
+  );
 }

--- a/website/components/feed-section.tsx
+++ b/website/components/feed-section.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+import { useRef, useCallback, useState } from "react";
+import {
+  Camera,
+  Clock3,
+  Heart,
+  Map,
+  Flame,
+  Plus,
+  MessageCircle,
+} from "lucide-react";
+import { ProfileAvatar } from "@/components/profile-avatar";
+import { usePublicUser } from "@/lib/public-user";
+
+// App palette (MADTheme)
+const MAD_RED = "#D94059";
+const NUDGE_ORANGE = "#FF9900";
+
+const STORY_FACES = [
+  { username: "rob", initials: "RW" },
+  { username: "dave", initials: "DS" },
+  { username: "MegsMiles", initials: "MM" },
+];
+
+function TiltCard({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const card = cardRef.current;
+    if (!card) return;
+    const rect = card.getBoundingClientRect();
+    const x = (e.clientX - rect.left) / rect.width - 0.5;
+    const y = (e.clientY - rect.top) / rect.height - 0.5;
+    card.style.transform = `perspective(600px) rotateY(${x * 8}deg) rotateX(${y * -8}deg) scale(1.01)`;
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    const card = cardRef.current;
+    if (!card) return;
+    card.style.transform =
+      "perspective(600px) rotateY(0deg) rotateX(0deg) scale(1)";
+  }, []);
+
+  return (
+    <div
+      ref={cardRef}
+      className={`transition-transform duration-200 ease-out ${className ?? ""}`}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+      style={{ transformStyle: "preserve-3d" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Story bubble with the app's red story ring. Real profile photos. */
+function StoryBubble({
+  username,
+  initials,
+  label,
+}: {
+  username: string;
+  initials: string;
+  label: string;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-1.5">
+      <div
+        className="rounded-full p-[2.5px]"
+        style={{ background: `linear-gradient(135deg, ${MAD_RED}, #ff4d7d)` }}
+      >
+        <div className="rounded-full border-2 border-[#101010] bg-[#101010]">
+          <ProfileAvatar username={username} initials={initials} size={46} />
+        </div>
+      </div>
+      <span className="text-[10px] font-medium text-white/50">{label}</span>
+    </div>
+  );
+}
+
+/** The feed post mock — a run card with route map, stats overlay, and a
+ * double-tap hype you can actually try. */
+function FeedPostCard() {
+  const rob = usePublicUser("rob");
+  const [hyped, setHyped] = useState(false);
+  const [burst, setBurst] = useState(0);
+
+  const hype = useCallback(() => {
+    setHyped(true);
+    setBurst((b) => b + 1);
+  }, []);
+
+  return (
+    <div className="overflow-hidden rounded-[20px] border border-white/[0.08] bg-[#101010]">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 py-3">
+        <ProfileAvatar username="rob" initials="RW" size={36} />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5">
+            <span className="text-sm font-bold text-white">Rob</span>
+            {rob?.currentStreak != null && (
+              <span className="flex items-center gap-0.5">
+                <Flame className="h-3 w-3" style={{ color: NUDGE_ORANGE }} />
+                <span
+                  className="text-[11px] font-extrabold"
+                  style={{ color: NUDGE_ORANGE }}
+                >
+                  {rob.currentStreak}
+                </span>
+              </span>
+            )}
+          </div>
+          <span className="text-[11px] text-white/40">
+            Morning mile · 7:04 AM
+          </span>
+        </div>
+        <span
+          className="rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider"
+          style={{
+            color: MAD_RED,
+            background: `${MAD_RED}1A`,
+            border: `1px solid ${MAD_RED}33`,
+          }}
+        >
+          Mile done
+        </span>
+      </div>
+
+      {/* Media area: photo stand-in + route + stats overlay. Double-tap (or
+          double-click) to hype, just like the app. */}
+      <div
+        className="relative aspect-[4/3] cursor-pointer select-none overflow-hidden"
+        onDoubleClick={hype}
+        style={{
+          background:
+            "linear-gradient(160deg, #2a1520 0%, #1a0f14 40%, #0d1a12 100%)",
+        }}
+      >
+        {/* Sunrise glow */}
+        <div
+          className="absolute -top-8 right-6 h-28 w-28 rounded-full opacity-30 blur-2xl"
+          style={{ background: "linear-gradient(180deg, #ff9900, #c72554)" }}
+        />
+        {/* Route polyline */}
+        <svg viewBox="0 0 320 240" className="absolute inset-0 h-full w-full">
+          <path
+            d="M 40 200 C 80 150, 70 110, 120 100 S 200 130, 230 90 S 280 40, 285 60"
+            fill="none"
+            stroke={MAD_RED}
+            strokeWidth="3.5"
+            strokeLinecap="round"
+            strokeDasharray="1 0"
+            style={{ filter: `drop-shadow(0 0 6px ${MAD_RED}AA)` }}
+          />
+          <circle cx="40" cy="200" r="5" fill="#33B34D" />
+          <circle cx="285" cy="60" r="5" fill={MAD_RED} />
+        </svg>
+        {/* Stats overlay chips — the app's customizable run-stats overlay */}
+        <div className="absolute bottom-3 left-3 flex gap-2">
+          {[
+            { label: "Distance", value: "1.24 mi" },
+            { label: "Pace", value: "8:41 /mi" },
+            { label: "Time", value: "10:46" },
+          ].map((stat) => (
+            <div
+              key={stat.label}
+              className="rounded-lg border border-white/10 bg-black/50 px-2.5 py-1.5 backdrop-blur-md"
+            >
+              <div className="text-[11px] font-bold leading-none text-white">
+                {stat.value}
+              </div>
+              <div className="mt-0.5 text-[8px] uppercase tracking-wider text-white/50">
+                {stat.label}
+              </div>
+            </div>
+          ))}
+        </div>
+        {/* Double-tap heart burst */}
+        {burst > 0 && (
+          <div
+            key={burst}
+            className="pointer-events-none absolute inset-0 flex items-center justify-center"
+          >
+            <Heart
+              className="h-20 w-20 animate-ping"
+              style={{
+                color: MAD_RED,
+                fill: MAD_RED,
+                animationIterationCount: 1,
+                animationDuration: "0.7s",
+              }}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Action row */}
+      <div className="flex items-center gap-4 px-4 py-3">
+        <button
+          onClick={hype}
+          className="flex items-center gap-1.5 transition-transform active:scale-90"
+          aria-label="Hype this run"
+        >
+          <Heart
+            className="h-5 w-5 transition-colors"
+            style={
+              hyped
+                ? { color: MAD_RED, fill: MAD_RED }
+                : { color: "rgba(255,255,255,0.6)" }
+            }
+          />
+          <span
+            className="text-xs font-semibold"
+            style={{ color: hyped ? MAD_RED : "rgba(255,255,255,0.6)" }}
+          >
+            {hyped ? 13 : 12}
+          </span>
+        </button>
+        <span className="flex items-center gap-1.5 text-white/40">
+          <MessageCircle
+            className="h-4.5 w-4.5"
+            style={{ width: 18, height: 18 }}
+          />
+          <span className="text-xs font-semibold">3</span>
+        </span>
+        <span className="ml-auto text-[10px] text-white/30">
+          Double-tap the photo — go on, try it
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function FeedSection() {
+  return (
+    <section className="section-lazy relative overflow-hidden px-6 py-24">
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            "radial-gradient(ellipse 700px 500px at 85% 30%, rgba(217,64,89,0.07) 0%, transparent 70%)",
+        }}
+      />
+      <div className="relative mx-auto max-w-6xl">
+        <div className="grid gap-12 lg:grid-cols-2 lg:items-center">
+          {/* Left: copy */}
+          <div>
+            <span className="reveal mb-4 inline-block rounded-full border border-[#c72554]/30 bg-[#c72554]/10 px-3 py-1 text-sm font-semibold uppercase tracking-widest text-[#c72554]">
+              New — The Feed
+            </span>
+            <h2 className="reveal reveal-delay-1 font-heading text-[clamp(40px,6vw,72px)] leading-[0.95] tracking-[-1px] text-[#f5f5f5]">
+              EVERY MILE
+              <br />
+              TELLS A <span className="text-[#c72554]">STORY</span>
+            </h2>
+            <p className="reveal reveal-delay-2 mt-5 max-w-lg text-[17px] leading-relaxed text-[#a0a0a0]">
+              Your daily mile deserves more than a checkmark. Share the run —
+              the photo, the route, the stats — and watch your friends show up
+              in the comments and the hypes.
+            </p>
+
+            <div className="reveal reveal-delay-3 mt-8 space-y-4">
+              {[
+                {
+                  icon: Camera,
+                  color: MAD_RED,
+                  title: "Snap it in the moment",
+                  desc: "A photo prompt after every run — or grab the shot mid-mile and decide later.",
+                },
+                {
+                  icon: Clock3,
+                  color: NUDGE_ORANGE,
+                  title: "Stories for the moment, feed for the record",
+                  desc: "Stories vanish after 24 hours. Your feed keeps every mile you've shared.",
+                },
+                {
+                  icon: Heart,
+                  color: "#ff4d7d",
+                  title: "Double-tap to hype",
+                  desc: "Cheer every mile. Hypes land as notifications your friends actually want.",
+                },
+                {
+                  icon: Map,
+                  color: "#33B34D",
+                  title: "Your route, your call",
+                  desc: "Show off the loop with a route map on your post — or keep it private with one toggle.",
+                },
+              ].map((item) => (
+                <div key={item.title} className="flex items-start gap-4">
+                  <div
+                    className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-xl"
+                    style={{
+                      background: `${item.color}1A`,
+                      border: `1px solid ${item.color}33`,
+                    }}
+                  >
+                    <item.icon
+                      className="h-4.5 w-4.5"
+                      style={{ width: 18, height: 18, color: item.color }}
+                    />
+                  </div>
+                  <div>
+                    <div className="text-[15px] font-bold text-[#f5f5f5]">
+                      {item.title}
+                    </div>
+                    <div className="mt-0.5 text-sm leading-relaxed text-[#a0a0a0]">
+                      {item.desc}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Right: interactive feed mock */}
+          <div className="reveal-right mx-auto w-full max-w-md">
+            <TiltCard>
+              <div className="rounded-[24px] border border-white/[0.08] bg-[#0d0d0d] p-4 shadow-[0_30px_80px_rgba(0,0,0,0.5)]">
+                {/* Stories rail */}
+                <div className="mb-4 flex items-center gap-4 px-1">
+                  <div className="flex flex-col items-center gap-1.5">
+                    <div className="flex h-[51px] w-[51px] items-center justify-center rounded-full border-2 border-dashed border-white/20">
+                      <Plus className="h-5 w-5 text-white/40" />
+                    </div>
+                    <span className="text-[10px] font-medium text-white/50">
+                      Your story
+                    </span>
+                  </div>
+                  {STORY_FACES.map((face) => (
+                    <StoryBubble
+                      key={face.username}
+                      username={face.username}
+                      initials={face.initials}
+                      label={
+                        face.username === "MegsMiles"
+                          ? "Megs"
+                          : face.username === "dave"
+                            ? "David"
+                            : "Rob"
+                      }
+                    />
+                  ))}
+                </div>
+
+                <FeedPostCard />
+              </div>
+            </TiltCard>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/components/live-stats-band.tsx
+++ b/website/components/live-stats-band.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Route, Flame, Heart, Bell } from "lucide-react";
+
+const API_URL =
+  process.env.NEXT_PUBLIC_API_URL || "https://mad.mindgoblin.tech";
+const STATS_URL = `${API_URL}/public/stats`;
+const POLL_MS = 60_000;
+
+type PublicStats = {
+  total_users: number;
+  total_miles: number;
+  miles_today: number;
+  total_hypes: number;
+  total_nudges: number;
+};
+
+/** Eases a displayed number toward `target` — same feel as the community
+ * counter. Handles decimals so "miles today" can animate to e.g. 41.3. */
+function useCountUp(target: number | null, decimals = 0) {
+  const [display, setDisplay] = useState(0);
+  const displayRef = useRef(0);
+
+  useEffect(() => {
+    if (target === null || displayRef.current === target) return;
+    const from = displayRef.current;
+    const duration = 1600;
+    const start = performance.now();
+    const factor = Math.pow(10, decimals);
+    let frame: number;
+    const tick = (now: number) => {
+      const t = Math.min((now - start) / duration, 1);
+      const eased = 1 - Math.pow(1 - t, 3);
+      const val =
+        Math.round((from + (target - from) * eased) * factor) / factor;
+      displayRef.current = val;
+      setDisplay(val);
+      if (t < 1) frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, [target, decimals]);
+
+  return display;
+}
+
+function StatCard({
+  icon: Icon,
+  color,
+  value,
+  suffix,
+  label,
+  sublabel,
+  delay,
+}: {
+  icon: typeof Route;
+  color: string;
+  value: string;
+  suffix?: string;
+  label: string;
+  sublabel: string;
+  delay: number;
+}) {
+  return (
+    <div
+      className={`reveal reveal-delay-${delay} group relative overflow-hidden rounded-3xl border border-white/[0.07] bg-white/[0.03] px-6 py-7 text-center backdrop-blur-xl transition-all duration-300 hover:-translate-y-1`}
+      style={{ boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)" }}
+    >
+      {/* Accent glow that breathes on hover */}
+      <div
+        className="pointer-events-none absolute -top-10 left-1/2 h-24 w-24 -translate-x-1/2 rounded-full opacity-[0.12] blur-2xl transition-opacity duration-300 group-hover:opacity-30"
+        style={{ background: color }}
+      />
+      <div
+        className="relative mx-auto mb-4 flex h-11 w-11 items-center justify-center rounded-2xl"
+        style={{ background: `${color}1F`, border: `1px solid ${color}33` }}
+      >
+        <Icon className="h-5 w-5" style={{ color }} />
+      </div>
+      <div className="relative font-heading text-[clamp(34px,4.5vw,52px)] leading-none tracking-[0.5px] text-[#f5f5f5] tabular-nums">
+        {value}
+        {suffix && (
+          <span className="ml-1 text-[0.45em] text-[#a0a0a0]">{suffix}</span>
+        )}
+      </div>
+      <div className="relative mt-2 text-sm font-semibold text-[#f5f5f5]/90">
+        {label}
+      </div>
+      <div className="relative mt-0.5 text-xs text-[#a0a0a0]">{sublabel}</div>
+    </div>
+  );
+}
+
+/** Live community counters — real numbers straight from the Mile A Day API
+ * (global aggregates only), refreshed every minute with an animated count-up
+ * so the page always shows the movement moving. */
+export function LiveStatsBand() {
+  const [stats, setStats] = useState<PublicStats | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const res = await fetch(STATS_URL, { cache: "no-store" });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as PublicStats;
+        if (!cancelled && typeof data.total_miles === "number") setStats(data);
+      } catch {
+        // Fail silently — the band just doesn't render.
+      }
+    };
+    load();
+    const id = setInterval(load, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  const totalMiles = useCountUp(stats ? stats.total_miles : null);
+  const milesToday = useCountUp(stats ? stats.miles_today : null, 1);
+  const hypes = useCountUp(stats ? stats.total_hypes : null);
+  const nudges = useCountUp(stats ? stats.total_nudges : null);
+
+  if (stats === null) return null;
+
+  return (
+    <section
+      className="section-lazy relative px-6 py-20"
+      style={{
+        background:
+          "radial-gradient(ellipse 800px 400px at 50% 0%, rgba(199,37,84,0.06) 0%, transparent 70%)",
+      }}
+    >
+      <div className="relative mx-auto max-w-6xl">
+        <div className="mx-auto mb-12 max-w-2xl text-center">
+          <span className="reveal mb-4 inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-widest text-[#c72554]">
+            <span className="relative flex h-2.5 w-2.5">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[#33B34D] opacity-75" />
+              <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-[#33B34D]" />
+            </span>
+            Live from the community
+          </span>
+          <h2 className="reveal reveal-delay-1 font-heading text-[clamp(40px,6vw,72px)] leading-none tracking-[-1px] text-[#f5f5f5]">
+            THE MILES ARE <span className="text-[#c72554]">ADDING UP</span>
+          </h2>
+          <p className="reveal reveal-delay-2 mt-4 text-base leading-relaxed text-[#a0a0a0]">
+            Real numbers from real runners — updating as the community moves.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-4 lg:gap-6">
+          <StatCard
+            icon={Route}
+            color="#c72554"
+            value={Math.round(totalMiles).toLocaleString()}
+            suffix="mi"
+            label="Total miles logged"
+            sublabel="every single one earned"
+            delay={1}
+          />
+          <StatCard
+            icon={Flame}
+            color="#33B34D"
+            value={milesToday.toLocaleString(undefined, {
+              minimumFractionDigits: 1,
+              maximumFractionDigits: 1,
+            })}
+            suffix="mi"
+            label="Miles today"
+            sublabel="and the day isn't over"
+            delay={2}
+          />
+          <StatCard
+            icon={Heart}
+            color="#D94059"
+            value={Math.round(hypes).toLocaleString()}
+            label="Hypes sent"
+            sublabel="double-taps of pure support"
+            delay={3}
+          />
+          <StatCard
+            icon={Bell}
+            color="#FF9900"
+            value={Math.round(nudges).toLocaleString()}
+            label="Nudges delivered"
+            sublabel="friendly kicks off the couch"
+            delay={4}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/components/scroll-reveal.tsx
+++ b/website/components/scroll-reveal.tsx
@@ -1,6 +1,8 @@
-"use client"
+"use client";
 
-import { useEffect } from "react"
+import { useEffect } from "react";
+
+const REVEAL_SELECTOR = ".reveal, .reveal-left, .reveal-right, .reveal-scale";
 
 export function ScrollReveal() {
   useEffect(() => {
@@ -8,17 +10,41 @@ export function ScrollReveal() {
       (entries) => {
         entries.forEach((entry) => {
           if (entry.isIntersecting) {
-            entry.target.classList.add("visible")
+            entry.target.classList.add("visible");
           }
-        })
+        });
       },
-      { threshold: 0.1, rootMargin: "0px 0px -40px 0px" }
-    )
+      { threshold: 0.1, rootMargin: "0px 0px -40px 0px" },
+    );
 
-    document.querySelectorAll(".reveal, .reveal-left, .reveal-right, .reveal-scale").forEach((el) => observer.observe(el))
+    const observeWithin = (root: ParentNode) => {
+      root
+        .querySelectorAll(REVEAL_SELECTOR)
+        .forEach((el) => observer.observe(el));
+    };
 
-    return () => observer.disconnect()
-  }, [])
+    observeWithin(document);
 
-  return null
+    // Components driven by live data (community count, stats band) mount their
+    // reveal elements AFTER this initial scan — without re-observing them they
+    // stay at the reveal classes' opacity:0 forever. Watch the DOM for
+    // late-mounted reveal elements and observe those too.
+    const mutations = new MutationObserver((records) => {
+      for (const record of records) {
+        record.addedNodes.forEach((node) => {
+          if (!(node instanceof Element)) return;
+          if (node.matches(REVEAL_SELECTOR)) observer.observe(node);
+          observeWithin(node);
+        });
+      }
+    });
+    mutations.observe(document.body, { childList: true, subtree: true });
+
+    return () => {
+      observer.disconnect();
+      mutations.disconnect();
+    };
+  }, []);
+
+  return null;
 }

--- a/website/components/social-section.tsx
+++ b/website/components/social-section.tsx
@@ -1,27 +1,39 @@
-"use client"
+"use client";
 
-import { useRef, useCallback } from "react"
-import { Flame, Bell, Share2, Check, ChevronRight } from "lucide-react"
-import { ProfileAvatar } from "@/components/profile-avatar"
-import { usePublicUser } from "@/lib/public-user"
+import { useRef, useCallback } from "react";
+import { Flame, Bell, Share2, Check, ChevronRight } from "lucide-react";
+import { ProfileAvatar } from "@/components/profile-avatar";
+import { usePublicUser } from "@/lib/public-user";
 
 // App palette (MADTheme): madRed #D94059, success #33B34D, warning #FF9900.
-const MAD_RED = "#D94059"
-const SUCCESS_GREEN = "#33B34D"
-const NUDGE_ORANGE = "#FF9900"
+const MAD_RED = "#D94059";
+const SUCCESS_GREEN = "#33B34D";
+const NUDGE_ORANGE = "#FF9900";
 
 // Real Mile A Day accounts. The profile picture and streak are pulled LIVE from
 // the public API (see usePublicUser) so the demo reflects real people. The
 // per-day progress/miles are illustrative — that data isn't exposed publicly.
 const cheerFriends = [
-  { name: "Aaron", username: "Aaron", progress: 0.55, milesToday: 0.55, avatar: "AA" },
-  { name: "Megs", username: "MegsMiles", progress: 0.2, milesToday: 0.2, avatar: "MM" },
-]
+  {
+    name: "Aaron",
+    username: "Aaron",
+    progress: 0.55,
+    milesToday: 0.55,
+    avatar: "AA",
+  },
+  {
+    name: "Megs",
+    username: "MegsMiles",
+    progress: 0.2,
+    milesToday: 0.2,
+    avatar: "MM",
+  },
+];
 
 const doneFriends = [
   { name: "David", username: "dave", milesToday: 1.3, avatar: "DS" },
   { name: "MAD", username: "mad", milesToday: 1.0, avatar: "M" },
-]
+];
 
 /** Avatar with progress ring — mirrors the app's AvatarWithRing component:
  * orange arc while in progress, solid green ring + check badge when done. */
@@ -31,20 +43,32 @@ function AvatarRing({
   size = 52,
   username,
 }: {
-  initials: string
-  progress: number
-  size?: number
-  username?: string
+  initials: string;
+  progress: number;
+  size?: number;
+  username?: string;
 }) {
-  const complete = progress >= 1
-  const r = size / 2 - 3
-  const circumference = 2 * Math.PI * r
-  const ringColor = complete ? SUCCESS_GREEN : NUDGE_ORANGE
+  const complete = progress >= 1;
+  const r = size / 2 - 3;
+  const circumference = 2 * Math.PI * r;
+  const ringColor = complete ? SUCCESS_GREEN : NUDGE_ORANGE;
 
   return (
     <div className="relative shrink-0" style={{ width: size, height: size }}>
-      <svg viewBox={`0 0 ${size} ${size}`} width={size} height={size} className="-rotate-90">
-        <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="rgba(255,255,255,0.08)" strokeWidth="3" />
+      <svg
+        viewBox={`0 0 ${size} ${size}`}
+        width={size}
+        height={size}
+        className="-rotate-90"
+      >
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          stroke="rgba(255,255,255,0.08)"
+          strokeWidth="3"
+        />
         <circle
           cx={size / 2}
           cy={size / 2}
@@ -72,33 +96,46 @@ function AvatarRing({
         </div>
       )}
     </div>
-  )
+  );
 }
 
 /** Streak flame + count, orange like the app's friend rows. Renders nothing
  * until the real streak loads so we never flash a placeholder number. */
 function StreakFlame({ streak }: { streak: number | null }) {
-  if (streak === null) return null
+  if (streak === null) return null;
   return (
     <span className="flex items-center gap-0.5">
       <Flame className="h-3 w-3" style={{ color: NUDGE_ORANGE }} />
-      <span className="text-[11px] font-extrabold" style={{ color: NUDGE_ORANGE }}>
+      <span
+        className="text-[11px] font-extrabold"
+        style={{ color: NUDGE_ORANGE }}
+      >
         {streak}
       </span>
     </span>
-  )
+  );
 }
 
-type Friend = { name: string; username: string; progress?: number; milesToday: number; avatar: string }
+type Friend = {
+  name: string;
+  username: string;
+  progress?: number;
+  milesToday: number;
+  avatar: string;
+};
 
 /** Friend who hasn't finished their mile yet — real photo + live streak,
  * with a "Nudge" button mirroring the app's Cheer Them On row. */
 function CheerRow({ friend }: { friend: Friend }) {
-  const user = usePublicUser(friend.username)
-  const progress = friend.progress ?? 0
+  const user = usePublicUser(friend.username);
+  const progress = friend.progress ?? 0;
   return (
     <div className="flex items-center gap-3 rounded-[12px] px-2 py-2">
-      <AvatarRing initials={friend.avatar} progress={progress} username={friend.username} />
+      <AvatarRing
+        initials={friend.avatar}
+        progress={progress}
+        username={friend.username}
+      />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1.5">
           <span className="text-sm font-bold text-white">{friend.name}</span>
@@ -121,15 +158,19 @@ function CheerRow({ friend }: { friend: Friend }) {
         <span className="text-[11px] font-semibold">Nudge</span>
       </button>
     </div>
-  )
+  );
 }
 
 /** Friend who hit their goal today — real photo + live streak, green ring. */
 function DoneRow({ friend }: { friend: Friend }) {
-  const user = usePublicUser(friend.username)
+  const user = usePublicUser(friend.username);
   return (
     <div className="flex items-center gap-3 rounded-[12px] px-2 py-2">
-      <AvatarRing initials={friend.avatar} progress={1} username={friend.username} />
+      <AvatarRing
+        initials={friend.avatar}
+        progress={1}
+        username={friend.username}
+      />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1.5">
           <span className="text-sm font-bold text-white">{friend.name}</span>
@@ -141,35 +182,54 @@ function DoneRow({ friend }: { friend: Friend }) {
       </div>
       <ChevronRight className="h-3.5 w-3.5 text-white/30" />
     </div>
-  )
+  );
 }
 
-function SectionHeader({ title, trailing }: { title: string; trailing?: string }) {
+function SectionHeader({
+  title,
+  trailing,
+}: {
+  title: string;
+  trailing?: string;
+}) {
   return (
     <div className="flex items-center justify-between px-1">
-      <span className="text-[11px] font-extrabold uppercase tracking-[1.4px] text-white/40">{title}</span>
-      {trailing && <span className="text-[11px] font-semibold text-white/40">{trailing}</span>}
+      <span className="text-[11px] font-extrabold uppercase tracking-[1.4px] text-white/40">
+        {title}
+      </span>
+      {trailing && (
+        <span className="text-[11px] font-semibold text-white/40">
+          {trailing}
+        </span>
+      )}
     </div>
-  )
+  );
 }
 
-function TiltCard({ children, className }: { children: React.ReactNode; className?: string }) {
-  const cardRef = useRef<HTMLDivElement>(null)
+function TiltCard({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const cardRef = useRef<HTMLDivElement>(null);
 
   const handleMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    const card = cardRef.current
-    if (!card) return
-    const rect = card.getBoundingClientRect()
-    const x = (e.clientX - rect.left) / rect.width - 0.5
-    const y = (e.clientY - rect.top) / rect.height - 0.5
-    card.style.transform = `perspective(600px) rotateY(${x * 8}deg) rotateX(${y * -8}deg) scale(1.01)`
-  }, [])
+    const card = cardRef.current;
+    if (!card) return;
+    const rect = card.getBoundingClientRect();
+    const x = (e.clientX - rect.left) / rect.width - 0.5;
+    const y = (e.clientY - rect.top) / rect.height - 0.5;
+    card.style.transform = `perspective(600px) rotateY(${x * 8}deg) rotateX(${y * -8}deg) scale(1.01)`;
+  }, []);
 
   const handleMouseLeave = useCallback(() => {
-    const card = cardRef.current
-    if (!card) return
-    card.style.transform = "perspective(600px) rotateY(0deg) rotateX(0deg) scale(1)"
-  }, [])
+    const card = cardRef.current;
+    if (!card) return;
+    card.style.transform =
+      "perspective(600px) rotateY(0deg) rotateX(0deg) scale(1)";
+  }, []);
 
   return (
     <div
@@ -181,7 +241,7 @@ function TiltCard({ children, className }: { children: React.ReactNode; classNam
     >
       {children}
     </div>
-  )
+  );
 }
 
 export function SocialSection() {
@@ -196,7 +256,8 @@ export function SocialSection() {
             FLEX ON YOUR FRIENDS
           </h2>
           <p className="reveal reveal-delay-2 mt-4 text-base leading-relaxed text-[#a0a0a0]">
-            See who&apos;s slacking. Nudge them. Or flex your streak and let them know who shows up every day.
+            See who&apos;s slacking. Nudge them. Hype the ones who showed up. Or
+            flex your streak and let them know who does this every single day.
           </p>
         </div>
 
@@ -204,47 +265,77 @@ export function SocialSection() {
           {/* Left: Streak share card — matches app's goal-completed celebration */}
           <div className="reveal-left">
             <TiltCard>
-              <div className="rounded-[20px] overflow-hidden border border-white/[0.08]" style={{ background: "linear-gradient(180deg, rgba(217,64,89,0.15) 0%, rgba(10,10,10,0.95) 50%)" }}>
+              <div
+                className="rounded-[20px] overflow-hidden border border-white/[0.08]"
+                style={{
+                  background:
+                    "linear-gradient(180deg, rgba(217,64,89,0.15) 0%, rgba(10,10,10,0.95) 50%)",
+                }}
+              >
                 {/* Celebration header */}
                 <div className="relative px-6 pt-8 pb-4 text-center overflow-hidden">
                   {/* Glow */}
                   <div className="absolute inset-0 flex items-start justify-center">
-                    <div className="h-32 w-32 rounded-full opacity-20 blur-3xl" style={{ background: MAD_RED }} />
+                    <div
+                      className="h-32 w-32 rounded-full opacity-20 blur-3xl"
+                      style={{ background: MAD_RED }}
+                    />
                   </div>
                   {/* Flame */}
                   <div className="relative mb-3 inline-flex h-16 w-16 items-center justify-center">
-                    <Flame className="h-12 w-12 drop-shadow-[0_0_15px_rgba(217,64,89,0.6)]" style={{ color: MAD_RED }} />
+                    <Flame
+                      className="h-12 w-12 drop-shadow-[0_0_15px_rgba(217,64,89,0.6)]"
+                      style={{ color: MAD_RED }}
+                    />
                   </div>
-                  <div className="relative font-heading text-[64px] leading-none text-white">288</div>
-                  <div className="relative font-heading text-[22px] tracking-[1px] text-white/80">day streak!</div>
+                  <div className="relative font-heading text-[64px] leading-none text-white">
+                    288
+                  </div>
+                  <div className="relative font-heading text-[22px] tracking-[1px] text-white/80">
+                    day streak!
+                  </div>
                 </div>
 
                 {/* Week calendar — every past day completed (the streak is alive) */}
                 <div className="flex justify-center gap-2.5 px-6 py-4">
                   {["S", "M", "T", "W", "T", "F", "S"].map((day, i) => {
-                    const isToday = i === 4
-                    const isPast = i < 4
+                    const isToday = i === 4;
+                    const isPast = i < 4;
                     return (
-                      <div key={`${day}-${i}`} className="flex flex-col items-center gap-1">
-                        <span className="text-[10px] font-bold text-white/40">{day}</span>
+                      <div
+                        key={`${day}-${i}`}
+                        className="flex flex-col items-center gap-1"
+                      >
+                        <span className="text-[10px] font-bold text-white/40">
+                          {day}
+                        </span>
                         <div
                           className="flex h-9 w-9 items-center justify-center rounded-full"
                           style={
                             isToday
-                              ? { background: MAD_RED, boxShadow: "0 0 12px rgba(217,64,89,0.5)" }
+                              ? {
+                                  background: MAD_RED,
+                                  boxShadow: "0 0 12px rgba(217,64,89,0.5)",
+                                }
                               : isPast
-                              ? { border: `1px solid ${SUCCESS_GREEN}66`, background: `${SUCCESS_GREEN}1A` }
-                              : { border: "1px solid rgba(255,255,255,0.1)" }
+                                ? {
+                                    border: `1px solid ${SUCCESS_GREEN}66`,
+                                    background: `${SUCCESS_GREEN}1A`,
+                                  }
+                                : { border: "1px solid rgba(255,255,255,0.1)" }
                           }
                         >
                           {isToday ? (
                             <Flame className="h-4 w-4 text-white" />
                           ) : isPast ? (
-                            <Check className="h-4 w-4" style={{ color: SUCCESS_GREEN }} />
+                            <Check
+                              className="h-4 w-4"
+                              style={{ color: SUCCESS_GREEN }}
+                            />
                           ) : null}
                         </div>
                       </div>
-                    )
+                    );
                   })}
                 </div>
 
@@ -255,18 +346,30 @@ export function SocialSection() {
                     { label: "Pace", value: "7:42/mi" },
                     { label: "Calories", value: "142" },
                   ].map((stat) => (
-                    <div key={stat.label} className="rounded-xl bg-white/[0.04] border border-white/[0.06] px-3 py-2 text-center">
-                      <div className="text-xs font-semibold text-white">{stat.value}</div>
-                      <div className="text-[9px] text-white/40 uppercase tracking-wider">{stat.label}</div>
+                    <div
+                      key={stat.label}
+                      className="rounded-xl bg-white/[0.04] border border-white/[0.06] px-3 py-2 text-center"
+                    >
+                      <div className="text-xs font-semibold text-white">
+                        {stat.value}
+                      </div>
+                      <div className="text-[9px] text-white/40 uppercase tracking-wider">
+                        {stat.label}
+                      </div>
                     </div>
                   ))}
                 </div>
 
                 {/* Share button */}
                 <div className="px-6 pb-6">
-                  <div className="flex items-center justify-center gap-2 rounded-2xl py-3 cursor-default" style={{ background: MAD_RED }}>
+                  <div
+                    className="flex items-center justify-center gap-2 rounded-2xl py-3 cursor-default"
+                    style={{ background: MAD_RED }}
+                  >
                     <Share2 className="h-4 w-4 text-white" />
-                    <span className="text-sm font-semibold text-white">Share Your Streak</span>
+                    <span className="text-sm font-semibold text-white">
+                      Share Your Streak
+                    </span>
                   </div>
                 </div>
               </div>
@@ -284,7 +387,10 @@ export function SocialSection() {
             </div>
 
             {/* DONE TODAY — friends who hit their goal */}
-            <SectionHeader title="Done Today" trailing={`${doneFriends.length} of ${doneFriends.length + cheerFriends.length}`} />
+            <SectionHeader
+              title="Done Today"
+              trailing={`${doneFriends.length} of ${doneFriends.length + cheerFriends.length}`}
+            />
             <div className="space-y-1.5 rounded-[16px] border border-white/[0.05] bg-white/[0.03] p-2">
               {doneFriends.map((friend) => (
                 <DoneRow key={friend.username} friend={friend} />
@@ -294,17 +400,27 @@ export function SocialSection() {
             {/* Flex hint */}
             <div
               className="flex items-center gap-2 rounded-[16px] px-4 py-3"
-              style={{ border: `1px solid ${MAD_RED}33`, background: `${MAD_RED}0F` }}
+              style={{
+                border: `1px solid ${MAD_RED}33`,
+                background: `${MAD_RED}0F`,
+              }}
             >
               <Flame className="h-4 w-4" style={{ color: MAD_RED }} />
               <span className="flex-1 text-sm text-white/50">
-                Tap a friend to <span className="font-semibold" style={{ color: MAD_RED }}>flex your streak</span> on them
+                Tap a friend to{" "}
+                <span className="font-semibold" style={{ color: MAD_RED }}>
+                  flex your streak
+                </span>{" "}
+                on them
               </span>
-              <ChevronRight className="h-4 w-4" style={{ color: `${MAD_RED}80` }} />
+              <ChevronRight
+                className="h-4 w-4"
+                style={{ color: `${MAD_RED}80` }}
+              />
             </div>
           </div>
         </div>
       </div>
     </section>
-  )
+  );
 }

--- a/website/components/story-section.tsx
+++ b/website/components/story-section.tsx
@@ -1,43 +1,49 @@
-"use client"
+"use client";
 
-import Image from "next/image"
-import { useEffect, useState } from "react"
+import Image from "next/image";
+import { useEffect, useState } from "react";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://mad.mindgoblin.tech"
+const API_URL =
+  process.env.NEXT_PUBLIC_API_URL || "https://mad.mindgoblin.tech";
 
 function getStreakDays(): number {
-  const start = new Date(2025, 4, 13) // May 13, 2025
-  const now = new Date()
-  const diff = now.getTime() - start.getTime()
-  return Math.floor(diff / (1000 * 60 * 60 * 24))
+  const start = new Date(2025, 4, 13); // May 13, 2025
+  const now = new Date();
+  const diff = now.getTime() - start.getTime();
+  return Math.floor(diff / (1000 * 60 * 60 * 24));
 }
 
 async function getProfileImageUrl(username: string): Promise<string | null> {
   try {
-    const res = await fetch(`${API_URL}/public/profile-image/${username}`)
-    if (!res.ok) return null
-    const data = await res.json()
-    return data.profile_image_url ? `${API_URL}${data.profile_image_url}` : null
+    const res = await fetch(`${API_URL}/public/profile-image/${username}`);
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.profile_image_url
+      ? `${API_URL}${data.profile_image_url}`
+      : null;
   } catch {
-    return null
+    return null;
   }
 }
 
 export function StorySection() {
-  const streakDays = getStreakDays()
-  const [robImage, setRobImage] = useState<string | null>(null)
-  const [daveImage, setDaveImage] = useState<string | null>(null)
+  const streakDays = getStreakDays();
+  const [robImage, setRobImage] = useState<string | null>(null);
+  const [daveImage, setDaveImage] = useState<string | null>(null);
 
   useEffect(() => {
-    getProfileImageUrl("rob").then(setRobImage)
-    getProfileImageUrl("dave").then(setDaveImage)
-  }, [])
+    getProfileImageUrl("rob").then(setRobImage);
+    getProfileImageUrl("dave").then(setDaveImage);
+  }, []);
 
   return (
     <section
       id="story"
       className="section-lazy relative px-6 py-24"
-      style={{ background: "radial-gradient(ellipse 350px 350px at 0% 15%, rgba(199,37,84,0.04) 0%, transparent 70%)" }}
+      style={{
+        background:
+          "radial-gradient(ellipse 350px 350px at 0% 15%, rgba(199,37,84,0.04) 0%, transparent 70%)",
+      }}
     >
       <div className="relative mx-auto grid max-w-6xl gap-12 lg:grid-cols-2 lg:gap-20 items-center">
         {/* Left column: narrative */}
@@ -46,29 +52,34 @@ export function StorySection() {
             Our Story
           </span>
           <h2 className="reveal-left reveal-delay-1 font-heading text-[clamp(40px,6vw,72px)] leading-none tracking-[-1px] text-[#f5f5f5] mb-6">
-            IT STARTED WITH<br />A STUPID BET
+            IT STARTED WITH
+            <br />A STUPID BET
           </h2>
           <p className="reveal-left reveal-delay-2 text-[17px] leading-[1.8] text-[#a0a0a0] mb-5">
-            <span className="font-semibold text-[#f5f5f5]">Rob Wiscount</span> and{" "}
-            <span className="font-semibold text-[#f5f5f5]">David Simmerman</span> made a simple
-            challenge: walk or run one mile every single day. Whoever broke first had to buy the
-            other a Call of Duty skin. That was it. No grand vision. No business plan. Just two
-            competitive guys who refused to lose.
+            <span className="font-semibold text-[#f5f5f5]">Rob Wiscount</span>{" "}
+            and{" "}
+            <span className="font-semibold text-[#f5f5f5]">
+              David Simmerman
+            </span>{" "}
+            made a simple challenge: walk or run one mile every single day.
+            Whoever broke first had to buy the other a Call of Duty skin. That
+            was it. No grand vision. No business plan. Just two competitive guys
+            who refused to lose.
           </p>
 
           {/* Blockquote */}
           <div className="reveal-left reveal-delay-3 rounded-r-2xl border-l-4 border-l-[#c72554] bg-[#1a1a1a]/50 p-6 my-7">
             <p className="text-[17px] font-medium italic leading-[1.7] text-[#f5f5f5]">
-              &ldquo;We&apos;re closing in on a full year without breaking. What started as a dumb
-              CoD skin bet became the best habit either of us ever built — so we turned it into an
-              app.&rdquo;
+              &ldquo;We&apos;re over 400 days in without missing a single one.
+              What started as a dumb CoD skin bet became the best habit either
+              of us ever built — so we turned it into an app.&rdquo;
             </p>
           </div>
 
           <p className="reveal-left reveal-delay-4 text-[17px] leading-[1.8] text-[#a0a0a0]">
-            Mile A Day isn&apos;t backed by venture capital. We&apos;re not in this for the money. We
-            built this because this challenge genuinely changed our lives, and we think it can change
-            yours too.
+            Mile A Day isn&apos;t backed by venture capital. We&apos;re not in
+            this for the money. We built this because this challenge genuinely
+            changed our lives, and we think it can change yours too.
           </p>
         </div>
 
@@ -92,8 +103,12 @@ export function StorySection() {
                 )}
               </div>
               <div>
-                <div className="text-[15px] font-semibold text-[#f5f5f5]">Rob Wiscount</div>
-                <div className="text-xs text-[#c72554]">Co-Founder & Developer</div>
+                <div className="text-[15px] font-semibold text-[#f5f5f5]">
+                  Rob Wiscount
+                </div>
+                <div className="text-xs text-[#c72554]">
+                  Co-Founder & Developer
+                </div>
               </div>
             </div>
             <div className="flex items-center gap-3">
@@ -109,8 +124,12 @@ export function StorySection() {
                 )}
               </div>
               <div>
-                <div className="text-[15px] font-semibold text-[#f5f5f5]">David Simmerman</div>
-                <div className="text-xs text-[#c72554]">Co-Founder & Developer</div>
+                <div className="text-[15px] font-semibold text-[#f5f5f5]">
+                  David Simmerman
+                </div>
+                <div className="text-xs text-[#c72554]">
+                  Co-Founder & Developer
+                </div>
               </div>
             </div>
           </div>
@@ -119,15 +138,16 @@ export function StorySection() {
             THE COD SKIN BET
           </h3>
           <p className="text-[15px] leading-[1.8] text-[#a0a0a0] mb-3">
-            It was supposed to be a quick thing. &ldquo;Let&apos;s see who breaks first — loser buys
-            a Call of Duty skin.&rdquo; Days turned into weeks. Weeks turned into months. Neither of
-            us would quit.
+            It was supposed to be a quick thing. &ldquo;Let&apos;s see who
+            breaks first — loser buys a Call of Duty skin.&rdquo; Days turned
+            into weeks. Weeks turned into months. Neither of us would quit.
           </p>
           <p className="text-[15px] leading-[1.8] text-[#a0a0a0] mb-3">
-            We realized we&apos;d accidentally built the most consistent fitness habit of our lives.
-            So we thought: what if everyone could feel this? The accountability. The streak you
-            refuse to break. The friendly competition that makes you lace up on days you really
-            don&apos;t want to.
+            We realized we&apos;d accidentally built the most consistent fitness
+            habit of our lives. So we thought: what if everyone could feel this?
+            The accountability. The streak you refuse to break. The friendly
+            competition that makes you lace up on days you really don&apos;t
+            want to.
           </p>
           <p className="text-[15px] leading-[1.8] text-[#a0a0a0] mb-5">
             That&apos;s how Mile A Day was born.
@@ -135,10 +155,11 @@ export function StorySection() {
 
           {/* Streak badge */}
           <div className="font-heading glass-card-highlight inline-flex items-center gap-2 rounded-xl px-4 py-2 text-[18px] text-[#c72554]">
-            <span className="text-[20px]">🔥</span> Founders&apos; Streak: {streakDays} Days & Counting
+            <span className="text-[20px]">🔥</span> Founders&apos; Streak:{" "}
+            {streakDays} Days & Counting
           </div>
         </div>
       </div>
     </section>
-  )
+  );
 }

--- a/website/components/whats-new-section.tsx
+++ b/website/components/whats-new-section.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import {
+  Timer,
+  Award,
+  Swords,
+  LayoutGrid,
+  CalendarRange,
+  Map,
+} from "lucide-react";
+
+const FEATURES = [
+  {
+    icon: Timer,
+    color: "#c72554",
+    title: "Race PRs",
+    desc: "Automatic personal records for 5K, 10K, and every standard distance — with pace, tracked from your real runs.",
+  },
+  {
+    icon: Award,
+    color: "#FF9900",
+    title: "3D Medals",
+    desc: "Milestones now come with premium, tiltable medals — plus a whole shelf of new social awards to chase.",
+  },
+  {
+    icon: Swords,
+    color: "#D94059",
+    title: "Head-to-Head Challenges",
+    desc: "Daily challenges went competitive. Call out a friend, run the same challenge, and settle it by sundown.",
+  },
+  {
+    icon: LayoutGrid,
+    color: "#33B34D",
+    title: "New Widgets",
+    desc: "Your streak, today's progress, and now a live friends leaderboard — right on your home screen.",
+  },
+  {
+    icon: CalendarRange,
+    color: "#5AC8FA",
+    title: "Weekly Recap",
+    desc: "Your week in miles, wrapped: distance, streak days, and the moments worth bragging about.",
+  },
+  {
+    icon: Map,
+    color: "#ff4d7d",
+    title: "Heatmap & Memories",
+    desc: "Every route you've ever run on one glowing map — and yearly memories that resurface your best days.",
+  },
+];
+
+export function WhatsNewSection() {
+  return (
+    <section className="section-lazy relative px-6 py-24">
+      <div className="relative mx-auto max-w-6xl">
+        <div className="mx-auto mb-14 max-w-2xl text-center">
+          <span className="reveal mb-4 inline-block text-sm font-semibold uppercase tracking-widest text-[#c72554]">
+            Just shipped
+          </span>
+          <h2 className="reveal reveal-delay-1 font-heading text-[clamp(40px,6vw,72px)] leading-none tracking-[-1px] text-[#f5f5f5]">
+            NEW IN <span className="text-[#c72554]">2.0</span>
+          </h2>
+          <p className="reveal reveal-delay-2 mt-4 text-base leading-relaxed text-[#a0a0a0]">
+            The biggest update since launch — built from what the community
+            asked for.
+          </p>
+        </div>
+
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {FEATURES.map((feature, i) => (
+            <div
+              key={feature.title}
+              className={`reveal reveal-delay-${(i % 3) + 1} group glass-card relative overflow-hidden rounded-3xl p-7 transition-all duration-300 hover:-translate-y-1`}
+            >
+              <div
+                className="pointer-events-none absolute -right-8 -top-8 h-28 w-28 rounded-full opacity-[0.07] blur-2xl transition-opacity duration-300 group-hover:opacity-20"
+                style={{ background: feature.color }}
+              />
+              <div
+                className="relative mb-4 flex h-11 w-11 items-center justify-center rounded-2xl"
+                style={{
+                  background: `${feature.color}1A`,
+                  border: `1px solid ${feature.color}33`,
+                }}
+              >
+                <feature.icon
+                  className="h-5 w-5"
+                  style={{ color: feature.color }}
+                />
+              </div>
+              <h3 className="relative mb-2 text-lg font-bold text-[#f5f5f5]">
+                {feature.title}
+              </h3>
+              <p className="relative text-sm leading-relaxed text-[#a0a0a0]">
+                {feature.desc}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
# Summary

Marketing-site refresh for the 2.0 launch plus the backend to power it: live community counters, a feed showcase, a "New in 2.0" grid, a waitlist that actually saves emails, and a fix for the miles-today counter zeroing out every evening.

## Backend

- **`GET /public/stats`** — community-wide aggregates for the site's live stats band: `total_users`, `total_miles` (rounded), `miles_today` (1dp), `total_hypes`, `total_nudges`. **Aggregates only** — no user ids, usernames, or per-user numbers can appear in this payload; the service header documents that contract. 60s in-memory cache so the public endpoint can't be turned into DB load (matches the site's 60s poll).
- **Miles-today fix** — the admin overview compared `local_date = CURRENT_DATE`, which is the DB server's **UTC** date: from 8 PM ET onward "today" flips to tomorrow and the counter reads ~0 all evening. New `TODAY_ET_DATE_SQL` keeps every daily counter on the app's canonical midnight-ET window (also applied to `active_users_7d` and the 30-day miles chart, and used by the new public stats).
- **`POST /public/android-waitlist`** + `android_waitlist` table (migration `0014`, additive `CREATE TABLE`). Emails are normalized (trim/lowercase), shape-validated, capped at 254 chars, and inserted with `ON CONFLICT DO NOTHING` — the response is identical for new and duplicate emails so addresses can't be enumerated. The public router now answers CORS preflight (`OPTIONS` previously fell through to the 404 guard, which would have blocked the JSON POST from the browser).

## Website

- **Live stats band** (`live-stats-band.tsx`) — four count-up tiles (total miles, miles today, hypes sent, nudges delivered) with the site's pulsing LIVE dot, polling `/public/stats` every minute. Renders nothing if the API is unreachable.
- **Feed section** (`feed-section.tsx`) — the 2.0 headline feature finally on the page: stories rail with real member photos, a run-post mock with route polyline + stats overlay, and a **working double-tap-to-hype** on the card. Copy covers photo prompts, 24h stories vs. permanent feed, hypes, and the route-map privacy toggle.
- **New in 2.0 section** (`whats-new-section.tsx`) — Race PRs, 3D medals, head-to-head challenges, new widgets (incl. the daily leaderboard), weekly recap, heatmap & memories.
- **Android waitlist fixed** — the form previously threw the email away client-side while telling users "You're on the list!" It now POSTs to the backend with sending/success/error states; success only shows on a 2xx.
- **ScrollReveal bug fix** — reveal elements start at `opacity: 0` and the observer only scanned on mount, so components that render after a data fetch (the existing live community banner!) were never revealed and stayed invisible. A MutationObserver now picks up late-mounted reveal elements.
- **Copy fixes** — founder quote no longer says "closing in on a full year" next to a 400+ day live counter; social + features sections now mention the feed, stories, and hypes.

## Verification

- Backend `npm run build` (tsc): ✅
- `npx drizzle-kit check`: ✅ (migration `0014_lyrical_shatterstar.sql` is a single additive `CREATE TABLE`)
- Website `npm run build`: ✅
- CI exercises the migrator twice against throwaway Postgres for idempotence.

## Compatibility

- New endpoints only; no existing endpoint, field, or semantics changed. The admin overview keys are unchanged (values now correct in the evening). Migration is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01As47P3oiGe1Q8f8eksd1L8

---
_Generated by [Claude Code](https://claude.ai/code/session_01As47P3oiGe1Q8f8eksd1L8)_