### PR TITLE
Fix walk-photo selection, sticker size consistency, camera flash/timer, guidelines-first gate, caption keyboard

### DIFF
--- a/.claude/rules/ios.md
+++ b/.claude/rules/ios.md
@@ -36,6 +36,7 @@ globs: app/**
 - Feature views live in `Views/<FeatureName>/` subdirectories.
 - Shared UI components in `Views/Components/`.
 - Watch app is a separate target at `Mile A Day Watch App/`.
+- fullScreenCover gotchas (post composer): pass tap-selected content via `.fullScreenCover(item:)` (isPresented + separate @State races to a stale nil), guard onAppear side effects with a one-shot flag (onAppear RE-FIRES when a cover dismisses — an auto-opened camera re-traps the user), and attach two covers to two different nodes or one drops.
 - iOS 26 auto-wraps custom `ToolbarItem` views in a shared glass capsule. For a custom-styled pill, apply `.sharedBackgroundVisibility(.hidden)` to the `ToolbarItem` itself (it's on `CustomizableToolbarContent`, NOT a `View` modifier; gate with `#available(iOS 26)`) or it renders pill-inside-a-pill. Also `.fixedSize()` toolbar HStacks — leading items truncate `Text` to zero width otherwise.
 
 ## Entitlements

--- a/app/Mile A Day/Services/PostService.swift
+++ b/app/Mile A Day/Services/PostService.swift
@@ -495,16 +495,54 @@ enum PostService {
     }
 
     static func termsStatus() async throws -> TermsStatus {
-        try await APIClient.fancyFetch(endpoint: "/posts/terms", responseType: TermsStatus.self)
+        // Pin the cache key BEFORE the await: if the account switches while
+        // the request is in flight, the response must land under the user
+        // who made it, not whoever is signed in when it returns.
+        let cacheKey = termsCacheKey(userId: currentUserId)
+        let status: TermsStatus = try await APIClient.fancyFetch(
+            endpoint: "/posts/terms",
+            responseType: TermsStatus.self
+        )
+        UserDefaults.standard.set(status.accepted, forKey: cacheKey)
+        return status
     }
 
     @discardableResult
     static func acceptTerms() async throws -> TermsStatus {
-        try await APIClient.fancyFetch(
+        let cacheKey = termsCacheKey(userId: currentUserId)
+        let status: TermsStatus = try await APIClient.fancyFetch(
             endpoint: "/posts/terms/accept",
             method: .POST,
             responseType: TermsStatus.self
         )
+        UserDefaults.standard.set(status.accepted, forKey: cacheKey)
+        return status
+    }
+
+    // MARK: Community-guidelines acceptance cache
+
+    /// Same accessor the sibling services (WorkoutService, FriendService…)
+    /// keep for the logged-in backend user id.
+    private static var currentUserId: String? {
+        UserDefaults.standard.string(forKey: "backendUserId")
+    }
+
+    /// Local memo of the server-side guidelines acceptance so composer gates
+    /// can decide instantly (and offline) instead of blocking on a round-trip.
+    /// The server stays the source of truth: every termsStatus/acceptTerms
+    /// response refreshes it, and a `terms_not_accepted` publish rejection
+    /// clears it. Keyed per backend user so account switches can't leak an
+    /// acceptance across users.
+    private static func termsCacheKey(userId: String?) -> String {
+        "post.terms.accepted.\(userId ?? "anon")"
+    }
+
+    static var termsAcceptedCached: Bool {
+        UserDefaults.standard.bool(forKey: termsCacheKey(userId: currentUserId))
+    }
+
+    static func cacheTermsAccepted(_ accepted: Bool) {
+        UserDefaults.standard.set(accepted, forKey: termsCacheKey(userId: currentUserId))
     }
 }
 

--- a/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
+++ b/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
@@ -14,13 +14,15 @@ struct PostRunPhotoPromptView: View {
     let workoutType: String
 
     @ObservedObject private var manager = CelebrationManager.shared
-    @State private var showComposer = false
     @State private var appeared = false
     @State private var didAct = false
     /// Photos captured during the run via the tracking screen's camera button.
     @State private var midRunSnaps: [UIImage] = []
-    /// The mid-run snap chosen for the composer; nil = fresh camera capture.
-    @State private var selectedSnap: UIImage?
+    /// Composer launch request — carries the tapped snap (nil = fresh camera).
+    /// Item-based so the cover is always built from THIS value; the old
+    /// isPresented + separate-selection pair could build the composer with a
+    /// stale nil snap and wrongly launch the live camera.
+    @State private var composerLaunch: ComposerLaunch?
 
     private var isWalk: Bool { workoutType == "walking" }
     private var accent: Color { isWalk ? .blue : MADTheme.Colors.madRed }
@@ -57,8 +59,7 @@ struct PostRunPhotoPromptView: View {
 
                 VStack(spacing: MADTheme.Spacing.sm) {
                     Button {
-                        selectedSnap = nil
-                        showComposer = true
+                        composerLaunch = ComposerLaunch(image: nil)
                     } label: {
                         HStack(spacing: 8) {
                             Image(systemName: "camera.fill")
@@ -83,22 +84,21 @@ struct PostRunPhotoPromptView: View {
             midRunSnaps = MidRunPhotoStash.loadAll()
             withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) { appeared = true }
         }
-        .fullScreenCover(isPresented: $showComposer) {
+        .fullScreenCover(item: $composerLaunch) { launch in
             PostComposerView(
                 stats: RunPostService.todayStats(workoutId: workoutId),
                 destination: .story,
                 // A chosen mid-run snap goes straight onto the canvas; only a
                 // fresh capture launches the camera.
-                autoOpenCamera: selectedSnap == nil,
-                initialImage: selectedSnap
+                autoOpenCamera: launch.image == nil,
+                initialImage: launch.image
             ) { outcome in
-                showComposer = false
+                composerLaunch = nil
                 switch outcome {
                 case .cancelled where !midRunSnaps.isEmpty:
                     // Backed out with snaps still to consider — return to this
                     // prompt so they can pick a different one or Skip. Nothing
                     // is finalized yet.
-                    selectedSnap = nil
                     return
                 case .published(let toFeed, _) where toFeed:
                     // The photo went to the feed, so it IS the feed item.
@@ -172,28 +172,46 @@ struct PostRunPhotoPromptView: View {
         }
     }
 
+    /// One snap gets a big hero card; multiples shrink so two still sit side
+    /// by side on the smallest screens. Always 4:5, like the post.
+    private var snapCardSize: CGSize {
+        midRunSnaps.count == 1
+            ? CGSize(width: 216, height: 270)
+            : CGSize(width: 150, height: 187)
+    }
+
     private func snapCard(index: Int, snap: UIImage) -> some View {
         Button {
             UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-            selectedSnap = snap
-            showComposer = true
+            composerLaunch = ComposerLaunch(image: snap)
         } label: {
             Image(uiImage: snap)
                 .resizable()
                 .scaledToFill()
-                .frame(width: 132, height: 165) // 4:5, like the post
+                .frame(width: snapCardSize.width, height: snapCardSize.height)
                 .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: 18, style: .continuous)
                         .strokeBorder(Color.white.opacity(0.25), lineWidth: 1)
                 )
-                .overlay(alignment: .bottomTrailing) {
-                    Image(systemName: "arrow.up.circle.fill")
-                        .font(.system(size: 22, weight: .bold))
-                        .foregroundStyle(.white, accent)
-                        .padding(8)
+                // An unmissable "this is the button" label — the old corner
+                // arrow read as decoration and people hunted for a tap target.
+                .overlay(alignment: .bottom) {
+                    HStack(spacing: 5) {
+                        Image(systemName: "arrow.up.circle.fill")
+                            .font(.system(size: 13, weight: .bold))
+                        Text(midRunSnaps.count == 1 ? "Use this photo" : "Use photo")
+                            .font(.system(size: 13, weight: .bold, design: .rounded))
+                    }
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .background(Capsule().fill(accent))
+                    .shadow(color: .black.opacity(0.35), radius: 6, y: 2)
+                    .padding(.bottom, 10)
                 }
                 .shadow(color: .black.opacity(0.4), radius: 10, y: 5)
+                .contentShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
         }
         .buttonStyle(.plain)
         .scaleEffect(appeared ? 1 : 0.8)
@@ -217,4 +235,12 @@ struct PostRunPhotoPromptView: View {
         MidRunPhotoStash.clear()
         manager.dismissCurrentCelebration()
     }
+}
+
+/// Identifiable wrapper for launching the composer, so the fullScreenCover is
+/// built from the exact tapped value instead of separately-tracked state.
+private struct ComposerLaunch: Identifiable {
+    let id = UUID()
+    /// The chosen mid-run snap; nil means open the live camera for a fresh shot.
+    let image: UIImage?
 }

--- a/app/Mile A Day/Views/Components/ImagePicker.swift
+++ b/app/Mile A Day/Views/Components/ImagePicker.swift
@@ -70,58 +70,9 @@ enum PhotoRollSaver {
 
 // MARK: - Camera Capture
 
-/// Camera-only capture (no photo library picking). Used by the post composer
-/// and the mid-run snap button so shared walks/runs are captured in the
-/// moment rather than uploaded from the roll. Every capture is ALSO saved to
-/// the camera roll (see PhotoRollSaver) — the user's own copy, independent of
-/// what happens to the post.
-struct CameraPicker: UIViewControllerRepresentable {
-    @Binding var image: UIImage?
-    @Environment(\.presentationMode) var presentationMode
-
-    /// Whether the device actually has a camera (false on Simulator).
-    static var isAvailable: Bool {
-        UIImagePickerController.isSourceTypeAvailable(.camera)
-    }
-
-    func makeUIViewController(context: Context) -> UIViewController {
-        // Guard against unavailable cameras (e.g. Simulator) — presenting a
-        // `.camera` source there would crash. Callers gate on `isAvailable`.
-        guard Self.isAvailable else { return UIViewController() }
-
-        let picker = UIImagePickerController()
-        picker.sourceType = .camera
-        picker.cameraCaptureMode = .photo
-        picker.allowsEditing = false
-        picker.delegate = context.coordinator
-        return picker
-    }
-
-    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
-
-    func makeCoordinator() -> Coordinator { Coordinator(self) }
-
-    class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
-        let parent: CameraPicker
-        init(_ parent: CameraPicker) { self.parent = parent }
-
-        func imagePickerController(
-            _ picker: UIImagePickerController,
-            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
-        ) {
-            if let img = info[.originalImage] as? UIImage {
-                parent.image = img
-                // Every in-app capture also lands in the camera roll.
-                PhotoRollSaver.save(img)
-            }
-            parent.presentationMode.wrappedValue.dismiss()
-        }
-
-        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
-            parent.presentationMode.wrappedValue.dismiss()
-        }
-    }
-}
+// In-app camera capture lives in MADCameraView (Views/Components/MADCameraView.swift) —
+// an AVFoundation camera with full flash control and a self-timer, which
+// replaced the UIImagePickerController-based CameraPicker that used to be here.
 
 // MARK: - Profile Image Cropper
 

--- a/app/Mile A Day/Views/Components/KeyboardDoneButton.swift
+++ b/app/Mile A Day/Views/Components/KeyboardDoneButton.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+extension View {
+    /// Shared "Done" accessory above the keyboard for multi-line caption
+    /// fields — with a vertical-axis TextField the Return key inserts
+    /// newlines, so without this the keyboard has no way off the screen.
+    func madKeyboardDoneButton(focus: FocusState<Bool>.Binding) -> some View {
+        toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button("Done") { focus.wrappedValue = false }
+                    .fontWeight(.semibold)
+            }
+        }
+    }
+}

--- a/app/Mile A Day/Views/Components/MADCameraView.swift
+++ b/app/Mile A Day/Views/Components/MADCameraView.swift
@@ -1,0 +1,598 @@
+import SwiftUI
+import AVFoundation
+import Observation
+import UIKit
+
+/// In-house camera for post + mid-run captures, replacing the stock
+/// UIImagePickerController so the capture flow gets the controls users kept
+/// reaching for: full flash control (off / auto / on — not just auto) and a
+/// self-timer (3s / 10s) for propped-up group shots. Camera-only by design —
+/// no library picking — so shared walks/runs stay captured in the moment.
+/// Every capture is also saved to the user's camera roll (PhotoRollSaver),
+/// same as the picker it replaces.
+struct MADCameraView: View {
+    @Binding var image: UIImage?
+    @Environment(\.dismiss) private var dismiss
+    @State private var camera = MADCameraController()
+    /// Seconds left on a running self-timer; nil when idle.
+    @State private var countdown: Int?
+    @State private var countdownTask: Task<Void, Never>?
+    /// One-shot latch, set the moment a capture is requested so a double-tap
+    /// can't fire two captures; reset only if the capture fails.
+    @State private var didCapture = false
+    /// A capture attempt produced nothing (session interrupted, processing
+    /// error) — surfaced instead of silently doing nothing.
+    @State private var showCaptureFailed = false
+
+    /// Whether the device has a camera the controller can actually drive
+    /// (false on Simulator). Asks AVFoundation — the same stack that
+    /// captures — and only once: camera presence can't change at runtime.
+    static let isAvailable: Bool =
+        AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back) != nil
+        || AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .front) != nil
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            MADCameraPreview(session: camera.session)
+                .ignoresSafeArea()
+
+            if camera.authorizationDenied {
+                permissionDeniedView
+            }
+
+            if let countdown {
+                Text("\(countdown)")
+                    .font(.system(size: 110, weight: .black, design: .rounded))
+                    .foregroundColor(.white)
+                    .shadow(color: .black.opacity(0.6), radius: 12)
+                    .transition(.scale.combined(with: .opacity))
+                    .id(countdown)
+            }
+
+            VStack {
+                topBar
+                Spacer()
+                bottomBar
+            }
+
+            if showCaptureFailed {
+                captureFailedToast
+            }
+        }
+        .statusBarHidden()
+        .onAppear { camera.start() }
+        .onDisappear {
+            countdownTask?.cancel()
+            camera.stop()
+        }
+    }
+
+    // MARK: - Controls
+
+    private var topBar: some View {
+        HStack {
+            glassCircleButton(icon: "xmark", size: 40, iconSize: 16) {
+                countdownTask?.cancel()
+                dismiss()
+            }
+
+            Spacer()
+
+            HStack(spacing: 10) {
+                if camera.isFlashAvailable {
+                    controlPill(
+                        icon: camera.flash.icon,
+                        label: camera.flash.label,
+                        active: camera.flash != .off
+                    ) { camera.cycleFlash() }
+                }
+                controlPill(
+                    icon: "timer",
+                    label: camera.timerSeconds == 0 ? "Off" : "\(camera.timerSeconds)s",
+                    active: camera.timerSeconds > 0
+                ) { camera.cycleTimer() }
+            }
+        }
+        .padding(.horizontal, MADTheme.Spacing.md)
+        .padding(.top, MADTheme.Spacing.sm)
+    }
+
+    private func glassCircleButton(
+        icon: String, size: CGFloat, iconSize: CGFloat, action: @escaping () -> Void
+    ) -> some View {
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            action()
+        } label: {
+            Image(systemName: icon)
+                .font(.system(size: iconSize, weight: .bold))
+                .foregroundColor(.white)
+                .frame(width: size, height: size)
+                .background(Circle().fill(Color.black.opacity(0.45)))
+                .overlay(Circle().strokeBorder(Color.white.opacity(0.2), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func controlPill(
+        icon: String, label: String, active: Bool, action: @escaping () -> Void
+    ) -> some View {
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            action()
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: icon)
+                    .font(.system(size: 13, weight: .bold))
+                Text(label)
+                    .font(.system(size: 13, weight: .bold, design: .rounded))
+            }
+            .foregroundColor(active ? .yellow : .white)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Capsule().fill(Color.black.opacity(0.45)))
+            .overlay(Capsule().strokeBorder(Color.white.opacity(0.2), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var bottomBar: some View {
+        ZStack {
+            shutterButton
+            HStack {
+                Spacer()
+                glassCircleButton(icon: "arrow.triangle.2.circlepath.camera.fill", size: 48, iconSize: 18) {
+                    camera.flip()
+                }
+            }
+            .padding(.trailing, MADTheme.Spacing.lg)
+        }
+        .padding(.bottom, 36)
+    }
+
+    private var shutterButton: some View {
+        Button(action: shutterTapped) {
+            ZStack {
+                Circle()
+                    .strokeBorder(Color.white, lineWidth: 4)
+                    .frame(width: 78, height: 78)
+                if countdownTask != nil {
+                    // A running countdown turns the shutter into a stop button.
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color.white)
+                        .frame(width: 30, height: 30)
+                } else {
+                    Circle()
+                        .fill(Color.white)
+                        .frame(width: 64, height: 64)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(camera.authorizationDenied || didCapture)
+    }
+
+    private var captureFailedToast: some View {
+        VStack {
+            Text("Couldn't take the photo — try again")
+                .font(.system(size: 14, weight: .bold, design: .rounded))
+                .foregroundColor(.white)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .background(
+                    Capsule()
+                        .fill(Color.black.opacity(0.75))
+                        .overlay(Capsule().strokeBorder(Color.white.opacity(0.15), lineWidth: 1))
+                )
+                .padding(.top, 64)
+            Spacer()
+        }
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
+
+    private var permissionDeniedView: some View {
+        VStack(spacing: MADTheme.Spacing.md) {
+            Image(systemName: "camera.fill")
+                .font(.system(size: 40, weight: .semibold))
+                .foregroundColor(.white.opacity(0.5))
+            Text("Camera access is off")
+                .font(.system(size: 20, weight: .heavy, design: .rounded))
+                .foregroundColor(.white)
+            Text("Turn on camera access in Settings to snap a photo of your walk or run.")
+                .font(.system(size: 14, weight: .medium, design: .rounded))
+                .foregroundColor(.white.opacity(0.6))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, MADTheme.Spacing.xl)
+            Button {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+            } label: {
+                Text("Open Settings")
+            }
+            .madPrimaryButton()
+        }
+    }
+
+    // MARK: - Capture flow
+
+    private func shutterTapped() {
+        // Tapping the shutter mid-countdown cancels the timer, Apple-style.
+        if let task = countdownTask {
+            task.cancel()
+            countdownTask = nil
+            withAnimation(.easeOut(duration: 0.15)) { countdown = nil }
+            return
+        }
+
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        guard camera.timerSeconds > 0 else {
+            capture()
+            return
+        }
+
+        let seconds = camera.timerSeconds
+        countdownTask = Task { @MainActor in
+            for remaining in stride(from: seconds, through: 1, by: -1) {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                    countdown = remaining
+                }
+                UIImpactFeedbackGenerator(style: remaining <= 3 ? .medium : .light).impactOccurred()
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                guard !Task.isCancelled else { return }
+            }
+            countdown = nil
+            countdownTask = nil
+            capture()
+        }
+    }
+
+    private func capture() {
+        guard !didCapture else { return }
+        // Latch immediately — the shutter disables and a second tap during
+        // the capture round-trip can't start a competing capture.
+        didCapture = true
+        camera.capturePhoto { captured in
+            guard let captured else {
+                // Failed (session interrupted, processing error): re-arm the
+                // shutter and say so — a silent no-op after a 10s countdown
+                // reads as "the app ate my photo".
+                didCapture = false
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                    showCaptureFailed = true
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2.2) {
+                    withAnimation(.easeOut(duration: 0.25)) { showCaptureFailed = false }
+                }
+                return
+            }
+            image = captured
+            // Every in-app capture also lands in the camera roll — the user's
+            // own copy, independent of what happens to the post.
+            PhotoRollSaver.save(captured)
+            dismiss()
+        }
+    }
+}
+
+// MARK: - Session controller
+
+/// Owns the AVCaptureSession. All session mutation happens on `sessionQueue`;
+/// observable UI state is always written back on the main queue.
+@Observable
+final class MADCameraController {
+    @ObservationIgnored let session = AVCaptureSession()
+
+    var authorizationDenied = false
+    /// Whether the CURRENT camera can flash — front cameras count too on
+    /// modern iPhones (Retina screen-flash), per supportedFlashModes.
+    var isFlashAvailable = false
+    var flash: FlashSetting
+    /// Self-timer length in seconds; 0 = off. Deliberately NOT persisted — a
+    /// remembered timer silently delaying tomorrow's quick snap is a surprise.
+    var timerSeconds = 0
+
+    @ObservationIgnored private let sessionQueue = DispatchQueue(label: "mad.camera.session")
+    @ObservationIgnored private let photoOutput = AVCapturePhotoOutput()
+    /// Session-queue-owned; also the source of truth for the active position.
+    @ObservationIgnored private var videoInput: AVCaptureDeviceInput?
+    @ObservationIgnored private var configured = false
+    /// In-flight capture delegates keyed by settings id — AVCapturePhotoOutput
+    /// does NOT retain its delegate, and a single slot would let overlapping
+    /// captures free each other mid-flight. Session-queue-owned.
+    @ObservationIgnored private var inFlightDelegates: [Int64: MADPhotoCaptureDelegate] = [:]
+    @ObservationIgnored private var sessionObservers: [NSObjectProtocol] = []
+
+    private static let flashKey = "mad.camera.flash"
+
+    enum FlashSetting: String, CaseIterable {
+        case off, auto, on
+
+        var next: FlashSetting {
+            switch self {
+            case .off: return .auto
+            case .auto: return .on
+            case .on: return .off
+            }
+        }
+
+        var avMode: AVCaptureDevice.FlashMode {
+            switch self {
+            case .off: return .off
+            case .auto: return .auto
+            case .on: return .on
+            }
+        }
+
+        var icon: String {
+            switch self {
+            case .off: return "bolt.slash.fill"
+            case .auto: return "bolt.badge.a.fill"
+            case .on: return "bolt.fill"
+            }
+        }
+
+        var label: String {
+            switch self {
+            case .off: return "Off"
+            case .auto: return "Auto"
+            case .on: return "On"
+            }
+        }
+    }
+
+    init() {
+        flash = FlashSetting(rawValue: UserDefaults.standard.string(forKey: Self.flashKey) ?? "") ?? .auto
+        observeSessionLifecycle()
+    }
+
+    deinit {
+        sessionObservers.forEach { NotificationCenter.default.removeObserver($0) }
+    }
+
+    func start() {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            startSession()
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                if granted {
+                    self?.startSession()
+                } else {
+                    DispatchQueue.main.async { self?.authorizationDenied = true }
+                }
+            }
+        default:
+            authorizationDenied = true
+        }
+    }
+
+    func stop() {
+        sessionQueue.async { [weak self] in
+            guard let self, self.session.isRunning else { return }
+            self.session.stopRunning()
+        }
+    }
+
+    /// Flip between back and front. The target is computed ON the session
+    /// queue from the actually-attached input, so rapid double-taps queue two
+    /// real flips instead of re-deriving the same target from a stale
+    /// published value.
+    func flip() {
+        sessionQueue.async { [weak self] in
+            guard let self else { return }
+            let current = self.videoInput?.device.position ?? .back
+            let target: AVCaptureDevice.Position = current == .back ? .front : .back
+            self.session.beginConfiguration()
+            self.attachInput(position: target)
+            self.session.commitConfiguration()
+            self.publishFlashAvailability()
+        }
+    }
+
+    func cycleFlash() {
+        flash = flash.next
+        UserDefaults.standard.set(flash.rawValue, forKey: Self.flashKey)
+    }
+
+    func cycleTimer() {
+        timerSeconds = timerSeconds == 0 ? 3 : (timerSeconds == 3 ? 10 : 0)
+    }
+
+    /// Completion runs on the main queue; nil means the capture failed.
+    func capturePhoto(completion: @escaping (UIImage?) -> Void) {
+        let flashMode = flash.avMode
+        sessionQueue.async { [weak self] in
+            guard let self, self.session.isRunning else {
+                DispatchQueue.main.async { completion(nil) }
+                return
+            }
+
+            let settings = AVCapturePhotoSettings()
+            if self.photoOutput.supportedFlashModes.contains(flashMode) {
+                settings.flashMode = flashMode
+            }
+            if let connection = self.photoOutput.connection(with: .video),
+               connection.isVideoRotationAngleSupported(90) {
+                connection.videoRotationAngle = 90
+            }
+
+            // Mirror front-camera shots so the saved photo matches what the
+            // preview showed — an unmirrored selfie reads as "flipped".
+            let mirror = self.videoInput?.device.position == .front
+            let settingsId = settings.uniqueID
+            let delegate = MADPhotoCaptureDelegate { [weak self] image in
+                let final: UIImage? = {
+                    guard let image else { return nil }
+                    return mirror ? MADCameraController.mirroredHorizontally(image) : image
+                }()
+                self?.sessionQueue.async { self?.inFlightDelegates[settingsId] = nil }
+                DispatchQueue.main.async { completion(final) }
+            }
+            self.inFlightDelegates[settingsId] = delegate
+            self.photoOutput.capturePhoto(with: settings, delegate: delegate)
+        }
+    }
+
+    // MARK: Session-queue internals
+
+    private func startSession() {
+        sessionQueue.async { [weak self] in
+            guard let self else { return }
+            self.configureIfNeeded()
+            if !self.session.isRunning { self.session.startRunning() }
+        }
+    }
+
+    private func configureIfNeeded() {
+        guard !configured else { return }
+        configured = true
+        session.beginConfiguration()
+        session.sessionPreset = .photo
+        attachInput(position: .back)
+        if session.canAddOutput(photoOutput) {
+            session.addOutput(photoOutput)
+        }
+        session.commitConfiguration()
+        publishFlashAvailability()
+    }
+
+    /// Swap (or attach) the camera for `position`. Session-queue only, inside
+    /// a begin/commitConfiguration pair (configureIfNeeded provides its own).
+    private func attachInput(position: AVCaptureDevice.Position) {
+        let previous = videoInput
+        if let previous {
+            session.removeInput(previous)
+            videoInput = nil
+        }
+        guard let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: position),
+              let input = try? AVCaptureDeviceInput(device: device),
+              session.canAddInput(input)
+        else {
+            // Couldn't attach the requested camera — put the previous one back
+            // rather than going black.
+            if let previous, session.canAddInput(previous) {
+                session.addInput(previous)
+                videoInput = previous
+            }
+            return
+        }
+        session.addInput(input)
+        videoInput = input
+    }
+
+    private func publishFlashAvailability() {
+        let supported = photoOutput.supportedFlashModes.contains(.on)
+        DispatchQueue.main.async { self.isFlashAvailable = supported }
+    }
+
+    /// UIImagePickerController used to handle these for us: restart the
+    /// session when an interruption (phone call, another app claiming the
+    /// camera) ends or a runtime error stops it — otherwise the user comes
+    /// back to a frozen preview with a dead shutter.
+    private func observeSessionLifecycle() {
+        let center = NotificationCenter.default
+        let restart: (Notification) -> Void = { [weak self] _ in
+            guard let self else { return }
+            self.sessionQueue.async { [weak self] in
+                guard let self, self.configured, !self.session.isRunning else { return }
+                self.session.startRunning()
+            }
+        }
+        sessionObservers.append(center.addObserver(
+            forName: AVCaptureSession.interruptionEndedNotification,
+            object: session, queue: nil, using: restart
+        ))
+        sessionObservers.append(center.addObserver(
+            forName: AVCaptureSession.runtimeErrorNotification,
+            object: session, queue: nil, using: restart
+        ))
+    }
+
+    private static func mirroredHorizontally(_ image: UIImage) -> UIImage {
+        // Fast path: with the capture connection rotated to portrait the
+        // decoded image is normally .up, and the flip is a metadata-only
+        // orientation swap — no pixel copy.
+        if image.imageOrientation == .up, let cg = image.cgImage {
+            return UIImage(cgImage: cg, scale: image.scale, orientation: .upMirrored)
+        }
+        // Fallback for EXIF-rotated variants: re-render. Orientation-flag
+        // arithmetic for the rotated+mirrored cases is easy to get wrong, and
+        // a slow correct selfie beats a fast sideways one.
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = image.scale
+        return UIGraphicsImageRenderer(size: image.size, format: format).image { ctx in
+            ctx.cgContext.translateBy(x: image.size.width, y: 0)
+            ctx.cgContext.scaleBy(x: -1, y: 1)
+            image.draw(in: CGRect(origin: .zero, size: image.size))
+        }
+    }
+}
+
+/// One-shot capture delegate. The controller keeps a strong reference (in
+/// `inFlightDelegates`) until the callback fires — AVCapturePhotoOutput does
+/// not retain its delegate.
+private final class MADPhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
+    private let completion: (UIImage?) -> Void
+
+    init(completion: @escaping (UIImage?) -> Void) {
+        self.completion = completion
+    }
+
+    func photoOutput(
+        _ output: AVCapturePhotoOutput,
+        didFinishProcessingPhoto photo: AVCapturePhoto,
+        error: Error?
+    ) {
+        guard error == nil,
+              let data = photo.fileDataRepresentation(),
+              let image = UIImage(data: data)
+        else {
+            completion(nil)
+            return
+        }
+        completion(image)
+    }
+}
+
+// MARK: - Preview layer host
+
+private struct MADCameraPreview: UIViewRepresentable {
+    let session: AVCaptureSession
+
+    func makeUIView(context: Context) -> PreviewHostView {
+        let view = PreviewHostView()
+        view.previewLayer.session = session
+        view.previewLayer.videoGravity = .resizeAspectFill
+        return view
+    }
+
+    func updateUIView(_ uiView: PreviewHostView, context: Context) {
+        // Re-runs whenever the hosting view re-renders (e.g. after the async
+        // session config flips an observable flag) — by then the connection
+        // exists even if the initial layout pass beat it.
+        uiView.pinToPortrait()
+    }
+
+    final class PreviewHostView: UIView {
+        override class var layerClass: AnyClass { AVCaptureVideoPreviewLayer.self }
+        var previewLayer: AVCaptureVideoPreviewLayer { layer as! AVCaptureVideoPreviewLayer }
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            pinToPortrait()
+        }
+
+        // The app is portrait-only; pin the preview to portrait once the
+        // connection exists (it forms only after inputs attach).
+        func pinToPortrait() {
+            if let connection = previewLayer.connection,
+               connection.isVideoRotationAngleSupported(90),
+               connection.videoRotationAngle != 90 {
+                connection.videoRotationAngle = 90
+            }
+        }
+    }
+}

--- a/app/Mile A Day/Views/Components/MADCameraView.swift
+++ b/app/Mile A Day/Views/Components/MADCameraView.swift
@@ -299,6 +299,9 @@ final class MADCameraController {
     /// Session-queue-owned; also the source of truth for the active position.
     @ObservationIgnored private var videoInput: AVCaptureDeviceInput?
     @ObservationIgnored private var configured = false
+    /// True between stop() and the next start() — blocks lifecycle-observer
+    /// restarts from reviving a session the user already closed.
+    @ObservationIgnored private var userStopped = false
     /// In-flight capture delegates keyed by settings id — AVCapturePhotoOutput
     /// does NOT retain its delegate, and a single slot would let overlapping
     /// captures free each other mid-flight. Session-queue-owned.
@@ -371,8 +374,9 @@ final class MADCameraController {
 
     func stop() {
         sessionQueue.async { [weak self] in
-            guard let self, self.session.isRunning else { return }
-            self.session.stopRunning()
+            guard let self else { return }
+            self.userStopped = true
+            if self.session.isRunning { self.session.stopRunning() }
         }
     }
 
@@ -441,6 +445,7 @@ final class MADCameraController {
     private func startSession() {
         sessionQueue.async { [weak self] in
             guard let self else { return }
+            self.userStopped = false
             self.configureIfNeeded()
             if !self.session.isRunning { self.session.startRunning() }
         }
@@ -494,21 +499,29 @@ final class MADCameraController {
     /// back to a frozen preview with a dead shutter.
     private func observeSessionLifecycle() {
         let center = NotificationCenter.default
-        let restart: (Notification) -> Void = { [weak self] _ in
+        let restart: () -> Void = { [weak self] in
             guard let self else { return }
             self.sessionQueue.async { [weak self] in
-                guard let self, self.configured, !self.session.isRunning else { return }
+                guard let self, self.configured, !self.userStopped,
+                      !self.session.isRunning else { return }
                 self.session.startRunning()
             }
         }
         sessionObservers.append(center.addObserver(
             forName: AVCaptureSession.interruptionEndedNotification,
-            object: session, queue: nil, using: restart
-        ))
+            object: session, queue: nil
+        ) { _ in restart() })
         sessionObservers.append(center.addObserver(
             forName: AVCaptureSession.runtimeErrorNotification,
-            object: session, queue: nil, using: restart
-        ))
+            object: session, queue: nil
+        ) { note in
+            // AVCam's rule: only a media-services reset warrants a restart. A
+            // failed startRunning() itself posts a runtime error, so a
+            // blanket retry ping-pongs forever under persistent failure.
+            let error = note.userInfo?[AVCaptureSessionErrorKey] as? AVError
+            guard error?.code == .mediaServicesWereReset else { return }
+            restart()
+        })
     }
 
     private static func mirroredHorizontally(_ image: UIImage) -> UIImage {

--- a/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
@@ -260,7 +260,7 @@ struct WorkoutTrackingView: View {
                     // one tap, keep moving — the end-of-run prompt asks whether
                     // it becomes the post. Pinned in the top bar so it never
                     // crowds the metrics or the Stop button.
-                    if CameraPicker.isAvailable && !isStopping {
+                    if MADCameraView.isAvailable && !isStopping {
                         midRunCameraButton
                             .padding(.trailing, 20)
                     }
@@ -339,8 +339,7 @@ struct WorkoutTrackingView: View {
         }
         .buttonStyle(PlainButtonStyle())
         .fullScreenCover(isPresented: $showMidRunCamera) {
-            CameraPicker(image: $midRunImage)
-                .ignoresSafeArea()
+            MADCameraView(image: $midRunImage)
         }
         .onChange(of: midRunImage) { _, newImage in
             guard let image = newImage else { return }

--- a/app/Mile A Day/Views/Feed/EditCaptionSheet.swift
+++ b/app/Mile A Day/Views/Feed/EditCaptionSheet.swift
@@ -86,6 +86,7 @@ struct EditCaptionSheet: View {
                     .disabled(isSaving)
                 }
             }
+            .madKeyboardDoneButton(focus: $focused)
             .onAppear { focused = true }
         }
         .presentationDetents([.medium])

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -371,8 +371,14 @@ struct PostComposerView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
+                    // Disabled while publishing: publish() has no cancellation
+                    // hook, so a Cancel racing an in-flight upload would fire
+                    // onFinished twice with contradictory outcomes (the
+                    // post-run prompt would auto-post the route card AND the
+                    // photo post would land server-side).
                     Button("Cancel") { onFinished(.cancelled); dismiss() }
-                        .foregroundColor(.white)
+                        .foregroundColor(.white.opacity(vm.isPublishing ? 0.4 : 1))
+                        .disabled(vm.isPublishing)
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     if vm.isPublishing {

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -118,6 +118,9 @@ final class PostComposerViewModel: ObservableObject {
     @Published var hasRoute = false
     /// User choice: show the route map with this post (carousel slide 2).
     @Published var includeRoute = true
+    /// Publish was rejected server-side for unaccepted guidelines — the view
+    /// re-presents the gate when this flips true.
+    @Published var needsTermsGate = false
 
     let stats: RunStatsInput
     /// Captured on-screen canvas size (points), reused to render the composite.
@@ -133,6 +136,10 @@ final class PostComposerViewModel: ObservableObject {
         cfg.enabled = cfg.enabled.filter { available.contains($0) }
         if cfg.enabled.isEmpty { cfg.enabled = Array(available.prefix(1)) }
         self.config = cfg
+        // Bring the sticker back at the size and spot it was last posted at
+        // (StickerConfig sanitizes on decode; ranges live there too).
+        self.stickerScale = cfg.scale
+        self.stickerPos = CGPoint(x: cfg.posX, y: cfg.posY)
         // Seed a pre-chosen photo (mid-run snap) AFTER all stored properties
         // are initialized — the @Published setter touches self.
         self.pickedImage = initialImage
@@ -208,6 +215,11 @@ final class PostComposerViewModel: ObservableObject {
                 let rememberedUnavailable = StickerConfig.load().enabled
                     .filter { !available.contains($0) }
                 toSave.enabled = config.enabled + rememberedUnavailable
+                // Remember the transform too, so the next post's sticker shows
+                // up at this exact size and position.
+                toSave.scale = stickerScale
+                toSave.posX = stickerPos.x
+                toSave.posY = stickerPos.y
                 toSave.save()
             }
             return true
@@ -215,7 +227,10 @@ final class PostComposerViewModel: ObservableObject {
             errorMessage = "Finish today's mile before you post."
             return false
         } catch let APIError.apiError(message) where message == "terms_not_accepted" {
-            errorMessage = "Please accept the community terms to post."
+            // Stale local acceptance — clear the memo and re-gate.
+            PostService.cacheTermsAccepted(false)
+            needsTermsGate = true
+            errorMessage = "Please accept the community guidelines to post."
             return false
         } catch APIError.conflict {
             // One deliberate post per workout — a reward, not a redo.
@@ -260,12 +275,33 @@ struct PostCanvas: View {
 }
 
 struct PostComposerView: View {
+    /// Community-guidelines acceptance, resolved before sharing is allowed
+    /// (App Review 1.2 — and the server rejects un-accepted posts anyway, so
+    /// gating up front beats a dead-end publish error). The CAMERA is never
+    /// blocked on this: capturing preserves the moment (and lands in the
+    /// user's camera roll) — only composing/sharing waits for acceptance.
+    private enum TermsState { case unknown, accepted, needsAcceptance }
+
     @StateObject private var vm: PostComposerViewModel
     @State private var showCamera = false
+    /// Seeded from the local cache so a returning poster never waits on (or
+    /// races) the network check in `resolveTermsIfNeeded`.
+    @State private var termsState: TermsState =
+        PostService.termsAcceptedCached ? .accepted : .unknown
+    @State private var showTermsGate = false
+    /// Gate outcome relayed by PostTermsGateView.onAccepted, read in the
+    /// cover's onDismiss — deliberately not inferred from the cache so gate
+    /// internals can change without silently breaking this flow.
+    @State private var gateAccepted = false
+    /// The auto camera open must fire exactly once: .onAppear re-fires every
+    /// time a fullScreenCover dismisses, and re-opening on each pass would
+    /// trap the user in the camera with no way back.
+    @State private var didAutoOpenCamera = false
     @State private var gestureBaseScale: CGFloat = 1.0
     /// Sticker position at drag start (normalized) — drags apply translation
     /// relative to this instead of jumping to the touch point.
     @State private var gestureBasePos: CGPoint? = nil
+    @FocusState private var captionFocused: Bool
     /// Launch straight into the camera on first appear (post-run prompt flow) —
     /// the user already tapped "Take a photo" once to get here.
     let autoOpenCamera: Bool
@@ -307,6 +343,29 @@ struct PostComposerView: View {
                     }
                     .padding(MADTheme.Spacing.md)
                 }
+                .scrollDismissesKeyboard(.interactively)
+                // The guidelines gate rides on the ScrollView so it never
+                // collides with the camera cover attached to the ZStack —
+                // two covers on one node drop one of the presentations.
+                .fullScreenCover(isPresented: $showTermsGate, onDismiss: {
+                    if gateAccepted {
+                        gateAccepted = false
+                        termsState = .accepted
+                        vm.errorMessage = nil
+                    } else if vm.pickedImage == nil {
+                        // Declined with nothing composed — nothing to lose;
+                        // back out so the post-run prompt / feed takes over.
+                        onFinished(.cancelled)
+                        dismiss()
+                    } else {
+                        // Declined with a draft on screen: NEVER destroy it.
+                        // Share stays locked (tapping it re-opens the gate);
+                        // Cancel remains the deliberate way out.
+                        vm.errorMessage = "Accept the community guidelines to share your post."
+                    }
+                }) {
+                    PostTermsGateView { gateAccepted = true }
+                }
             }
             .navigationTitle("New Post")
             .navigationBarTitleDisplayMode(.inline)
@@ -320,34 +379,48 @@ struct PostComposerView: View {
                         ProgressView().tint(.white)
                     } else {
                         Button("Share") {
-                            Task {
-                                let ok = await vm.publish()
-                                if ok {
-                                    onFinished(.published(
-                                        toFeed: vm.destination.toFeed,
-                                        toStory: vm.destination.toStory
-                                    ))
-                                    dismiss()
+                            switch termsState {
+                            case .accepted:
+                                Task {
+                                    let ok = await vm.publish()
+                                    if ok {
+                                        onFinished(.published(
+                                            toFeed: vm.destination.toFeed,
+                                            toStory: vm.destination.toStory
+                                        ))
+                                        dismiss()
+                                    }
                                 }
+                            case .needsAcceptance:
+                                // Not allowed to post yet — the button routes
+                                // to the guidelines instead of a dead upload.
+                                presentGateIfNeeded()
+                            case .unknown:
+                                // Still resolving; the gate auto-presents if
+                                // the answer comes back unaccepted.
+                                break
                             }
                         }
                         .fontWeight(.bold)
-                        .foregroundColor(vm.canPublish ? MADTheme.Colors.madRed : .white.opacity(0.3))
+                        .foregroundColor(vm.canPublish && termsState == .accepted
+                            ? MADTheme.Colors.madRed : .white.opacity(0.3))
                         .disabled(!vm.canPublish)
                     }
                 }
             }
             .toolbarBackground(.black, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
+            .madKeyboardDoneButton(focus: $captionFocused)
             .fullScreenCover(isPresented: $showCamera) {
-                CameraPicker(image: $vm.pickedImage)
-                    .ignoresSafeArea()
+                MADCameraView(image: $vm.pickedImage)
             }
             .onAppear {
-                if autoOpenCamera, vm.pickedImage == nil, CameraPicker.isAvailable {
-                    showCamera = true
+                if autoOpenCamera, !didAutoOpenCamera, vm.pickedImage == nil {
+                    didAutoOpenCamera = true
+                    requestCamera()
                 }
             }
+            .task { await resolveTermsIfNeeded() }
             .task { await vm.checkRouteAvailability() }
             // Re-probe once a photo lands — todaysWorkouts may not have been
             // loaded yet when the composer first appeared.
@@ -355,7 +428,50 @@ struct PostComposerView: View {
                 guard newImage != nil else { return }
                 Task { await vm.checkRouteAvailability() }
             }
+            // A gate held back while the camera cover was up presents as soon
+            // as the camera closes.
+            .onChange(of: showCamera) { _, isUp in
+                guard !isUp else { return }
+                presentGateIfNeeded()
+            }
+            // The server rejected a publish for unaccepted terms (stale local
+            // state) — re-gate instead of dead-ending on the error label.
+            .onChange(of: vm.needsTermsGate) { _, needs in
+                guard needs else { return }
+                vm.needsTermsGate = false
+                termsState = .needsAcceptance
+                presentGateIfNeeded()
+            }
         }
+    }
+
+    // MARK: - Guidelines gate
+
+    /// Opening the camera never waits on the guidelines — see TermsState.
+    private func requestCamera() {
+        guard MADCameraView.isAvailable else { return }
+        showCamera = true
+    }
+
+    private func resolveTermsIfNeeded() async {
+        guard termsState == .unknown else { return }
+        if PostService.termsAcceptedCached {
+            termsState = .accepted
+            return
+        }
+        // Failed check (offline) ⇒ treat as not accepted: the gate explains
+        // the block and Share stays locked, while the camera keeps working so
+        // the moment itself is never lost.
+        let accepted = (try? await PostService.termsStatus())?.accepted ?? false
+        termsState = accepted ? .accepted : .needsAcceptance
+        presentGateIfNeeded()
+    }
+
+    /// Present the gate once no other cover is up — presenting while the
+    /// camera cover is active would drop the presentation entirely.
+    private func presentGateIfNeeded() {
+        guard termsState == .needsAcceptance, !showCamera, !showTermsGate else { return }
+        showTermsGate = true
     }
 
     /// Offer to ride the run's GPS route along with the photo (shown as a
@@ -404,9 +520,17 @@ struct PostComposerView: View {
                     }
                     .frame(width: width, height: height)
                     .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous))
-                    .onAppear { vm.canvasSize = CGSize(width: width, height: height) }
+                    // Track the LIVE geometry (initial + every later pass) —
+                    // a size captured once on appear can go stale (e.g. first
+                    // layout while the camera cover is up) and flatten() would
+                    // render the sticker at a different relative size than the
+                    // preview. geo.size is already 4:5 via the aspectRatio.
+                    .onChange(of: geo.size, initial: true) { _, size in
+                        guard size.width > 0 else { return }
+                        vm.canvasSize = size
+                    }
                     .overlay(alignment: .topTrailing) {
-                        Button { showCamera = true } label: {
+                        Button { requestCamera() } label: {
                             HStack(spacing: 5) {
                                 Image(systemName: "camera.fill")
                                     .font(.system(size: 12, weight: .bold))
@@ -439,7 +563,7 @@ struct PostComposerView: View {
     }
 
     private var photoPlaceholder: some View {
-        Button { if CameraPicker.isAvailable { showCamera = true } } label: {
+        Button { requestCamera() } label: {
             VStack(spacing: MADTheme.Spacing.md) {
                 ZStack {
                     Circle()
@@ -452,10 +576,10 @@ struct PostComposerView: View {
                 }
 
                 VStack(spacing: 4) {
-                    Text(CameraPicker.isAvailable ? "Take a photo" : "Camera unavailable")
+                    Text(MADCameraView.isAvailable ? "Take a photo" : "Camera unavailable")
                         .font(.system(size: 18, weight: .heavy, design: .rounded))
                         .foregroundColor(.white)
-                    Text(CameraPicker.isAvailable
+                    Text(MADCameraView.isAvailable
                         ? "Snap today's walk or run — camera keeps it real."
                         : "A camera is required to share a post.")
                         .font(.system(size: 13, weight: .medium, design: .rounded))
@@ -464,7 +588,7 @@ struct PostComposerView: View {
                         .padding(.horizontal, MADTheme.Spacing.lg)
                 }
 
-                if CameraPicker.isAvailable {
+                if MADCameraView.isAvailable {
                     HStack(spacing: 6) {
                         Image(systemName: "camera.fill").font(.system(size: 13, weight: .bold))
                         Text("Open camera").font(.system(size: 14, weight: .bold, design: .rounded))
@@ -487,12 +611,15 @@ struct PostComposerView: View {
             )
         }
         .buttonStyle(.plain)
-        .disabled(!CameraPicker.isAvailable)
+        .disabled(!MADCameraView.isAvailable)
     }
 
     private func stickerGestureLayer(canvas: CGSize) -> some View {
         Color.clear
             .contentShape(Rectangle())
+            // Base the first pinch on the RESTORED scale — the default 1.0
+            // would make a remembered smaller/larger sticker jump on touch.
+            .onAppear { gestureBaseScale = vm.stickerScale }
             .gesture(
                 SimultaneousGesture(
                     DragGesture()
@@ -505,14 +632,15 @@ struct PostComposerView: View {
                             let x = base.x + value.translation.width / canvas.width
                             let y = base.y + value.translation.height / canvas.height
                             vm.stickerPos = CGPoint(
-                                x: min(max(x, 0.12), 0.88),
-                                y: min(max(y, 0.1), 0.9)
+                                x: x.clamped(to: StickerConfig.posXRange),
+                                y: y.clamped(to: StickerConfig.posYRange)
                             )
                         }
                         .onEnded { _ in gestureBasePos = nil },
                     MagnificationGesture()
                         .onChanged { value in
-                            vm.stickerScale = min(max(gestureBaseScale * value, 0.6), 1.9)
+                            vm.stickerScale = (gestureBaseScale * value)
+                                .clamped(to: StickerConfig.scaleRange)
                         }
                         .onEnded { _ in gestureBaseScale = vm.stickerScale }
                 )
@@ -614,6 +742,7 @@ struct PostComposerView: View {
         VStack(alignment: .leading, spacing: 6) {
             TextField("", text: $vm.caption, prompt: Text("Add a caption…").foregroundColor(.white.opacity(0.4)), axis: .vertical)
                 .lineLimit(1...4)
+                .focused($captionFocused)
                 .font(.system(size: 15, weight: .medium, design: .rounded))
                 .foregroundColor(.white)
                 .padding(MADTheme.Spacing.md)

--- a/app/Mile A Day/Views/Feed/RunStatsStickerView.swift
+++ b/app/Mile A Day/Views/Feed/RunStatsStickerView.swift
@@ -69,12 +69,51 @@ enum StickerAccent: String, CaseIterable, Identifiable, Codable {
     }
 }
 
+extension Comparable {
+    func clamped(to range: ClosedRange<Self>) -> Self {
+        min(max(self, range.lowerBound), range.upperBound)
+    }
+}
+
 /// User-controlled overlay configuration. Persisted between sessions so the
 /// composer remembers how someone likes to show their run.
 struct StickerConfig: Equatable, Codable {
+    /// Transform bounds, owned HERE so every consumer of a persisted config
+    /// (composer gestures, decode-time sanitizing, any future render path)
+    /// enforces the same invariant.
+    static let scaleRange: ClosedRange<CGFloat> = 0.6...1.9
+    static let posXRange: ClosedRange<CGFloat> = 0.12...0.88
+    static let posYRange: ClosedRange<CGFloat> = 0.1...0.9
+
     var style: StickerStyle = .card
     var accent: StickerAccent = .orange
     var enabled: [RunStatKind] = [.distance, .streak]
+    /// Remembered overlay transform — pinch scale and normalized center — so
+    /// the sticker comes back exactly the size and spot it was last posted at
+    /// instead of resetting to a full-size default every time.
+    var scale: CGFloat = 1.0
+    var posX: CGFloat = 0.5
+    var posY: CGFloat = 0.82
+
+    init() {}
+
+    /// The transform keys shipped after v1 — decode every field against the
+    /// declared defaults so configs saved by older builds keep their
+    /// style/stats choices instead of failing wholesale and resetting, and
+    /// clamp the transform so a stale/corrupt value can't render off-canvas.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let defaults = StickerConfig()
+        style = (try? c.decode(StickerStyle.self, forKey: .style)) ?? defaults.style
+        accent = (try? c.decode(StickerAccent.self, forKey: .accent)) ?? defaults.accent
+        enabled = (try? c.decode([RunStatKind].self, forKey: .enabled)) ?? defaults.enabled
+        scale = ((try? c.decode(CGFloat.self, forKey: .scale)) ?? defaults.scale)
+            .clamped(to: Self.scaleRange)
+        posX = ((try? c.decode(CGFloat.self, forKey: .posX)) ?? defaults.posX)
+            .clamped(to: Self.posXRange)
+        posY = ((try? c.decode(CGFloat.self, forKey: .posY)) ?? defaults.posY)
+            .clamped(to: Self.posYRange)
+    }
 
     func isOn(_ kind: RunStatKind) -> Bool { enabled.contains(kind) }
 

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -474,7 +474,9 @@ struct SocialFeedView: View {
         // Reachable from the rail's own-story cell even after the FAB hides —
         // enforce one-share-per-workout at the entry point too.
         guard !alreadySharedWorkout else { showAlreadySharedHint = true; return }
-        if termsAccepted == true {
+        // The cache also covers acceptance that happened OUTSIDE this view
+        // (post-run composer gate) after our one-shot loadTermsStatus ran.
+        if termsAccepted == true || PostService.termsAcceptedCached {
             presentingComposer = true
         } else {
             pendingCompose = true


### PR DESCRIPTION
Fixes five reported issues in the walk/run photo posting flow.

## 1. "Use a photo from your walk" was hard to select and opened the live camera
Tapping a mid-run snap could open the live camera instead of the tapped photo: the composer was presented via `fullScreenCover(isPresented:)` with the selection in separate `@State`, and the cover could be built with a stale `nil` selection (`autoOpenCamera: selectedSnap == nil` → camera). The composer is now presented via `fullScreenCover(item:)`, so it is always built from the exact tapped snap. Snap cards are also much bigger (single snap gets a 216pt hero card) with an explicit **"Use this photo"** pill instead of the small corner arrow.

## 2. Streak sticker posted bigger than composed
The sticker's pinch scale and position reset to the full-size default on every new post — only style/accent/stats were remembered. `StickerConfig` now persists `scale`/`posX`/`posY` (backward-compatible decoding with defaults, clamped to editor bounds that now live on `StickerConfig` itself), and the composer restores them, so the sticker keeps the exact size and spot the user last posted with. `flatten()` also now tracks the live canvas geometry (`.onChange(of: geo.size, initial: true)`) instead of a one-shot `onAppear` capture, so the rendered image always matches the on-screen preview.

## 3. Full flash control + self-timer
`UIImagePickerController` (auto-flash only, no timer) is replaced by `MADCameraView`, an AVFoundation camera used by both the post composer and the mid-run snap button:
- Flash **Off / Auto / On** (persisted choice), including front-camera screen flash where supported
- Self-timer **Off / 3s / 10s** with a big countdown, per-second haptics, and tap-shutter-to-cancel
- Front/back flip; front captures are mirrored to match the preview
- Every capture still saves to the camera roll (same as before)
- Robustness: session restarts after interruptions (phone calls), capture failures show a toast instead of silently doing nothing, a one-shot shutter latch plus per-capture delegate retention prevents dropped/duplicate captures, permission-denied state links to Settings

## 4. Guidelines shown before posting, not as a publish error
First-time posters previously composed a full post and only then hit the server's `terms_not_accepted` rejection. The composer now resolves acceptance up front (cached per-user after the first check — the cache key is pinned at request time so account switches can't leak acceptance across users) and presents the community-guidelines gate before composing/sharing:
- The **camera is never blocked** — capturing preserves the moment (and the camera-roll copy) even offline
- Share stays locked until accepted; tapping Share while unaccepted re-opens the guidelines instead of attempting a dead upload
- Declining with a draft on screen keeps the draft; declining with nothing composed backs out cleanly
- A stale local acceptance (server rejects at publish) clears the cache and re-gates instead of dead-ending
- The feed tab's existing gate now also honors acceptance recorded via the composer flow

## 5. Caption keyboard can always be dismissed
Both caption fields (composer + edit-caption sheet) get a shared keyboard **Done** accessory (`madKeyboardDoneButton`), plus interactive scroll-to-dismiss in the composer — the multi-line field's Return key inserts newlines, so the keyboard previously had no way off the screen.

## Notes
- No backend changes; no new entitlements or Info.plist keys (camera + add-only photo-library usage strings already cover the new camera — App Review 5.1.1/5.1.3 unaffected; the gate itself is the Guideline 1.2 requirement).
- New files `MADCameraView.swift` and `KeyboardDoneButton.swift` are picked up by the synchronized folder structure; `project.pbxproj` untouched.
- iOS builds are Xcode-only per repo policy, so this was desk-checked (8-angle review pass with fixes applied) but needs a device build + camera smoke test: mid-run snap → prompt → pick photo, flash on at night, 10s timer shot, first-post guidelines flow, caption Done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GshhkqMsKx9PkL6WHrpgto

---
_Generated by [Claude Code](https://claude.ai/code/session_01GshhkqMsKx9PkL6WHrpgto)_