### PR TITLE
Fix mobile alignment of Watch/Widgets feature card

### DIFF
--- a/website/components/features-section.tsx
+++ b/website/components/features-section.tsx
@@ -102,7 +102,7 @@ export function FeaturesSection() {
             className="reveal-scale reveal-delay-4 glass-card type-card group rounded-2xl p-6 lg:col-span-3"
             style={{ "--accent": "#D94059" } as React.CSSProperties}
           >
-            <div className="flex items-start gap-4 mb-4">
+            <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-start">
               <div
                 className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl"
                 style={{
@@ -124,7 +124,7 @@ export function FeaturesSection() {
             </div>
 
             {/* Device mockups — matching app's actual UI */}
-            <div className="mt-6 flex items-end justify-center gap-6 sm:gap-10">
+            <div className="mt-6 flex flex-wrap items-end justify-center gap-6 sm:gap-10">
               {/* Home screen widget mockup — the app's actual streak widget is
                   a progress ring with the day count in orange (StreakCountWidget) */}
               <div className="flex flex-col items-center gap-2">


### PR DESCRIPTION
## Problem

On phones, the "Watch, Widgets & Live Activities" card in the website features section looked misaligned (see user screenshot from mileaday.run on an iPhone):

- The card header laid the icon and text side-by-side, squeezing the title and description into a narrow indented column — inconsistent with every other feature card, which stacks the icon above the text.
- The three device mockups (Widget, Apple Watch, Dynamic Island) have fixed widths that exceed the card's inner width on phones. The row couldn't wrap, so flexbox squished the widget/watch mockups out of shape and pinned the Dynamic Island pill flush against the card edge.

## Fix

Two class changes in `website/components/features-section.tsx`:

- Header row: `flex items-start gap-4` → `flex flex-col gap-4 sm:flex-row sm:items-start` — icon stacks above the title/description on mobile (matching the other cards), side-by-side from `sm:` up.
- Mockup row: added `flex-wrap` — on narrow screens the Dynamic Island pill wraps to its own centered row instead of squishing its siblings; on `sm:`+ all three still fit on one row.

Desktop layout is unchanged (verified via screenshot at 1280px).

## Verification

- Screenshotted the card at 390px and 430px viewports: header stacks correctly, mockups keep their intended sizes, Dynamic Island wraps to a centered second row.
- Screenshotted at 1280px: identical to current desktop layout.
- `npm run build` passes (the website pre-merge gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXMqbpqHkBH8zEtg4Cebmc

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXMqbpqHkBH8zEtg4Cebmc)_