### PR TITLE
Website polish: app-accurate feed mock (claps, no comments), unified card hovers, narrative section order

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -308,6 +308,27 @@ html {
   transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1), border-color 0.3s ease, box-shadow 0.3s ease;
 }
 
+/* Feed-mock hype clap burst — mirrors the app's HypeBurstView: a hero clap
+   springs from the center while mini claps radiate outward and fade. */
+@keyframes clap-pop {
+  0% { transform: scale(0.2); opacity: 0; }
+  25% { transform: scale(1.25); opacity: 1; }
+  55% { transform: scale(1); opacity: 1; }
+  100% { transform: scale(0.9) translateY(-10px); opacity: 0; }
+}
+.clap-pop {
+  animation: clap-pop 0.8s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+@keyframes clap-fly {
+  0% { transform: translate(0, 0) scale(0.4); opacity: 0; }
+  30% { opacity: 1; }
+  100% { transform: translate(var(--dx), var(--dy)) scale(1); opacity: 0; }
+}
+.clap-fly {
+  animation: clap-fly 0.8s ease-out forwards;
+}
+
 /* Section divider line animation */
 @keyframes line-grow {
   from { transform: scaleX(0); }

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -15,6 +15,11 @@ import { CtaSection } from "@/components/cta-section";
 import { Footer } from "@/components/footer";
 import { ScrollReveal } from "@/components/scroll-reveal";
 
+// Section order tells the story top to bottom: hook (hero) → live proof the
+// community is real (stats band) → what the app does (features) → the new
+// social experience (feed, then friends/nudges) → the competitive layer
+// (competitions, medals) → what just shipped (2.0) → why one mile works
+// (habit) → how to start → who built it → download.
 export default function Home() {
   return (
     <main className="relative min-h-screen overflow-x-hidden bg-[#0a0a0a]">
@@ -23,13 +28,13 @@ export default function Home() {
       <HeroSection />
       <MarqueeSection />
       <LiveStatsBand />
-      <FeedSection />
-      <WhatsNewSection />
       <FeaturesSection />
-      <BadgeShowcaseSection />
-      <HabitSection />
-      <CompetitionsSection />
+      <FeedSection />
       <SocialSection />
+      <CompetitionsSection />
+      <BadgeShowcaseSection />
+      <WhatsNewSection />
+      <HabitSection />
       <HowItWorksSection />
       <StorySection />
       <CtaSection />

--- a/website/components/feed-section.tsx
+++ b/website/components/feed-section.tsx
@@ -1,26 +1,18 @@
 "use client";
 
 import { useRef, useCallback, useState } from "react";
-import {
-  Camera,
-  Clock3,
-  Heart,
-  Map,
-  Flame,
-  Plus,
-  MessageCircle,
-} from "lucide-react";
+import { Flame, Gauge, Footprints, Plus, MoreHorizontal } from "lucide-react";
 import { ProfileAvatar } from "@/components/profile-avatar";
 import { usePublicUser } from "@/lib/public-user";
 
-// App palette (MADTheme)
+// App palette (MADTheme). Hype is ALWAYS the clap 👏 in Mile A Day — the
+// button is solid orange, the tally clap is orange (see HypeControls.swift).
 const MAD_RED = "#D94059";
-const NUDGE_ORANGE = "#FF9900";
+const HYPE_ORANGE = "#FF9900";
 
-const STORY_FACES = [
-  { username: "rob", initials: "RW" },
-  { username: "dave", initials: "DS" },
-  { username: "MegsMiles", initials: "MM" },
+const STORY_FRIENDS = [
+  { username: "dave", initials: "DS", label: "David" },
+  { username: "MegsMiles", initials: "MM", label: "Megs" },
 ];
 
 function TiltCard({
@@ -61,8 +53,67 @@ function TiltCard({
   );
 }
 
-/** Story bubble with the app's red story ring. Real profile photos. */
-function StoryBubble({
+/** Story ring, exactly like StoriesRailView: unviewed = red→orange gradient
+ * ring, dashed white ring for "Your story" with nothing posted yet. */
+function StoryRing({
+  children,
+  unviewed,
+  dashed,
+}: {
+  children: React.ReactNode;
+  unviewed?: boolean;
+  dashed?: boolean;
+}) {
+  if (unviewed) {
+    return (
+      <div
+        className="rounded-full p-[2.5px]"
+        style={{
+          background: `linear-gradient(135deg, ${MAD_RED}, ${HYPE_ORANGE})`,
+        }}
+      >
+        <div className="rounded-full border-[3px] border-[#0d0d0d]">
+          {children}
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div
+      className="rounded-full p-[2.5px]"
+      style={{
+        border: `2.5px ${dashed ? "dashed" : "solid"} rgba(255,255,255,0.25)`,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** "Your story" cell — the viewer's own avatar in a dashed ring with the red
+ * add badge bottom-right, exactly like the app's addCell. */
+function YourStoryCell() {
+  return (
+    <div className="flex w-[62px] flex-col items-center gap-1.5">
+      <div className="relative">
+        <StoryRing dashed>
+          <ProfileAvatar username="rob" initials="RW" size={46} />
+        </StoryRing>
+        <div
+          className="absolute -bottom-0.5 -right-0.5 flex h-[18px] w-[18px] items-center justify-center rounded-full border-2 border-[#0d0d0d]"
+          style={{ background: MAD_RED }}
+        >
+          <Plus className="h-3 w-3 text-white" strokeWidth={3} />
+        </div>
+      </div>
+      <span className="text-[10px] font-semibold text-white/70">
+        Your story
+      </span>
+    </div>
+  );
+}
+
+function FriendStoryCell({
   username,
   initials,
   label,
@@ -72,168 +123,181 @@ function StoryBubble({
   label: string;
 }) {
   return (
-    <div className="flex flex-col items-center gap-1.5">
-      <div
-        className="rounded-full p-[2.5px]"
-        style={{ background: `linear-gradient(135deg, ${MAD_RED}, #ff4d7d)` }}
-      >
-        <div className="rounded-full border-2 border-[#101010] bg-[#101010]">
-          <ProfileAvatar username={username} initials={initials} size={46} />
-        </div>
-      </div>
-      <span className="text-[10px] font-medium text-white/50">{label}</span>
+    <div className="flex w-[62px] flex-col items-center gap-1.5">
+      <StoryRing unviewed>
+        <ProfileAvatar username={username} initials={initials} size={46} />
+      </StoryRing>
+      <span className="max-w-full truncate text-[10px] font-semibold text-white/70">
+        {label}
+      </span>
     </div>
   );
 }
 
-/** The feed post mock — a run card with route map, stats overlay, and a
- * double-tap hype you can actually try. */
+/** Radiating mini claps for the burst — precomputed offsets so the render is
+ * deterministic. */
+const MINI_CLAPS = Array.from({ length: 6 }, (_, i) => {
+  const angle = (i / 6) * Math.PI * 2 - Math.PI / 2;
+  return {
+    dx: Math.round(Math.cos(angle) * 74),
+    dy: Math.round(Math.sin(angle) * 74),
+  };
+});
+
+/** One post, faithful to PostCardView: author header (avatar, name, relative
+ * time, activity chip, ellipsis menu) → 4:5 media with page dots → stat strip
+ * chips → caption → footer with the hype tally left and the solid-orange
+ * clap Hype button right. No comments — hypes ARE the social currency. */
 function FeedPostCard() {
   const rob = usePublicUser("rob");
+  const streak = rob?.currentStreak ?? 427;
   const [hyped, setHyped] = useState(false);
   const [burst, setBurst] = useState(0);
 
+  // Mirrors doubleTapHype(): the burst replays on every double-tap, but the
+  // hype itself only counts once.
   const hype = useCallback(() => {
-    setHyped(true);
     setBurst((b) => b + 1);
+    setHyped(true);
   }, []);
 
   return (
-    <div className="overflow-hidden rounded-[20px] border border-white/[0.08] bg-[#101010]">
+    <div className="rounded-2xl bg-white/[0.04] p-2.5">
       {/* Header */}
-      <div className="flex items-center gap-3 px-4 py-3">
-        <ProfileAvatar username="rob" initials="RW" size={36} />
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5">
-            <span className="text-sm font-bold text-white">Rob</span>
-            {rob?.currentStreak != null && (
-              <span className="flex items-center gap-0.5">
-                <Flame className="h-3 w-3" style={{ color: NUDGE_ORANGE }} />
-                <span
-                  className="text-[11px] font-extrabold"
-                  style={{ color: NUDGE_ORANGE }}
-                >
-                  {rob.currentStreak}
-                </span>
-              </span>
-            )}
+      <div className="flex items-center gap-2.5 px-1 pb-2 pt-0.5">
+        <ProfileAvatar username="rob" initials="RW" size={40} />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[15px] font-bold leading-tight text-white">
+            Rob
           </div>
-          <span className="text-[11px] text-white/40">
-            Morning mile · 7:04 AM
-          </span>
+          <div className="text-xs font-medium text-white/50">2h ago</div>
         </div>
-        <span
-          className="rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider"
-          style={{
-            color: MAD_RED,
-            background: `${MAD_RED}1A`,
-            border: `1px solid ${MAD_RED}33`,
-          }}
+        <div
+          className="flex h-[30px] w-[30px] items-center justify-center rounded-full text-[14px]"
+          style={{ background: `${MAD_RED}26` }}
         >
-          Mile done
-        </span>
+          🏃
+        </div>
+        <MoreHorizontal className="h-4 w-4 text-white/60" />
       </div>
 
-      {/* Media area: photo stand-in + route + stats overlay. Double-tap (or
-          double-click) to hype, just like the app. */}
+      {/* Media — 4:5 like the app, double-tap (or double-click) to hype */}
       <div
-        className="relative aspect-[4/3] cursor-pointer select-none overflow-hidden"
+        className="relative aspect-[4/5] cursor-pointer select-none overflow-hidden rounded-xl"
         onDoubleClick={hype}
         style={{
           background:
-            "linear-gradient(160deg, #2a1520 0%, #1a0f14 40%, #0d1a12 100%)",
+            "linear-gradient(165deg, #3a1c28 0%, #1c1016 45%, #0e1812 100%)",
         }}
       >
-        {/* Sunrise glow */}
+        {/* Sunrise glow — stands in for the run photo */}
         <div
-          className="absolute -top-8 right-6 h-28 w-28 rounded-full opacity-30 blur-2xl"
-          style={{ background: "linear-gradient(180deg, #ff9900, #c72554)" }}
+          className="absolute -top-6 right-8 h-32 w-32 rounded-full opacity-35 blur-2xl"
+          style={{
+            background: `linear-gradient(180deg, ${HYPE_ORANGE}, ${MAD_RED})`,
+          }}
         />
-        {/* Route polyline */}
-        <svg viewBox="0 0 320 240" className="absolute inset-0 h-full w-full">
-          <path
-            d="M 40 200 C 80 150, 70 110, 120 100 S 200 130, 230 90 S 280 40, 285 60"
-            fill="none"
-            stroke={MAD_RED}
-            strokeWidth="3.5"
-            strokeLinecap="round"
-            strokeDasharray="1 0"
-            style={{ filter: `drop-shadow(0 0 6px ${MAD_RED}AA)` }}
-          />
-          <circle cx="40" cy="200" r="5" fill="#33B34D" />
-          <circle cx="285" cy="60" r="5" fill={MAD_RED} />
-        </svg>
-        {/* Stats overlay chips — the app's customizable run-stats overlay */}
-        <div className="absolute bottom-3 left-3 flex gap-2">
-          {[
-            { label: "Distance", value: "1.24 mi" },
-            { label: "Pace", value: "8:41 /mi" },
-            { label: "Time", value: "10:46" },
-          ].map((stat) => (
-            <div
-              key={stat.label}
-              className="rounded-lg border border-white/10 bg-black/50 px-2.5 py-1.5 backdrop-blur-md"
-            >
-              <div className="text-[11px] font-bold leading-none text-white">
-                {stat.value}
-              </div>
-              <div className="mt-0.5 text-[8px] uppercase tracking-wider text-white/50">
-                {stat.label}
-              </div>
-            </div>
-          ))}
-        </div>
-        {/* Double-tap heart burst */}
+        <div className="absolute bottom-0 left-0 right-0 h-1/3 bg-gradient-to-t from-black/40 to-transparent" />
+
+        {/* Clap burst — hero clap + radiating mini claps (HypeBurstView) */}
         {burst > 0 && (
           <div
             key={burst}
             className="pointer-events-none absolute inset-0 flex items-center justify-center"
           >
-            <Heart
-              className="h-20 w-20 animate-ping"
-              style={{
-                color: MAD_RED,
-                fill: MAD_RED,
-                animationIterationCount: 1,
-                animationDuration: "0.7s",
-              }}
-            />
+            <span className="clap-pop absolute text-[64px] leading-none drop-shadow-[0_4px_16px_rgba(0,0,0,0.6)]">
+              👏
+            </span>
+            {MINI_CLAPS.map((c, i) => (
+              <span
+                key={i}
+                className="clap-fly absolute text-[22px] leading-none"
+                style={
+                  {
+                    "--dx": `${c.dx}px`,
+                    "--dy": `${c.dy}px`,
+                  } as React.CSSProperties
+                }
+              >
+                👏
+              </span>
+            ))}
           </div>
         )}
+
+        {/* Page dots — photo → stats card → route map slides */}
+        <div className="absolute bottom-2.5 left-0 right-0 flex justify-center gap-1.5">
+          <span className="h-1.5 w-1.5 rounded-full bg-white" />
+          <span className="h-1.5 w-1.5 rounded-full bg-white/40" />
+          <span className="h-1.5 w-1.5 rounded-full bg-white/40" />
+        </div>
       </div>
 
-      {/* Action row */}
-      <div className="flex items-center gap-4 px-4 py-3">
+      {/* Stat strip — flame streak, distance, pace chips (PostStatStrip) */}
+      <div className="flex flex-wrap gap-2 px-0.5 pt-2.5">
+        <span className="flex items-center gap-1 rounded-full bg-white/[0.06] px-2 py-1">
+          <Flame className="h-3 w-3" style={{ color: HYPE_ORANGE }} />
+          <span
+            className="text-[11px] font-extrabold tabular-nums"
+            style={{ color: HYPE_ORANGE }}
+          >
+            {streak} day streak
+          </span>
+        </span>
+        <span className="flex items-center gap-1 rounded-full bg-white/[0.06] px-2 py-1 text-white/85">
+          <Footprints className="h-3 w-3" />
+          <span className="text-[11px] font-extrabold tabular-nums">
+            1.24 mi
+          </span>
+        </span>
+        <span className="flex items-center gap-1 rounded-full bg-white/[0.06] px-2 py-1 text-white/85">
+          <Gauge className="h-3 w-3" />
+          <span className="text-[11px] font-extrabold tabular-nums">
+            8:41 /mi
+          </span>
+        </span>
+      </div>
+
+      {/* Caption */}
+      <p className="px-0.5 pt-2 text-sm font-medium text-white/90">
+        Morning mile ☀️ another one in the books.
+      </p>
+
+      {/* Footer — hype tally left, Hype button right (HypeControls) */}
+      <div className="flex items-center justify-between px-0.5 pb-1 pt-2.5">
+        <span className="flex items-center gap-1.5">
+          <span className="text-[13px] leading-none">👏</span>
+          <span className="text-[13px] font-extrabold tabular-nums text-white/90">
+            {hyped ? 13 : 12} hypes
+          </span>
+        </span>
         <button
           onClick={hype}
-          className="flex items-center gap-1.5 transition-transform active:scale-90"
           aria-label="Hype this run"
+          className="flex items-center gap-1 rounded-full px-3 py-1.5 transition-all active:scale-90"
+          style={
+            hyped
+              ? {
+                  background: "rgba(255,255,255,0.06)",
+                  color: "rgba(255,255,255,0.35)",
+                }
+              : {
+                  background: HYPE_ORANGE,
+                  color: "#fff",
+                  boxShadow: `0 2px 10px ${HYPE_ORANGE}59`,
+                }
+          }
         >
-          <Heart
-            className="h-5 w-5 transition-colors"
-            style={
-              hyped
-                ? { color: MAD_RED, fill: MAD_RED }
-                : { color: "rgba(255,255,255,0.6)" }
-            }
-          />
           <span
-            className="text-xs font-semibold"
-            style={{ color: hyped ? MAD_RED : "rgba(255,255,255,0.6)" }}
+            className="text-[13px] leading-none"
+            style={{ opacity: hyped ? 0.55 : 1 }}
           >
-            {hyped ? 13 : 12}
+            👏
+          </span>
+          <span className="text-xs font-extrabold">
+            {hyped ? "Hyped" : "Hype"}
           </span>
         </button>
-        <span className="flex items-center gap-1.5 text-white/40">
-          <MessageCircle
-            className="h-4.5 w-4.5"
-            style={{ width: 18, height: 18 }}
-          />
-          <span className="text-xs font-semibold">3</span>
-        </span>
-        <span className="ml-auto text-[10px] text-white/30">
-          Double-tap the photo — go on, try it
-        </span>
       </div>
     </div>
   );
@@ -263,32 +327,31 @@ export function FeedSection() {
             </h2>
             <p className="reveal reveal-delay-2 mt-5 max-w-lg text-[17px] leading-relaxed text-[#a0a0a0]">
               Your daily mile deserves more than a checkmark. Share the run —
-              the photo, the route, the stats — and watch your friends show up
-              in the comments and the hypes.
+              the photo, the route, the stats — and let the hypes roll in.
             </p>
 
             <div className="reveal reveal-delay-3 mt-8 space-y-4">
               {[
                 {
-                  icon: Camera,
+                  emoji: "📸",
                   color: MAD_RED,
                   title: "Snap it in the moment",
                   desc: "A photo prompt after every run — or grab the shot mid-mile and decide later.",
                 },
                 {
-                  icon: Clock3,
-                  color: NUDGE_ORANGE,
+                  emoji: "⏳",
+                  color: HYPE_ORANGE,
                   title: "Stories for the moment, feed for the record",
                   desc: "Stories vanish after 24 hours. Your feed keeps every mile you've shared.",
                 },
                 {
-                  icon: Heart,
-                  color: "#ff4d7d",
+                  emoji: "👏",
+                  color: HYPE_ORANGE,
                   title: "Double-tap to hype",
-                  desc: "Cheer every mile. Hypes land as notifications your friends actually want.",
+                  desc: "No likes here — hypes. A clap burst for every friend who got their mile in.",
                 },
                 {
-                  icon: Map,
+                  emoji: "🗺️",
                   color: "#33B34D",
                   title: "Your route, your call",
                   desc: "Show off the loop with a route map on your post — or keep it private with one toggle.",
@@ -296,16 +359,13 @@ export function FeedSection() {
               ].map((item) => (
                 <div key={item.title} className="flex items-start gap-4">
                   <div
-                    className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-xl"
+                    className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-[17px]"
                     style={{
                       background: `${item.color}1A`,
                       border: `1px solid ${item.color}33`,
                     }}
                   >
-                    <item.icon
-                      className="h-4.5 w-4.5"
-                      style={{ width: 18, height: 18, color: item.color }}
-                    />
+                    {item.emoji}
                   </div>
                   <div>
                     <div className="text-[15px] font-bold text-[#f5f5f5]">
@@ -320,39 +380,24 @@ export function FeedSection() {
             </div>
           </div>
 
-          {/* Right: interactive feed mock */}
+          {/* Right: the feed, as it actually looks in the app */}
           <div className="reveal-right mx-auto w-full max-w-md">
             <TiltCard>
-              <div className="rounded-[24px] border border-white/[0.08] bg-[#0d0d0d] p-4 shadow-[0_30px_80px_rgba(0,0,0,0.5)]">
+              <div className="rounded-[24px] border border-white/[0.08] bg-[#0d0d0d] p-3.5 shadow-[0_30px_80px_rgba(0,0,0,0.5)]">
                 {/* Stories rail */}
-                <div className="mb-4 flex items-center gap-4 px-1">
-                  <div className="flex flex-col items-center gap-1.5">
-                    <div className="flex h-[51px] w-[51px] items-center justify-center rounded-full border-2 border-dashed border-white/20">
-                      <Plus className="h-5 w-5 text-white/40" />
-                    </div>
-                    <span className="text-[10px] font-medium text-white/50">
-                      Your story
-                    </span>
-                  </div>
-                  {STORY_FACES.map((face) => (
-                    <StoryBubble
-                      key={face.username}
-                      username={face.username}
-                      initials={face.initials}
-                      label={
-                        face.username === "MegsMiles"
-                          ? "Megs"
-                          : face.username === "dave"
-                            ? "David"
-                            : "Rob"
-                      }
-                    />
+                <div className="mb-3 flex items-start gap-3 px-1 pt-1">
+                  <YourStoryCell />
+                  {STORY_FRIENDS.map((f) => (
+                    <FriendStoryCell key={f.username} {...f} />
                   ))}
                 </div>
 
                 <FeedPostCard />
               </div>
             </TiltCard>
+            <p className="mt-4 text-center text-xs text-white/35">
+              Go on — double-tap the photo. 👏
+            </p>
           </div>
         </div>
       </div>

--- a/website/components/live-stats-band.tsx
+++ b/website/components/live-stats-band.tsx
@@ -64,8 +64,8 @@ function StatCard({
 }) {
   return (
     <div
-      className={`reveal reveal-delay-${delay} group relative overflow-hidden rounded-3xl border border-white/[0.07] bg-white/[0.03] px-6 py-7 text-center backdrop-blur-xl transition-all duration-300 hover:-translate-y-1`}
-      style={{ boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)" }}
+      className={`reveal-scale reveal-delay-${delay} glass-card type-card group relative overflow-hidden rounded-2xl px-6 py-7 text-center`}
+      style={{ "--accent": color } as React.CSSProperties}
     >
       {/* Accent glow that breathes on hover */}
       <div

--- a/website/components/whats-new-section.tsx
+++ b/website/components/whats-new-section.tsx
@@ -69,25 +69,25 @@ export function WhatsNewSection() {
           {FEATURES.map((feature, i) => (
             <div
               key={feature.title}
-              className={`reveal reveal-delay-${(i % 3) + 1} group glass-card relative overflow-hidden rounded-3xl p-7 transition-all duration-300 hover:-translate-y-1`}
+              className={`reveal-scale reveal-delay-${(i % 3) + 1} glass-card type-card group relative overflow-hidden rounded-2xl p-6`}
+              style={{ "--accent": feature.color } as React.CSSProperties}
             >
               <div
                 className="pointer-events-none absolute -right-8 -top-8 h-28 w-28 rounded-full opacity-[0.07] blur-2xl transition-opacity duration-300 group-hover:opacity-20"
                 style={{ background: feature.color }}
               />
               <div
-                className="relative mb-4 flex h-11 w-11 items-center justify-center rounded-2xl"
+                className="relative mb-4 flex h-12 w-12 items-center justify-center rounded-xl"
                 style={{
-                  background: `${feature.color}1A`,
-                  border: `1px solid ${feature.color}33`,
+                  background: `linear-gradient(135deg, ${feature.color}20, ${feature.color}08)`,
                 }}
               >
                 <feature.icon
-                  className="h-5 w-5"
+                  className="h-6 w-6"
                   style={{ color: feature.color }}
                 />
               </div>
-              <h3 className="relative mb-2 text-lg font-bold text-[#f5f5f5]">
+              <h3 className="font-heading relative mb-2 text-[22px] uppercase tracking-[1px] text-[#f5f5f5]">
                 {feature.title}
               </h3>
               <p className="relative text-sm leading-relaxed text-[#a0a0a0]">


### PR DESCRIPTION
# Summary

Follow-up polish on the 2.0 site refresh: the feed showcase now mirrors the real app UI, the new sections use the site's canonical card hover, and the page order tells a coherent story.

## Feed mock — rebuilt from the actual SwiftUI components

Cross-referenced `PostCardView`, `HypeControls`, `PostStatStrip`, and `StoriesRailView`:

- **Claps, not hearts.** Hype tally reads "👏 12 hypes" (orange clap) and the action is the app's solid-orange **👏 Hype** capsule, fading to the grey "Hyped" chip once spent — `HypeButton`'s exact states.
- **No comments** — the app has none; the footer is tally left, Hype button right.
- **Double-tap = clap burst**: hero clap springs from center with six mini claps radiating out (new `clap-pop` / `clap-fly` keyframes), replayable without double-counting the hype — same as `doubleTapHype()`.
- Correct card anatomy: header (avatar, name, relative time, tinted activity chip, ellipsis), 4:5 media with carousel page dots, stat-strip chips **below** the media (🔥 streak in orange, distance, pace), caption. Removed the invented "Mile done" chip and in-photo stat chips.
- Stories rail matches the app: "Your story" avatar in a **dashed ring with the red plus badge**, friends in red→orange unviewed gradient rings, labels beneath. Rob's streak number is pulled live from the public API.
- The "try it" hint moved outside the phone frame so the card stays authentic.

## Card hover fix

The live-stats and New-in-2.0 cards used Tailwind `hover:-translate-y-1` + `transition-all`, but the site's unlayered `.glass-card`/`.reveal` CSS overrides utility transitions (they only transition `transform`), so the hover snapped with no easing — the "bad hover". Both sections now use the site's canonical **`glass-card type-card` + `--accent`** pattern (smooth 4px lift, accent-tinted border + glow, `prefers-reduced-motion` respected), with `reveal-scale` entrances and features-section heading typography.

## Section order

Hero → Marquee → **Live stats** (proof) → **Features** (what it does) → **Feed** → **Social** (the social cluster) → **Competitions** → **Medals** (the competitive cluster) → **New in 2.0** → Habit (why) → How it works → Story (who) → CTA. Rationale documented in `page.tsx`. Navbar anchors (`#features`, `#competitions`, `#story`) are unaffected.

## Verification

- Website `npm run build` (type-check + build): ✅
- No backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01As47P3oiGe1Q8f8eksd1L8

---
_Generated by [Claude Code](https://claude.ai/code/session_01As47P3oiGe1Q8f8eksd1L8)_