### PR TITLE
Feed route zoom, hype-button burst, notification deep links, explicit share destination, walk-blue/run-red everywhere, camera polish

### DIFF
--- a/app/Mile A Day/Core/Theme/MADTheme.swift
+++ b/app/Mile A Day/Core/Theme/MADTheme.swift
@@ -66,10 +66,28 @@ struct MADTheme {
         static let success = Color(red: 0.2, green: 0.7, blue: 0.3)
         static let warning = Color(red: 1.0, green: 0.6, blue: 0.0)
         static let error = Color(red: 0.9, green: 0.2, blue: 0.2)
-        
+
+        // Workout-type accent: walks are BLUE everywhere (runs use madRed).
+        static let walkBlue = Color(red: 0.25, green: 0.6, blue: 0.95)
+
         // Shadow and overlay - adapt to dark mode
         static let shadow = Color.primary.opacity(0.1)
         static let overlay = Color.primary.opacity(0.3)
+    }
+
+    /// THE workout-type color language, app-wide: runs are red, walks are
+    /// blue — on the feed, dashboard, profiles, prompts, and the route
+    /// heatmap alike. Every surface must route through this (directly or via
+    /// ActivityCardView.color); local switch statements drifted into three
+    /// conflicting palettes before this existed.
+    static func workoutColor(_ type: String?) -> Color {
+        switch (type ?? "").lowercased() {
+        case "running": return Colors.madRed
+        case "walking": return Colors.walkBlue
+        case "hiking": return Colors.success
+        case "cycling": return Colors.warning
+        default: return Colors.madRed
+        }
     }
     
     // MARK: - Typography

--- a/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
+++ b/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
@@ -25,7 +25,8 @@ struct PostRunPhotoPromptView: View {
     @State private var composerLaunch: ComposerLaunch?
 
     private var isWalk: Bool { workoutType == "walking" }
-    private var accent: Color { isWalk ? .blue : MADTheme.Colors.madRed }
+    /// App-wide type language: walks blue, runs red.
+    private var accent: Color { MADTheme.workoutColor(workoutType) }
 
     var body: some View {
         ZStack {
@@ -87,7 +88,6 @@ struct PostRunPhotoPromptView: View {
         .fullScreenCover(item: $composerLaunch) { launch in
             PostComposerView(
                 stats: RunPostService.todayStats(workoutId: workoutId),
-                destination: .story,
                 // A chosen mid-run snap goes straight onto the canvas; only a
                 // fresh capture launches the camera.
                 autoOpenCamera: launch.image == nil,

--- a/app/Mile A Day/Views/Components/FriendWorkoutsSection.swift
+++ b/app/Mile A Day/Views/Components/FriendWorkoutsSection.swift
@@ -56,69 +56,62 @@ struct FriendWorkoutsSection: View {
     }
 }
 
+/// A friend's workout in the EXACT row grammar of the dashboard's own
+/// WorkoutRow (accent icon chip, verb + hero distance, duration • pace,
+/// date/time trailing) — a workout reads the same no matter whose it is.
 struct FriendWorkoutRow: View {
     let workout: FriendWorkout
     var showChevron: Bool = false
 
     var body: some View {
         HStack(spacing: MADTheme.Spacing.md) {
-            // Workout Icon in colored circle
             ZStack {
                 Circle()
                     .fill(workoutColor.opacity(0.15))
-                    .frame(width: 44, height: 44)
-
+                    .frame(width: 40, height: 40)
                 Image(systemName: workoutIcon)
-                    .font(.system(size: 18, weight: .medium))
+                    .font(.system(size: 17, weight: .bold))
                     .foregroundColor(workoutColor)
             }
 
-            // Workout Details
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 6) {
-                    Text(workout.formattedDate)
-                        .font(MADTheme.Typography.body)
-                        .fontWeight(.medium)
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(alignment: .firstTextBaseline, spacing: 5) {
+                    Text(verb)
+                        .font(.system(size: 14, weight: .bold, design: .rounded))
+                        .foregroundColor(MADTheme.Colors.secondaryText)
+                    Text(workout.distance.milesFormatted)
+                        .font(.system(size: 17, weight: .black, design: .rounded))
+                        .monospacedDigit()
                         .foregroundColor(MADTheme.Colors.primaryText)
-
-                    Text(workout.workoutType.capitalized)
-                        .font(.system(size: 11, weight: .semibold, design: .rounded))
-                        .foregroundColor(workoutColor)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 3)
-                        .background(
-                            Capsule()
-                                .fill(workoutColor.opacity(0.15))
-                        )
-
                     if workout.isManualOrEdited {
                         ManualWorkoutBadgeFromString(source: workout.source)
                     }
                 }
-
-                HStack(spacing: 12) {
-                    HStack(spacing: 4) {
-                        Image(systemName: "location.fill")
-                            .font(.system(size: 10))
-                            .foregroundColor(MADTheme.Colors.secondaryText)
-                        Text(workout.formattedDistance)
-                            .font(MADTheme.Typography.caption)
-                            .fontWeight(.medium)
-                            .foregroundColor(MADTheme.Colors.primaryText)
-                    }
-
-                    HStack(spacing: 4) {
-                        Image(systemName: "clock.fill")
-                            .font(.system(size: 10))
-                            .foregroundColor(MADTheme.Colors.secondaryText)
-                        Text(workout.formattedDuration)
-                            .font(MADTheme.Typography.caption)
-                            .foregroundColor(MADTheme.Colors.secondaryText)
-                    }
+                HStack(spacing: 5) {
+                    Image(systemName: "clock.fill")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(.orange)
+                    Text(paceText == nil
+                         ? workout.formattedDuration
+                         : "\(workout.formattedDuration) \u{2022} \(paceText!)")
+                        .font(.system(size: 12, weight: .semibold, design: .rounded))
+                        .monospacedDigit()
+                        .foregroundColor(MADTheme.Colors.secondaryText)
                 }
             }
 
             Spacer()
+
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(dateLabel)
+                    .font(.system(size: 12, weight: .bold, design: .rounded))
+                    .foregroundColor(MADTheme.Colors.primaryText)
+                if let time = startTimeLabel {
+                    Text(time)
+                        .font(.system(size: 12, weight: .medium, design: .rounded))
+                        .foregroundColor(MADTheme.Colors.secondaryText)
+                }
+            }
 
             if showChevron {
                 Image(systemName: "chevron.right")
@@ -129,6 +122,49 @@ struct FriendWorkoutRow: View {
         .padding(MADTheme.Spacing.md)
         .background(Color.white.opacity(0.05))
         .cornerRadius(MADTheme.CornerRadius.medium)
+    }
+
+    /// Feed-style verb, same as WorkoutRow's headline.
+    private var verb: String {
+        switch workout.workoutType.lowercased() {
+        case "running": return "Ran"
+        case "walking": return "Walked"
+        case "hiking": return "Hiked"
+        case "cycling": return "Cycled"
+        default: return "Moved"
+        }
+    }
+
+    /// "18:27 /mi" when distance + duration allow it — same as WorkoutRow.
+    private var paceText: String? {
+        guard workout.distance > 0, workout.totalDuration > 0 else { return nil }
+        return "\(RunStatsStickerView.paceText(workout.totalDuration / workout.distance)) /mi"
+    }
+
+    /// Start time derived the same way WorkoutRow does it: end − duration.
+    private var startDate: Date? {
+        guard let end = workout.deviceEndDate, let d = RelativeTime.date(from: end) else { return nil }
+        return d.addingTimeInterval(-workout.totalDuration)
+    }
+
+    private var dateLabel: String {
+        if let d = startDate {
+            if Calendar.current.isDateInToday(d) { return "Today" }
+            if Calendar.current.isDateInYesterday(d) { return "Yesterday" }
+            return DateFormatter.workoutRowDate.string(from: d)
+        }
+        // No device timestamp — fall back to the server's local_date.
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        guard let d = f.date(from: workout.date) else { return workout.formattedDate }
+        if Calendar.current.isDateInToday(d) { return "Today" }
+        if Calendar.current.isDateInYesterday(d) { return "Yesterday" }
+        return DateFormatter.workoutRowDate.string(from: d)
+    }
+
+    private var startTimeLabel: String? {
+        guard let d = startDate else { return nil }
+        return DateFormatter.shortTime.string(from: d)
     }
 
     private var workoutIcon: String {
@@ -147,17 +183,6 @@ struct FriendWorkoutRow: View {
     }
 
     private var workoutColor: Color {
-        switch workout.workoutType.lowercased() {
-        case "running":
-            return MADTheme.Colors.madRed
-        case "walking":
-            return .blue
-        case "cycling":
-            return .green
-        case "hiking":
-            return .orange
-        default:
-            return MADTheme.Colors.madRed
-        }
+        MADTheme.workoutColor(workout.workoutType)
     }
 }

--- a/app/Mile A Day/Views/Components/MADCameraView.swift
+++ b/app/Mile A Day/Views/Components/MADCameraView.swift
@@ -23,6 +23,12 @@ struct MADCameraView: View {
     /// A capture attempt produced nothing (session interrupted, processing
     /// error) — surfaced instead of silently doing nothing.
     @State private var showCaptureFailed = false
+    /// Staggered entrance for the chrome so opening feels composed, not popped.
+    @State private var controlsAppeared = false
+    /// Quick white blink at shutter time — the classic capture acknowledgment.
+    @State private var captureFlash = false
+    /// Accumulated flip-icon rotation (each flip adds a half turn).
+    @State private var flipRotation: Double = 0
 
     /// Whether the device has a camera the controller can actually drive
     /// (false on Simulator). Asks AVFoundation — the same stack that
@@ -35,8 +41,38 @@ struct MADCameraView: View {
         ZStack {
             Color.black.ignoresSafeArea()
 
+            // Preview fades in once frames are actually flowing — no black
+            // pop, and a soft spinner while the session spins up.
             MADCameraPreview(session: camera.session)
                 .ignoresSafeArea()
+                .opacity(camera.isSessionRunning ? 1 : 0)
+                .animation(.easeIn(duration: 0.35), value: camera.isSessionRunning)
+
+            if !camera.isSessionRunning && !camera.authorizationDenied {
+                ProgressView()
+                    .tint(.white.opacity(0.6))
+                    .scaleEffect(1.2)
+            }
+
+            // Legibility scrims behind the chrome — controls read cleanly on
+            // any scene without boxing the whole preview.
+            VStack(spacing: 0) {
+                LinearGradient(colors: [.black.opacity(0.45), .clear],
+                               startPoint: .top, endPoint: .bottom)
+                    .frame(height: 130)
+                Spacer()
+                LinearGradient(colors: [.clear, .black.opacity(0.5)],
+                               startPoint: .top, endPoint: .bottom)
+                    .frame(height: 190)
+            }
+            .ignoresSafeArea()
+            .allowsHitTesting(false)
+
+            // Countdown: dim the scene and pop the seconds, Apple-style.
+            Color.black.opacity(countdown != nil ? 0.28 : 0)
+                .ignoresSafeArea()
+                .allowsHitTesting(false)
+                .animation(.easeInOut(duration: 0.25), value: countdown != nil)
 
             if camera.authorizationDenied {
                 permissionDeniedView
@@ -53,16 +89,33 @@ struct MADCameraView: View {
 
             VStack {
                 topBar
+                    .opacity(controlsAppeared ? 1 : 0)
+                    .offset(y: controlsAppeared ? 0 : -14)
                 Spacer()
                 bottomBar
+                    .opacity(controlsAppeared ? 1 : 0)
+                    .offset(y: controlsAppeared ? 0 : 16)
             }
+
+            // Shutter acknowledgment blink.
+            Color.white.opacity(captureFlash ? 0.85 : 0)
+                .ignoresSafeArea()
+                .allowsHitTesting(false)
 
             if showCaptureFailed {
                 captureFailedToast
             }
         }
+        // Camera chrome is a dark surface regardless of system setting —
+        // keeps the material pills consistent over the live preview.
+        .environment(\.colorScheme, .dark)
         .statusBarHidden()
-        .onAppear { camera.start() }
+        .onAppear {
+            camera.start()
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.8).delay(0.08)) {
+                controlsAppeared = true
+            }
+        }
         .onDisappear {
             countdownTask?.cancel()
             camera.stop()
@@ -100,7 +153,8 @@ struct MADCameraView: View {
     }
 
     private func glassCircleButton(
-        icon: String, size: CGFloat, iconSize: CGFloat, action: @escaping () -> Void
+        icon: String, size: CGFloat, iconSize: CGFloat,
+        rotation: Double = 0, action: @escaping () -> Void
     ) -> some View {
         Button {
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
@@ -109,11 +163,12 @@ struct MADCameraView: View {
             Image(systemName: icon)
                 .font(.system(size: iconSize, weight: .bold))
                 .foregroundColor(.white)
+                .rotationEffect(.degrees(rotation))
                 .frame(width: size, height: size)
-                .background(Circle().fill(Color.black.opacity(0.45)))
-                .overlay(Circle().strokeBorder(Color.white.opacity(0.2), lineWidth: 1))
+                .background(.ultraThinMaterial, in: Circle())
+                .overlay(Circle().strokeBorder(Color.white.opacity(0.18), lineWidth: 1))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(CameraControlButtonStyle())
     }
 
     private func controlPill(
@@ -132,10 +187,12 @@ struct MADCameraView: View {
             .foregroundColor(active ? .yellow : .white)
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
-            .background(Capsule().fill(Color.black.opacity(0.45)))
-            .overlay(Capsule().strokeBorder(Color.white.opacity(0.2), lineWidth: 1))
+            .background(.ultraThinMaterial, in: Capsule())
+            .overlay(Capsule().strokeBorder(Color.white.opacity(0.18), lineWidth: 1))
+            .contentTransition(.symbolEffect(.replace))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(CameraControlButtonStyle())
+        .animation(.easeInOut(duration: 0.15), value: active)
     }
 
     private var bottomBar: some View {
@@ -143,7 +200,13 @@ struct MADCameraView: View {
             shutterButton
             HStack {
                 Spacer()
-                glassCircleButton(icon: "arrow.triangle.2.circlepath.camera.fill", size: 48, iconSize: 18) {
+                glassCircleButton(
+                    icon: "arrow.triangle.2.circlepath.camera.fill",
+                    size: 48, iconSize: 18, rotation: flipRotation
+                ) {
+                    withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
+                        flipRotation += 180
+                    }
                     camera.flip()
                 }
             }
@@ -158,19 +221,23 @@ struct MADCameraView: View {
                 Circle()
                     .strokeBorder(Color.white, lineWidth: 4)
                     .frame(width: 78, height: 78)
+                    .shadow(color: .black.opacity(0.25), radius: 8, y: 2)
                 if countdownTask != nil {
                     // A running countdown turns the shutter into a stop button.
                     RoundedRectangle(cornerRadius: 6, style: .continuous)
                         .fill(Color.white)
                         .frame(width: 30, height: 30)
+                        .transition(.scale.combined(with: .opacity))
                 } else {
                     Circle()
                         .fill(Color.white)
                         .frame(width: 64, height: 64)
+                        .transition(.scale.combined(with: .opacity))
                 }
             }
+            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: countdownTask != nil)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(ShutterButtonStyle())
         .disabled(camera.authorizationDenied || didCapture)
     }
 
@@ -254,6 +321,12 @@ struct MADCameraView: View {
         // Latch immediately — the shutter disables and a second tap during
         // the capture round-trip can't start a competing capture.
         didCapture = true
+        // Classic white blink acknowledges the shutter instantly, before the
+        // capture round-trip finishes.
+        withAnimation(.easeIn(duration: 0.06)) { captureFlash = true }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            withAnimation(.easeOut(duration: 0.2)) { captureFlash = false }
+        }
         camera.capturePhoto { captured in
             guard let captured else {
                 // Failed (session interrupted, processing error): re-arm the
@@ -277,6 +350,26 @@ struct MADCameraView: View {
     }
 }
 
+// MARK: - Button styles
+
+/// Shutter press: a satisfying squeeze instead of the default opacity dip.
+private struct ShutterButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.86 : 1)
+            .animation(.spring(response: 0.25, dampingFraction: 0.6), value: configuration.isPressed)
+    }
+}
+
+/// Small chrome buttons: subtle press scale, no opacity flash over the preview.
+private struct CameraControlButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.92 : 1)
+            .animation(.spring(response: 0.2, dampingFraction: 0.7), value: configuration.isPressed)
+    }
+}
+
 // MARK: - Session controller
 
 /// Owns the AVCaptureSession. All session mutation happens on `sessionQueue`;
@@ -286,6 +379,9 @@ final class MADCameraController {
     @ObservationIgnored let session = AVCaptureSession()
 
     var authorizationDenied = false
+    /// Frames are flowing — the view fades the preview in on this so opening
+    /// never black-pops.
+    var isSessionRunning = false
     /// Whether the CURRENT camera can flash — front cameras count too on
     /// modern iPhones (Retina screen-flash), per supportedFlashModes.
     var isFlashAvailable = false
@@ -377,6 +473,7 @@ final class MADCameraController {
             guard let self else { return }
             self.userStopped = true
             if self.session.isRunning { self.session.stopRunning() }
+            DispatchQueue.main.async { self.isSessionRunning = false }
         }
     }
 
@@ -448,6 +545,8 @@ final class MADCameraController {
             self.userStopped = false
             self.configureIfNeeded()
             if !self.session.isRunning { self.session.startRunning() }
+            let running = self.session.isRunning
+            DispatchQueue.main.async { self.isSessionRunning = running }
         }
     }
 
@@ -505,8 +604,19 @@ final class MADCameraController {
                 guard let self, self.configured, !self.userStopped,
                       !self.session.isRunning else { return }
                 self.session.startRunning()
+                let running = self.session.isRunning
+                DispatchQueue.main.async { self.isSessionRunning = running }
             }
         }
+        // Interruption began (phone call, another app claimed the camera):
+        // reflect the stop immediately so the view swaps the frozen frame
+        // for the spinner and the shutter reads as not-live.
+        sessionObservers.append(center.addObserver(
+            forName: AVCaptureSession.wasInterruptedNotification,
+            object: session, queue: nil
+        ) { [weak self] _ in
+            self?.publishSessionRunning()
+        })
         sessionObservers.append(center.addObserver(
             forName: AVCaptureSession.interruptionEndedNotification,
             object: session, queue: nil
@@ -514,7 +624,8 @@ final class MADCameraController {
         sessionObservers.append(center.addObserver(
             forName: AVCaptureSession.runtimeErrorNotification,
             object: session, queue: nil
-        ) { note in
+        ) { [weak self] note in
+            self?.publishSessionRunning()
             // AVCam's rule: only a media-services reset warrants a restart. A
             // failed startRunning() itself posts a runtime error, so a
             // blanket retry ping-pongs forever under persistent failure.
@@ -522,6 +633,15 @@ final class MADCameraController {
             guard error?.code == .mediaServicesWereReset else { return }
             restart()
         })
+    }
+
+    /// Re-read the session's actual running state (on its queue) and publish.
+    private func publishSessionRunning() {
+        sessionQueue.async { [weak self] in
+            guard let self else { return }
+            let running = self.session.isRunning
+            DispatchQueue.main.async { self.isSessionRunning = running }
+        }
     }
 
     private static func mirroredHorizontally(_ image: UIImage) -> UIImage {

--- a/app/Mile A Day/Views/Components/WorkoutRouteMapView.swift
+++ b/app/Mile A Day/Views/Components/WorkoutRouteMapView.swift
@@ -4,13 +4,18 @@ import MapKit
 struct WorkoutRouteMapView: View {
     let coordinates: [CLLocationCoordinate2D]
     let routeColor: Color
+    /// Fired once the map snapshot lands — lets containers build a static
+    /// composite (map + fully-drawn route) for the pinch-zoom floating copy.
+    var onSnapshot: ((UIImage) -> Void)? = nil
 
     @State private var snapshotImage: UIImage?
     @State private var trimProgress: CGFloat = 0
     @State private var showMarkers = false
     @State private var hasLoaded = false
 
-    private var region: MKCoordinateRegion {
+    /// Region math is static so the zoom composite can reproject the same
+    /// framing without an instance.
+    static func region(for coordinates: [CLLocationCoordinate2D]) -> MKCoordinateRegion {
         guard !coordinates.isEmpty else {
             return MKCoordinateRegion()
         }
@@ -38,6 +43,45 @@ struct WorkoutRouteMapView: View {
         )
 
         return MKCoordinateRegion(center: center, span: span)
+    }
+
+    private var region: MKCoordinateRegion { Self.region(for: coordinates) }
+
+    /// Static composite of the snapshot + fully-drawn route (+ an optional
+    /// caller overlay, e.g. the stats band) at `size` — what the Instagram
+    /// pinch-zoom floats. Composed ON DEMAND at pinch-begin (never eagerly
+    /// per card — a feed of routes would retain megabytes for gestures that
+    /// mostly never happen); pixel-equivalent to the live view because the
+    /// overlay projection is purely proportional to the view size.
+    static func zoomComposite<Overlay: View>(
+        snapshot: UIImage,
+        coordinates: [CLLocationCoordinate2D],
+        routeColor: Color,
+        size: CGSize,
+        @ViewBuilder overlay: () -> Overlay
+    ) -> UIImage? {
+        let content = ZStack(alignment: .topLeading) {
+            Image(uiImage: snapshot)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: size.width, height: size.height)
+                .clipped()
+            RouteOverlay(
+                coordinates: coordinates,
+                region: region(for: coordinates),
+                viewSize: size,
+                routeColor: routeColor,
+                trimProgress: 1,
+                showMarkers: true
+            )
+            overlay()
+        }
+        .frame(width: size.width, height: size.height)
+
+        let renderer = ImageRenderer(content: content)
+        renderer.scale = 2
+        renderer.isOpaque = true
+        return renderer.uiImage
     }
 
     var body: some View {
@@ -98,6 +142,7 @@ struct WorkoutRouteMapView: View {
         do {
             let snapshot = try await snapshotter.start()
             snapshotImage = snapshot.image
+            onSnapshot?(snapshot.image)
         } catch {
             print("[WorkoutRouteMapView] Snapshot failed: \(error)")
         }

--- a/app/Mile A Day/Views/Dashboard/WorkoutDetailView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutDetailView.swift
@@ -74,13 +74,7 @@ struct WorkoutDetailView: View {
     // Same accent per type as the feed (ActivityCardView.color) — one color
     // language for a workout everywhere it appears.
     private var workoutColor: Color {
-        switch workout.workoutActivityType {
-        case .running: return MADTheme.Colors.madRed
-        case .walking: return .orange
-        case .hiking: return .green
-        case .cycling: return .blue
-        default: return MADTheme.Colors.madRed
-        }
+        MADTheme.workoutColor(workout.workoutActivityType.madTypeKey)
     }
 
     private var distanceMiles: Double {

--- a/app/Mile A Day/Views/Feed/ActivityCardView.swift
+++ b/app/Mile A Day/Views/Feed/ActivityCardView.swift
@@ -21,6 +21,8 @@ struct ActivityCardView: View {
     /// Collapses duplicate reports of one physical double-tap (see
     /// PostCardView.lastDoubleTapAt).
     @State private var lastDoubleTapAt = Date.distantPast
+    /// The map snapshot (~400×300) kept for the zoom's on-demand composite.
+    @State private var routeSnapshot: UIImage?
 
     private var distance: Double { entry.distance ?? 0 }
     private var completedMile: Bool { distance >= ProgressCalculator.dailyGoalTolerance }
@@ -35,7 +37,8 @@ struct ActivityCardView: View {
             VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
                 heroLine
                 if let coords = entry.routeCoordinates {
-                    WorkoutRouteMapView(coordinates: coords, routeColor: accent)
+                    WorkoutRouteMapView(coordinates: coords, routeColor: accent,
+                                        onSnapshot: { routeSnapshot = $0 })
                         .frame(maxWidth: .infinity)
                         // Proportional, not a fixed 160pt: the map scales with the
                         // card on every screen size instead of shrinking to a strip.
@@ -44,6 +47,21 @@ struct ActivityCardView: View {
                         .overlay(
                             RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
                                 .strokeBorder(Color.white.opacity(0.08), lineWidth: 1)
+                        )
+                        // Pinch-zooms like a photo; the floating copy is
+                        // composed on demand at the card's own 16:10 aspect
+                        // so the lift matches the on-screen slide exactly.
+                        .instagramZoomable(
+                            imageProvider: {
+                                guard let snapshot = routeSnapshot else { return nil }
+                                return WorkoutRouteMapView.zoomComposite(
+                                    snapshot: snapshot,
+                                    coordinates: coords,
+                                    routeColor: accent,
+                                    size: CGSize(width: 720, height: 450)
+                                ) { EmptyView() }
+                            },
+                            onDoubleTap: entry.is_self ? nil : doubleTapHype
                         )
                 }
                 statStrip
@@ -63,16 +81,22 @@ struct ActivityCardView: View {
         .overlay(HypeBurstView(trigger: hypeBurst))
     }
 
-    private func doubleTapHype() {
-        guard !entry.is_self else { return }
-        let now = Date()
-        guard now.timeIntervalSince(lastDoubleTapAt) > 0.35 else { return }
-        lastDoubleTapAt = now
+    /// Shared by double-tap and the footer HypeButton, so the button plays
+    /// the same clap burst the double-tap does.
+    private func celebrateAndHype() {
         hypeBurst += 1
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
         if !entry.is_hyped {
             onHype()
         }
+    }
+
+    private func doubleTapHype() {
+        guard !entry.is_self else { return }
+        let now = Date()
+        guard now.timeIntervalSince(lastDoubleTapAt) > 0.35 else { return }
+        lastDoubleTapAt = now
+        celebrateAndHype()
     }
 
     private var header: some View {
@@ -172,7 +196,7 @@ struct ActivityCardView: View {
                     isHyped: entry.is_hyped,
                     isBusy: isHyping,
                     isOutOfHypes: isOutOfHypes && !entry.is_hyped,
-                    action: onHype
+                    action: celebrateAndHype
                 )
             }
         }
@@ -218,12 +242,8 @@ struct ActivityCardView: View {
         }
     }
     static func color(_ type: String?) -> Color {
-        switch (type ?? "").lowercased() {
-        case "running": return MADTheme.Colors.madRed
-        case "walking": return .orange
-        case "hiking": return .green
-        case "cycling": return .blue
-        default: return MADTheme.Colors.madRed
-        }
+        // Delegates to the app-wide language (walks BLUE, runs red) so the
+        // feed can never drift from the rest of the app again.
+        MADTheme.workoutColor(type)
     }
 }

--- a/app/Mile A Day/Views/Feed/FeedMediaViews.swift
+++ b/app/Mile A Day/Views/Feed/FeedMediaViews.swift
@@ -87,7 +87,11 @@ struct FeedImageView: View {
 /// overlay side-steps all of that. One- finger gestures (paging, scrolling)
 /// are untouched — the pinch needs two fingers.
 struct InstagramZoomModifier: ViewModifier {
-    let image: UIImage?
+    /// Resolved at pinch-BEGIN, not stored: photo slides hand back their
+    /// already-loaded image for free, while composite slides (route maps,
+    /// stats cards) render their floating copy on demand — nothing is baked
+    /// eagerly or retained per-card for a gesture most cards never receive.
+    let imageProvider: () -> UIImage?
     var cornerRadius: CGFloat = MADTheme.CornerRadius.medium
     var onDoubleTap: (() -> Void)? = nil
 
@@ -100,7 +104,7 @@ struct InstagramZoomModifier: ViewModifier {
             .opacity(isZooming ? 0 : 1)
             .overlay(
                 ZoomGestureHost(
-                    image: image,
+                    imageProvider: imageProvider,
                     cornerRadius: cornerRadius,
                     isZooming: $isZooming,
                     onDoubleTap: onDoubleTap
@@ -116,12 +120,23 @@ extension View {
         cornerRadius: CGFloat = MADTheme.CornerRadius.medium,
         onDoubleTap: (() -> Void)? = nil
     ) -> some View {
-        modifier(InstagramZoomModifier(image: image, cornerRadius: cornerRadius, onDoubleTap: onDoubleTap))
+        modifier(InstagramZoomModifier(
+            imageProvider: { image }, cornerRadius: cornerRadius, onDoubleTap: onDoubleTap))
+    }
+
+    /// Variant for slides whose floating copy is composed on demand.
+    func instagramZoomable(
+        imageProvider: @escaping () -> UIImage?,
+        cornerRadius: CGFloat = MADTheme.CornerRadius.medium,
+        onDoubleTap: (() -> Void)? = nil
+    ) -> some View {
+        modifier(InstagramZoomModifier(
+            imageProvider: imageProvider, cornerRadius: cornerRadius, onDoubleTap: onDoubleTap))
     }
 }
 
 private struct ZoomGestureHost: UIViewRepresentable {
-    let image: UIImage?
+    let imageProvider: () -> UIImage?
     let cornerRadius: CGFloat
     @Binding var isZooming: Bool
     let onDoubleTap: (() -> Void)?
@@ -179,7 +194,7 @@ private struct ZoomGestureHost: UIViewRepresentable {
 
             switch gesture.state {
             case .began:
-                guard parent.image != nil, floatingImageView == nil else { return }
+                guard floatingImageView == nil, let image = parent.imageProvider() else { return }
                 sourceFrame = hostView.convert(hostView.bounds, to: window)
                 startCentroid = gesture.location(in: window)
 
@@ -189,7 +204,7 @@ private struct ZoomGestureHost: UIViewRepresentable {
                 window.addSubview(dim)
                 dimView = dim
 
-                let iv = UIImageView(image: parent.image)
+                let iv = UIImageView(image: image)
                 iv.frame = sourceFrame
                 iv.contentMode = .scaleAspectFill
                 iv.clipsToBounds = true

--- a/app/Mile A Day/Views/Feed/PostCardView.swift
+++ b/app/Mile A Day/Views/Feed/PostCardView.swift
@@ -34,6 +34,9 @@ struct PostCardView: View {
     /// (the card-level SwiftUI gesture AND the zoom host's UIKit one) into a
     /// single burst + hype.
     @State private var lastDoubleTapAt = Date.distantPast
+    /// The route slide's raw map snapshot (~400×300) — the only piece kept
+    /// around; the zoom's floating composite is rendered on demand from it.
+    @State private var routeSnapshot: UIImage?
 
     var body: some View {
         VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
@@ -154,6 +157,18 @@ struct PostCardView: View {
         return stats
     }
 
+    /// The celebration both hype paths share — the Instagram-style clap
+    /// burst + haptic, then the hype call if this post isn't hyped yet.
+    /// Double-tap AND the footer HypeButton land here so tapping the button
+    /// feels identical to double-tapping the photo.
+    private func celebrateAndHype() {
+        hypeBurst += 1
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        if !post.is_hyped {
+            onHype()
+        }
+    }
+
     /// Double-tap anywhere on the post body: clap burst + hype (friends'
     /// posts only, once — a re-double-tap replays the burst without
     /// double-counting).
@@ -162,11 +177,7 @@ struct PostCardView: View {
         let now = Date()
         guard now.timeIntervalSince(lastDoubleTapAt) > 0.35 else { return }
         lastDoubleTapAt = now
-        hypeBurst += 1
-        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-        if !post.is_hyped {
-            onHype()
-        }
+        celebrateAndHype()
     }
 
     /// A single photo, or a full-size swipeable carousel:
@@ -212,10 +223,25 @@ struct PostCardView: View {
 
     /// The run itself as a branded stats card — the second slide when a photo
     /// post has no GPS route to show. The card-level double-tap covers it.
+    /// Zooms like every other slide; the card is pure SwiftUI so its zoom
+    /// copy renders on demand at pinch-begin from the same inputs.
     private func workoutCardSlide(_ stats: PostStats) -> some View {
         FeedWorkoutCard(stats: stats, workoutType: post.workout_type)
             .frame(maxWidth: .infinity)
             .aspectRatio(4.0 / 5.0, contentMode: .fit)
+            .instagramZoomable(
+                imageProvider: {
+                    let renderer = ImageRenderer(content:
+                        FeedWorkoutCard(stats: stats, workoutType: post.workout_type)
+                            .frame(width: RunStatsCardView.designSize.width,
+                                   height: RunStatsCardView.designSize.height)
+                    )
+                    renderer.scale = 2
+                    renderer.isOpaque = true
+                    return renderer.uiImage
+                },
+                onDoubleTap: post.is_self ? nil : doubleTapHype
+            )
     }
 
     /// Stats to overlay on the live route slide — same band the auto post
@@ -239,7 +265,8 @@ struct PostCardView: View {
     private func routeSlide(_ coords: [CLLocationCoordinate2D]) -> some View {
         WorkoutRouteMapView(
             coordinates: coords,
-            routeColor: ActivityCardView.color(post.workout_type)
+            routeColor: ActivityCardView.color(post.workout_type),
+            onSnapshot: { routeSnapshot = $0 }
         )
         .frame(maxWidth: .infinity)
         .aspectRatio(4.0 / 5.0, contentMode: .fit)
@@ -262,6 +289,35 @@ struct PostCardView: View {
             // the bare-map fallback (posts without a stats snapshot).
             if routeOverlayStats == nil {
                 slideBadge("Route", icon: "map.fill")
+            }
+        }
+        // Same pinch-zoom as the photo slides. The floating copy (map +
+        // route + stats band) is composed at pinch-begin from the small
+        // retained snapshot — nothing big is baked per card up front.
+        .instagramZoomable(
+            imageProvider: { routeZoomComposite(coords) },
+            onDoubleTap: post.is_self ? nil : doubleTapHype
+        )
+    }
+
+    /// The route slide's floating zoom copy, on demand. 720×900 keeps the
+    /// photo slides' 4:5 so the lift is pixel-identical.
+    private func routeZoomComposite(_ coords: [CLLocationCoordinate2D]) -> UIImage? {
+        guard let snapshot = routeSnapshot else { return nil }
+        let type = post.workout_type ?? "running"
+        let stats = routeOverlayStats
+        return WorkoutRouteMapView.zoomComposite(
+            snapshot: snapshot,
+            coordinates: coords,
+            routeColor: ActivityCardView.color(post.workout_type),
+            size: CGSize(width: 720, height: 900)
+        ) {
+            if let stats {
+                RouteStatsOverlayView(stats: stats, workoutType: type)
+                    .frame(width: RunStatsCardView.designSize.width,
+                           height: RunStatsCardView.designSize.height,
+                           alignment: .topLeading)
+                    .scaleEffect(720 / RunStatsCardView.designSize.width, anchor: .topLeading)
             }
         }
     }
@@ -297,7 +353,7 @@ struct PostCardView: View {
                     isHyped: post.is_hyped,
                     isBusy: isHyping,
                     isOutOfHypes: isOutOfHypes && !post.is_hyped,
-                    action: onHype
+                    action: celebrateAndHype
                 )
             }
         }

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -106,7 +106,10 @@ enum PostComposeOutcome {
 final class PostComposerViewModel: ObservableObject {
     @Published var pickedImage: UIImage?
     @Published var caption: String = ""
-    @Published var destination: PostDestination
+    /// Where the post goes. Starts nil ON PURPOSE — the user must make the
+    /// story/feed/both choice themselves before Share enables, so nobody
+    /// posts somewhere they didn't mean to.
+    @Published var destination: PostDestination?
     @Published var stickerEnabled: Bool = true
     /// Sticker center in normalized canvas coordinates (0…1).
     @Published var stickerPos: CGPoint = CGPoint(x: 0.5, y: 0.82)
@@ -126,9 +129,8 @@ final class PostComposerViewModel: ObservableObject {
     /// Captured on-screen canvas size (points), reused to render the composite.
     var canvasSize: CGSize = .zero
 
-    init(stats: RunStatsInput, destination: PostDestination, initialImage: UIImage? = nil) {
+    init(stats: RunStatsInput, initialImage: UIImage? = nil) {
         self.stats = stats
-        self.destination = destination
         var cfg = StickerConfig.load()
         // Drop any remembered stats that aren't available today, and make sure
         // at least one available stat is shown.
@@ -146,7 +148,7 @@ final class PostComposerViewModel: ObservableObject {
     }
 
     var canPublish: Bool {
-        pickedImage != nil && !isPublishing
+        pickedImage != nil && destination != nil && !isPublishing
     }
 
     /// Check whether the linked workout has GPS route data, enabling the
@@ -187,6 +189,10 @@ final class PostComposerViewModel: ObservableObject {
         guard !isPublishing else { return false }
         guard let flat = flatten() else {
             errorMessage = "Add a photo first."
+            return false
+        }
+        guard let destination else {
+            errorMessage = "Choose where to share — story, feed, or both."
             return false
         }
         isPublishing = true
@@ -310,13 +316,12 @@ struct PostComposerView: View {
 
     init(
         stats: RunStatsInput,
-        destination: PostDestination = .feed,
         autoOpenCamera: Bool = false,
         initialImage: UIImage? = nil,
         onFinished: @escaping (PostComposeOutcome) -> Void
     ) {
         _vm = StateObject(wrappedValue: PostComposerViewModel(
-            stats: stats, destination: destination, initialImage: initialImage))
+            stats: stats, initialImage: initialImage))
         self.autoOpenCamera = autoOpenCamera
         self.onFinished = onFinished
     }
@@ -389,10 +394,10 @@ struct PostComposerView: View {
                             case .accepted:
                                 Task {
                                     let ok = await vm.publish()
-                                    if ok {
+                                    if ok, let dest = vm.destination {
                                         onFinished(.published(
-                                            toFeed: vm.destination.toFeed,
-                                            toStory: vm.destination.toStory
+                                            toFeed: dest.toFeed,
+                                            toStory: dest.toStory
                                         ))
                                         dismiss()
                                     }
@@ -768,46 +773,80 @@ struct PostComposerView: View {
 
     /// Story / Feed / Both — a single deliberate destination choice, so the
     /// story stays the ephemeral moment and the feed stays the curated record.
+    /// Nothing is preselected: Share stays disabled until the user picks, and
+    /// the picked card is unmistakable (gradient fill + checkmark badge).
     private var destinationToggles: some View {
         VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
             editorLabel("SHARE TO")
             HStack(spacing: MADTheme.Spacing.sm) {
                 ForEach(PostDestination.allCases) { dest in
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.15)) { vm.destination = dest }
-                    } label: {
-                        VStack(spacing: 4) {
-                            Image(systemName: dest.icon)
-                                .font(.system(size: 16, weight: .bold))
-                            Text(dest.title)
-                                .font(.system(size: 13, weight: .bold, design: .rounded))
-                        }
-                        .foregroundColor(vm.destination == dest ? .white : .white.opacity(0.55))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 10)
-                        .background(
-                            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
-                                .fill(vm.destination == dest
-                                    ? AnyShapeStyle(MADTheme.Colors.redGradient)
-                                    : AnyShapeStyle(Color.white.opacity(0.06)))
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
-                                .strokeBorder(Color.white.opacity(vm.destination == dest ? 0 : 0.1), lineWidth: 1)
-                        )
-                    }
-                    .buttonStyle(.plain)
+                    destinationCard(dest, selected: vm.destination == dest)
                 }
             }
-            Text(vm.destination.footnote)
-                .font(.system(size: 12, weight: .medium, design: .rounded))
-                .foregroundColor(.white.opacity(0.5))
-                .fixedSize(horizontal: false, vertical: true)
+            if let dest = vm.destination {
+                Text(dest.footnote)
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundColor(.white.opacity(0.5))
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Label("Pick where this goes — Share unlocks once you choose.",
+                      systemImage: "hand.tap.fill")
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                    .foregroundColor(MADTheme.Colors.madRed.opacity(0.9))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
         .padding(MADTheme.Spacing.md)
         .background(
             RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
                 .fill(Color.white.opacity(0.04))
         )
+        // Until a destination is chosen this section is the one thing left to
+        // do — a soft accent border pulls the eye to it.
+        .overlay(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
+                .strokeBorder(
+                    MADTheme.Colors.madRed.opacity(vm.destination == nil ? 0.45 : 0),
+                    lineWidth: 1.5
+                )
+        )
+        .animation(.easeInOut(duration: 0.2), value: vm.destination)
+    }
+
+    private func destinationCard(_ dest: PostDestination, selected: Bool) -> some View {
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            withAnimation(.easeInOut(duration: 0.15)) { vm.destination = dest }
+        } label: {
+            VStack(spacing: 4) {
+                Image(systemName: dest.icon)
+                    .font(.system(size: 16, weight: .bold))
+                Text(dest.title)
+                    .font(.system(size: 13, weight: .bold, design: .rounded))
+            }
+            .foregroundColor(selected ? .white : .white.opacity(0.55))
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
+                    .fill(selected
+                        ? AnyShapeStyle(MADTheme.Colors.redGradient)
+                        : AnyShapeStyle(Color.white.opacity(0.06)))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
+                    .strokeBorder(Color.white.opacity(selected ? 0 : 0.1), lineWidth: 1)
+            )
+            .overlay(alignment: .topTrailing) {
+                if selected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundStyle(.white, .black.opacity(0.35))
+                        .padding(5)
+                        .transition(.scale.combined(with: .opacity))
+                }
+            }
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -1,5 +1,23 @@
 import SwiftUI
 
+/// One-shot handoff from the notification inbox (or any other surface) to the
+/// feed: which workout's entry to reveal. Parked statically because the Feed
+/// tab may not be mounted when the tap happens — the feed consumes it on
+/// appear, or immediately via the `poke` notification when already mounted.
+enum FeedDeepLink {
+    struct Target {
+        /// Exact match against FeedEntry.workout_id (workout + linked posts).
+        var workoutId: String?
+        /// mile_completed notifications carry no workout id — fall back to
+        /// the friend's newest entry on that local day.
+        var userId: String?
+        var localDate: String?
+    }
+
+    static var pending: Target?
+    static let poke = NSNotification.Name("MAD_OpenFeedWorkout")
+}
+
 /// The single social surface inside the Friends tab: a stories rail, an optional
 /// "On this day" memories card, then one unified, infinitely-scrollable feed of
 /// photo posts AND raw walk/run activity. Posting and viewing friends' stories
@@ -50,6 +68,9 @@ struct SocialFeedView: View {
     @State private var showAlreadySharedHint = false
     @State private var showMemories = false
     @State private var showWeeklyRecap = false
+    /// Entry briefly ringed after a notification deep-link lands on it, so
+    /// the user can tell exactly which workout they were brought to.
+    @State private var highlightedEntryId: String?
     @State private var profileUser: BackendUser?
     /// Tapped hype tally — presents the "who hyped this" sheet.
     @State private var hypersContext: HypersListContext?
@@ -155,6 +176,7 @@ struct SocialFeedView: View {
                     }
                 }
 
+            ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(spacing: MADTheme.Spacing.md) {
                     StoriesRailView(
@@ -191,6 +213,16 @@ struct SocialFeedView: View {
                     } else {
                         ForEach(feed) { entry in
                             feedCard(entry)
+                                // Deep-link landing ring — fades once seen.
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
+                                        .strokeBorder(
+                                            Color.orange.opacity(highlightedEntryId == entry.id ? 0.75 : 0),
+                                            lineWidth: 2
+                                        )
+                                        .allowsHitTesting(false)
+                                )
+                                .animation(.easeInOut(duration: 0.35), value: highlightedEntryId)
                                 // Prefetch a few cards early (not just on the
                                 // very last row) so the next page is usually
                                 // there before the user reaches the bottom.
@@ -200,6 +232,7 @@ struct SocialFeedView: View {
                                     }
                                 }
                                 .padding(.horizontal, MADTheme.Spacing.md)
+                                .id(entry.id)
                         }
                         if isLoadingMore {
                             ProgressView().tint(.white).padding(.vertical, MADTheme.Spacing.md)
@@ -215,6 +248,14 @@ struct SocialFeedView: View {
             .refreshable {
                 await refresh()
                 await loadHypeStatus()
+            }
+            // Deep-link consumption: the poke covers "feed already mounted";
+            // the task covers "feed first mounted because of the deep link"
+            // (the poke fires before this view exists and is missed).
+            .onReceive(NotificationCenter.default.publisher(for: FeedDeepLink.poke)) { _ in
+                revealDeepLink(using: proxy)
+            }
+            .task { revealDeepLink(using: proxy) }
             }
         }
         .background(MADTheme.Colors.appBackgroundGradient)
@@ -247,7 +288,7 @@ struct SocialFeedView: View {
             }
         }
         .sheet(isPresented: $presentingComposer) {
-            PostComposerView(stats: statsInput, destination: .feed) { outcome in
+            PostComposerView(stats: statsInput) { outcome in
                 if case .published = outcome { Task { await refresh() } }
             }
         }
@@ -465,6 +506,90 @@ struct SocialFeedView: View {
         }
         .padding(.top, MADTheme.Spacing.xxl)
         .padding(.horizontal, MADTheme.Spacing.xl)
+    }
+
+    // MARK: - Notification deep link
+
+    /// Scroll the feed to the workout a tapped notification pointed at.
+    /// Resolves against loaded entries, refreshing once and then paging a
+    /// few times if needed (an inbox tapped a day later usually points past
+    /// page 1). Double scrollTo — a LazyVStack lands short on deep targets
+    /// (see ProfilePostsFeedSheet).
+    private func revealDeepLink(using proxy: ScrollViewProxy) {
+        guard FeedDeepLink.pending != nil else { return }
+        Task {
+            // Let an in-flight (initial) load settle before looking.
+            var waited = 0
+            while isLoading, waited < 40 {
+                try? await Task.sleep(nanoseconds: 100_000_000)
+                waited += 1
+            }
+            if resolvedDeepLinkEntry() == nil {
+                await refresh()
+            }
+            // Older target: page deeper, bounded so a pruned/ancient target
+            // can't fetch the whole feed history.
+            var pagesLoaded = 0
+            while resolvedDeepLinkEntry() == nil, nextBefore != nil, pagesLoaded < 3 {
+                await loadMore()
+                pagesLoaded += 1
+            }
+            guard let entry = resolvedDeepLinkEntry() else {
+                // Not in the feed (very old, or friendship changed) — land at
+                // the top rather than pretending.
+                FeedDeepLink.pending = nil
+                return
+            }
+            FeedDeepLink.pending = nil
+            withAnimation(.easeInOut(duration: 0.35)) {
+                proxy.scrollTo(entry.id, anchor: .top)
+            }
+            highlightedEntryId = entry.id
+            try? await Task.sleep(nanoseconds: 400_000_000)
+            withAnimation(.easeInOut(duration: 0.2)) {
+                proxy.scrollTo(entry.id, anchor: .top)
+            }
+            try? await Task.sleep(nanoseconds: 1_400_000_000)
+            highlightedEntryId = nil
+        }
+    }
+
+    private func resolvedDeepLinkEntry() -> FeedEntry? {
+        guard let target = FeedDeepLink.pending else { return nil }
+        // Precise: workout ids match both raw workout entries and the post
+        // that replaced one (the backend surfaces exactly one of the two).
+        if let wid = target.workoutId,
+           let hit = feed.first(where: { $0.workout_id == wid }) {
+            return hit
+        }
+        // mile_completed carries no workout id — the friend's entry on that
+        // local day (±1 day: their `local_date` is stamped in THEIR timezone,
+        // our timestamps render in OURS), else their newest entry.
+        if let uid = target.userId {
+            let sameUser = feed.filter { $0.user_id == uid && !$0.is_self }
+            if let date = target.localDate,
+               let hit = sameUser.first(where: { dayDistance(of: $0, to: date).map { $0 <= 1 } ?? false }) {
+                return hit
+            }
+            return sameUser.first
+        }
+        return nil
+    }
+
+    /// Whole days between an entry's timestamp (viewer tz) and a
+    /// "yyyy-MM-dd" target day; nil when either side doesn't parse.
+    private func dayDistance(of entry: FeedEntry, to targetDay: String) -> Int? {
+        guard let entryDate = RelativeTime.date(from: entry.sort_ts) else { return nil }
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        guard let target = f.date(from: targetDay) else { return nil }
+        let cal = Calendar.current
+        let days = cal.dateComponents(
+            [.day],
+            from: cal.startOfDay(for: entryDate),
+            to: cal.startOfDay(for: target)
+        ).day ?? 0
+        return abs(days)
     }
 
     // MARK: - Compose flow

--- a/app/Mile A Day/Views/Friends/FriendsListView.swift
+++ b/app/Mile A Day/Views/Friends/FriendsListView.swift
@@ -413,6 +413,11 @@ struct FriendsListView: View {
                                 && (hypesRemaining ?? HypeService.dailyLimit) <= 0
                                 && !item.is_hyped
                         ) {
+                            // Same clap burst as double-tapping the row — the
+                            // button and the gesture feel identical (and match
+                            // the feed cards' behavior).
+                            rowHypeBursts[item.workout_id, default: 0] += 1
+                            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                             Task { await sendHype(for: item) }
                         }
                     }
@@ -568,13 +573,7 @@ struct FriendsListView: View {
     }
 
     private func workoutColor(_ type: String) -> Color {
-        switch type.lowercased() {
-        case "running": return MADTheme.Colors.madRed
-        case "walking": return .blue
-        case "cycling": return .green
-        case "hiking": return .orange
-        default: return MADTheme.Colors.madRed
-        }
+        MADTheme.workoutColor(type)
     }
 
     /// Double-tap on a row = hype, mirroring the feed cards: clap burst +

--- a/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
+++ b/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
@@ -1112,13 +1112,7 @@ struct FriendWorkoutDetailSheet: View {
     }
 
     private var workoutColor: Color {
-        switch workout.workoutType.lowercased() {
-        case "running": return MADTheme.Colors.madRed
-        case "walking": return .blue
-        case "cycling": return .green
-        case "hiking": return .orange
-        default: return MADTheme.Colors.madRed
-        }
+        MADTheme.workoutColor(workout.workoutType)
     }
 
     private var workoutIcon: String {
@@ -1663,13 +1657,7 @@ struct Last7DaysChart: View {
     }
 
     private func workoutTypeColor(_ type: String) -> Color {
-        switch type.lowercased() {
-        case "running": return .red
-        case "walking": return .blue
-        case "cycling": return .green
-        case "hiking": return .brown
-        default: return .gray
-        }
+        MADTheme.workoutColor(type)
     }
 
     /// Three-letter localized weekday ("Sun", "Mon", "Tue"…). Unambiguous

--- a/app/Mile A Day/Views/NotificationInboxView.swift
+++ b/app/Mile A Day/Views/NotificationInboxView.swift
@@ -83,15 +83,16 @@ struct NotificationInboxView: View {
         .toolbarColorScheme(.dark, for: .navigationBar)
         .toolbar {
             if let remaining = hypesRemaining {
+                // Top RIGHT, mirroring the feed's header pill placement.
                 // iOS 26 wraps toolbar items in a shared glass capsule; hiding it
                 // stops the orange pill from rendering inside a second system pill.
                 if #available(iOS 26.0, *) {
-                    ToolbarItem(placement: .navigationBarLeading) {
+                    ToolbarItem(placement: .navigationBarTrailing) {
                         HypePill(remaining: remaining, compact: true, unlimited: hypesUnlimited)
                     }
                     .sharedBackgroundVisibility(.hidden)
                 } else {
-                    ToolbarItem(placement: .navigationBarLeading) {
+                    ToolbarItem(placement: .navigationBarTrailing) {
                         HypePill(remaining: remaining, compact: true, unlimited: hypesUnlimited)
                     }
                 }
@@ -559,6 +560,22 @@ struct NotificationInboxView: View {
 
         let type = notification.type
         switch type {
+        case "friend_activity" where isWorkoutActivity(notification):
+            // A friend's completed walk/run/mile lives on the FEED — land on
+            // its entry, not the Friends list. The target is parked statically
+            // because the Feed tab may not be mounted yet; the poke wakes it
+            // when it is.
+            FeedDeepLink.pending = FeedDeepLink.Target(
+                workoutId: notification.data?["workout_id"],
+                userId: notification.data?["user_id"],
+                localDate: notification.data?["local_date"]
+            )
+            NotificationCenter.default.post(
+                name: NSNotification.Name("MAD_SwitchTab"),
+                object: nil,
+                userInfo: ["tab": 2]
+            )
+            NotificationCenter.default.post(name: FeedDeepLink.poke, object: nil)
         case "friend_request", "friend_request_accepted", "friend_nudge", "friend_activity":
             NotificationCenter.default.post(
                 name: NSNotification.Name("MAD_SwitchTab"),
@@ -587,6 +604,15 @@ struct NotificationInboxView: View {
             )
         default:
             break
+        }
+    }
+
+    /// friend_activity kinds that correspond to a concrete walk/run the feed
+    /// can show (streak_broken etc. keep the Friends-tab destination).
+    private func isWorkoutActivity(_ notification: InAppNotification) -> Bool {
+        switch notification.data?["kind"] {
+        case "mile_completed", "workout", "extra_workout": return true
+        default: return false
         }
     }
 
@@ -859,7 +885,10 @@ struct NotificationInboxView: View {
             hype_context_type: n.hype_context_type,
             hype_context_id: n.hype_context_id,
             hype_context_label: n.hype_context_label,
-            is_hyped: n.is_hyped
+            is_hyped: n.is_hyped,
+            // Dropping this defaulted the tally to nil — marking an unread
+            // hypeable row read wiped its displayed count until next reload.
+            hype_count: n.hype_count
         )
     }
 

--- a/app/Mile A Day/Views/Profile/MostMilesDetailView.swift
+++ b/app/Mile A Day/Views/Profile/MostMilesDetailView.swift
@@ -232,6 +232,21 @@ struct StatBox: View {
     }
 }
 
+/// Bridges HealthKit's activity enum onto the app's canonical workout-type
+/// strings so HK-sourced views hit the SAME MADTheme.workoutColor language
+/// as backend-sourced ones (walks blue, runs red — everywhere).
+extension HKWorkoutActivityType {
+    var madTypeKey: String {
+        switch self {
+        case .running: return "running"
+        case .walking: return "walking"
+        case .hiking: return "hiking"
+        case .cycling: return "cycling"
+        default: return "running"
+        }
+    }
+}
+
 // Workout row component
 struct WorkoutRow: View {
     let workout: HKWorkout
@@ -261,13 +276,7 @@ struct WorkoutRow: View {
     // Same accent per type as the feed (ActivityCardView.color) — one color
     // language for a workout everywhere it appears.
     private var workoutColor: Color {
-        switch workout.workoutActivityType {
-        case .running: return MADTheme.Colors.madRed
-        case .walking: return .orange
-        case .hiking: return .green
-        case .cycling: return .blue
-        default: return MADTheme.Colors.madRed
-        }
+        MADTheme.workoutColor(workout.workoutActivityType.madTypeKey)
     }
 
     private var workoutSource: WorkoutSource {


### PR DESCRIPTION
Eight improvements across the feed, notifications, composer, profiles, theming, and the in-app camera.

## 1. Routes zoom like photos
Route-map slides (in photo-post carousels and activity cards) and the stats-card slide now pinch-zoom with the same Instagram-style lift photos have. The zoom machinery now takes an on-demand image provider: photo slides hand back their loaded image as before, and composite slides render their floating copy at pinch-begin from the small retained map snapshot — nothing heavy is baked eagerly or retained per card (a long feed of routes stays light).

## 2. Hype button = double-tap
Tapping the Hype button now plays the exact same clap-burst overlay + haptic as double-tapping the media, Instagram-style — on feed post cards, activity cards, and the friends-list rows. Both paths share one `celebrateAndHype()` per card.

## 3. Notification → the workout on the feed
Tapping a friend's "completed a walk/run/mile" notification now switches to the **Feed** tab and scrolls to that workout's entry, ringing it briefly so it's obvious which one. Matching is by `workout_id` when the notification carries one, with a timezone-tolerant same-day fallback for mile notifications; the feed refreshes and digs up to three pages before giving up gracefully. Handoff works whether or not the Feed tab is already mounted (`FeedDeepLink` park + poke). Other friend notifications keep their existing destinations.

## 4. Notifications header matches the feed
The clap + remaining-count pill moved from the top left to the **top right**, mirroring the feed header. Also fixed: marking an unread hypeable row read no longer wipes its displayed hype count.

## 5. Share destination is an explicit choice
Story / Feed / Both starts **unselected**. Share stays disabled until the user picks; the section shows a "pick where this goes" hint with an accent border, and the chosen card gets a gradient fill + checkmark badge so the destination is unmistakable.

## 6. Friend workouts look like your workouts
A friend's recent workouts now render in the dashboard's exact row grammar: accent icon chip, verb + hero distance, duration • pace line, and date/start time trailing (start derived from the device end timestamp minus duration).

## 7. Walks are blue, runs are red — everywhere
New single source of truth `MADTheme.workoutColor` (walking = `walkBlue`, running = `madRed`, hiking = green, cycling = orange). Six divergent local color switches now delegate to it: feed cards, dashboard rows + workout detail, friend profile rows + detail sheet, friends list, the 7-day chart, and the post-run photo prompt. The **Route Heatmap** inherits it automatically since it colors via `ActivityCardView.color`. Previously walks were orange on your own surfaces, blue on friend surfaces, and the 7-day chart used a third palette.

## 8. Camera look & feel
Preview fades in only when frames are flowing (spinner until then — and the flag now tracks interruptions, so a phone call shows the loading state instead of a frozen-but-live-looking preview). Top/bottom legibility scrims, ultra-thin-material control pills with press-scale button styles, a capture flash blink, animated shutter↔stop morph, flip-icon rotation, countdown scene dim, and staggered chrome entrance.

## Notes
- iOS-only; no backend or Info.plist changes. No new entitlements (App Review unaffected).
- Desk-checked with an adversarial verification pass (4 findings found and fixed: eager zoom-composite memory retention, stale camera running-state during interruptions, cross-timezone day matching, page-1-only deep-link resolution). Needs a device build for final visual QA.
- Suggested smoke test: pinch a route slide and the stats slide; tap Hype on a friend's card (burst should play); tap a friend's walk notification (should land ringed on the feed); compose a post (Share locked until Story/Feed/Both picked); check a friend's profile workout rows vs your dashboard; confirm walks are blue on the dashboard, feed, heatmap; open the camera (fade-in, flash/timer, flip, timer countdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GshhkqMsKx9PkL6WHrpgto

---
_Generated by [Claude Code](https://claude.ai/code/session_01GshhkqMsKx9PkL6WHrpgto)_