### PR TITLE
Head-to-Head: score duels at day's end + reciprocal daily matchups

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -40,7 +40,7 @@ Service (`services/`) → controller (`controllers/`) → route (`routes/`) → 
 
 ## Daily Challenges
 - `head_to_head` is scored END-OF-DAY by `h2hChallengeCron` (after BOTH users' local midnight + 6h late-sync grace), never at workout sync — `evaluatePredicate` returns false for it and live progress caps at 0.99. Winner push (`challenge_won`) is deferred to the winner's local 9 AM–10 PM.
-- Rivals are PINNED per day in `h2h_matchups` (reciprocal `mutual` pairs where the friend graph allows, deterministic one-sided fallback otherwise). Challenge-selection parity between per-user reads and the matchmaker lives in `challengeRotation.ts` — never fork that walk.
+- Rivals are PINNED per day in `h2h_matchups` (reciprocal `mutual` pairs where the friend graph + each side's `h2h_close_friends_only` pref allow, deterministic one-sided fallback otherwise; a restricted user with no close friends skips h2h in the rotation). Selection parity between per-user reads and the matchmaker lives in `challengeRotation.ts` + `hasH2hRivalCandidates` — never fork that walk.
 
 ## Competition Resolution
 - Standings are recomputed LIVE on every read (`getUserScores` in `getCompetition`) — even for finished comps. So a competition's stored `end_date` directly bounds which days count (scoring includes `local_date <= end_date`; `local_date` = workout START date in user tz).

--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -36,10 +36,11 @@ globs: backend/**
 - Use `requireSelfAccess('paramName')` middleware when a route should only allow users to access their own resources.
 
 ## Adding a New Endpoint
-1. Add service function in `services/` (DB queries + business logic)
-2. Add controller function in `controllers/` (req/res handling)
-3. Add route in `routes/` (wire to controller)
-4. If new route file, register in `server.ts` (before or after `authenticateToken` depending on auth needs)
+Service (`services/`) → controller (`controllers/`) → route (`routes/`) → if a new route file, register in `server.ts` (before/after `authenticateToken` per auth needs).
+
+## Daily Challenges
+- `head_to_head` is scored END-OF-DAY by `h2hChallengeCron` (after BOTH users' local midnight + 6h late-sync grace), never at workout sync — `evaluatePredicate` returns false for it and live progress caps at 0.99. Winner push (`challenge_won`) is deferred to the winner's local 9 AM–10 PM.
+- Rivals are PINNED per day in `h2h_matchups` (reciprocal `mutual` pairs where the friend graph allows, deterministic one-sided fallback otherwise). Challenge-selection parity between per-user reads and the matchmaker lives in `challengeRotation.ts` — never fork that walk.
 
 ## Competition Resolution
 - Standings are recomputed LIVE on every read (`getUserScores` in `getCompetition`) — even for finished comps. So a competition's stored `end_date` directly bounds which days count (scoring includes `local_date <= end_date`; `local_date` = workout START date in user tz).

--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -40,7 +40,7 @@ Service (`services/`) → controller (`controllers/`) → route (`routes/`) → 
 
 ## Daily Challenges
 - `head_to_head` is scored END-OF-DAY by `h2hChallengeCron` (after BOTH users' local midnight + 6h late-sync grace), never at workout sync — `evaluatePredicate` returns false for it and live progress caps at 0.99. Winner push (`challenge_won`) is deferred to the winner's local 9 AM–10 PM.
-- Rivals are PINNED per day in `h2h_matchups` (reciprocal `mutual` pairs where the friend graph + each side's `h2h_close_friends_only` pref allow, deterministic one-sided fallback otherwise; a restricted user with no close friends skips h2h in the rotation). Selection parity between per-user reads and the matchmaker lives in `challengeRotation.ts` + `hasH2hRivalCandidates` — never fork that walk.
+- Rivals are PINNED per day in `h2h_matchups` (reciprocal `mutual` pairs where the friend graph + each side's `h2h_close_friends_only` pref allow; one-sided fallbacks prefer 7-day-active friends; a restricted user with no close friends skips h2h in rotation). FRIENDLESS users get the `add_friend` substitute instead (catalog row with active=FALSE, awarded at friendship-accept via `evaluateAddFriendCompletion` — the sync path can't catch it). Selection parity between per-user reads and the matchmaker lives in `challengeRotation.ts` + `hasH2hRivalCandidates` — never fork that walk.
 
 ## Competition Resolution
 - Standings are recomputed LIVE on every read (`getUserScores` in `getCompetition`) — even for finished comps. So a competition's stored `end_date` directly bounds which days count (scoring includes `local_date <= end_date`; `local_date` = workout START date in user tz).

--- a/app/Mile A Day/Models/Competition.swift
+++ b/app/Mile A Day/Models/Competition.swift
@@ -868,6 +868,8 @@ struct NotificationSettingsResponse: Codable {
     let competition_milestones_enabled: Bool
     let quiet_hours_start: Int?
     let quiet_hours_end: Int?
+    // Optional: absent on older server builds.
+    let h2h_close_friends_only: Bool?
 }
 
 struct FriendNotificationSetting: Codable, Identifiable {

--- a/app/Mile A Day/Services/RemoteChallengeService.swift
+++ b/app/Mile A Day/Services/RemoteChallengeService.swift
@@ -259,6 +259,8 @@ final class RemoteChallengeService: ChallengeServiceProtocol {
         let profileImageUrl: String?
         let miles: Double
         let myMiles: Double
+        // Optional: older server builds don't send it.
+        let mutual: Bool?
 
         func toOpponent() -> ChallengeOpponent {
             ChallengeOpponent(
@@ -266,7 +268,8 @@ final class RemoteChallengeService: ChallengeServiceProtocol {
                 username: username,
                 profileImageUrl: profileImageUrl,
                 miles: miles,
-                myMiles: myMiles
+                myMiles: myMiles,
+                mutual: mutual ?? false
             )
         }
     }

--- a/app/Mile A Day/Views/Dashboard/DashboardComponents.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardComponents.swift
@@ -926,6 +926,8 @@ struct ChallengeOpponent: Equatable {
     let profileImageUrl: String?
     let miles: Double
     let myMiles: Double
+    /// TRUE when the rival's own Head-to-Head is against you too (reciprocal pair).
+    let mutual: Bool
 }
 
 /// Fun "you vs rival" strip for the Head-to-Head daily challenge. Shows both
@@ -954,25 +956,38 @@ struct HeadToHeadStrip: View {
     private var statusColor: Color { tied ? .yellow : (leading ? .green : .orange) }
 
     var body: some View {
-        HStack(spacing: 10) {
-            side(name: "You", image: myImage, miles: opponent.myMiles,
-                 highlight: leading, color: accent)
+        VStack(spacing: 6) {
+            HStack(spacing: 10) {
+                side(name: "You", image: myImage, miles: opponent.myMiles,
+                     highlight: leading, color: accent)
 
-            VStack(spacing: 2) {
-                Text("VS")
-                    .font(.system(size: 13, weight: .black, design: .rounded))
-                    .foregroundColor(.primary.opacity(0.6))
-                Text(statusText)
-                    .font(.system(size: 9, weight: .bold, design: .rounded))
-                    .foregroundColor(statusColor)
-                    .multilineTextAlignment(.center)
-                    .lineLimit(2)
-                    .fixedSize(horizontal: false, vertical: true)
+                VStack(spacing: 2) {
+                    Text("VS")
+                        .font(.system(size: 13, weight: .black, design: .rounded))
+                        .foregroundColor(.primary.opacity(0.6))
+                    Text(statusText)
+                        .font(.system(size: 9, weight: .bold, design: .rounded))
+                        .foregroundColor(statusColor)
+                        .multilineTextAlignment(.center)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .frame(width: 86)
+
+                side(name: rivalName, image: opponent.profileImageUrl, miles: opponent.miles,
+                     highlight: !leading && !tied, color: .orange)
             }
-            .frame(width: 86)
 
-            side(name: rivalName, image: opponent.profileImageUrl, miles: opponent.miles,
-                 highlight: !leading && !tied, color: .orange)
+            // The duel is a whole-day total scored after midnight, so the lead
+            // shown above is live standings, not a verdict.
+            Text(opponent.mutual
+                 ? "\(rivalName) got the same matchup · winner decided at day's end"
+                 : "Winner decided at day's end")
+                .font(.system(size: 9, weight: .semibold, design: .rounded))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
         }
         .padding(.vertical, 10)
         .padding(.horizontal, 12)

--- a/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
+++ b/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
@@ -1392,6 +1392,13 @@ private struct FriendHeadToHeadStrip: View {
                 .foregroundColor(statusColor)
                 .lineLimit(1)
                 .minimumScaleFactor(0.82)
+
+            // Live standings, not a verdict — the duel is a whole-day total
+            // the server scores after midnight.
+            Text("Winner decided at day's end")
+                .font(.system(size: 9, weight: .semibold, design: .rounded))
+                .foregroundColor(.white.opacity(0.55))
+                .lineLimit(1)
         }
         .padding(.vertical, 10)
         .padding(.horizontal, 12)

--- a/app/Mile A Day/Views/MainTabView.swift
+++ b/app/Mile A Day/Views/MainTabView.swift
@@ -137,6 +137,10 @@ struct MainTabView: View {
                      // silently. Route to Dashboard + open the inbox so the
                      // user actually sees the badge they earned.
                      "badge_earned", "friend_badge_earned",
+                     // challenge_won = the overnight Head-to-Head verdict; the
+                     // completion already sits in the history by the time the
+                     // push arrives, so Dashboard + inbox shows the full story.
+                     "challenge_won",
                      "friend_challenge_completed", "friend_personal_best":
                     selectedTab = 0
                     showNotificationInbox = true

--- a/app/Mile A Day/Views/NotificationInboxView.swift
+++ b/app/Mile A Day/Views/NotificationInboxView.swift
@@ -705,6 +705,7 @@ struct NotificationInboxView: View {
         case "friend_badge_earned": return "FRIEND BADGE"
         case "friend_personal_best": return "FRIEND PR"
         case "friend_challenge_completed": return "FRIEND CHALLENGE"
+        case "challenge_won": return "CHALLENGE WON"
         case "competition_invite": return "COMP INVITE"
         case "competition_accepted": return "COMP JOINED"
         case "competition_started": return "COMP STARTED"
@@ -747,6 +748,7 @@ struct NotificationInboxView: View {
         case "personal_best": return ("medal.fill", .yellow)
         case "lead_change": return ("arrow.up.right", .green)
         case "clash_tie": return ("equal.circle.fill", .purple)
+        case "challenge_won": return ("flag.2.crossed.fill", .yellow)
         default: return ("bell.fill", .white.opacity(0.5))
         }
     }

--- a/app/Mile A Day/Views/Profile/DailyChallengeSettingsView.swift
+++ b/app/Mile A Day/Views/Profile/DailyChallengeSettingsView.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+
+/// Preferences for the daily challenge system — currently the Head-to-Head
+/// rival pool. The close-friends-only toggle is server-authoritative
+/// (`h2h_close_friends_only` on /notifications/preferences): matchmaking
+/// happens backend-side, so the value is loaded fresh here rather than from
+/// the UserDefaults-backed NotificationPreferences.
+struct DailyChallengeSettingsView: View {
+    @ObservedObject var friendService: FriendService
+    @ObservedObject private var closeFriendsService = CloseFriendsService.shared
+
+    @State private var closeFriendsOnly = false
+    @State private var hasLoaded = false
+    @State private var saveError: String?
+
+    /// The toggle is only enableable with at least one close friend — with an
+    /// empty close list the rival pool would be empty and the server rejects
+    /// the update (400 no_close_friends).
+    private var hasCloseFriends: Bool {
+        !closeFriendsService.closeFriendIds.isEmpty
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: MADTheme.Spacing.lg) {
+                headToHeadSection
+            }
+            .padding(MADTheme.Spacing.md)
+        }
+        .background(MADTheme.Colors.appBackgroundGradient)
+        .navigationTitle("Daily Challenges")
+        .navigationBarTitleDisplayMode(.large)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .task {
+            await closeFriendsService.loadIfNeeded()
+            await loadCurrentPreference()
+        }
+    }
+
+    private var headToHeadSection: some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
+            HStack(spacing: MADTheme.Spacing.sm) {
+                Image(systemName: "flag.2.crossed.fill")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(MADTheme.Colors.madRed)
+
+                Text("HEAD-TO-HEAD")
+                    .font(MADTheme.Typography.caption)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.secondary)
+                    .tracking(0.5)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Toggle("Rivals from close friends only", isOn: $closeFriendsOnly)
+                    .font(MADTheme.Typography.body)
+                    .tint(MADTheme.Colors.madRed)
+                    .disabled(!hasLoaded || (!hasCloseFriends && !closeFriendsOnly))
+                    .onChange(of: closeFriendsOnly) { oldValue, newValue in
+                        guard hasLoaded else { return }
+                        savePreference(newValue, revertTo: oldValue)
+                    }
+
+                Text(
+                    hasCloseFriends || closeFriendsOnly
+                        ? "Head-to-Head matchups will only pull rivals from your close friends. Applies starting with your next matchup."
+                        : "Add at least one close friend to unlock this."
+                )
+                .font(.system(size: 11, design: .rounded))
+                .foregroundColor(.white.opacity(0.35))
+                .padding(.leading, 2)
+
+                if let saveError {
+                    Text(saveError)
+                        .font(.system(size: 11, design: .rounded))
+                        .foregroundColor(.orange)
+                        .padding(.leading, 2)
+                        .padding(.top, 2)
+                }
+            }
+
+            Divider().overlay(Color.white.opacity(0.06))
+
+            NavigationLink(destination: CloseFriendsListView(friendService: friendService)) {
+                HStack {
+                    Image(systemName: "star.fill")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.yellow)
+                    Text("Manage Close Friends")
+                        .font(MADTheme.Typography.body)
+                        .foregroundColor(.primary)
+                    Spacer()
+                    if closeFriendsService.hasLoadedOnce {
+                        Text("\(closeFriendsService.closeFriendIds.count)")
+                            .font(.system(size: 13, weight: .semibold, design: .rounded))
+                            .foregroundColor(.secondary)
+                    }
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(.white.opacity(0.3))
+                }
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(MADTheme.Spacing.md)
+        .madLiquidGlass()
+    }
+
+    // MARK: - Backend sync
+
+    private func loadCurrentPreference() async {
+        do {
+            let settings = try await friendService.getNotificationSettings()
+            closeFriendsOnly = settings.h2h_close_friends_only ?? false
+        } catch {
+            print("[ChallengeSettings] Failed to load preference: \(error)")
+        }
+        hasLoaded = true
+    }
+
+    private func savePreference(_ newValue: Bool, revertTo oldValue: Bool) {
+        saveError = nil
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        Task {
+            do {
+                _ = try await friendService.updateNotificationSettings([
+                    "h2h_close_friends_only": newValue
+                ])
+            } catch {
+                // Server refused (e.g. close list emptied on another device) —
+                // put the switch back where it was.
+                closeFriendsOnly = oldValue
+                saveError = "Couldn't save — add a close friend first."
+                print("[ChallengeSettings] Failed to save preference: \(error)")
+            }
+        }
+    }
+}

--- a/app/Mile A Day/Views/Profile/ProfileSettingsView.swift
+++ b/app/Mile A Day/Views/Profile/ProfileSettingsView.swift
@@ -89,6 +89,17 @@ struct ProfileSettingsView: View {
 
             settingsDivider
 
+            NavigationLink(destination: DailyChallengeSettingsView(friendService: friendService)) {
+                MADSettingsRow(
+                    icon: "flag.2.crossed.fill",
+                    title: "Daily Challenges",
+                    subtitle: "Head-to-Head matchup preferences",
+                    iconColor: Color.purple
+                )
+            }
+
+            settingsDivider
+
             Button(action: onPrivacySettings) {
                 MADSettingsRow(
                     icon: "lock.shield.fill",

--- a/backend/src/controllers/friendshipsController.ts
+++ b/backend/src/controllers/friendshipsController.ts
@@ -1,188 +1,234 @@
-import { Request, Response } from 'express';
+import { Request, Response } from "express";
 import {
-	sendFriendRequest,
-	getFriends as getUserFriends,
-	getFriendRequests as getUserFriendRequests,
-	getSentRequests as getUserSentRequests,
-	updateFriendship,
-	getFriendsActivityToday as getActivityToday,
-	getFriendSuggestions,
-	getMutualFriendCount,
-	getFriendsWorkoutFeed
-} from '../services/friendshipService.js';
-import { AuthenticatedRequest } from '../middleware/auth.js';
-import hasRequiredKeys from '../utils/hasRequiredKeys.js';
-import { getUser, getUsers } from '../services/userService.js';
-import { sendPush } from '../services/pushNotificationService.js';
+  sendFriendRequest,
+  getFriends as getUserFriends,
+  getFriendRequests as getUserFriendRequests,
+  getSentRequests as getUserSentRequests,
+  updateFriendship,
+  getFriendsActivityToday as getActivityToday,
+  getFriendSuggestions,
+  getMutualFriendCount,
+  getFriendsWorkoutFeed,
+} from "../services/friendshipService.js";
+import { AuthenticatedRequest } from "../middleware/auth.js";
+import hasRequiredKeys from "../utils/hasRequiredKeys.js";
+import { getUser, getUsers } from "../services/userService.js";
+import {
+  sendPush,
+  fanOutFriendChallengePush,
+} from "../services/pushNotificationService.js";
+import { evaluateAddFriendCompletion } from "../services/dailyChallengeService.js";
 
 const BAD_REQUEST_ERRORS = [
-	'No friendship found',
-	'Friendship already has status',
-	`User can't update a request they sent`,
-	'Invalid status'
+  "No friendship found",
+  "Friendship already has status",
+  `User can't update a request they sent`,
+  "Invalid status",
 ];
 
 export async function getFriends(req: Request, res: Response) {
-	if (!hasRequiredKeys(['userId'], req, res)) return;
+  if (!hasRequiredKeys(["userId"], req, res)) return;
 
-	const { userId } = req.params;
+  const { userId } = req.params;
 
-	const user = await getUser({ userId });
-	if (!user) {
-		return res.status(400).send({ error: `No user found with ID ${userId}` });
-	}
+  const user = await getUser({ userId });
+  if (!user) {
+    return res.status(400).send({ error: `No user found with ID ${userId}` });
+  }
 
-	const friends = await getUserFriends(userId);
+  const friends = await getUserFriends(userId);
 
-	res.send(friends);
+  res.send(friends);
 }
 
 export async function getSentRequests(req: Request, res: Response) {
-	if (!hasRequiredKeys(['userId'], req, res)) return;
+  if (!hasRequiredKeys(["userId"], req, res)) return;
 
-	const { userId } = req.params;
+  const { userId } = req.params;
 
-	const user = await getUser({ userId });
-	if (!user) {
-		return res.status(400).send({ error: `No user found with ID ${userId}` });
-	}
+  const user = await getUser({ userId });
+  if (!user) {
+    return res.status(400).send({ error: `No user found with ID ${userId}` });
+  }
 
-	const friendRequests = await getUserSentRequests(userId);
+  const friendRequests = await getUserSentRequests(userId);
 
-	res.send(friendRequests);
+  res.send(friendRequests);
 }
 
 export async function getFriendRequests(req: Request, res: Response) {
-	if (!hasRequiredKeys(['userId'], req, res)) return;
+  if (!hasRequiredKeys(["userId"], req, res)) return;
 
-	const { userId } = req.params;
+  const { userId } = req.params;
 
-	const user = await getUser({ userId });
-	if (!user) {
-		return res.status(400).send({ error: `No user found with ID ${userId}` });
-	}
+  const user = await getUser({ userId });
+  if (!user) {
+    return res.status(400).send({ error: `No user found with ID ${userId}` });
+  }
 
-	const friendRequests = await getUserFriendRequests(userId);
+  const friendRequests = await getUserFriendRequests(userId);
 
-	res.send(friendRequests);
+  res.send(friendRequests);
 }
 
 export async function sendRequest(req: Request, res: Response) {
-	if (!hasRequiredKeys(['fromUser', 'toUser'], req, res)) return;
+  if (!hasRequiredKeys(["fromUser", "toUser"], req, res)) return;
 
-	const { fromUser, toUser } = req.body;
+  const { fromUser, toUser } = req.body;
 
-	const users = await getUsers([fromUser, toUser]);
-	if (users.length !== 2) {
-		const missingUser = [fromUser, toUser].find(uId => !users.find(u => u.user_id === uId));
-		return res.status(400).send({ error: `No user found with ID ${missingUser}` });
-	}
+  const users = await getUsers([fromUser, toUser]);
+  if (users.length !== 2) {
+    const missingUser = [fromUser, toUser].find(
+      (uId) => !users.find((u) => u.user_id === uId),
+    );
+    return res
+      .status(400)
+      .send({ error: `No user found with ID ${missingUser}` });
+  }
 
-	const friendResult = await sendFriendRequest(fromUser, toUser);
+  const friendResult = await sendFriendRequest(fromUser, toUser);
 
-	if ('error' in friendResult) {
-		throw new Error(friendResult.error);
-	}
+  if ("error" in friendResult) {
+    throw new Error(friendResult.error);
+  }
 
-	// Send push notification to the recipient
-	const sender = users.find(u => u.user_id === fromUser);
-	const senderName = sender?.username || 'Someone';
-	sendPush(toUser, {
-		title: 'New friend request',
-		body: `${senderName} wants to be friends`,
-		type: 'friend_request',
-		data: { user_id: fromUser }
-	}).catch(err => console.error('[Push] Error sending friend request notification:', err.message));
+  // Send push notification to the recipient
+  const sender = users.find((u) => u.user_id === fromUser);
+  const senderName = sender?.username || "Someone";
+  sendPush(toUser, {
+    title: "New friend request",
+    body: `${senderName} wants to be friends`,
+    type: "friend_request",
+    data: { user_id: fromUser },
+  }).catch((err) =>
+    console.error(
+      "[Push] Error sending friend request notification:",
+      err.message,
+    ),
+  );
 
-	res.send(friendResult);
+  res.send(friendResult);
 }
 
 export async function getSuggestions(req: Request, res: Response) {
-	if (!hasRequiredKeys(['userId'], req, res)) return;
+  if (!hasRequiredKeys(["userId"], req, res)) return;
 
-	const { userId } = req.params;
+  const { userId } = req.params;
 
-	const user = await getUser({ userId });
-	if (!user) {
-		return res.status(400).send({ error: `No user found with ID ${userId}` });
-	}
+  const user = await getUser({ userId });
+  if (!user) {
+    return res.status(400).send({ error: `No user found with ID ${userId}` });
+  }
 
-	const suggestions = await getFriendSuggestions(userId);
+  const suggestions = await getFriendSuggestions(userId);
 
-	res.send(suggestions);
+  res.send(suggestions);
 }
 
 export async function getFriendsFeed(req: Request, res: Response) {
-	const userId = (req as AuthenticatedRequest).userId;
-	if (!userId) {
-		return res.status(401).send({ error: 'Not authenticated' });
-	}
+  const userId = (req as AuthenticatedRequest).userId;
+  if (!userId) {
+    return res.status(401).send({ error: "Not authenticated" });
+  }
 
-	const feed = await getFriendsWorkoutFeed(userId);
+  const feed = await getFriendsWorkoutFeed(userId);
 
-	res.send(feed);
+  res.send(feed);
 }
 
 export async function getMutualFriends(req: Request, res: Response) {
-	if (!hasRequiredKeys(['userId'], req, res)) return;
+  if (!hasRequiredKeys(["userId"], req, res)) return;
 
-	const viewerId = (req as AuthenticatedRequest).userId;
-	const { userId } = req.params;
+  const viewerId = (req as AuthenticatedRequest).userId;
+  const { userId } = req.params;
 
-	const count = await getMutualFriendCount(viewerId as string, userId);
+  const count = await getMutualFriendCount(viewerId as string, userId);
 
-	res.send({ count });
+  res.send({ count });
 }
 
 export async function getFriendsActivityToday(req: Request, res: Response) {
-	if (!hasRequiredKeys(['userId'], req, res)) return;
+  if (!hasRequiredKeys(["userId"], req, res)) return;
 
-	const { userId } = req.params;
+  const { userId } = req.params;
 
-	const user = await getUser({ userId });
-	if (!user) {
-		return res.status(400).send({ error: `No user found with ID ${userId}` });
-	}
+  const user = await getUser({ userId });
+  if (!user) {
+    return res.status(400).send({ error: `No user found with ID ${userId}` });
+  }
 
-	const activity = await getActivityToday(userId);
+  const activity = await getActivityToday(userId);
 
-	res.send(activity);
+  res.send(activity);
 }
 
-export function getFriendshipHandler(status: 'accepted' | 'rejected' | 'ignored' | 'removed') {
-	return async function friendshipHandler(req: Request, res: Response) {
-		if (!hasRequiredKeys(['fromUser', 'toUser'], req, res)) return;
+export function getFriendshipHandler(
+  status: "accepted" | "rejected" | "ignored" | "removed",
+) {
+  return async function friendshipHandler(req: Request, res: Response) {
+    if (!hasRequiredKeys(["fromUser", "toUser"], req, res)) return;
 
-		const { fromUser, toUser } = req.body;
+    const { fromUser, toUser } = req.body;
 
-		const users = await getUsers([fromUser, toUser]);
-		if (users.length !== 2) {
-			const missingUser = [fromUser, toUser].find(uId => !users.find(u => u.user_id === uId));
-			return res.status(400).send({ error: `No user found with ID ${missingUser}` });
-		}
+    const users = await getUsers([fromUser, toUser]);
+    if (users.length !== 2) {
+      const missingUser = [fromUser, toUser].find(
+        (uId) => !users.find((u) => u.user_id === uId),
+      );
+      return res
+        .status(400)
+        .send({ error: `No user found with ID ${missingUser}` });
+    }
 
-		const friendResult = await updateFriendship(toUser, fromUser, status);
+    const friendResult = await updateFriendship(toUser, fromUser, status);
 
-		if ('error' in friendResult) {
-			if (BAD_REQUEST_ERRORS.find(e => friendResult.error.startsWith(e))) {
-				return res.status(400).send(friendResult);
-			} else {
-				throw new Error(friendResult.error);
-			}
-		}
+    if ("error" in friendResult) {
+      if (BAD_REQUEST_ERRORS.find((e) => friendResult.error.startsWith(e))) {
+        return res.status(400).send(friendResult);
+      } else {
+        throw new Error(friendResult.error);
+      }
+    }
 
-		// Notify the original sender that their request was accepted
-		if (status === 'accepted') {
-			const accepter = users.find(u => u.user_id === toUser);
-			const accepterName = accepter?.username || 'Someone';
-			sendPush(fromUser, {
-				title: 'Friend request accepted',
-				body: `${accepterName} accepted your friend request`,
-				type: 'friend_request_accepted',
-				data: { user_id: toUser }
-			}).catch(err => console.error('[Push] Error sending friend accepted notification:', err.message));
-		}
+    // Notify the original sender that their request was accepted
+    if (status === "accepted") {
+      // "Make a Friend" daily challenge: award whichever side just crossed
+      // 0 → 1 friends. Fire-and-forget — never blocks or fails the accept.
+      for (const uid of [fromUser, toUser]) {
+        evaluateAddFriendCompletion(uid)
+          .then((completion) => {
+            if (completion) {
+              fanOutFriendChallengePush(uid, completion).catch((err) =>
+                console.error(
+                  "[Challenges] add_friend fan-out failed:",
+                  err.message,
+                ),
+              );
+            }
+          })
+          .catch((err) =>
+            console.error(
+              "[Challenges] add_friend award failed:",
+              err?.message ?? err,
+            ),
+          );
+      }
 
-		res.send(friendResult);
-	};
+      const accepter = users.find((u) => u.user_id === toUser);
+      const accepterName = accepter?.username || "Someone";
+      sendPush(fromUser, {
+        title: "Friend request accepted",
+        body: `${accepterName} accepted your friend request`,
+        type: "friend_request_accepted",
+        data: { user_id: toUser },
+      }).catch((err) =>
+        console.error(
+          "[Push] Error sending friend accepted notification:",
+          err.message,
+        ),
+      );
+    }
+
+    res.send(friendResult);
+  };
 }

--- a/backend/src/controllers/notificationSettingsController.ts
+++ b/backend/src/controllers/notificationSettingsController.ts
@@ -1,78 +1,133 @@
-import { Response } from 'express';
-import { AuthenticatedRequest } from '../middleware/auth.js';
+import { Response } from "express";
+import { AuthenticatedRequest } from "../middleware/auth.js";
 import {
-	getNotificationPreferences,
-	updateNotificationPreferences,
-	getFriendNotificationSettings,
-	updateFriendNotificationSettings
-} from '../services/notificationSettingsService.js';
+  getNotificationPreferences,
+  updateNotificationPreferences,
+  getFriendNotificationSettings,
+  updateFriendNotificationSettings,
+} from "../services/notificationSettingsService.js";
+import { getCloseFriendIds } from "../services/closeFriendsService.js";
 
 export async function getPreferences(req: AuthenticatedRequest, res: Response) {
-	try {
-		const prefs = await getNotificationPreferences(req.userId!);
-		res.status(200).json(prefs);
-	} catch (error: any) {
-		console.error('Error getting notification preferences:', error.message);
-		res.status(500).json({ error: 'Error getting notification preferences' });
-	}
+  try {
+    const prefs = await getNotificationPreferences(req.userId!);
+    res.status(200).json(prefs);
+  } catch (error: any) {
+    console.error("Error getting notification preferences:", error.message);
+    res.status(500).json({ error: "Error getting notification preferences" });
+  }
 }
 
-export async function updatePreferences(req: AuthenticatedRequest, res: Response) {
-	try {
-		const { quiet_hours_start, quiet_hours_end, daily_reminder_hour, timezone_offset_minutes } = req.body;
-		if (quiet_hours_start !== undefined && quiet_hours_start !== null && (quiet_hours_start < 0 || quiet_hours_start > 23)) {
-			return res.status(400).json({ error: 'quiet_hours_start must be 0-23 or null' });
-		}
-		if (quiet_hours_end !== undefined && quiet_hours_end !== null && (quiet_hours_end < 0 || quiet_hours_end > 23)) {
-			return res.status(400).json({ error: 'quiet_hours_end must be 0-23 or null' });
-		}
-		if (
-			daily_reminder_hour !== undefined &&
-			daily_reminder_hour !== null &&
-			(daily_reminder_hour < 0 || daily_reminder_hour > 23)
-		) {
-			return res.status(400).json({ error: 'daily_reminder_hour must be 0-23' });
-		}
-		// UTC offsets range roughly from -12:00 (-720) to +14:00 (+840) minutes.
-		if (
-			timezone_offset_minutes !== undefined &&
-			timezone_offset_minutes !== null &&
-			(timezone_offset_minutes < -720 || timezone_offset_minutes > 840)
-		) {
-			return res.status(400).json({ error: 'timezone_offset_minutes must be between -720 and 840' });
-		}
+export async function updatePreferences(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  try {
+    const {
+      quiet_hours_start,
+      quiet_hours_end,
+      daily_reminder_hour,
+      timezone_offset_minutes,
+    } = req.body;
+    if (
+      quiet_hours_start !== undefined &&
+      quiet_hours_start !== null &&
+      (quiet_hours_start < 0 || quiet_hours_start > 23)
+    ) {
+      return res
+        .status(400)
+        .json({ error: "quiet_hours_start must be 0-23 or null" });
+    }
+    if (
+      quiet_hours_end !== undefined &&
+      quiet_hours_end !== null &&
+      (quiet_hours_end < 0 || quiet_hours_end > 23)
+    ) {
+      return res
+        .status(400)
+        .json({ error: "quiet_hours_end must be 0-23 or null" });
+    }
+    if (
+      daily_reminder_hour !== undefined &&
+      daily_reminder_hour !== null &&
+      (daily_reminder_hour < 0 || daily_reminder_hour > 23)
+    ) {
+      return res
+        .status(400)
+        .json({ error: "daily_reminder_hour must be 0-23" });
+    }
+    // UTC offsets range roughly from -12:00 (-720) to +14:00 (+840) minutes.
+    if (
+      timezone_offset_minutes !== undefined &&
+      timezone_offset_minutes !== null &&
+      (timezone_offset_minutes < -720 || timezone_offset_minutes > 840)
+    ) {
+      return res.status(400).json({
+        error: "timezone_offset_minutes must be between -720 and 840",
+      });
+    }
+    // Restricting Head-to-Head to close friends is only enableable when the
+    // user actually HAS close friends — otherwise their rival pool would be
+    // empty and the challenge would silently vanish from their rotation.
+    // Disabling is always allowed.
+    if (req.body.h2h_close_friends_only === true) {
+      const closeIds = await getCloseFriendIds(req.userId!);
+      if (closeIds.length === 0) {
+        return res.status(400).json({
+          error: "Add at least one close friend before turning this on",
+          code: "no_close_friends",
+        });
+      }
+    }
 
-		const updated = await updateNotificationPreferences(req.userId!, req.body);
-		res.status(200).json(updated);
-	} catch (error: any) {
-		console.error('Error updating notification preferences:', error.message);
-		res.status(500).json({ error: 'Error updating notification preferences' });
-	}
+    const updated = await updateNotificationPreferences(req.userId!, req.body);
+    res.status(200).json(updated);
+  } catch (error: any) {
+    console.error("Error updating notification preferences:", error.message);
+    res.status(500).json({ error: "Error updating notification preferences" });
+  }
 }
 
-export async function getFriendSettings(req: AuthenticatedRequest, res: Response) {
-	try {
-		const settings = await getFriendNotificationSettings(req.userId!);
-		res.status(200).json({ settings });
-	} catch (error: any) {
-		console.error('Error getting friend notification settings:', error.message);
-		res.status(500).json({ error: 'Error getting friend notification settings' });
-	}
+export async function getFriendSettings(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  try {
+    const settings = await getFriendNotificationSettings(req.userId!);
+    res.status(200).json({ settings });
+  } catch (error: any) {
+    console.error("Error getting friend notification settings:", error.message);
+    res
+      .status(500)
+      .json({ error: "Error getting friend notification settings" });
+  }
 }
 
-export async function updateFriendSettings(req: AuthenticatedRequest, res: Response) {
-	const friendId = req.params.friendId;
-	const { muted, nudges_muted, activity_muted } = req.body;
+export async function updateFriendSettings(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  const friendId = req.params.friendId;
+  const { muted, nudges_muted, activity_muted } = req.body;
 
-	try {
-		const updated = await updateFriendNotificationSettings(req.userId!, friendId, {
-			muted,
-			nudges_muted,
-			activity_muted
-		});
-		res.status(200).json(updated);
-	} catch (error: any) {
-		console.error('Error updating friend notification settings:', error.message);
-		res.status(500).json({ error: 'Error updating friend notification settings' });
-	}
+  try {
+    const updated = await updateFriendNotificationSettings(
+      req.userId!,
+      friendId,
+      {
+        muted,
+        nudges_muted,
+        activity_muted,
+      },
+    );
+    res.status(200).json(updated);
+  } catch (error: any) {
+    console.error(
+      "Error updating friend notification settings:",
+      error.message,
+    );
+    res
+      .status(500)
+      .json({ error: "Error updating friend notification settings" });
+  }
 }

--- a/backend/src/cron/h2hChallengeCron.ts
+++ b/backend/src/cron/h2hChallengeCron.ts
@@ -1,0 +1,32 @@
+import cron from "node-cron";
+import {
+  resolveDueMatchups,
+  notifyPendingWinners,
+} from "../services/h2hMatchupService.js";
+
+/**
+ * Head-to-Head daily-challenge lifecycle:
+ *  - resolveDueMatchups: scores each duel once BOTH users' local day is over
+ *    (+ grace for late HealthKit syncs) and awards the winner's completion.
+ *  - notifyPendingWinners: sends the "you won" push during the winner's local
+ *    daytime instead of at the small-hours scoring moment.
+ * Hourly so each timezone is picked up shortly after its own cutoffs pass;
+ * both steps are idempotent per matchup, so re-runs are no-ops. :20 keeps it
+ * clear of the :00 (daily reminders) and :50 (weekly recap) hourly jobs.
+ */
+export function startH2hChallengeCron(): void {
+  cron.schedule("20 * * * *", async () => {
+    try {
+      await resolveDueMatchups();
+    } catch (error: any) {
+      console.error("[CRON] Error resolving H2H matchups:", error.message);
+    }
+    try {
+      await notifyPendingWinners();
+    } catch (error: any) {
+      console.error("[CRON] Error notifying H2H winners:", error.message);
+    }
+  });
+
+  console.log("H2H challenge cron scheduled (hourly resolve + winner notify).");
+}

--- a/backend/src/db/drizzle/0016_wonderful_sandman.sql
+++ b/backend/src/db/drizzle/0016_wonderful_sandman.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "h2h_matchups" (
+	"local_date" date NOT NULL,
+	"user_id" text NOT NULL,
+	"rival_id" text NOT NULL,
+	"mutual" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"resolved_at" timestamp with time zone,
+	"won" boolean,
+	"notified_at" timestamp with time zone,
+	CONSTRAINT "h2h_matchups_pkey" PRIMARY KEY("local_date","user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "h2h_matchups" ADD CONSTRAINT "h2h_matchups_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("user_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "h2h_matchups" ADD CONSTRAINT "h2h_matchups_rival_id_fkey" FOREIGN KEY ("rival_id") REFERENCES "public"."users"("user_id") ON DELETE cascade ON UPDATE no action;

--- a/backend/src/db/drizzle/0017_faulty_shiver_man.sql
+++ b/backend/src/db/drizzle/0017_faulty_shiver_man.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "notification_settings" ADD COLUMN "h2h_close_friends_only" boolean DEFAULT false NOT NULL;

--- a/backend/src/db/drizzle/meta/0016_snapshot.json
+++ b/backend/src/db/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,3938 @@
+{
+  "id": "c2b86a5a-d9f9-45c9-b874-3b8968ff0451",
+  "prevId": "c4869218-c667-499b-85fe-2b00962bed2a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.android_waitlist": {
+      "name": "android_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'website'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "android_waitlist_email_unique": {
+          "name": "android_waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_badges_category": {
+          "name": "idx_badges_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "badges_rarity_check": {
+          "name": "badges_rarity_check",
+          "value": "rarity = ANY (ARRAY['common'::text, 'rare'::text, 'legendary'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.close_friends": {
+      "name": "close_friends",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_friend_id": {
+          "name": "close_friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_close_friends_friend": {
+          "name": "idx_close_friends_friend",
+          "columns": [
+            {
+              "expression": "close_friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "close_friends_pkey": {
+          "name": "close_friends_pkey",
+          "columns": [
+            "user_id",
+            "close_friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_users": {
+      "name": "competition_users",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_rank": {
+          "name": "last_known_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_score": {
+          "name": "last_known_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rank_updated_at": {
+          "name": "last_rank_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_competition_users_comp": {
+          "name": "idx_competition_users_comp",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_competition": {
+          "name": "idx_competition_users_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_rank_cache": {
+          "name": "idx_competition_users_rank_cache",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_known_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((invite_status)::text = 'accepted'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user": {
+          "name": "idx_competition_users_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user_status": {
+          "name": "idx_competition_users_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invite_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_users_user_id_fkey": {
+          "name": "competition_users_user_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_users_competition_id_fkey": {
+          "name": "competition_users_competition_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_users_pkey": {
+          "name": "competition_users_pkey",
+          "columns": [
+            "competition_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_users_invite_status_check": {
+          "name": "competition_users_invite_status_check",
+          "value": "(invite_status)::text = ANY ((ARRAY['pending'::character varying, 'accepted'::character varying, 'declined'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workouts": {
+          "name": "workouts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_winner": {
+          "name": "idx_competitions_winner",
+          "columns": [
+            {
+              "expression": "winner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(winner IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_winner_fkey": {
+          "name": "competitions_winner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "competitions_owner_fkey": {
+          "name": "competitions_owner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitions_type_check": {
+          "name": "competitions_type_check",
+          "value": "(type)::text = ANY ((ARRAY['streaks'::character varying, 'apex'::character varying, 'clash'::character varying, 'targets'::character varying, 'race'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_challenges": {
+      "name": "daily_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_template": {
+          "name": "description_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_start": {
+          "name": "gradient_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_end": {
+          "name": "gradient_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rotation_index": {
+          "name": "rotation_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_challenges_rotation_index_key": {
+          "name": "daily_challenges_rotation_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rotation_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daily_challenges_type_check": {
+          "name": "daily_challenges_type_check",
+          "value": "type = ANY (ARRAY['pace'::text, 'distance'::text, 'time'::text, 'activity'::text, 'steps'::text, 'social'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_steps": {
+      "name": "daily_steps",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_steps_user_date": {
+          "name": "idx_daily_steps_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_steps_user_id_fkey": {
+          "name": "daily_steps_user_id_fkey",
+          "tableFrom": "daily_steps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_steps_pkey": {
+          "name": "daily_steps_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "daily_steps_steps_check": {
+          "name": "daily_steps_steps_check",
+          "value": "steps >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token": {
+          "name": "device_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_tokens_user_id": {
+          "name": "idx_device_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_user_id_fkey": {
+          "name": "device_tokens_user_id_fkey",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_user_id_device_token_key": {
+          "name": "device_tokens_user_id_device_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_log": {
+      "name": "error_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_error_log_created_at": {
+          "name": "idx_error_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_error_log_category": {
+          "name": "idx_error_log_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flex_log": {
+      "name": "flex_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flex_log_lookup": {
+          "name": "idx_flex_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_notification_settings": {
+      "name": "friend_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted": {
+          "name": "muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nudges_muted": {
+          "name": "nudges_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "activity_muted": {
+          "name": "activity_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "friend_notification_settings_pkey": {
+          "name": "friend_notification_settings_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_nudge_log": {
+      "name": "friend_nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_nudge_log_lookup": {
+          "name": "idx_friend_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_friendships_friend_status": {
+          "name": "idx_friendships_friend_status",
+          "columns": [
+            {
+              "expression": "friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_friendships_user_status": {
+          "name": "idx_friendships_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_user_id_fkey": {
+          "name": "friendships_user_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_friend_id_fkey": {
+          "name": "friendships_friend_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendships_pkey": {
+          "name": "friendships_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_friendship_pair": {
+          "name": "unique_friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.h2h_matchups": {
+      "name": "h2h_matchups",
+      "schema": "",
+      "columns": {
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rival_id": {
+          "name": "rival_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mutual": {
+          "name": "mutual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "won": {
+          "name": "won",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "h2h_matchups_user_id_fkey": {
+          "name": "h2h_matchups_user_id_fkey",
+          "tableFrom": "h2h_matchups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "h2h_matchups_rival_id_fkey": {
+          "name": "h2h_matchups_rival_id_fkey",
+          "tableFrom": "h2h_matchups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "rival_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "h2h_matchups_pkey": {
+          "name": "h2h_matchups_pkey",
+          "columns": [
+            "local_date",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hype_log": {
+      "name": "hype_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_label": {
+          "name": "context_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hype_log_context_dedupe_idx": {
+          "name": "hype_log_context_dedupe_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_lookup": {
+          "name": "idx_hype_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_app_notifications": {
+      "name": "in_app_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_in_app_notifications_unread": {
+          "name": "idx_in_app_notifications_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_read = false)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_app_notifications_user": {
+          "name": "idx_in_app_notifications_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_app_notifications_user_id_fkey": {
+          "name": "in_app_notifications_user_id_fkey",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_notifications": {
+      "name": "milestone_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_key": {
+          "name": "milestone_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_notifications_milestone_key_key": {
+          "name": "milestone_notifications_milestone_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_audience_settings": {
+      "name": "notification_audience_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_audience_settings_pkey": {
+          "name": "notification_audience_settings_pkey",
+          "columns": [
+            "user_id",
+            "direction",
+            "event_type",
+            "activity_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_audience_settings_direction_check": {
+          "name": "notification_audience_settings_direction_check",
+          "value": "direction = ANY (ARRAY['outgoing'::text, 'incoming'::text])"
+        },
+        "notification_audience_settings_audience_check": {
+          "name": "notification_audience_settings_audience_check",
+          "value": "audience = ANY (ARRAY['none'::text, 'close'::text, 'all'::text, 'ask'::text, 'match_run'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_user_date": {
+          "name": "idx_notification_log_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nudges_enabled": {
+          "name": "nudges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "flexes_enabled": {
+          "name": "flexes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_activity_enabled": {
+          "name": "friend_activity_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_invites_enabled": {
+          "name": "competition_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_updates_enabled": {
+          "name": "competition_updates_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_milestones_enabled": {
+          "name": "competition_milestones_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "hypes_enabled": {
+          "name": "hypes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "step_goal_enabled": {
+          "name": "step_goal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "friend_personal_best_enabled": {
+          "name": "friend_personal_best_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_enabled": {
+          "name": "daily_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_hour": {
+          "name": "daily_reminder_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 18
+        },
+        "timezone_offset_minutes": {
+          "name": "timezone_offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_workouts_to_feed": {
+          "name": "share_workouts_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_posts_enabled": {
+          "name": "friend_posts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "share_route_maps": {
+          "name": "share_route_maps",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "weekly_recap_enabled": {
+          "name": "weekly_recap_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nudge_log": {
+      "name": "nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_nudge_log_lookup": {
+          "name": "idx_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nudge_log_rate_limit": {
+          "name": "idx_nudge_log_rate_limit",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_friend_notifications": {
+      "name": "pending_friend_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "send_after_at": {
+          "name": "send_after_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_friend_notif_user": {
+          "name": "idx_pending_friend_notif_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_pending_friend_notif_workout": {
+          "name": "uq_pending_friend_notif_workout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((workout_id IS NOT NULL) AND (status = 'pending'::text))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pending_friend_notifications_status_check": {
+          "name": "pending_friend_notifications_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'sent'::text, 'dismissed'::text, 'expired'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_notifications": {
+      "name": "pending_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_notifications_unsent": {
+          "name": "idx_pending_notifications_unsent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(sent_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_notifications_user_id_fkey": {
+          "name": "pending_notifications_user_id_fkey",
+          "tableFrom": "pending_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_reports": {
+      "name": "post_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_reports_dedupe_idx": {
+          "name": "post_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_reports_status": {
+          "name": "idx_post_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_reports_post_id_fkey": {
+          "name": "post_reports_post_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_reports_reporter_id_fkey": {
+          "name": "post_reports_reporter_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_reports_reason_check": {
+          "name": "post_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_snapshot": {
+          "name": "stats_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_to_feed": {
+          "name": "share_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_to_story": {
+          "name": "share_to_story",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "story_expires_at": {
+          "name": "story_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto": {
+          "name": "is_auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_route": {
+          "name": "include_route",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_posts_user_created": {
+          "name": "idx_posts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_feed": {
+          "name": "idx_posts_feed",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_story_active": {
+          "name": "idx_posts_story_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "story_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_story)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_active": {
+          "name": "uq_posts_workout_active",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_story": {
+          "name": "uq_posts_workout_story",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_story AND NOT share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_fkey": {
+          "name": "posts_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_workout_id_fkey": {
+          "name": "posts_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_family_id": {
+          "name": "token_family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_hash": {
+          "name": "replaced_by_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "token_family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_revoked_at": {
+          "name": "idx_refresh_tokens_revoked_at",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(revoked_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_token_hash": {
+          "name": "idx_refresh_tokens_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_fkey": {
+          "name": "refresh_tokens_user_id_fkey",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_key": {
+          "name": "refresh_tokens_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_reactions": {
+      "name": "story_reactions",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_reactions_post_id_fkey": {
+          "name": "story_reactions_post_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_reactions_user_id_fkey": {
+          "name": "story_reactions_user_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_reactions_pkey": {
+          "name": "story_reactions_pkey",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_views": {
+      "name": "story_views",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_views_post_id_fkey": {
+          "name": "story_views_post_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_views_viewer_id_fkey": {
+          "name": "story_views_viewer_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_views_pkey": {
+          "name": "story_views_pkey",
+          "columns": [
+            "post_id",
+            "viewer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggering_workout_id": {
+          "name": "triggering_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_snapshot": {
+          "name": "progress_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_slot": {
+          "name": "pin_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_badges_user": {
+          "name": "idx_user_badges_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_new": {
+          "name": "idx_user_badges_user_new",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_new = true)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_pin_slot": {
+          "name": "idx_user_badges_user_pin_slot",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(pin_slot IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_workout": {
+          "name": "idx_user_badges_workout",
+          "columns": [
+            {
+              "expression": "triggering_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_badges_user_id_fkey": {
+          "name": "user_badges_user_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_fkey": {
+          "name": "user_badges_badge_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "badge_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_triggering_workout_id_fkey": {
+          "name": "user_badges_triggering_workout_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "triggering_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_badges_user_id_badge_id_key": {
+          "name": "user_badges_user_id_badge_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "badge_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_badges_pin_slot_range": {
+          "name": "user_badges_pin_slot_range",
+          "value": "(pin_slot IS NULL) OR ((pin_slot >= 0) AND (pin_slot <= 2))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_blocks_blocked": {
+          "name": "idx_user_blocks_blocked",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_fkey": {
+          "name": "user_blocks_blocker_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_blocks_blocked_id_fkey": {
+          "name": "user_blocks_blocked_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_pkey": {
+          "name": "user_blocks_pkey",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenge_completions": {
+      "name": "user_challenge_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completing_workout_id": {
+          "name": "completing_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ucc_user": {
+          "name": "idx_ucc_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ucc_user_date": {
+          "name": "idx_ucc_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenge_completions_user_id_fkey": {
+          "name": "user_challenge_completions_user_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_challenge_key_fkey": {
+          "name": "user_challenge_completions_challenge_key_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "daily_challenges",
+          "columnsFrom": [
+            "challenge_key"
+          ],
+          "columnsTo": [
+            "challenge_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_completing_workout_id_fkey": {
+          "name": "user_challenge_completions_completing_workout_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "completing_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_challenge_completions_user_id_local_date_key": {
+          "name": "user_challenge_completions_user_id_local_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_sub": {
+          "name": "apple_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "goal_miles": {
+          "name": "goal_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_current_streak_desc": {
+          "name": "idx_users_current_streak_desc",
+          "columns": [
+            {
+              "expression": "current_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email_trgm": {
+          "name": "idx_users_email_trgm",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_username_trgm": {
+          "name": "idx_users_username_trgm",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_apple_id_key": {
+          "name": "users_apple_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_apple_sub_key": {
+          "name": "users_apple_sub_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "apple_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_recap_log": {
+      "name": "weekly_recap_log",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "weekly_recap_log_pkey": {
+          "name": "weekly_recap_log_pkey",
+          "columns": [
+            "user_id",
+            "week_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_completion_notifications": {
+      "name": "workout_completion_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_date": {
+          "name": "notified_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_completion_notifications_user_id_notified_date_key": {
+          "name": "workout_completion_notifications_user_id_notified_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "notified_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_routes": {
+      "name": "workout_routes",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "point_count": {
+          "name": "point_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workout_routes_workout_id_fkey": {
+          "name": "workout_routes_workout_id_fkey",
+          "tableFrom": "workout_routes",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_splits": {
+      "name": "workout_splits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_number": {
+          "name": "split_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_duration": {
+          "name": "split_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_distance": {
+          "name": "split_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_pace": {
+          "name": "split_pace",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_splits_time": {
+          "name": "idx_splits_time",
+          "columns": [
+            {
+              "expression": "split_duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_splits_workout": {
+          "name": "idx_splits_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_splits_workout_id_fkey": {
+          "name": "workout_splits_workout_id_fkey",
+          "tableFrom": "workout_splits",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_splits_workout_id_split_number_key": {
+          "name": "workout_splits_workout_id_split_number_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "split_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workouts": {
+      "name": "workouts",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_end_date": {
+          "name": "device_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthkit'"
+        },
+        "original_distance": {
+          "name": "original_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_duration": {
+          "name": "original_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_flagged": {
+          "name": "speed_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_workouts_local_date_user_id": {
+          "name": "idx_workouts_local_date_user_id",
+          "columns": [
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_device_end": {
+          "name": "idx_workouts_user_device_end",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_local_date": {
+          "name": "idx_workouts_user_local_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workouts_user_workout_unique": {
+          "name": "workouts_user_workout_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/drizzle/meta/0017_snapshot.json
+++ b/backend/src/db/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,3945 @@
+{
+  "id": "38eeb59e-bb83-436c-b7c0-0c6669445fc7",
+  "prevId": "c2b86a5a-d9f9-45c9-b874-3b8968ff0451",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.android_waitlist": {
+      "name": "android_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'website'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "android_waitlist_email_unique": {
+          "name": "android_waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_badges_category": {
+          "name": "idx_badges_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "badges_rarity_check": {
+          "name": "badges_rarity_check",
+          "value": "rarity = ANY (ARRAY['common'::text, 'rare'::text, 'legendary'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.close_friends": {
+      "name": "close_friends",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_friend_id": {
+          "name": "close_friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_close_friends_friend": {
+          "name": "idx_close_friends_friend",
+          "columns": [
+            {
+              "expression": "close_friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "close_friends_pkey": {
+          "name": "close_friends_pkey",
+          "columns": [
+            "user_id",
+            "close_friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_users": {
+      "name": "competition_users",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_rank": {
+          "name": "last_known_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_score": {
+          "name": "last_known_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rank_updated_at": {
+          "name": "last_rank_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_competition_users_comp": {
+          "name": "idx_competition_users_comp",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_competition": {
+          "name": "idx_competition_users_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_rank_cache": {
+          "name": "idx_competition_users_rank_cache",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_known_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((invite_status)::text = 'accepted'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user": {
+          "name": "idx_competition_users_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user_status": {
+          "name": "idx_competition_users_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invite_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_users_user_id_fkey": {
+          "name": "competition_users_user_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_users_competition_id_fkey": {
+          "name": "competition_users_competition_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_users_pkey": {
+          "name": "competition_users_pkey",
+          "columns": [
+            "competition_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_users_invite_status_check": {
+          "name": "competition_users_invite_status_check",
+          "value": "(invite_status)::text = ANY ((ARRAY['pending'::character varying, 'accepted'::character varying, 'declined'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workouts": {
+          "name": "workouts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_winner": {
+          "name": "idx_competitions_winner",
+          "columns": [
+            {
+              "expression": "winner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(winner IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_winner_fkey": {
+          "name": "competitions_winner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "competitions_owner_fkey": {
+          "name": "competitions_owner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitions_type_check": {
+          "name": "competitions_type_check",
+          "value": "(type)::text = ANY ((ARRAY['streaks'::character varying, 'apex'::character varying, 'clash'::character varying, 'targets'::character varying, 'race'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_challenges": {
+      "name": "daily_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_template": {
+          "name": "description_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_start": {
+          "name": "gradient_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_end": {
+          "name": "gradient_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rotation_index": {
+          "name": "rotation_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_challenges_rotation_index_key": {
+          "name": "daily_challenges_rotation_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rotation_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daily_challenges_type_check": {
+          "name": "daily_challenges_type_check",
+          "value": "type = ANY (ARRAY['pace'::text, 'distance'::text, 'time'::text, 'activity'::text, 'steps'::text, 'social'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_steps": {
+      "name": "daily_steps",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_steps_user_date": {
+          "name": "idx_daily_steps_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_steps_user_id_fkey": {
+          "name": "daily_steps_user_id_fkey",
+          "tableFrom": "daily_steps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_steps_pkey": {
+          "name": "daily_steps_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "daily_steps_steps_check": {
+          "name": "daily_steps_steps_check",
+          "value": "steps >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token": {
+          "name": "device_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_tokens_user_id": {
+          "name": "idx_device_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_user_id_fkey": {
+          "name": "device_tokens_user_id_fkey",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_user_id_device_token_key": {
+          "name": "device_tokens_user_id_device_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_log": {
+      "name": "error_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_error_log_created_at": {
+          "name": "idx_error_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_error_log_category": {
+          "name": "idx_error_log_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flex_log": {
+      "name": "flex_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flex_log_lookup": {
+          "name": "idx_flex_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_notification_settings": {
+      "name": "friend_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted": {
+          "name": "muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nudges_muted": {
+          "name": "nudges_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "activity_muted": {
+          "name": "activity_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "friend_notification_settings_pkey": {
+          "name": "friend_notification_settings_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_nudge_log": {
+      "name": "friend_nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_nudge_log_lookup": {
+          "name": "idx_friend_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_friendships_friend_status": {
+          "name": "idx_friendships_friend_status",
+          "columns": [
+            {
+              "expression": "friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_friendships_user_status": {
+          "name": "idx_friendships_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_user_id_fkey": {
+          "name": "friendships_user_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_friend_id_fkey": {
+          "name": "friendships_friend_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendships_pkey": {
+          "name": "friendships_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_friendship_pair": {
+          "name": "unique_friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.h2h_matchups": {
+      "name": "h2h_matchups",
+      "schema": "",
+      "columns": {
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rival_id": {
+          "name": "rival_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mutual": {
+          "name": "mutual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "won": {
+          "name": "won",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "h2h_matchups_user_id_fkey": {
+          "name": "h2h_matchups_user_id_fkey",
+          "tableFrom": "h2h_matchups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "h2h_matchups_rival_id_fkey": {
+          "name": "h2h_matchups_rival_id_fkey",
+          "tableFrom": "h2h_matchups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "rival_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "h2h_matchups_pkey": {
+          "name": "h2h_matchups_pkey",
+          "columns": [
+            "local_date",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hype_log": {
+      "name": "hype_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_label": {
+          "name": "context_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hype_log_context_dedupe_idx": {
+          "name": "hype_log_context_dedupe_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_lookup": {
+          "name": "idx_hype_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_app_notifications": {
+      "name": "in_app_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_in_app_notifications_unread": {
+          "name": "idx_in_app_notifications_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_read = false)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_app_notifications_user": {
+          "name": "idx_in_app_notifications_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_app_notifications_user_id_fkey": {
+          "name": "in_app_notifications_user_id_fkey",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_notifications": {
+      "name": "milestone_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_key": {
+          "name": "milestone_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_notifications_milestone_key_key": {
+          "name": "milestone_notifications_milestone_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_audience_settings": {
+      "name": "notification_audience_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_audience_settings_pkey": {
+          "name": "notification_audience_settings_pkey",
+          "columns": [
+            "user_id",
+            "direction",
+            "event_type",
+            "activity_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_audience_settings_direction_check": {
+          "name": "notification_audience_settings_direction_check",
+          "value": "direction = ANY (ARRAY['outgoing'::text, 'incoming'::text])"
+        },
+        "notification_audience_settings_audience_check": {
+          "name": "notification_audience_settings_audience_check",
+          "value": "audience = ANY (ARRAY['none'::text, 'close'::text, 'all'::text, 'ask'::text, 'match_run'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_user_date": {
+          "name": "idx_notification_log_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nudges_enabled": {
+          "name": "nudges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "flexes_enabled": {
+          "name": "flexes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_activity_enabled": {
+          "name": "friend_activity_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_invites_enabled": {
+          "name": "competition_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_updates_enabled": {
+          "name": "competition_updates_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_milestones_enabled": {
+          "name": "competition_milestones_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "hypes_enabled": {
+          "name": "hypes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "step_goal_enabled": {
+          "name": "step_goal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "friend_personal_best_enabled": {
+          "name": "friend_personal_best_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_enabled": {
+          "name": "daily_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_hour": {
+          "name": "daily_reminder_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 18
+        },
+        "h2h_close_friends_only": {
+          "name": "h2h_close_friends_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone_offset_minutes": {
+          "name": "timezone_offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_workouts_to_feed": {
+          "name": "share_workouts_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_posts_enabled": {
+          "name": "friend_posts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "share_route_maps": {
+          "name": "share_route_maps",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "weekly_recap_enabled": {
+          "name": "weekly_recap_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nudge_log": {
+      "name": "nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_nudge_log_lookup": {
+          "name": "idx_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nudge_log_rate_limit": {
+          "name": "idx_nudge_log_rate_limit",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_friend_notifications": {
+      "name": "pending_friend_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "send_after_at": {
+          "name": "send_after_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_friend_notif_user": {
+          "name": "idx_pending_friend_notif_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_pending_friend_notif_workout": {
+          "name": "uq_pending_friend_notif_workout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((workout_id IS NOT NULL) AND (status = 'pending'::text))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pending_friend_notifications_status_check": {
+          "name": "pending_friend_notifications_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'sent'::text, 'dismissed'::text, 'expired'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_notifications": {
+      "name": "pending_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_notifications_unsent": {
+          "name": "idx_pending_notifications_unsent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(sent_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_notifications_user_id_fkey": {
+          "name": "pending_notifications_user_id_fkey",
+          "tableFrom": "pending_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_reports": {
+      "name": "post_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_reports_dedupe_idx": {
+          "name": "post_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_reports_status": {
+          "name": "idx_post_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_reports_post_id_fkey": {
+          "name": "post_reports_post_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_reports_reporter_id_fkey": {
+          "name": "post_reports_reporter_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_reports_reason_check": {
+          "name": "post_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_snapshot": {
+          "name": "stats_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_to_feed": {
+          "name": "share_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_to_story": {
+          "name": "share_to_story",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "story_expires_at": {
+          "name": "story_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto": {
+          "name": "is_auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_route": {
+          "name": "include_route",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_posts_user_created": {
+          "name": "idx_posts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_feed": {
+          "name": "idx_posts_feed",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_story_active": {
+          "name": "idx_posts_story_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "story_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_story)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_active": {
+          "name": "uq_posts_workout_active",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_story": {
+          "name": "uq_posts_workout_story",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_story AND NOT share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_fkey": {
+          "name": "posts_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_workout_id_fkey": {
+          "name": "posts_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_family_id": {
+          "name": "token_family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_hash": {
+          "name": "replaced_by_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "token_family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_revoked_at": {
+          "name": "idx_refresh_tokens_revoked_at",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(revoked_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_token_hash": {
+          "name": "idx_refresh_tokens_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_fkey": {
+          "name": "refresh_tokens_user_id_fkey",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_key": {
+          "name": "refresh_tokens_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_reactions": {
+      "name": "story_reactions",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_reactions_post_id_fkey": {
+          "name": "story_reactions_post_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_reactions_user_id_fkey": {
+          "name": "story_reactions_user_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_reactions_pkey": {
+          "name": "story_reactions_pkey",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_views": {
+      "name": "story_views",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_views_post_id_fkey": {
+          "name": "story_views_post_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_views_viewer_id_fkey": {
+          "name": "story_views_viewer_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_views_pkey": {
+          "name": "story_views_pkey",
+          "columns": [
+            "post_id",
+            "viewer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggering_workout_id": {
+          "name": "triggering_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_snapshot": {
+          "name": "progress_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_slot": {
+          "name": "pin_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_badges_user": {
+          "name": "idx_user_badges_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_new": {
+          "name": "idx_user_badges_user_new",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_new = true)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_pin_slot": {
+          "name": "idx_user_badges_user_pin_slot",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(pin_slot IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_workout": {
+          "name": "idx_user_badges_workout",
+          "columns": [
+            {
+              "expression": "triggering_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_badges_user_id_fkey": {
+          "name": "user_badges_user_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_fkey": {
+          "name": "user_badges_badge_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "badge_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_triggering_workout_id_fkey": {
+          "name": "user_badges_triggering_workout_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "triggering_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_badges_user_id_badge_id_key": {
+          "name": "user_badges_user_id_badge_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "badge_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_badges_pin_slot_range": {
+          "name": "user_badges_pin_slot_range",
+          "value": "(pin_slot IS NULL) OR ((pin_slot >= 0) AND (pin_slot <= 2))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_blocks_blocked": {
+          "name": "idx_user_blocks_blocked",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_fkey": {
+          "name": "user_blocks_blocker_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_blocks_blocked_id_fkey": {
+          "name": "user_blocks_blocked_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_pkey": {
+          "name": "user_blocks_pkey",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenge_completions": {
+      "name": "user_challenge_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completing_workout_id": {
+          "name": "completing_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ucc_user": {
+          "name": "idx_ucc_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ucc_user_date": {
+          "name": "idx_ucc_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenge_completions_user_id_fkey": {
+          "name": "user_challenge_completions_user_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_challenge_key_fkey": {
+          "name": "user_challenge_completions_challenge_key_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "daily_challenges",
+          "columnsFrom": [
+            "challenge_key"
+          ],
+          "columnsTo": [
+            "challenge_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_completing_workout_id_fkey": {
+          "name": "user_challenge_completions_completing_workout_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "completing_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_challenge_completions_user_id_local_date_key": {
+          "name": "user_challenge_completions_user_id_local_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_sub": {
+          "name": "apple_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "goal_miles": {
+          "name": "goal_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_current_streak_desc": {
+          "name": "idx_users_current_streak_desc",
+          "columns": [
+            {
+              "expression": "current_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email_trgm": {
+          "name": "idx_users_email_trgm",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_username_trgm": {
+          "name": "idx_users_username_trgm",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_apple_id_key": {
+          "name": "users_apple_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_apple_sub_key": {
+          "name": "users_apple_sub_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "apple_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_recap_log": {
+      "name": "weekly_recap_log",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "weekly_recap_log_pkey": {
+          "name": "weekly_recap_log_pkey",
+          "columns": [
+            "user_id",
+            "week_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_completion_notifications": {
+      "name": "workout_completion_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_date": {
+          "name": "notified_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_completion_notifications_user_id_notified_date_key": {
+          "name": "workout_completion_notifications_user_id_notified_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "notified_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_routes": {
+      "name": "workout_routes",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "point_count": {
+          "name": "point_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workout_routes_workout_id_fkey": {
+          "name": "workout_routes_workout_id_fkey",
+          "tableFrom": "workout_routes",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_splits": {
+      "name": "workout_splits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_number": {
+          "name": "split_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_duration": {
+          "name": "split_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_distance": {
+          "name": "split_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_pace": {
+          "name": "split_pace",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_splits_time": {
+          "name": "idx_splits_time",
+          "columns": [
+            {
+              "expression": "split_duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_splits_workout": {
+          "name": "idx_splits_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_splits_workout_id_fkey": {
+          "name": "workout_splits_workout_id_fkey",
+          "tableFrom": "workout_splits",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_splits_workout_id_split_number_key": {
+          "name": "workout_splits_workout_id_split_number_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "split_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workouts": {
+      "name": "workouts",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_end_date": {
+          "name": "device_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthkit'"
+        },
+        "original_distance": {
+          "name": "original_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_duration": {
+          "name": "original_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_flagged": {
+          "name": "speed_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_workouts_local_date_user_id": {
+          "name": "idx_workouts_local_date_user_id",
+          "columns": [
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_device_end": {
+          "name": "idx_workouts_user_device_end",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_local_date": {
+          "name": "idx_workouts_user_local_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workouts_user_workout_unique": {
+          "name": "workouts_user_workout_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/drizzle/meta/_journal.json
+++ b/backend/src/db/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1783996800000,
       "tag": "0015_device_token_environment",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1784000000000,
+      "tag": "0016_wonderful_sandman",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/drizzle/meta/_journal.json
+++ b/backend/src/db/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1784000000000,
       "tag": "0016_wonderful_sandman",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1784000060000,
+      "tag": "0017_faulty_shiver_man",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/drizzle/schema.ts
+++ b/backend/src/db/drizzle/schema.ts
@@ -258,6 +258,12 @@ export const notificationSettings = pgTable("notification_settings", {
   ),
   dailyReminderEnabled: boolean("daily_reminder_enabled").default(true),
   dailyReminderHour: integer("daily_reminder_hour").default(18),
+  // Head-to-Head rivals drawn only from the user's close-friends list.
+  // Not a notification pref, but this table is the de-facto per-user
+  // preferences row (see share_workouts_to_feed / share_route_maps).
+  h2hCloseFriendsOnly: boolean("h2h_close_friends_only")
+    .default(false)
+    .notNull(),
   timezoneOffsetMinutes: integer("timezone_offset_minutes"),
   // Social feed settings (added v2). share_workouts_to_feed: include my raw
   // walks/runs as activity cards in friends' unified feed. friend_posts_enabled:

--- a/backend/src/db/drizzle/schema.ts
+++ b/backend/src/db/drizzle/schema.ts
@@ -694,6 +694,49 @@ export const userChallengeCompletions = pgTable(
   ],
 );
 
+export const h2hMatchups = pgTable(
+  "h2h_matchups",
+  {
+    localDate: date("local_date").notNull(),
+    userId: text("user_id").notNull(),
+    rivalId: text("rival_id").notNull(),
+    // TRUE only when this row is half of a reciprocal pair (both users see
+    // each other). Fallback assignments (odd-one-out, mid-day joiners) are FALSE.
+    mutual: boolean().default(false).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+    // Stamped by the end-of-day cron once the duel outcome is final.
+    // `won` is TRUE only when the user won AND the completion row was inserted.
+    resolvedAt: timestamp("resolved_at", {
+      withTimezone: true,
+      mode: "string",
+    }),
+    won: boolean(),
+    // Stamped when the winner push was sent (deferred to the winner's local morning).
+    notifiedAt: timestamp("notified_at", {
+      withTimezone: true,
+      mode: "string",
+    }),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.userId],
+      name: "h2h_matchups_user_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.rivalId],
+      foreignColumns: [users.userId],
+      name: "h2h_matchups_rival_id_fkey",
+    }).onDelete("cascade"),
+    primaryKey({
+      columns: [table.localDate, table.userId],
+      name: "h2h_matchups_pkey",
+    }),
+  ],
+);
+
 export const dailyChallenges = pgTable(
   "daily_challenges",
   {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -33,6 +33,7 @@ import { startSilentSyncCron } from "./cron/silentSyncCron.js";
 import { startStoriesCron } from "./cron/storiesCron.js";
 import { startPendingSendCron } from "./cron/pendingSendCron.js";
 import { startWeeklyRecapCron } from "./cron/weeklyRecapCron.js";
+import { startH2hChallengeCron } from "./cron/h2hChallengeCron.js";
 import { seedExtraBadges } from "./services/badgeService.js";
 import { seedExtraChallenges } from "./services/dailyChallengeService.js";
 import { PostgresService } from "./services/DbService.js";
@@ -251,6 +252,7 @@ function startCrons() {
   startStoriesCron();
   startPendingSendCron();
   startWeeklyRecapCron();
+  startH2hChallengeCron();
   // Idempotently ensure the v2 social/app-function badges exist in the catalog.
   seedExtraBadges();
   // Idempotently ensure the v2 daily challenges (5K/10K/social) exist.

--- a/backend/src/services/challengeRotation.ts
+++ b/backend/src/services/challengeRotation.ts
@@ -25,6 +25,15 @@ export const SOCIAL_CHALLENGE_KEYS = new Set([
 ]);
 
 /**
+ * Substitute challenge shown to FRIENDLESS users on a day their rotation walk
+ * hits head_to_head: instead of silently rotating past the duel, the day
+ * becomes "make your first friend" — the on-ramp into everything social.
+ * Lives in the catalog with active = FALSE so it never enters the normal
+ * rotation; selection substitutes it explicitly (see selectChallengeForUser).
+ */
+export const ADD_FRIEND_CHALLENGE_KEY = "add_friend";
+
+/**
  * Challenges that require the social feed (photo posts). The feed UI is not in
  * the live App Store build yet — and even once it ships, users lingering on
  * older versions won't have it, and there is no app-version signal on API

--- a/backend/src/services/challengeRotation.ts
+++ b/backend/src/services/challengeRotation.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure daily-challenge rotation logic, shared between the per-user selection
+ * in dailyChallengeService and the batch Head-to-Head matchmaker in
+ * h2hMatchupService. Both MUST walk the rotation identically — a drift here
+ * would pair users into duels they can't see (their card shows a different
+ * challenge). Keep this module free of DB access.
+ */
+
+export interface ChallengeRow {
+  challenge_key: string;
+  title: string;
+  description_template: string;
+  icon: string;
+  gradient_start: string;
+  gradient_end: string;
+  type: "pace" | "distance" | "time" | "activity" | "steps" | "social";
+}
+
+/** Social challenges need friends; they're skipped for users with none. */
+export const SOCIAL_CHALLENGE_KEYS = new Set([
+  "hype_squad",
+  "share_journey",
+  "head_to_head",
+  "wingman",
+]);
+
+/**
+ * Challenges that require the social feed (photo posts). The feed UI is not in
+ * the live App Store build yet — and even once it ships, users lingering on
+ * older versions won't have it, and there is no app-version signal on API
+ * calls. A user provably has the feature once their client has touched a
+ * feed-only endpoint: any `posts` row (the feed build auto-posts each
+ * completed mile) or UGC-terms acceptance (only reachable from the composer).
+ * No signal → the challenge is never offered. Self-heals as users update.
+ */
+export const FEED_CHALLENGE_KEYS = new Set(["share_journey"]);
+
+export function dayOfYear(ymd: string): number {
+  const [y, m, d] = ymd.split("-").map((n) => parseInt(n, 10));
+  const start = Date.UTC(y, 0, 1);
+  const curr = Date.UTC(y, m - 1, d);
+  return Math.floor((curr - start) / 86400000) + 1;
+}
+
+/**
+ * The base pick is deterministic by date (so friends on the same day tend to
+ * share a challenge); an ineligible pick deterministically advances to the
+ * next eligible challenge in the rotation. Falls back to the base pick if
+ * nothing is eligible (shouldn't happen).
+ */
+export async function walkRotation(
+  rows: ChallengeRow[],
+  localDate: string,
+  isEligible: (row: ChallengeRow) => Promise<boolean> | boolean,
+): Promise<ChallengeRow> {
+  const baseIdx = dayOfYear(localDate) % rows.length;
+  for (let i = 0; i < rows.length; i++) {
+    const candidate = rows[(baseIdx + i) % rows.length];
+    if (await isEligible(candidate)) return candidate;
+  }
+  return rows[baseIdx];
+}
+
+/**
+ * Deterministic per-day score for an UNDIRECTED friendship edge: identical no
+ * matter which side computes it, so both members of a pair independently
+ * derive the same matching. Plain 32-bit string hash — distribution only, not
+ * cryptographic.
+ */
+export function edgeScore(
+  userA: string,
+  userB: string,
+  localDate: string,
+): number {
+  const [lo, hi] = userA < userB ? [userA, userB] : [userB, userA];
+  const seedStr = `${lo}|${hi}|${localDate}`;
+  let hash = 0;
+  for (let i = 0; i < seedStr.length; i++) {
+    hash = (hash * 31 + seedStr.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}

--- a/backend/src/services/dailyChallengeService.ts
+++ b/backend/src/services/dailyChallengeService.ts
@@ -7,7 +7,15 @@ import {
   FriendTodayChallengeResponse,
   NewChallengeCompletion,
   DailyChallengeType,
+  ChallengeOpponent,
 } from "../types/badge.js";
+import {
+  ChallengeRow,
+  SOCIAL_CHALLENGE_KEYS,
+  FEED_CHALLENGE_KEYS,
+  walkRotation,
+} from "./challengeRotation.js";
+import { getOrAssignRival } from "./h2hMatchupService.js";
 
 const db = PostgresService.getInstance();
 
@@ -28,7 +36,15 @@ export async function getTodaysChallenge(
     : null;
   const challengeRow =
     completedRow ?? (await selectChallengeForUser(userId, localDate));
-  const challenge = await renderChallenge(userId, challengeRow);
+
+  // Head-to-Head: pin today's rival + live mileage so the UI can render the
+  // duel. Built once and threaded through render/progress below.
+  const opponent =
+    challengeRow.challenge_key === "head_to_head"
+      ? await buildOpponent(userId, localDate)
+      : null;
+
+  const challenge = await renderChallenge(userId, challengeRow, { opponent });
 
   const progress = completionRow
     ? 1.0
@@ -37,16 +53,13 @@ export async function getTodaysChallenge(
         localDate,
         challengeRow.challenge_key,
         goalMiles,
+        opponent,
       );
-
-  // Head-to-Head: attach today's rival + live mileage so the UI can render the duel.
-  const opponent =
-    challengeRow.challenge_key === "head_to_head"
-      ? await buildOpponent(userId, localDate)
-      : null;
 
   const tomorrowLocalDate = addDays(localDate, 1);
   const tomorrowRow = await selectChallengeForUser(userId, tomorrowLocalDate);
+  // No opponent passed: tomorrow's matchup isn't set yet, so a Head-to-Head
+  // preview stays generic instead of naming a rival that may change.
   const tomorrowChallenge = await renderChallenge(userId, tomorrowRow);
 
   return {
@@ -119,13 +132,13 @@ export async function getTodaysCompletion(
   } catch {
     challengeRow = null;
   }
-  const rendered = challengeRow
-    ? await renderChallenge(userId, challengeRow)
-    : null;
   const opponent =
     challengeRow?.challenge_key === "head_to_head"
       ? await buildOpponent(userId, localDate)
       : null;
+  const rendered = challengeRow
+    ? await renderChallenge(userId, challengeRow, { opponent })
+    : null;
   return {
     userId,
     localDate,
@@ -238,6 +251,8 @@ async function computeProgress(
   localDate: string,
   challengeKey: string,
   goalMiles: number,
+  // Prefetched Head-to-Head duel (avoids re-querying it per call site).
+  opponent?: ChallengeOpponent | null,
 ): Promise<number> {
   switch (challengeKey) {
     case "double_down": {
@@ -397,10 +412,15 @@ async function computeProgress(
     case "wingman":
       return Math.min((await nudgesToday(userId, localDate)) / 1.0, 1.0);
     case "head_to_head": {
-      const opp = await buildOpponent(userId, localDate);
+      const opp =
+        opponent !== undefined
+          ? opponent
+          : await buildOpponent(userId, localDate);
       if (!opp) return 0;
-      if (opp.myMiles >= goalMiles * 0.95 && opp.myMiles > opp.miles)
-        return 1.0;
+      // The duel is a whole-day total, scored only after BOTH users' local day
+      // ends (h2hMatchupService.resolveDueMatchups). Leading right now is not
+      // winning, so live progress never reports 1.0 — the completion row the
+      // resolver inserts is what pins progress to 1.0 the next day.
       const target = Math.max(opp.miles + 0.01, goalMiles * 0.95);
       return Math.min(opp.myMiles / Math.max(target, 0.01), 0.99);
     }
@@ -552,9 +572,11 @@ async function evaluatePredicate(
       return (await nudgesToday(userId, localDate)) >= 1;
 
     case "head_to_head": {
-      const opp = await buildOpponent(userId, localDate);
-      if (!opp) return false;
-      return opp.myMiles >= goalMiles * 0.95 && opp.myMiles > opp.miles;
+      // Never satisfied at workout-sync time: the duel is a whole-day mileage
+      // total, so nobody can "win" while the rival still has hours left to
+      // run. Scored after BOTH users' local day ends (+ a late-sync grace) by
+      // the hourly cron — see h2hMatchupService.resolveDueMatchups.
+      return false;
     }
 
     default:
@@ -763,34 +785,8 @@ export async function hasChallengeCompletion(
   return rows[0]?.exists === true;
 }
 
-interface ChallengeRow {
-  challenge_key: string;
-  title: string;
-  description_template: string;
-  icon: string;
-  gradient_start: string;
-  gradient_end: string;
-  type: "pace" | "distance" | "time" | "activity" | "steps" | "social";
-}
-
-/** Social challenges need friends; they're skipped for users with none. */
-const SOCIAL_CHALLENGE_KEYS = new Set([
-  "hype_squad",
-  "share_journey",
-  "head_to_head",
-  "wingman",
-]);
-
-/**
- * Challenges that require the social feed (photo posts). The feed UI is not in
- * the live App Store build yet — and even once it ships, users lingering on
- * older versions won't have it, and there is no app-version signal on API
- * calls. A user provably has the feature once their client has touched a
- * feed-only endpoint: any `posts` row (the feed build auto-posts each
- * completed mile) or UGC-terms acceptance (only reachable from the composer).
- * No signal → the challenge is never offered. Self-heals as users update.
- */
-const FEED_CHALLENGE_KEYS = new Set(["share_journey"]);
+// ChallengeRow + rotation eligibility sets live in challengeRotation.ts,
+// shared with the Head-to-Head matchmaker so both walk the rotation identically.
 
 async function getAcceptedFriendCount(userId: string): Promise<number> {
   try {
@@ -843,13 +839,11 @@ async function selectChallengeForUser(
   if (rows.length === 0)
     throw new Error("No active daily challenges configured");
 
-  const baseIdx = dayOfYear(localDate) % rows.length;
-
   // Eligibility signals resolved lazily and at most once per selection —
   // the common (non-gated) base pick costs no extra queries.
   let friendCount: number | null = null;
   let hasFeed: boolean | null = null;
-  const isEligible = async (row: ChallengeRow): Promise<boolean> => {
+  return walkRotation(rows, localDate, async (row) => {
     if (SOCIAL_CHALLENGE_KEYS.has(row.challenge_key)) {
       friendCount ??= await getAcceptedFriendCount(userId);
       if (friendCount === 0) return false;
@@ -859,35 +853,7 @@ async function selectChallengeForUser(
       if (!hasFeed) return false;
     }
     return true;
-  };
-
-  for (let i = 0; i < rows.length; i++) {
-    const candidate = rows[(baseIdx + i) % rows.length];
-    if (await isEligible(candidate)) return candidate;
-  }
-  return rows[baseIdx]; // nothing eligible (shouldn't happen) — fall back to the base pick
-}
-
-/**
- * Deterministic "rival of the day" for Head-to-Head: a stable pick from the
- * user's accepted friends seeded by user + date. Returns null if no friends.
- */
-async function selectRival(
-  userId: string,
-  localDate: string,
-): Promise<string | null> {
-  const rows = await db.query<{ friend_id: string }>(
-    `SELECT friend_id FROM friendships WHERE user_id = $1 AND status = 'accepted' ORDER BY friend_id ASC`,
-    [userId],
-  );
-  if (rows.length === 0) return null;
-  // Simple stable hash of (userId + localDate).
-  const seedStr = `${userId}|${localDate}`;
-  let hash = 0;
-  for (let i = 0; i < seedStr.length; i++) {
-    hash = (hash * 31 + seedStr.charCodeAt(i)) >>> 0;
-  }
-  return rows[hash % rows.length].friend_id;
+  });
 }
 
 async function getChallengeRowByKey(key: string): Promise<ChallengeRow | null> {
@@ -899,35 +865,33 @@ async function getChallengeRowByKey(key: string): Promise<ChallengeRow | null> {
   return rows[0] ?? null;
 }
 
-/** Build the Head-to-Head opponent payload (rival + both of today's mileages). */
+/**
+ * Build the Head-to-Head opponent payload (rival + both of today's mileages).
+ * The rival is PINNED for the day via h2h_matchups — reciprocal with the
+ * rival's own matchup wherever the day's matching could pair them (`mutual`).
+ */
 async function buildOpponent(
   userId: string,
   localDate: string,
-): Promise<import("../types/badge.js").ChallengeOpponent | null> {
-  const rivalId = await selectRival(userId, localDate);
-  if (!rivalId) return null;
+): Promise<ChallengeOpponent | null> {
+  const pin = await getOrAssignRival(userId, localDate);
+  if (!pin) return null;
   const [info] = await db.query<{
     username: string | null;
     profile_image_url: string | null;
   }>(`SELECT username, profile_image_url FROM users WHERE user_id = $1`, [
-    rivalId,
+    pin.rivalId,
   ]);
-  const rivalMiles = await dayTotalDistance(rivalId, localDate);
+  const rivalMiles = await dayTotalDistance(pin.rivalId, localDate);
   const myMiles = await dayTotalDistance(userId, localDate);
   return {
-    userId: rivalId,
+    userId: pin.rivalId,
     username: info?.username ?? null,
     profileImageUrl: info?.profile_image_url ?? null,
     miles: Math.round(rivalMiles * 100) / 100,
     myMiles: Math.round(myMiles * 100) / 100,
+    mutual: pin.mutual,
   };
-}
-
-function dayOfYear(ymd: string): number {
-  const [y, m, d] = ymd.split("-").map((n) => parseInt(n, 10));
-  const start = Date.UTC(y, 0, 1);
-  const curr = Date.UTC(y, m - 1, d);
-  return Math.floor((curr - start) / 86400000) + 1;
 }
 
 function addDays(ymd: string, n: number): string {
@@ -947,6 +911,12 @@ function addDays(ymd: string, n: number): string {
 async function renderChallenge(
   userId: string,
   row: ChallengeRow,
+  opts?: {
+    // Today's pinned duel, prefetched by the caller. Omitted for previews
+    // (tomorrow's card), which must not name a rival — the matchup for a
+    // future date isn't set yet.
+    opponent?: ChallengeOpponent | null;
+  },
 ): Promise<DailyChallenge> {
   // Dynamic cross-train variant — title / description / icon all flex with the user's recent mix.
   if (row.challenge_key === "cross_train") {
@@ -958,14 +928,15 @@ async function renderChallenge(
 
   // Head-to-Head: personalize the description with today's rival's name.
   if (row.challenge_key === "head_to_head") {
-    const localDate = await resolveUserLocalDate(userId);
-    const opp = await buildOpponent(userId, localDate);
-    const name = opp?.username ?? "a friend";
+    const opp = opts?.opponent ?? null;
+    const name = opp?.username;
     return {
       key: row.challenge_key,
       title: row.title,
-      description: opp
-        ? `Out-run ${name} today — log more miles than them!`
+      description: name
+        ? opp!.mutual
+          ? `Out-run ${name} today — they got the same matchup, so they're gunning for you too!`
+          : `Out-run ${name} today — log more miles than them!`
         : "Out-run a friend today — log more miles than them!",
       icon: row.icon,
       gradientStart: row.gradient_start,

--- a/backend/src/services/dailyChallengeService.ts
+++ b/backend/src/services/dailyChallengeService.ts
@@ -15,7 +15,10 @@ import {
   FEED_CHALLENGE_KEYS,
   walkRotation,
 } from "./challengeRotation.js";
-import { getOrAssignRival } from "./h2hMatchupService.js";
+import {
+  getOrAssignRival,
+  hasH2hRivalCandidates,
+} from "./h2hMatchupService.js";
 
 const db = PostgresService.getInstance();
 
@@ -843,10 +846,18 @@ async function selectChallengeForUser(
   // the common (non-gated) base pick costs no extra queries.
   let friendCount: number | null = null;
   let hasFeed: boolean | null = null;
+  let h2hOk: boolean | null = null;
   return walkRotation(rows, localDate, async (row) => {
     if (SOCIAL_CHALLENGE_KEYS.has(row.challenge_key)) {
       friendCount ??= await getAcceptedFriendCount(userId);
       if (friendCount === 0) return false;
+    }
+    // Head-to-Head additionally needs an eligible rival: with the
+    // close-friends-only preference on, having friends isn't enough — a
+    // restricted user with no close friends rotates onto the next challenge.
+    if (row.challenge_key === "head_to_head") {
+      h2hOk ??= await hasH2hRivalCandidates(userId);
+      if (!h2hOk) return false;
     }
     if (FEED_CHALLENGE_KEYS.has(row.challenge_key)) {
       hasFeed ??= await userHasFeedFeature(userId);

--- a/backend/src/services/dailyChallengeService.ts
+++ b/backend/src/services/dailyChallengeService.ts
@@ -13,6 +13,7 @@ import {
   ChallengeRow,
   SOCIAL_CHALLENGE_KEYS,
   FEED_CHALLENGE_KEYS,
+  ADD_FRIEND_CHALLENGE_KEY,
   walkRotation,
 } from "./challengeRotation.js";
 import {
@@ -247,6 +248,70 @@ export async function evaluateForDay(
   };
 }
 
+/**
+ * Award "Make a Friend" the moment a friendship is ACCEPTED, for whichever
+ * side just crossed 0 → 1 accepted friends. This is the reliable award point:
+ * once the friendship exists, the rotation flips the user back onto
+ * head_to_head, so the workout-sync evaluator can never catch it after the
+ * fact. Idempotent and cheap — call it fire-and-forget from the accept path.
+ * Returns the completion (for the friend fan-out push) or null.
+ */
+export async function evaluateAddFriendCompletion(
+  userId: string,
+): Promise<NewChallengeCompletion | null> {
+  // Exactly one accepted friend = this accept took them from zero, i.e.
+  // their card today showed "Make a Friend" (users with friends were on the
+  // regular rotation and must not retro-earn this).
+  if ((await getAcceptedFriendCount(userId)) !== 1) return null;
+
+  // Local "today" preferring the app-reported offset — brand-new users have
+  // no workouts to derive a timezone from.
+  const rows = await db.query<{ local_date: string }>(
+    `SELECT ((NOW() AT TIME ZONE 'UTC') + (COALESCE(
+			(SELECT ns.timezone_offset_minutes FROM notification_settings ns WHERE ns.user_id = $1),
+			(SELECT w.timezone_offset FROM workouts w WHERE w.user_id = $1 ORDER BY w.device_end_date DESC LIMIT 1),
+			0) || ' minutes')::interval)::date::text AS local_date`,
+    [userId],
+  );
+  const localDate = rows[0]?.local_date;
+  if (!localDate) return null;
+
+  if (await getCompletionRow(userId, localDate)) return null;
+
+  // Would a friendless user's rotation walk have hit head_to_head today?
+  // (Selection can't answer this post-accept — the user has a friend now.)
+  const catalog = await db.query<ChallengeRow>(
+    `SELECT challenge_key, title, description_template, icon, gradient_start, gradient_end, type
+		FROM daily_challenges WHERE active = TRUE ORDER BY rotation_index ASC`,
+  );
+  if (catalog.length === 0) return null;
+  let hitH2h = false;
+  await walkRotation(catalog, localDate, (row) => {
+    if (row.challenge_key === "head_to_head") hitH2h = true;
+    return !SOCIAL_CHALLENGE_KEYS.has(row.challenge_key);
+  });
+  if (!hitH2h) return null;
+
+  const challenge = await getChallengeRowByKey(ADD_FRIEND_CHALLENGE_KEY);
+  if (!challenge) return null;
+
+  const inserted = await db.query<{ id: string }>(
+    `INSERT INTO user_challenge_completions (user_id, local_date, challenge_key, completing_workout_id)
+		VALUES ($1, $2, $3, NULL)
+		ON CONFLICT (user_id, local_date) DO NOTHING
+		RETURNING id`,
+    [userId, localDate, ADD_FRIEND_CHALLENGE_KEY],
+  );
+  if (inserted.length === 0) return null;
+
+  return {
+    localDate,
+    challengeKey: ADD_FRIEND_CHALLENGE_KEY,
+    challengeTitle: challenge.title,
+    completingWorkoutId: null,
+  };
+}
+
 // ─── Progress (0..1) for dashboard ring ─────────────────────────────
 
 async function computeProgress(
@@ -414,6 +479,18 @@ async function computeProgress(
       return (await hasPostToday(userId, localDate)) ? 1.0 : 0;
     case "wingman":
       return Math.min((await nudgesToday(userId, localDate)) / 1.0, 1.0);
+    case ADD_FRIEND_CHALLENGE_KEY: {
+      if ((await getAcceptedFriendCount(userId)) > 0) return 1.0;
+      // A pending request in either direction is meaningful progress.
+      const rows = await db.query<{ ok: boolean }>(
+        `SELECT EXISTS (
+					SELECT 1 FROM friendships
+					WHERE (user_id = $1 OR friend_id = $1) AND status = 'pending'
+				) AS ok`,
+        [userId],
+      );
+      return rows[0]?.ok === true ? 0.5 : 0;
+    }
     case "head_to_head": {
       const opp =
         opponent !== undefined
@@ -573,6 +650,12 @@ async function evaluatePredicate(
 
     case "wingman":
       return (await nudgesToday(userId, localDate)) >= 1;
+
+    // Note: after the friend is added, selection flips back to head_to_head,
+    // so this sync-path predicate rarely fires — the reliable award point is
+    // evaluateAddFriendCompletion at friendship-accept time.
+    case ADD_FRIEND_CHALLENGE_KEY:
+      return (await getAcceptedFriendCount(userId)) > 0;
 
     case "head_to_head": {
       // Never satisfied at workout-sync time: the duel is a whole-day mileage
@@ -847,10 +930,17 @@ async function selectChallengeForUser(
   let friendCount: number | null = null;
   let hasFeed: boolean | null = null;
   let h2hOk: boolean | null = null;
-  return walkRotation(rows, localDate, async (row) => {
+  let friendlessOnH2hDay = false;
+  const picked = await walkRotation(rows, localDate, async (row) => {
     if (SOCIAL_CHALLENGE_KEYS.has(row.challenge_key)) {
       friendCount ??= await getAcceptedFriendCount(userId);
-      if (friendCount === 0) return false;
+      if (friendCount === 0) {
+        // A FRIENDLESS user's Head-to-Head day becomes "Make a Friend" (the
+        // duel's on-ramp) instead of silently rotating past it — flag it and
+        // substitute after the walk.
+        if (row.challenge_key === "head_to_head") friendlessOnH2hDay = true;
+        return false;
+      }
     }
     // Head-to-Head additionally needs an eligible rival: with the
     // close-friends-only preference on, having friends isn't enough — a
@@ -865,6 +955,13 @@ async function selectChallengeForUser(
     }
     return true;
   });
+  if (friendlessOnH2hDay) {
+    // Seeded at startup with active = FALSE; if it's somehow missing, the
+    // walk's own pick is the safe fallback.
+    const substitute = await getChallengeRowByKey(ADD_FRIEND_CHALLENGE_KEY);
+    if (substitute) return substitute;
+  }
+  return picked;
 }
 
 async function getChallengeRowByKey(key: string): Promise<ChallengeRow | null> {
@@ -1071,6 +1168,8 @@ const EXTRA_CHALLENGES: Array<{
   gradientEnd: string;
   type: DailyChallengeType;
   rotationIndex: number;
+  /** Defaults to true; FALSE = catalog-only (never enters the rotation). */
+  active?: boolean;
 }> = [
   {
     key: "five_k_day",
@@ -1142,6 +1241,22 @@ const EXTRA_CHALLENGES: Array<{
     type: "social",
     rotationIndex: 13,
   },
+  {
+    // Head-to-Head's friendless substitute (see ADD_FRIEND_CHALLENGE_KEY).
+    // active: false keeps it OUT of the rotation — selection injects it
+    // explicitly. rotation_index 200+: reserved band for non-rotation rows
+    // (retired legacy rows live at 100+).
+    key: ADD_FRIEND_CHALLENGE_KEY,
+    title: "Make a Friend",
+    description:
+      "Add your first friend on MAD today — challenges are better together!",
+    icon: "person.badge.plus",
+    gradientStart: "#5AC8FA",
+    gradientEnd: "#5856D6",
+    type: "social",
+    rotationIndex: 200,
+    active: false,
+  },
 ];
 
 export async function seedExtraChallenges(): Promise<void> {
@@ -1160,7 +1275,7 @@ export async function seedExtraChallenges(): Promise<void> {
     const queries = EXTRA_CHALLENGES.map((c) => ({
       query: `INSERT INTO daily_challenges
 					(challenge_key, title, description_template, icon, gradient_start, gradient_end, type, active, rotation_index)
-				VALUES ($1, $2, $3, $4, $5, $6, $7, true, $8)
+				VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 				ON CONFLICT (challenge_key) DO NOTHING`,
       params: [
         c.key,
@@ -1170,6 +1285,7 @@ export async function seedExtraChallenges(): Promise<void> {
         c.gradientStart,
         c.gradientEnd,
         c.type,
+        c.active ?? true,
         c.rotationIndex,
       ],
     }));

--- a/backend/src/services/h2hMatchupService.ts
+++ b/backend/src/services/h2hMatchupService.ts
@@ -33,10 +33,40 @@ export interface PinnedRival {
 }
 
 /**
+ * WHERE fragment selecting user $1's eligible Head-to-Head rivals: accepted
+ * friends, narrowed to their close-friends list when the user's
+ * h2h_close_friends_only preference is on. Shared by the existence probe and
+ * the fallback pick so the two can never disagree.
+ */
+const H2H_CANDIDATE_WHERE = `
+	f.user_id = $1 AND f.status = 'accepted'
+	AND (
+		NOT COALESCE((SELECT ns.h2h_close_friends_only FROM notification_settings ns WHERE ns.user_id = $1), FALSE)
+		OR EXISTS (SELECT 1 FROM close_friends cf WHERE cf.user_id = $1 AND cf.close_friend_id = f.friend_id)
+	)`;
+
+/**
+ * TRUE when the user has at least one eligible Head-to-Head rival. Gates the
+ * challenge in the rotation walk: a user restricting to close friends who has
+ * none (left) simply rotates onto the next challenge instead of getting an
+ * unwinnable duel-less card.
+ */
+export async function hasH2hRivalCandidates(userId: string): Promise<boolean> {
+  const rows = await db.query<{ ok: boolean }>(
+    `SELECT EXISTS (SELECT 1 FROM friendships f WHERE ${H2H_CANDIDATE_WHERE}) AS ok`,
+    [userId],
+  );
+  return rows[0]?.ok === true;
+}
+
+/**
  * The user's pinned rival for the date, creating pins if this is the first
- * Head-to-Head read of the day. Returns null only for users with no accepted
- * friends. A pin whose friendship has since ended (unfriend/block deletes both
- * friendship rows) is treated as absent and deterministically re-pinned.
+ * Head-to-Head read of the day. Returns null only for users with no eligible
+ * rivals (no accepted friends, or none on their close list while restricting).
+ * A pin whose friendship has since ended (unfriend/block deletes both
+ * friendship rows) is treated as absent and deterministically re-pinned;
+ * close-list edits alone do NOT re-roll an already-pinned day — the
+ * preference shapes pin creation, starting with the next matchup.
  */
 export async function getOrAssignRival(
   userId: string,
@@ -76,7 +106,7 @@ export async function getOrAssignRival(
   // Deterministic one-sided fallback among current accepted friends, then pin
   // it so the rest of the day (and the resolver) sees the same duel.
   const friends = await db.query<{ friend_id: string }>(
-    `SELECT friend_id FROM friendships WHERE user_id = $1 AND status = 'accepted'`,
+    `SELECT f.friend_id FROM friendships f WHERE ${H2H_CANDIDATE_WHERE}`,
     [userId],
   );
   if (friends.length === 0) return null;
@@ -164,15 +194,17 @@ type PoolClient = Awaited<ReturnType<PostgresService["getClient"]>>;
  *
  * Pool = users whose rotation selection for the date is head_to_head. All pool
  * candidates have friends (social challenges are skipped otherwise), so
- * selection only varies by the feed flag — the rotation is walked once per
- * flag value instead of once per user (see selectChallengeForUser, whose
- * semantics this mirrors via the shared walkRotation).
+ * selection varies only by the feed flag and by Head-to-Head rival
+ * eligibility (the close-friends restriction) — the rotation is walked once
+ * per flag combination instead of once per user (see selectChallengeForUser,
+ * whose semantics this mirrors via the shared walkRotation).
  *
- * Matching: every undirected friendship edge inside the pool gets the
- * deterministic per-day edgeScore; ascending greedy pass pairs both-free
- * endpoints (mutual). Leftover pool users get a one-sided rival: their
- * best-scored pool neighbor (someone also dueling today) if any, else their
- * best-scored friend overall.
+ * Matching: every undirected friendship edge inside the pool — allowed by
+ * BOTH endpoints' close-friends preferences — gets the deterministic per-day
+ * edgeScore; ascending greedy pass pairs both-free endpoints (mutual).
+ * Leftover pool users get a one-sided rival: their best-scored allowed pool
+ * neighbor (someone also dueling today) if any, else their best-scored
+ * allowed friend overall.
  */
 async function computeAndInsertMatchups(
   client: PoolClient,
@@ -186,17 +218,31 @@ async function computeAndInsertMatchups(
   ).rows;
   if (challengeRows.length === 0) return;
 
-  // Everyone in the candidate set below has accepted friends, so the social
-  // gate always passes — selection varies only by the feed flag.
-  const selectsH2h = async (hasFeed: boolean): Promise<boolean> => {
-    const picked = await walkRotation(challengeRows, localDate, (row) =>
-      FEED_CHALLENGE_KEYS.has(row.challenge_key) ? hasFeed : true,
-    );
+  // Selection varies by two per-user flags: the feed signal (share_journey
+  // gate) and Head-to-Head rival eligibility (close-friends restriction —
+  // see hasH2hRivalCandidates). Everyone in the candidate set has accepted
+  // friends, so the plain social gate always passes. Walk the rotation once
+  // per flag combination instead of once per user.
+  const selectsH2h = async (
+    userHasFeed: boolean,
+    h2hOk: boolean,
+  ): Promise<boolean> => {
+    const picked = await walkRotation(challengeRows, localDate, (row) => {
+      if (row.challenge_key === "head_to_head") return h2hOk;
+      return FEED_CHALLENGE_KEYS.has(row.challenge_key) ? userHasFeed : true;
+    });
     return picked.challenge_key === "head_to_head";
   };
-  const h2hWithFeed = await selectsH2h(true);
-  const h2hWithoutFeed = await selectsH2h(false);
-  if (!h2hWithFeed && !h2hWithoutFeed) return; // nobody duels on this date
+  const h2hSelected = new Map<string, boolean>();
+  for (const feedFlag of [true, false]) {
+    for (const h2hOk of [true, false]) {
+      h2hSelected.set(
+        `${feedFlag}:${h2hOk}`,
+        await selectsH2h(feedFlag, h2hOk),
+      );
+    }
+  }
+  if (![...h2hSelected.values()].some(Boolean)) return; // nobody duels on this date
 
   // Undirected accepted-friendship edges (accepted rows exist in both
   // directions; user_id < friend_id keeps one per pair).
@@ -224,13 +270,59 @@ async function computeAndInsertMatchups(
     feedRows.map((r) => [r.user_id, r.has_feed === true]),
   );
 
-  const inPool = (uid: string): boolean =>
-    hasFeed.get(uid) ? h2hWithFeed : h2hWithoutFeed;
-  const pool = new Set(userIds.filter(inPool));
+  // Close-friends restriction, in batch — mirrors H2H_CANDIDATE_WHERE.
+  const restrictedRows = (
+    await client.query<{ user_id: string }>(
+      `SELECT user_id FROM notification_settings
+				WHERE h2h_close_friends_only = TRUE AND user_id = ANY($1::text[])`,
+      [userIds],
+    )
+  ).rows;
+  const restricted = new Set(restrictedRows.map((r) => r.user_id));
+  const closeOf = new Map<string, Set<string>>();
+  if (restricted.size > 0) {
+    const closeRows = (
+      await client.query<{ user_id: string; close_friend_id: string }>(
+        `SELECT user_id, close_friend_id FROM close_friends WHERE user_id = ANY($1::text[])`,
+        [[...restricted]],
+      )
+    ).rows;
+    for (const r of closeRows) {
+      const set = closeOf.get(r.user_id);
+      if (set) set.add(r.close_friend_id);
+      else closeOf.set(r.user_id, new Set([r.close_friend_id]));
+    }
+  }
+  /** May x duel y? Only x's own preference matters (one direction). */
+  const allows = (x: string, y: string): boolean =>
+    !restricted.has(x) || closeOf.get(x)?.has(y) === true;
+
+  // Restricted users are h2h-eligible only with >= 1 close friend among
+  // their accepted friends (edge endpoints), matching hasH2hRivalCandidates.
+  const h2hEligible = new Set<string>(
+    userIds.filter((u) => !restricted.has(u)),
+  );
+  for (const e of edges) {
+    if (allows(e.user_id, e.friend_id)) h2hEligible.add(e.user_id);
+    if (allows(e.friend_id, e.user_id)) h2hEligible.add(e.friend_id);
+  }
+
+  const pool = new Set(
+    userIds.filter((uid) =>
+      h2hSelected.get(`${hasFeed.get(uid) === true}:${h2hEligible.has(uid)}`),
+    ),
+  );
   if (pool.size === 0) return;
 
+  // Mutual pairs need BOTH directions allowed — each side must see the other.
   const scored = edges
-    .filter((e) => pool.has(e.user_id) && pool.has(e.friend_id))
+    .filter(
+      (e) =>
+        pool.has(e.user_id) &&
+        pool.has(e.friend_id) &&
+        allows(e.user_id, e.friend_id) &&
+        allows(e.friend_id, e.user_id),
+    )
     .map((e) => ({
       a: e.user_id,
       b: e.friend_id,
@@ -249,8 +341,9 @@ async function computeAndInsertMatchups(
     }
   }
 
-  // Leftovers: best pool neighbor first (they're at least dueling today),
-  // else best friend overall. One-sided, so mutual = FALSE.
+  // Leftovers: best allowed pool neighbor first (they're at least dueling
+  // today), else best allowed friend overall. One-sided, so mutual = FALSE —
+  // only the chooser's close-friends preference filters their candidates.
   const neighbors = new Map<string, string[]>();
   const addNeighbor = (from: string, to: string) => {
     const list = neighbors.get(from);
@@ -263,7 +356,7 @@ async function computeAndInsertMatchups(
   }
   for (const uid of pool) {
     if (rivalOf.has(uid)) continue;
-    const all = neighbors.get(uid) ?? [];
+    const all = (neighbors.get(uid) ?? []).filter((c) => allows(uid, c));
     const pick = (candidates: string[]): string | null => {
       let bestId: string | null = null;
       let best = Number.POSITIVE_INFINITY;
@@ -431,6 +524,7 @@ async function selectedChallengeKey(
 
   let friendCount: number | null = null;
   let hasFeed: boolean | null = null;
+  let h2hOk: boolean | null = null;
   const picked = await walkRotation(rows, localDate, async (row) => {
     if (SOCIAL_CHALLENGE_KEYS.has(row.challenge_key)) {
       if (friendCount === null) {
@@ -441,6 +535,12 @@ async function selectedChallengeKey(
         friendCount = parseInt(r[0]?.c ?? "0", 10) || 0;
       }
       if (friendCount === 0) return false;
+    }
+    // Head-to-Head additionally needs an eligible rival: with the
+    // close-friends-only preference on, having friends isn't enough.
+    if (row.challenge_key === "head_to_head") {
+      h2hOk ??= await hasH2hRivalCandidates(userId);
+      if (!h2hOk) return false;
     }
     if (FEED_CHALLENGE_KEYS.has(row.challenge_key)) {
       if (hasFeed === null) {

--- a/backend/src/services/h2hMatchupService.ts
+++ b/backend/src/services/h2hMatchupService.ts
@@ -4,6 +4,7 @@ import {
   ChallengeRow,
   SOCIAL_CHALLENGE_KEYS,
   FEED_CHALLENGE_KEYS,
+  ADD_FRIEND_CHALLENGE_KEY,
   walkRotation,
   edgeScore,
 } from "./challengeRotation.js";
@@ -111,13 +112,31 @@ export async function getOrAssignRival(
   );
   if (friends.length === 0) return null;
 
-  let rivalId = friends[0].friend_id;
-  let best = Number.POSITIVE_INFINITY;
-  for (const f of friends) {
-    const s = edgeScore(userId, f.friend_id, localDate);
-    if (s < best || (s === best && f.friend_id < rivalId)) {
-      best = s;
-      rivalId = f.friend_id;
+  // Prefer a recently-active rival (same 7-days-before-date signal as the
+  // matchmaker's leftover ranking), then the day's edge score.
+  const candidateIds = friends.map((f) => f.friend_id);
+  const activeRows = await db.query<{ user_id: string }>(
+    `SELECT DISTINCT user_id FROM workouts
+		WHERE user_id = ANY($1::text[])
+			AND local_date >= ($2::date - INTERVAL '7 days') AND local_date < $2::date
+			AND deleted_at IS NULL AND exclusion_reason IS NULL`,
+    [candidateIds, localDate],
+  );
+  const recentlyActive = new Set(activeRows.map((r) => r.user_id));
+
+  let rivalId = candidateIds[0];
+  let bestTier = Number.POSITIVE_INFINITY;
+  let bestScore = Number.POSITIVE_INFINITY;
+  for (const c of candidateIds) {
+    const t = recentlyActive.has(c) ? 0 : 1;
+    const s = edgeScore(userId, c, localDate);
+    const better =
+      t < bestTier ||
+      (t === bestTier && (s < bestScore || (s === bestScore && c < rivalId)));
+    if (better) {
+      bestTier = t;
+      bestScore = s;
+      rivalId = c;
     }
   }
 
@@ -297,6 +316,20 @@ async function computeAndInsertMatchups(
   const allows = (x: string, y: string): boolean =>
     !restricted.has(x) || closeOf.get(x)?.has(y) === true;
 
+  // Fallback quality signal: friends who logged a workout in the 7 days
+  // BEFORE this date make livelier one-sided rivals than dormant accounts.
+  // Strictly before the date, so the ranking is stable for the whole day.
+  const activeRows = (
+    await client.query<{ user_id: string }>(
+      `SELECT DISTINCT user_id FROM workouts
+				WHERE user_id = ANY($1::text[])
+					AND local_date >= ($2::date - INTERVAL '7 days') AND local_date < $2::date
+					AND deleted_at IS NULL AND exclusion_reason IS NULL`,
+      [userIds, localDate],
+    )
+  ).rows;
+  const recentlyActive = new Set(activeRows.map((r) => r.user_id));
+
   // Restricted users are h2h-eligible only with >= 1 close friend among
   // their accepted friends (edge endpoints), matching hasH2hRivalCandidates.
   const h2hEligible = new Set<string>(
@@ -341,9 +374,10 @@ async function computeAndInsertMatchups(
     }
   }
 
-  // Leftovers: best allowed pool neighbor first (they're at least dueling
-  // today), else best allowed friend overall. One-sided, so mutual = FALSE —
-  // only the chooser's close-friends preference filters their candidates.
+  // Leftovers get a one-sided rival (mutual = FALSE); only the chooser's
+  // close-friends preference filters their candidates. Ranking: recently
+  // active beats dormant, then someone also dueling today (pool) beats
+  // someone who isn't, then the day's edge score keeps it deterministic.
   const neighbors = new Map<string, string[]>();
   const addNeighbor = (from: string, to: string) => {
     const list = neighbors.get(from);
@@ -356,20 +390,24 @@ async function computeAndInsertMatchups(
   }
   for (const uid of pool) {
     if (rivalOf.has(uid)) continue;
-    const all = (neighbors.get(uid) ?? []).filter((c) => allows(uid, c));
-    const pick = (candidates: string[]): string | null => {
-      let bestId: string | null = null;
-      let best = Number.POSITIVE_INFINITY;
-      for (const c of candidates) {
-        const s = edgeScore(uid, c, localDate);
-        if (s < best || (s === best && (bestId === null || c < bestId))) {
-          best = s;
-          bestId = c;
-        }
+    let rival: string | null = null;
+    let bestTier = Number.POSITIVE_INFINITY;
+    let bestScore = Number.POSITIVE_INFINITY;
+    for (const c of neighbors.get(uid) ?? []) {
+      if (!allows(uid, c)) continue;
+      const t = (recentlyActive.has(c) ? 0 : 2) + (pool.has(c) ? 0 : 1);
+      const s = edgeScore(uid, c, localDate);
+      const better =
+        t < bestTier ||
+        (t === bestTier &&
+          (s < bestScore ||
+            (s === bestScore && (rival === null || c < rival))));
+      if (better) {
+        bestTier = t;
+        bestScore = s;
+        rival = c;
       }
-      return bestId;
-    };
-    const rival = pick(all.filter((c) => pool.has(c))) ?? pick(all);
+    }
     if (rival) rivalOf.set(uid, { rivalId: rival, mutual: false });
   }
 
@@ -525,6 +563,7 @@ async function selectedChallengeKey(
   let friendCount: number | null = null;
   let hasFeed: boolean | null = null;
   let h2hOk: boolean | null = null;
+  let friendlessOnH2hDay = false;
   const picked = await walkRotation(rows, localDate, async (row) => {
     if (SOCIAL_CHALLENGE_KEYS.has(row.challenge_key)) {
       if (friendCount === null) {
@@ -534,7 +573,13 @@ async function selectedChallengeKey(
         );
         friendCount = parseInt(r[0]?.c ?? "0", 10) || 0;
       }
-      if (friendCount === 0) return false;
+      if (friendCount === 0) {
+        // Friendless users get the add_friend substitute on h2h days —
+        // mirror selectChallengeForUser so the resolver judges the same
+        // challenge the user's card showed.
+        if (row.challenge_key === "head_to_head") friendlessOnH2hDay = true;
+        return false;
+      }
     }
     // Head-to-Head additionally needs an eligible rival: with the
     // close-friends-only preference on, having friends isn't enough.
@@ -555,6 +600,7 @@ async function selectedChallengeKey(
     }
     return true;
   });
+  if (friendlessOnH2hDay) return ADD_FRIEND_CHALLENGE_KEY;
   return picked.challenge_key;
 }
 

--- a/backend/src/services/h2hMatchupService.ts
+++ b/backend/src/services/h2hMatchupService.ts
@@ -1,0 +1,554 @@
+import { PostgresService } from "./DbService.js";
+import { sendPush } from "./pushNotificationService.js";
+import {
+  ChallengeRow,
+  SOCIAL_CHALLENGE_KEYS,
+  FEED_CHALLENGE_KEYS,
+  walkRotation,
+  edgeScore,
+} from "./challengeRotation.js";
+
+const db = PostgresService.getInstance();
+
+/**
+ * Head-to-Head daily matchups.
+ *
+ * Rivals are PINNED in `h2h_matchups`, one row per (local_date, user): the
+ * duel a user sees in the morning is the duel that gets scored, even if their
+ * friend list changes mid-day. Pins are created by a once-per-day global
+ * matching that pairs users RECIPROCALLY wherever possible (both users get
+ * each other, `mutual = TRUE`). Reciprocity for everyone is mathematically
+ * impossible (odd counts, star-shaped friend graphs), so unpaired users fall
+ * back to a deterministic one-sided rival (`mutual = FALSE`) — same experience
+ * as the legacy behavior, never worse.
+ *
+ * The duel is scored by the end-of-day cron (see resolveDueMatchups), NOT at
+ * workout-sync time: it's a whole-day mileage total, so nobody can "win" while
+ * the other side still has hours left to run.
+ */
+
+export interface PinnedRival {
+  rivalId: string;
+  mutual: boolean;
+}
+
+/**
+ * The user's pinned rival for the date, creating pins if this is the first
+ * Head-to-Head read of the day. Returns null only for users with no accepted
+ * friends. A pin whose friendship has since ended (unfriend/block deletes both
+ * friendship rows) is treated as absent and deterministically re-pinned.
+ */
+export async function getOrAssignRival(
+  userId: string,
+  localDate: string,
+): Promise<PinnedRival | null> {
+  const readPin = async (): Promise<PinnedRival | null> => {
+    const rows = await db.query<{ rival_id: string; mutual: boolean }>(
+      `SELECT m.rival_id, m.mutual
+			FROM h2h_matchups m
+			JOIN friendships f
+				ON f.user_id = m.user_id AND f.friend_id = m.rival_id AND f.status = 'accepted'
+			WHERE m.local_date = $1 AND m.user_id = $2`,
+      [localDate, userId],
+    );
+    return rows[0]
+      ? { rivalId: rows[0].rival_id, mutual: rows[0].mutual === true }
+      : null;
+  };
+
+  let pin = await readPin();
+  if (pin) return pin;
+
+  // First Head-to-Head read of this date anywhere → compute the day's matching.
+  try {
+    await ensureMatchupsForDate(localDate);
+  } catch (e: any) {
+    console.error(
+      `[H2H] ensureMatchupsForDate(${localDate}) failed:`,
+      e?.message ?? e,
+    );
+  }
+  pin = await readPin();
+  if (pin) return pin;
+
+  // Still no usable pin: the user joined the pool after matching ran (new
+  // friendship, eligibility flip) or their pinned rival unfriended them.
+  // Deterministic one-sided fallback among current accepted friends, then pin
+  // it so the rest of the day (and the resolver) sees the same duel.
+  const friends = await db.query<{ friend_id: string }>(
+    `SELECT friend_id FROM friendships WHERE user_id = $1 AND status = 'accepted'`,
+    [userId],
+  );
+  if (friends.length === 0) return null;
+
+  let rivalId = friends[0].friend_id;
+  let best = Number.POSITIVE_INFINITY;
+  for (const f of friends) {
+    const s = edgeScore(userId, f.friend_id, localDate);
+    if (s < best || (s === best && f.friend_id < rivalId)) {
+      best = s;
+      rivalId = f.friend_id;
+    }
+  }
+
+  // Upsert replaces a dead pin (unfriended rival). Never rewrite a row the
+  // resolver already scored — by then the user's local date has moved past
+  // this date anyway, so live reads can't reach here; belt and suspenders.
+  const upserted = await db.query<{ rival_id: string; mutual: boolean }>(
+    `INSERT INTO h2h_matchups (local_date, user_id, rival_id, mutual)
+		VALUES ($1, $2, $3, FALSE)
+		ON CONFLICT (local_date, user_id) DO UPDATE
+			SET rival_id = EXCLUDED.rival_id, mutual = FALSE
+			WHERE h2h_matchups.resolved_at IS NULL
+		RETURNING rival_id, mutual`,
+    [localDate, userId, rivalId],
+  );
+  if (upserted[0]) {
+    return { rivalId: upserted[0].rival_id, mutual: false };
+  }
+  // Upsert was blocked by the resolved guard — surface whatever is stored.
+  const stored = await db.query<{ rival_id: string; mutual: boolean }>(
+    `SELECT rival_id, mutual FROM h2h_matchups WHERE local_date = $1 AND user_id = $2`,
+    [localDate, userId],
+  );
+  return stored[0]
+    ? { rivalId: stored[0].rival_id, mutual: stored[0].mutual === true }
+    : null;
+}
+
+// ─── Once-per-day global matching ───────────────────────────────────
+
+/**
+ * Compute and insert the day's matchups exactly once, serialized by an
+ * advisory lock. Concurrent first-readers block on the lock, then see the
+ * winner's rows and skip. Rows for a date existing at all means the matching
+ * already ran (individual fallback pins can only be created AFTER this).
+ */
+async function ensureMatchupsForDate(localDate: string): Promise<void> {
+  const existing = await db.query(
+    `SELECT 1 FROM h2h_matchups WHERE local_date = $1 LIMIT 1`,
+    [localDate],
+  );
+  if (existing.length > 0) return;
+
+  const client = await db.getClient();
+  try {
+    await client.query("BEGIN");
+    await client.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [
+      `h2h_matchups:${localDate}`,
+    ]);
+    const again = await client.query(
+      `SELECT 1 FROM h2h_matchups WHERE local_date = $1 LIMIT 1`,
+      [localDate],
+    );
+    if (again.rows.length === 0) {
+      await computeAndInsertMatchups(client, localDate);
+    }
+    await client.query("COMMIT");
+  } catch (e) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      /* connection-level failure; release below */
+    }
+    throw e;
+  } finally {
+    client.release();
+  }
+}
+
+type PoolClient = Awaited<ReturnType<PostgresService["getClient"]>>;
+
+/**
+ * Global greedy matching for one date.
+ *
+ * Pool = users whose rotation selection for the date is head_to_head. All pool
+ * candidates have friends (social challenges are skipped otherwise), so
+ * selection only varies by the feed flag — the rotation is walked once per
+ * flag value instead of once per user (see selectChallengeForUser, whose
+ * semantics this mirrors via the shared walkRotation).
+ *
+ * Matching: every undirected friendship edge inside the pool gets the
+ * deterministic per-day edgeScore; ascending greedy pass pairs both-free
+ * endpoints (mutual). Leftover pool users get a one-sided rival: their
+ * best-scored pool neighbor (someone also dueling today) if any, else their
+ * best-scored friend overall.
+ */
+async function computeAndInsertMatchups(
+  client: PoolClient,
+  localDate: string,
+): Promise<void> {
+  const challengeRows = (
+    await client.query<ChallengeRow>(
+      `SELECT challenge_key, title, description_template, icon, gradient_start, gradient_end, type
+			FROM daily_challenges WHERE active = TRUE ORDER BY rotation_index ASC`,
+    )
+  ).rows;
+  if (challengeRows.length === 0) return;
+
+  // Everyone in the candidate set below has accepted friends, so the social
+  // gate always passes — selection varies only by the feed flag.
+  const selectsH2h = async (hasFeed: boolean): Promise<boolean> => {
+    const picked = await walkRotation(challengeRows, localDate, (row) =>
+      FEED_CHALLENGE_KEYS.has(row.challenge_key) ? hasFeed : true,
+    );
+    return picked.challenge_key === "head_to_head";
+  };
+  const h2hWithFeed = await selectsH2h(true);
+  const h2hWithoutFeed = await selectsH2h(false);
+  if (!h2hWithFeed && !h2hWithoutFeed) return; // nobody duels on this date
+
+  // Undirected accepted-friendship edges (accepted rows exist in both
+  // directions; user_id < friend_id keeps one per pair).
+  const edges = (
+    await client.query<{ user_id: string; friend_id: string }>(
+      `SELECT user_id, friend_id FROM friendships
+			WHERE status = 'accepted' AND user_id < friend_id`,
+    )
+  ).rows;
+  if (edges.length === 0) return;
+
+  const userIds = [...new Set(edges.flatMap((e) => [e.user_id, e.friend_id]))];
+
+  // Feed flags in one batch — same signal as userHasFeedFeature.
+  const feedRows = (
+    await client.query<{ user_id: string; has_feed: boolean }>(
+      `SELECT u.user_id,
+				(EXISTS (SELECT 1 FROM posts p WHERE p.user_id = u.user_id)
+					OR u.terms_accepted_at IS NOT NULL) AS has_feed
+			FROM users u WHERE u.user_id = ANY($1::text[])`,
+      [userIds],
+    )
+  ).rows;
+  const hasFeed = new Map(
+    feedRows.map((r) => [r.user_id, r.has_feed === true]),
+  );
+
+  const inPool = (uid: string): boolean =>
+    hasFeed.get(uid) ? h2hWithFeed : h2hWithoutFeed;
+  const pool = new Set(userIds.filter(inPool));
+  if (pool.size === 0) return;
+
+  const scored = edges
+    .filter((e) => pool.has(e.user_id) && pool.has(e.friend_id))
+    .map((e) => ({
+      a: e.user_id,
+      b: e.friend_id,
+      score: edgeScore(e.user_id, e.friend_id, localDate),
+    }))
+    .sort(
+      (x, y) =>
+        x.score - y.score || x.a.localeCompare(y.a) || x.b.localeCompare(y.b),
+    );
+
+  const rivalOf = new Map<string, { rivalId: string; mutual: boolean }>();
+  for (const { a, b } of scored) {
+    if (!rivalOf.has(a) && !rivalOf.has(b)) {
+      rivalOf.set(a, { rivalId: b, mutual: true });
+      rivalOf.set(b, { rivalId: a, mutual: true });
+    }
+  }
+
+  // Leftovers: best pool neighbor first (they're at least dueling today),
+  // else best friend overall. One-sided, so mutual = FALSE.
+  const neighbors = new Map<string, string[]>();
+  const addNeighbor = (from: string, to: string) => {
+    const list = neighbors.get(from);
+    if (list) list.push(to);
+    else neighbors.set(from, [to]);
+  };
+  for (const e of edges) {
+    addNeighbor(e.user_id, e.friend_id);
+    addNeighbor(e.friend_id, e.user_id);
+  }
+  for (const uid of pool) {
+    if (rivalOf.has(uid)) continue;
+    const all = neighbors.get(uid) ?? [];
+    const pick = (candidates: string[]): string | null => {
+      let bestId: string | null = null;
+      let best = Number.POSITIVE_INFINITY;
+      for (const c of candidates) {
+        const s = edgeScore(uid, c, localDate);
+        if (s < best || (s === best && (bestId === null || c < bestId))) {
+          best = s;
+          bestId = c;
+        }
+      }
+      return bestId;
+    };
+    const rival = pick(all.filter((c) => pool.has(c))) ?? pick(all);
+    if (rival) rivalOf.set(uid, { rivalId: rival, mutual: false });
+  }
+
+  const entries = [...rivalOf.entries()];
+  const CHUNK = 2000;
+  for (let i = 0; i < entries.length; i += CHUNK) {
+    const chunk = entries.slice(i, i + CHUNK);
+    const values: string[] = [];
+    const params: any[] = [localDate];
+    for (const [uid, { rivalId, mutual }] of chunk) {
+      values.push(
+        `($1, $${params.length + 1}, $${params.length + 2}, $${params.length + 3})`,
+      );
+      params.push(uid, rivalId, mutual);
+    }
+    await client.query(
+      `INSERT INTO h2h_matchups (local_date, user_id, rival_id, mutual)
+			VALUES ${values.join(", ")}
+			ON CONFLICT (local_date, user_id) DO NOTHING`,
+      params,
+    );
+  }
+  console.log(
+    `[H2H] Matched ${entries.length} user(s) for ${localDate} (${
+      [...rivalOf.values()].filter((r) => r.mutual).length
+    } in mutual pairs).`,
+  );
+}
+
+// ─── End-of-day resolution (cron) ───────────────────────────────────
+
+/**
+ * A user's local "now" as a tz-less timestamp, preferring the app-reported
+ * notification offset and falling back to the last workout's offset (same
+ * precedence as the weekly recap cron). `col` is a code-controlled column
+ * reference, never user input.
+ */
+function localNowSql(col: string): string {
+  return `((NOW() AT TIME ZONE 'UTC') + (COALESCE(
+		(SELECT ns.timezone_offset_minutes FROM notification_settings ns WHERE ns.user_id = ${col}),
+		(SELECT w.timezone_offset FROM workouts w WHERE w.user_id = ${col} ORDER BY w.device_end_date DESC LIMIT 1),
+		0) || ' minutes')::interval)`;
+}
+
+/**
+ * Hours past local midnight before a day's duel is scored. Late HealthKit
+ * syncs (phone locked overnight, Watch backlog) can add workouts to a
+ * finished day; waiting until 6 AM local absorbs most of them. There is no
+ * revocation path for challenge completions, so scoring too early records a
+ * wrong winner permanently.
+ */
+const RESOLVE_GRACE_HOURS = 6;
+
+/**
+ * Score every unresolved matchup whose day is over — for BOTH sides — plus the
+ * grace period (the rival's late-night miles are part of the outcome, so their
+ * clock matters too). Winner inserts the day's challenge completion; the push
+ * is deferred to notifyPendingWinners. Hourly-cron safe: idempotent per row.
+ */
+export async function resolveDueMatchups(): Promise<void> {
+  const cutoff = `(m.local_date::timestamp + INTERVAL '1 day' + INTERVAL '${RESOLVE_GRACE_HOURS} hours')`;
+  const due = await db.query<{
+    local_date: string;
+    user_id: string;
+    rival_id: string;
+  }>(
+    `SELECT m.local_date::text AS local_date, m.user_id, m.rival_id
+		FROM h2h_matchups m
+		WHERE m.resolved_at IS NULL
+			AND m.local_date >= (CURRENT_DATE - INTERVAL '7 days')
+			AND ${localNowSql("m.user_id")} >= ${cutoff}
+			AND ${localNowSql("m.rival_id")} >= ${cutoff}`,
+  );
+  if (due.length === 0) return;
+  console.log(`[H2H] Resolving ${due.length} finished matchup(s)...`);
+
+  for (const row of due) {
+    try {
+      await resolveOne(row.local_date, row.user_id, row.rival_id);
+    } catch (e: any) {
+      console.error(
+        `[H2H] Failed to resolve ${row.user_id} @ ${row.local_date}:`,
+        e?.message ?? e,
+      );
+    }
+  }
+}
+
+async function resolveOne(
+  localDate: string,
+  userId: string,
+  rivalId: string,
+): Promise<void> {
+  let awarded = false;
+
+  // The pin can go stale between morning and scoring: friendship ended, or an
+  // eligibility flip re-selected the user onto a different challenge (their
+  // card stopped showing the duel). Only award what the user actually saw.
+  const stillFriends = await db.query(
+    `SELECT 1 FROM friendships WHERE user_id = $1 AND friend_id = $2 AND status = 'accepted'`,
+    [userId, rivalId],
+  );
+  if (
+    stillFriends.length > 0 &&
+    (await selectedChallengeKey(userId, localDate)) === "head_to_head"
+  ) {
+    const [mineRaw, theirsRaw, goal] = await Promise.all([
+      dayTotalDistance(userId, localDate),
+      dayTotalDistance(rivalId, localDate),
+      getGoalMiles(userId),
+    ]);
+    // Compare at display precision: the duel card shows 2-decimal miles, so
+    // 2dp is the truth that decides it. A 2dp tie awards nobody ("Dead even").
+    const mine = Math.round(mineRaw * 100) / 100;
+    const theirs = Math.round(theirsRaw * 100) / 100;
+    if (mine >= goal * 0.95 && mine > theirs) {
+      const completingWorkoutId = await latestWorkoutId(userId, localDate);
+      const inserted = await db.query<{ id: string }>(
+        `INSERT INTO user_challenge_completions (user_id, local_date, challenge_key, completing_workout_id)
+				VALUES ($1, $2, 'head_to_head', $3)
+				ON CONFLICT (user_id, local_date) DO NOTHING
+				RETURNING id`,
+        [userId, localDate, completingWorkoutId],
+      );
+      awarded = inserted.length > 0;
+    }
+  }
+
+  // `won` doubles as "notify this user": TRUE only when the completion row
+  // was actually inserted by this resolution.
+  await db.query(
+    `UPDATE h2h_matchups SET resolved_at = NOW(), won = $3
+		WHERE local_date = $1 AND user_id = $2`,
+    [localDate, userId, awarded],
+  );
+}
+
+/**
+ * Re-derive which challenge the rotation gave this user for the date. Mirrors
+ * dailyChallengeService.selectChallengeForUser exactly (shared walkRotation +
+ * key sets); kept separate to avoid a service import cycle.
+ */
+async function selectedChallengeKey(
+  userId: string,
+  localDate: string,
+): Promise<string | null> {
+  const rows = await db.query<ChallengeRow>(
+    `SELECT challenge_key, title, description_template, icon, gradient_start, gradient_end, type
+		FROM daily_challenges WHERE active = TRUE ORDER BY rotation_index ASC`,
+  );
+  if (rows.length === 0) return null;
+
+  let friendCount: number | null = null;
+  let hasFeed: boolean | null = null;
+  const picked = await walkRotation(rows, localDate, async (row) => {
+    if (SOCIAL_CHALLENGE_KEYS.has(row.challenge_key)) {
+      if (friendCount === null) {
+        const r = await db.query<{ c: string }>(
+          `SELECT COUNT(*)::text AS c FROM friendships WHERE user_id = $1 AND status = 'accepted'`,
+          [userId],
+        );
+        friendCount = parseInt(r[0]?.c ?? "0", 10) || 0;
+      }
+      if (friendCount === 0) return false;
+    }
+    if (FEED_CHALLENGE_KEYS.has(row.challenge_key)) {
+      if (hasFeed === null) {
+        const r = await db.query<{ ok: boolean }>(
+          `SELECT (EXISTS (SELECT 1 FROM posts WHERE user_id = $1)
+						OR EXISTS (SELECT 1 FROM users WHERE user_id = $1 AND terms_accepted_at IS NOT NULL)) AS ok`,
+          [userId],
+        );
+        hasFeed = r[0]?.ok === true;
+      }
+      if (!hasFeed) return false;
+    }
+    return true;
+  });
+  return picked.challenge_key;
+}
+
+// ─── Winner notification (cron) ─────────────────────────────────────
+
+/**
+ * Push the "you won" celebration during the winner's local morning/daytime
+ * (9 AM–9:59 PM) rather than at the 6 AM scoring moment — a middle-of-the-
+ * night push would only land in the quiet-hours queue and resurface as a
+ * degraded digest. Claim-then-send keeps it exactly-once per matchup.
+ */
+export async function notifyPendingWinners(): Promise<void> {
+  const winners = await db.query<{
+    local_date: string;
+    user_id: string;
+    rival_id: string;
+  }>(
+    `SELECT m.local_date::text AS local_date, m.user_id, m.rival_id
+		FROM h2h_matchups m
+		WHERE m.won = TRUE AND m.notified_at IS NULL
+			AND m.local_date >= (CURRENT_DATE - INTERVAL '7 days')
+			AND EXTRACT(HOUR FROM ${localNowSql("m.user_id")}) BETWEEN 9 AND 21`,
+  );
+
+  for (const w of winners) {
+    const claimed = await db.query<{ user_id: string }>(
+      `UPDATE h2h_matchups SET notified_at = NOW()
+			WHERE local_date = $1 AND user_id = $2 AND notified_at IS NULL
+			RETURNING user_id`,
+      [w.local_date, w.user_id],
+    );
+    if (claimed.length === 0) continue;
+
+    try {
+      const [rival] = await db.query<{ username: string | null }>(
+        `SELECT username FROM users WHERE user_id = $1`,
+        [w.rival_id],
+      );
+      const [mine, theirs] = await Promise.all([
+        dayTotalDistance(w.user_id, w.local_date),
+        dayTotalDistance(w.rival_id, w.local_date),
+      ]);
+      const name = rival?.username ?? "your rival";
+      await sendPush(w.user_id, {
+        title: "You won your Head-to-Head! 🏆",
+        body: `You out-ran ${name} ${mine.toFixed(2)} to ${theirs.toFixed(2)} mi. Daily challenge complete!`,
+        type: "challenge_won",
+        data: {
+          challenge_key: "head_to_head",
+          local_date: w.local_date,
+          rival_id: w.rival_id,
+          rival_username: rival?.username ?? "",
+        },
+      });
+    } catch (e: any) {
+      console.error(
+        `[H2H] Winner push failed for ${w.user_id} @ ${w.local_date}:`,
+        e?.message ?? e,
+      );
+    }
+  }
+}
+
+// ─── Local SQL helpers (mirrors of dailyChallengeService's) ─────────
+
+async function dayTotalDistance(
+  userId: string,
+  localDate: string,
+): Promise<number> {
+  const rows = await db.query<{ total: string | null }>(
+    `SELECT COALESCE(SUM(distance),0)::text AS total FROM workouts
+		WHERE user_id = $1 AND local_date = $2 AND deleted_at IS NULL AND exclusion_reason IS NULL`,
+    [userId, localDate],
+  );
+  return parseFloat(rows[0]?.total ?? "0") || 0;
+}
+
+async function getGoalMiles(userId: string): Promise<number> {
+  const rows = await db.query<{ goal_miles: string }>(
+    `SELECT goal_miles::text AS goal_miles FROM users WHERE user_id = $1`,
+    [userId],
+  );
+  return parseFloat(rows[0]?.goal_miles ?? "1.0") || 1.0;
+}
+
+async function latestWorkoutId(
+  userId: string,
+  localDate: string,
+): Promise<string | null> {
+  const rows = await db.query<{ workout_id: string }>(
+    `SELECT workout_id FROM workouts
+		WHERE user_id = $1 AND local_date = $2 AND deleted_at IS NULL AND exclusion_reason IS NULL
+		ORDER BY device_end_date DESC LIMIT 1`,
+    [userId, localDate],
+  );
+  return rows[0]?.workout_id ?? null;
+}

--- a/backend/src/services/notificationSettingsService.ts
+++ b/backend/src/services/notificationSettingsService.ts
@@ -23,6 +23,7 @@ export interface NotificationPreferences {
   friend_posts_enabled: boolean; // notify me when a friend shares a new post
   share_route_maps: boolean; // show my GPS route maps on my feed entries/posts
   weekly_recap_enabled: boolean; // Sunday-evening weekly recap push + story card
+  h2h_close_friends_only: boolean; // Head-to-Head rivals only from my close friends
 }
 
 const DEFAULT_PREFERENCES: NotificationPreferences = {
@@ -44,6 +45,7 @@ const DEFAULT_PREFERENCES: NotificationPreferences = {
   friend_posts_enabled: true,
   share_route_maps: true,
   weekly_recap_enabled: true,
+  h2h_close_friends_only: false,
 };
 
 export async function getNotificationPreferences(
@@ -76,6 +78,7 @@ export async function getNotificationPreferences(
     friend_posts_enabled: row.friend_posts_enabled ?? true,
     share_route_maps: row.share_route_maps ?? true,
     weekly_recap_enabled: row.weekly_recap_enabled ?? true,
+    h2h_close_friends_only: row.h2h_close_friends_only ?? false,
   };
 }
 
@@ -120,6 +123,7 @@ export async function updateNotificationPreferences(
     { key: "friend_posts_enabled", value: prefs.friend_posts_enabled },
     { key: "share_route_maps", value: prefs.share_route_maps },
     { key: "weekly_recap_enabled", value: prefs.weekly_recap_enabled },
+    { key: "h2h_close_friends_only", value: prefs.h2h_close_friends_only },
   ];
 
   for (const field of fields) {

--- a/backend/src/services/pushNotificationService.ts
+++ b/backend/src/services/pushNotificationService.ts
@@ -125,6 +125,7 @@ export type NotificationType =
   | "badge_earned"
   | "friend_badge_earned"
   | "friend_challenge_completed"
+  | "challenge_won"
   | "hype_received"
   | "friend_post"
   | "story_reaction"
@@ -376,10 +377,9 @@ export async function sendPush(
   const tokens = await db.query<{
     device_token: string;
     environment: string | null;
-  }>(
-    "SELECT device_token, environment FROM device_tokens WHERE user_id = $1",
-    [userId],
-  );
+  }>("SELECT device_token, environment FROM device_tokens WHERE user_id = $1", [
+    userId,
+  ]);
 
   if (tokens.length === 0) {
     console.log(`[Push] No device tokens found for user ${userId}`);
@@ -553,10 +553,9 @@ export async function sendSilentPushToUser(
   const tokens = await db.query<{
     device_token: string;
     environment: string | null;
-  }>(
-    "SELECT device_token, environment FROM device_tokens WHERE user_id = $1",
-    [userId],
-  );
+  }>("SELECT device_token, environment FROM device_tokens WHERE user_id = $1", [
+    userId,
+  ]);
   if (tokens.length === 0) return 0;
 
   const results = await Promise.all(

--- a/backend/src/types/badge.ts
+++ b/backend/src/types/badge.ts
@@ -63,6 +63,8 @@ export interface ChallengeOpponent {
   profileImageUrl: string | null;
   miles: number;
   myMiles: number;
+  /** TRUE when the rival got the same matchup back (reciprocal pair). */
+  mutual: boolean;
 }
 
 export interface TodaysChallengeResponse {


### PR DESCRIPTION
# Head-to-Head: end-of-day scoring, reciprocal matchups, close-friends preference, add-friend on-ramp

Fixes the reported bug where a Head-to-Head duel was marked **Done and awarded mid-day**, makes matchups **reciprocal wherever possible**, adds an opt-in **close-friends-only rival pool**, guarantees **good fallbacks** in every matchup path, and turns a friendless user's h2h day into a **"Make a Friend"** challenge.

## Bug: instant award

`evaluatePredicate` satisfied `head_to_head` at workout-sync time, so the first runner ahead was awarded while the rival still had hours to answer.

**Now:**
- Sync-time evaluation never completes `head_to_head`; live progress caps at **0.99** (leading ≠ winning).
- A new hourly cron (`h2hChallengeCron` → `resolveDueMatchups`) scores each duel once **both** users' local day is over **+ 6h grace** for late HealthKit syncs (completions have no revocation path, so scoring early would record a wrong winner permanently).
- Comparison at display precision (2 dp); a tie awards nobody, matching the live "Dead even" state.
- Winners get a new `challenge_won` push with the final score, deferred to their **local 9 AM–10 PM** so the verdict doesn't degrade into the quiet-hours digest. Completions land on the challenge day's `local_date`, keeping challenge streaks contiguous.

## Reciprocal matchups

- New `h2h_matchups` table (migration `0016`, additive) **pins** each user's rival per day.
- First Head-to-Head read of a date runs a **once-per-day greedy matching** (advisory-locked, deterministic date-seeded symmetric edge hash): paired users get each other (`mutual = true`); everyone else gets a deterministic one-sided rival. Full mutuality for all is mathematically impossible (odd counts, star graphs), but nobody does worse than the old behavior.
- Pins also fix a latent bug where a rival could silently change mid-day when a friendship was added/removed.
- Rotation-walk logic extracted to `challengeRotation.ts`, shared by per-user selection, the matchmaker, and the resolver so they can't drift.
- `opponent.mutual` added to the API payload (additive); mutual duels get personalized copy.

## Close-friends-only preference (opt-in)

`h2h_close_friends_only` on `notification_settings` (migration `0017`, additive):

- **Enable-gated**: PUT `/notifications/preferences` 400s (`no_close_friends`) when enabling with an empty close list; disabling always allowed. iOS toggle (new Settings → Daily Challenges screen) is disabled with an explainer until close friends exist; optimistic save reverts on rejection.
- Mutual pairs require the edge allowed by **both** sides' preferences; one-sided fallbacks honor the chooser's preference only.
- If a restricted user's close list later empties, h2h becomes ineligible in their rotation and they get the next challenge — no unwinnable duel-less card.

## Fallbacks: everyone gets something good

- **Every pool member always has a rival**: mutual pair, or one-sided fallback vs their best-ranked allowed friend (never null by construction).
- **One-sided picks prefer lively rivals**: friends with a workout in the 7 days before the matchup date rank above dormant accounts, then pool membership (also dueling today), then the deterministic edge score. Signal is frozen strictly before the date, so the ranking is stable all day.
- **Friendless users get an on-ramp instead of a skip**: their h2h day becomes the new `add_friend` challenge — *"Add your first friend on MAD today — challenges are better together!"* (catalog row with `active = FALSE`, injected by selection, never in the normal rotation). Progress shows 0.5 with a pending request in either direction. The award fires at **friendship-accept time** for whichever side just crossed 0 → 1 friends (after that, rotation flips them back to head_to_head, so accept-time is the only reliable award point), with the existing friend fan-out push to the brand-new friend. Mid-day friend loss degrades the same way: the card self-heals to Make a Friend on next fetch.
- No iOS changes needed for `add_friend`: cards render entirely from server-sent fields and server progress, so **shipped builds display it correctly**.

## Verification

Full local CI ladder each round (tsc, `drizzle-kit check`, real migrator **twice**, `ci-smoke.mjs`) plus an 8-phase e2e scenario suite against a throwaway Postgres 16 through the real service code:

1. Matching: star/pair topologies, reciprocity of every mutual pin, pin stability, `mutual` in API
2. Close-friends restriction: mutual only with close friends; blocked edges never pair; one-sided targeting unaffected; restricted-no-close skips h2h; endpoint gate (400 → add close friend → 200)
3. No mid-day award; capped progress; both mileages in payload
4. Resolution: correct winners incl. one-sided duels; ties award nobody; workout attribution
5. Resolver idempotence
6. Winner notify claimed exactly once
7. add_friend: friendless user gets it on h2h day; 0 → 0.5 (pending) progress; accept awards **both** newly-friended sides exactly once; long-friended users never retro-earn; completed card stays pinned
8. Activity-aware fallback: two independent late-joiners each picked their only recently-active friend out of three candidates

**All green.** Production-safety: all migrations additive; API changes additive; backend deploys safely before any app update; legacy same-day completions untouched; unique `(user_id, local_date)` prevents double-awards everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iw2kwQbcaimbiJaE2nVYx