### PR TITLE
Feed composer: fresh-post window + Instagram-smooth stats sticker

### DIFF
--- a/app/Mile A Day/Core/State/FreshPostWindowManager.swift
+++ b/app/Mile A Day/Core/State/FreshPostWindowManager.swift
@@ -112,11 +112,6 @@ final class FreshPostWindowManager: ObservableObject {
         return max(0, Self.duration - Date().timeIntervalSince(opened))
     }
 
-    /// 0…1 share of the window still remaining — drives the countdown ring.
-    var fractionRemaining: Double {
-        Self.duration > 0 ? secondsRemaining / Self.duration : 0
-    }
-
     /// End instant for `Text(timerInterval:)`. Falls back to now when closed.
     var windowEndDate: Date {
         (windowOpenedAt ?? Date()).addingTimeInterval(Self.duration)
@@ -175,20 +170,26 @@ final class FreshPostWindowManager: ObservableObject {
 }
 
 /// A thin countdown ring drawn around content (the compose FAB, a story "+"
-/// cell). `fraction` is 0…1 of the window remaining; the parent recomputes it
-/// on its own 1 Hz tick and only mounts the ring while the window is open, so
-/// no timer runs otherwise. Decoupled from the manager on purpose — components
-/// like `StoriesRailView` receive a plain fraction, not the singleton.
+/// cell). Self-ticks via `TimelineView` from `openedAt`, so it needs no parent
+/// timer and stops the moment it's unmounted (i.e. when the window closes and
+/// the parent stops showing it). Once the window elapses the trim reaches 0 and
+/// nothing is drawn, so it also self-hides even before the parent re-renders.
+/// Decoupled from the manager — callers pass a plain `openedAt`, not the
+/// singleton — so components like `StoriesRailView` stay independent.
 struct FreshWindowRing: View {
-    let fraction: Double
+    let openedAt: Date
+    var duration: TimeInterval = FreshPostWindowManager.duration
     var color: Color = .white
     var lineWidth: CGFloat = 3
 
     var body: some View {
-        Circle()
-            .trim(from: 0, to: max(0, min(1, fraction)))
-            .stroke(color, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
-            .rotationEffect(.degrees(-90))
-            .animation(.linear(duration: 1), value: fraction)
+        TimelineView(.periodic(from: openedAt, by: 1)) { context in
+            let remaining = max(0, duration - context.date.timeIntervalSince(openedAt))
+            let fraction = duration > 0 ? remaining / duration : 0
+            Circle()
+                .trim(from: 0, to: fraction)
+                .stroke(color, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+        }
     }
 }

--- a/app/Mile A Day/Core/State/FreshPostWindowManager.swift
+++ b/app/Mile A Day/Core/State/FreshPostWindowManager.swift
@@ -1,0 +1,194 @@
+import Foundation
+import SwiftUI
+
+/// The 10-minute "fresh window" that opens when a workout completes with the
+/// daily goal met. It is a POSITIVE nudge to share in the moment — it drives a
+/// post-run countdown, a ring on the compose affordances, and a "Fresh" badge
+/// on posts made while it is open. It never BLOCKS posting: the daily-goal gate
+/// (`SocialFeedView.mileDone` + the server's `mile_not_completed` 403) is the
+/// only thing that gates the composer. When this window closes the user can
+/// still post the rest of the day exactly as before — they just don't earn the
+/// "Fresh" reward. Each additional qualifying walk/run opens its own window.
+///
+/// Anchored to OBSERVATION time (when the app first sees the finished workout),
+/// never `HKWorkout.endDate`: a Watch run whose `endDate` is 20 min old still
+/// gets a full window at the moment it syncs in, which is exactly when the user
+/// can actually post it.
+///
+/// Persisted to plain `UserDefaults.standard` (NOT the `group.mileaday.shared`
+/// App Group): no widget consumes it, and staying out of the group avoids
+/// spending the rationed widget-reload budget. Day-stamped like `WidgetDataStore`
+/// so a window left open across midnight reads as closed.
+final class FreshPostWindowManager: ObservableObject {
+    static let shared = FreshPostWindowManager()
+
+    /// How long a fresh window stays open after a qualifying workout.
+    static let duration: TimeInterval = 600 // 10 minutes
+
+    /// Re-entrancy reconcile window: `open()` fires from several DashboardView
+    /// observers in one tick, and an optional early stamp in WorkoutTrackingView
+    /// lands ~500 ms before the Dashboard stamp. A window opened this recently
+    /// (any id) is treated as the SAME finish event so the two form one
+    /// continuous countdown instead of restarting it.
+    private static let reconcile: TimeInterval = 3
+
+    /// Published so SwiftUI re-renders when a window opens or resets. The
+    /// per-second countdown itself is driven by the views (a gated 1 Hz tick /
+    /// `Text(timerInterval:)`), since `secondsRemaining` reads the wall clock.
+    @Published private(set) var windowOpenedAt: Date?
+    @Published private(set) var windowWorkoutId: String?
+
+    private let defaults = UserDefaults.standard
+    private let openedAtKey = "fresh_window_opened_at"
+    private let workoutIdKey = "fresh_window_workout_id"
+    private let dayKey = "fresh_window_day"
+    private let postedLiveKeysKey = "fresh_window_posted_live_keys"
+    private let postedLiveDayKey = "fresh_window_posted_live_day"
+
+    private init() {
+        // Rehydrate only if the stored window is from today; a stale day reads
+        // as closed (matches WidgetDataStore's day-stamp behavior).
+        if defaults.string(forKey: dayKey) == Self.dayStamp(),
+           let opened = defaults.object(forKey: openedAtKey) as? Date {
+            windowOpenedAt = opened
+            windowWorkoutId = defaults.string(forKey: workoutIdKey)
+        }
+    }
+
+    /// Device-local day stamp, pinned to a Gregorian/POSIX formatter so a
+    /// non-Gregorian device calendar can't emit keys that never match.
+    private static func dayStamp(for date: Date = Date()) -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.calendar = Calendar(identifier: .gregorian)
+        f.timeZone = TimeZone.current
+        f.dateFormat = "yyyy-MM-dd"
+        return f.string(from: date)
+    }
+
+    // MARK: - Open / reset
+
+    /// Open (or reset) the fresh window for a completed qualifying workout.
+    /// Idempotent for the SAME workout on the SAME day so the many re-entrant
+    /// observers don't restart the countdown; a NEW `workoutId` resets to a
+    /// full window so each extra qualifying walk/run earns its own 10 minutes.
+    /// `at` defaults to now — the observation time, never a workout's `endDate`.
+    func open(workoutId: String, at date: Date = Date()) {
+        let today = Self.dayStamp(for: date)
+
+        // Same workout, still today, still open → no-op (don't restart it).
+        if defaults.string(forKey: dayKey) == today,
+           windowWorkoutId == workoutId,
+           let opened = windowOpenedAt,
+           date.timeIntervalSince(opened) < Self.duration {
+            return
+        }
+
+        // A window opened moments ago (any id) is the same finish event seen by
+        // a second observer — keep its anchor, just record the real workout id.
+        if defaults.string(forKey: dayKey) == today,
+           let opened = windowOpenedAt,
+           (0..<Self.reconcile).contains(date.timeIntervalSince(opened)) {
+            windowWorkoutId = workoutId
+            defaults.set(workoutId, forKey: workoutIdKey)
+            return
+        }
+
+        // Fresh window.
+        windowOpenedAt = date
+        windowWorkoutId = workoutId
+        defaults.set(date, forKey: openedAtKey)
+        defaults.set(workoutId, forKey: workoutIdKey)
+        defaults.set(today, forKey: dayKey)
+    }
+
+    // MARK: - Queries
+
+    var isOpen: Bool { secondsRemaining > 0 }
+
+    var secondsRemaining: TimeInterval {
+        guard defaults.string(forKey: dayKey) == Self.dayStamp(),
+              let opened = windowOpenedAt else { return 0 }
+        return max(0, Self.duration - Date().timeIntervalSince(opened))
+    }
+
+    /// 0…1 share of the window still remaining — drives the countdown ring.
+    var fractionRemaining: Double {
+        Self.duration > 0 ? secondsRemaining / Self.duration : 0
+    }
+
+    /// End instant for `Text(timerInterval:)`. Falls back to now when closed.
+    var windowEndDate: Date {
+        (windowOpenedAt ?? Date()).addingTimeInterval(Self.duration)
+    }
+
+    /// True when the window is open AND scoped to this specific workout — used
+    /// to scope the post-run prompt's pill to the run that just finished.
+    func isOpen(forWorkout id: String) -> Bool {
+        isOpen && windowWorkoutId == id
+    }
+
+    // MARK: - "Posted live" reward (client-only for v1)
+
+    /// Keys (post ids AND workout ids) posted while the window was open today.
+    /// Day-stamped so yesterday's "Fresh" badges don't linger into a new day.
+    private var postedLiveKeys: Set<String> {
+        guard defaults.string(forKey: postedLiveDayKey) == Self.dayStamp(),
+              let arr = defaults.array(forKey: postedLiveKeysKey) as? [String] else {
+            return []
+        }
+        return Set(arr)
+    }
+
+    /// Record a just-published post as "fresh" when it went out during the
+    /// window. Stores the post id AND the linked workout id, so the feed can
+    /// match either (a raw-workout entry replaced by a post keys on workout id).
+    func markPostedLive(postId: String?, workoutId: String?) {
+        guard isOpen else { return }
+        var keys = postedLiveKeys
+        if let postId, !postId.isEmpty { keys.insert(postId) }
+        if let workoutId, !workoutId.isEmpty { keys.insert(workoutId) }
+        defaults.set(Array(keys), forKey: postedLiveKeysKey)
+        defaults.set(Self.dayStamp(), forKey: postedLiveDayKey)
+        objectWillChange.send()
+    }
+
+    /// Whether a feed entry (matched by post id or workout id) was posted live
+    /// today — drives the "Fresh" badge on the poster's own cards.
+    func wasPostedLive(postId: String?, workoutId: String?) -> Bool {
+        let keys = postedLiveKeys
+        if let postId, keys.contains(postId) { return true }
+        if let workoutId, keys.contains(workoutId) { return true }
+        return false
+    }
+
+    #if DEBUG
+    /// Test hook: force the window closed.
+    func reset() {
+        windowOpenedAt = nil
+        windowWorkoutId = nil
+        defaults.removeObject(forKey: openedAtKey)
+        defaults.removeObject(forKey: workoutIdKey)
+        defaults.removeObject(forKey: dayKey)
+    }
+    #endif
+}
+
+/// A thin countdown ring drawn around content (the compose FAB, a story "+"
+/// cell). `fraction` is 0…1 of the window remaining; the parent recomputes it
+/// on its own 1 Hz tick and only mounts the ring while the window is open, so
+/// no timer runs otherwise. Decoupled from the manager on purpose — components
+/// like `StoriesRailView` receive a plain fraction, not the singleton.
+struct FreshWindowRing: View {
+    let fraction: Double
+    var color: Color = .white
+    var lineWidth: CGFloat = 3
+
+    var body: some View {
+        Circle()
+            .trim(from: 0, to: max(0, min(1, fraction)))
+            .stroke(color, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+            .rotationEffect(.degrees(-90))
+            .animation(.linear(duration: 1), value: fraction)
+    }
+}

--- a/app/Mile A Day/Services/RunPostService.swift
+++ b/app/Mile A Day/Services/RunPostService.swift
@@ -79,7 +79,7 @@ enum RunPostService {
             let mediaUrl = try await PostService.uploadMedia(finalImage)
             // isAuto — the server may replace this card in place with a later
             // photo post, but it never counts as the user's one post per workout.
-            _ = try await PostService.createPost(
+            let created = try await PostService.createPost(
                 mediaUrl: mediaUrl,
                 caption: nil,
                 workoutId: workoutId,
@@ -87,6 +87,12 @@ enum RunPostService {
                 shareToStory: false,
                 stats: stats.snapshot,
                 isAuto: true
+            )
+            // Skipping the photo still counts as posting this run live if it's
+            // within the fresh window (no-op otherwise).
+            FreshPostWindowManager.shared.markPostedLive(
+                postId: created.post_id,
+                workoutId: created.workout_id ?? workoutId
             )
         } catch {
             print("[RunPostService] autoPostMile failed: \(error)")

--- a/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
+++ b/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
@@ -232,7 +232,8 @@ struct PostRunPhotoPromptView: View {
             )
             .font(.system(size: 13, weight: .bold, design: .rounded))
             .monospacedDigit()
-            .frame(width: 46, alignment: .leading)
+            .lineLimit(1)
+            .fixedSize()
         }
         .foregroundColor(.white)
         .padding(.horizontal, 14)

--- a/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
+++ b/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
@@ -14,6 +14,7 @@ struct PostRunPhotoPromptView: View {
     let workoutType: String
 
     @ObservedObject private var manager = CelebrationManager.shared
+    @ObservedObject private var freshWindow = FreshPostWindowManager.shared
     @State private var appeared = false
     @State private var didAct = false
     /// Photos captured during the run via the tracking screen's camera button.
@@ -70,6 +71,13 @@ struct PostRunPhotoPromptView: View {
                     cameraHero
                 } else {
                     midRunSnapStrip
+                }
+
+                // Countdown pill — the fresh window is open for this run. Purely
+                // an in-the-moment nudge; posting stays available after it ends.
+                if freshWindow.isOpen(forWorkout: workoutId) {
+                    countdownPill
+                        .opacity(appeared ? 1 : 0)
                 }
 
                 VStack(spacing: 8) {
@@ -206,6 +214,31 @@ struct PostRunPhotoPromptView: View {
         return count == 1
             ? "You snapped a photo out there — tap it to share it, or take a fresh one."
             : "You snapped \(count) photos out there — tap your favorite to share it, or take a fresh one."
+    }
+
+    // MARK: - Fresh-window countdown
+
+    /// Self-ticking countdown for the run's 10-minute fresh window. Uses the
+    /// native `Text(timerInterval:)` (no manual timer) so it stays cheap.
+    private var countdownPill: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "bolt.fill")
+                .font(.system(size: 11, weight: .bold))
+            Text("Post now — fresh for")
+                .font(.system(size: 13, weight: .semibold, design: .rounded))
+            Text(
+                timerInterval: (freshWindow.windowOpenedAt ?? Date())...freshWindow.windowEndDate,
+                countsDown: true
+            )
+            .font(.system(size: 13, weight: .bold, design: .rounded))
+            .monospacedDigit()
+            .frame(width: 46, alignment: .leading)
+        }
+        .foregroundColor(.white)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(Capsule().fill(accent.opacity(0.9)))
+        .shadow(color: accent.opacity(0.4), radius: 8, y: 2)
     }
 
     // MARK: - Hero (no mid-run snaps)

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -538,6 +538,8 @@ struct DashboardView: View {
                     checkAndShowGoalCelebration()
                     // Pick up ask-mode pendings created while backgrounded.
                     loadPendingNotifications()
+                    // A mid-run snap may have been taken in another surface.
+                    refreshMidRunPhotoWaiting()
                 } else if newPhase == .background || newPhase == .inactive {
                     celebrationManager.onAppResignedActive()
                 }

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -93,6 +93,11 @@ struct DashboardView: View {
     /// competitions, badges) has loaded and we confirm items remain incomplete.
     @State private var gettingStartedReady = false
 
+    /// Cached "a mid-run photo is waiting but the goal isn't done" flag, so the
+    /// nudge renders without touching disk in `body` (MidRunPhotoStash.count
+    /// enumerates the sandbox dir). Refreshed on appear + workout changes.
+    @State private var midRunPhotoWaiting = false
+
 
     /// Build goal completion stats for the celebration
     private func buildGoalCompletionStats() -> GoalCompletionStats {
@@ -266,10 +271,16 @@ struct DashboardView: View {
 
             // Finale: BeReal-style "add a photo of your run" prompt for the mile
             // that just completed. Skipping still shares the run (route/stats).
-            if autoShareRunsToFeed, let uuid = healthManager.workoutIndex?.latestWorkoutUUID {
-                let hk = healthManager.todaysWorkouts.first { $0.uuid.uuidString == uuid }
-                let wtype = hk?.workoutActivityType == .walking ? "walking" : "running"
-                celebrationManager.addCelebration(.postRunPhotoPrompt(workoutId: uuid, workoutType: wtype))
+            if let uuid = healthManager.workoutIndex?.latestWorkoutUUID {
+                // Open the 10-min fresh-post window on the goal-completing run
+                // regardless of the auto-share prompt, so the feed countdown /
+                // ring and "Fresh" reward work even when auto-share is off.
+                FreshPostWindowManager.shared.open(workoutId: uuid)
+                if autoShareRunsToFeed {
+                    let hk = healthManager.todaysWorkouts.first { $0.uuid.uuidString == uuid }
+                    let wtype = hk?.workoutActivityType == .walking ? "walking" : "running"
+                    celebrationManager.addCelebration(.postRunPhotoPrompt(workoutId: uuid, workoutType: wtype))
+                }
             }
         }
     }
@@ -296,10 +307,15 @@ struct DashboardView: View {
         // Every walk/run gets its own photo moment, not just the goal-crossing
         // one — same finale as the goal path. The celebration id is keyed by
         // workout uuid, so each new workout prompts exactly once.
-        if autoShareRunsToFeed, let uuid = healthManager.workoutIndex?.latestWorkoutUUID {
-            let hk = healthManager.todaysWorkouts.first { $0.uuid.uuidString == uuid }
-            let wtype = hk?.workoutActivityType == .walking ? "walking" : "running"
-            celebrationManager.addCelebration(.postRunPhotoPrompt(workoutId: uuid, workoutType: wtype))
+        if let uuid = healthManager.workoutIndex?.latestWorkoutUUID {
+            // Each extra qualifying walk/run reopens a fresh 10-min window (a
+            // new uuid resets it), regardless of the auto-share prompt.
+            FreshPostWindowManager.shared.open(workoutId: uuid)
+            if autoShareRunsToFeed {
+                let hk = healthManager.todaysWorkouts.first { $0.uuid.uuidString == uuid }
+                let wtype = hk?.workoutActivityType == .walking ? "walking" : "running"
+                celebrationManager.addCelebration(.postRunPhotoPrompt(workoutId: uuid, workoutType: wtype))
+            }
         }
     }
 
@@ -343,6 +359,16 @@ struct DashboardView: View {
                         && celebrationManager.hasShownGoalCelebrationToday
                         && !celebrationManager.isShowingCelebration {
                         replayTodaysCelebrationCard
+                            .padding(.horizontal, MADTheme.Spacing.md)
+                            .padding(.top, MADTheme.Spacing.sm)
+                    }
+
+                    // "Photo waiting" nudge — a mid-run snap is held but the
+                    // goal isn't done yet. It does NOT unlock posting (the goal
+                    // gate stands); it reassures the user the shot is kept and
+                    // will be offered once they finish the mile.
+                    if midRunPhotoWaiting {
+                        photoWaitingBanner
                             .padding(.horizontal, MADTheme.Spacing.md)
                             .padding(.top, MADTheme.Spacing.sm)
                     }
@@ -413,6 +439,9 @@ struct DashboardView: View {
                 }
                 // A workout just finished/synced — refresh ask-mode pendings.
                 loadPendingNotifications()
+                // A mid-run snap may have been taken (or the goal met) — refresh
+                // the "photo waiting" nudge.
+                refreshMidRunPhotoWaiting()
             }) {
                 // One WorkoutTrackingView with stable structural identity. This was
                 // an if/else between two WorkoutTrackingView initializers — when the
@@ -431,6 +460,7 @@ struct DashboardView: View {
             }
             .onAppear {
                 refreshData()
+                refreshMidRunPhotoWaiting()
                 // Sync widget data immediately
                 syncWidgetData()
                 // Load ask-mode pending notifications (cheap-guarded on settings).
@@ -543,6 +573,9 @@ struct DashboardView: View {
                     // Also check for goal celebration when completion status changes
                     checkAndShowGoalCelebration()
                 }
+                // Completing the goal clears the "photo waiting" state (the
+                // post-run prompt now offers the snap directly).
+                refreshMidRunPhotoWaiting()
             }
             .onChange(of: healthManager.todaysDistance) { oldValue, newValue in
                 // Check for extra mile when distance increases after goal already celebrated
@@ -555,6 +588,8 @@ struct DashboardView: View {
                 if newValue > oldValue && celebrationManager.hasShownGoalCelebrationToday {
                     checkAndShowPostGoalEncouragement()
                 }
+                // A workout finishing may leave a mid-run snap waiting.
+                refreshMidRunPhotoWaiting()
             }
             .confetti(isShowing: $showConfetti)
             .overlay(
@@ -866,6 +901,51 @@ struct DashboardView: View {
             )
         }
         .buttonStyle(.plain)
+    }
+
+    /// Nudge shown when a mid-run snap is waiting but today's goal isn't met.
+    /// Tapping reopens the tracker so the user can finish their mile.
+    private var photoWaitingBanner: some View {
+        Button {
+            showWorkoutView = true
+        } label: {
+            HStack(spacing: MADTheme.Spacing.sm) {
+                Image(systemName: "camera.badge.clock")
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundStyle(
+                        LinearGradient(colors: [.white, MADTheme.Colors.walkBlue], startPoint: .top, endPoint: .bottom)
+                    )
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Photo waiting")
+                        .font(.system(size: 13, weight: .bold, design: .rounded))
+                        .foregroundColor(.white)
+                    Text("Finish today's mile to share it")
+                        .font(.system(size: 11, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.55))
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundColor(.white.opacity(0.4))
+            }
+            .padding(MADTheme.Spacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large)
+                    .fill(Color.white.opacity(0.04))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large)
+                            .strokeBorder(MADTheme.Colors.walkBlue.opacity(0.3), lineWidth: 1)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    /// Cache whether a mid-run photo is waiting to be shared while today's goal
+    /// is still unmet, so `photoWaitingBanner` never enumerates the sandbox dir
+    /// from within `body`.
+    private func refreshMidRunPhotoWaiting() {
+        midRunPhotoWaiting = !currentState.isCompleted && MidRunPhotoStash.count > 0
     }
 
     // MARK: - HealthKit Permission Banner

--- a/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
@@ -1007,11 +1007,18 @@ struct WorkoutTrackingView: View {
 
         workoutStartDate = Date()
 
-        // Fresh session: drop any mid-run snaps left over from a previous
-        // workout (crash, force-quit) so an old photo can't hijack this run's
-        // post-run prompt.
-        MidRunPhotoStash.clear()
-        midRunSnapCount = 0
+        // Fresh session: drop mid-run snaps left over from a previous workout
+        // ONLY when today's goal was already met before this one. A workout on
+        // an already-completed day is "extra", so a stale snap shouldn't hijack
+        // its prompt. But when the goal ISN'T met yet, keep leftover snaps so a
+        // photo taken on an earlier sub-goal effort survives into the workout
+        // that finally finishes the mile (24h prune still bounds staleness).
+        if startingDistance >= goalDistance {
+            MidRunPhotoStash.clear()
+            midRunSnapCount = 0
+        } else {
+            midRunSnapCount = MidRunPhotoStash.count
+        }
 
         // Immediately persist initial workout state
         let initialState = InProgressWorkoutState(

--- a/app/Mile A Day/Views/Feed/PostCardView.swift
+++ b/app/Mile A Day/Views/Feed/PostCardView.swift
@@ -14,6 +14,9 @@ struct PostCardView: View {
     let post: PostItem
     /// The run's story-only photo, when different from the post media.
     var storyPhotoURL: URL? = nil
+    /// The viewer's OWN post that went out during the 10-min fresh window —
+    /// wears a "Fresh" chip. Client-derived, so it shows only to the poster.
+    var isFresh: Bool = false
     var isHyping: Bool = false
     /// Daily hype allowance spent (never true for unlimited roles) — dims the
     /// unspent Hype button, same as the friends list.
@@ -71,6 +74,20 @@ struct PostCardView: View {
         )
     }
 
+    /// "Fresh" chip for a post shared inside the run's 10-minute window.
+    private var freshChip: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "bolt.fill")
+                .font(.system(size: 9, weight: .black))
+            Text("FRESH")
+                .font(.system(size: 10, weight: .black, design: .rounded))
+        }
+        .foregroundColor(.white)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(Capsule().fill(MADTheme.Colors.madRed))
+    }
+
     private var header: some View {
         HStack(spacing: 10) {
             Button {
@@ -91,6 +108,7 @@ struct PostCardView: View {
             }
             .buttonStyle(.plain)
             .disabled(onTapAuthor == nil)
+            if isFresh { freshChip }
             Spacer()
             if let type = post.workout_type {
                 Image(systemName: ActivityCardView.icon(type))

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -201,7 +201,7 @@ final class PostComposerViewModel: ObservableObject {
 
         do {
             let mediaUrl = try await PostService.uploadMedia(flat)
-            _ = try await PostService.createPost(
+            let created = try await PostService.createPost(
                 mediaUrl: mediaUrl,
                 caption: caption.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : caption,
                 workoutId: stats.workoutId,
@@ -210,6 +210,12 @@ final class PostComposerViewModel: ObservableObject {
                 stats: stats.snapshot,
                 isAuto: false,
                 includeRoute: includeRoute
+            )
+            // Reward posts shared inside the run's 10-min fresh window with a
+            // "Fresh" badge. No-op when the window is closed.
+            FreshPostWindowManager.shared.markPostedLive(
+                postId: created.post_id,
+                workoutId: created.workout_id ?? stats.workoutId
             )
             if stickerEnabled {
                 // Remember the user's overlay style — but merge back any stats

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Run stats handed to the composer to seed the overlay sticker. Carries every
 /// stat we can show; `datum(for:)` formats one and returns nil when there's no
 /// data, so unavailable stats simply don't appear (and aren't offered as toggles).
-struct RunStatsInput {
+struct RunStatsInput: Equatable {
     var distance: Double
     var paceSecondsPerMile: Double?
     var durationSeconds: Double?
@@ -55,10 +55,16 @@ struct RunStatsInput {
         }
     }
 
-    private static func grouped(_ n: Int) -> String {
+    /// Shared decimal formatter — allocating a `NumberFormatter` per render was
+    /// a needless per-frame cost. Rendering is @MainActor, so sharing is safe.
+    private static let stepsFormatter: NumberFormatter = {
         let f = NumberFormatter()
         f.numberStyle = .decimal
-        return f.string(from: NSNumber(value: n)) ?? "\(n)"
+        return f
+    }()
+
+    private static func grouped(_ n: Int) -> String {
+        stepsFormatter.string(from: NSNumber(value: n)) ?? "\(n)"
     }
 }
 
@@ -114,6 +120,8 @@ final class PostComposerViewModel: ObservableObject {
     /// Sticker center in normalized canvas coordinates (0…1).
     @Published var stickerPos: CGPoint = CGPoint(x: 0.5, y: 0.82)
     @Published var stickerScale: CGFloat = 1.0
+    /// Sticker rotation (two-finger twist), baked into the shared image.
+    @Published var stickerRotation: Angle = .zero
     @Published var config: StickerConfig
     @Published var isPublishing = false
     @Published var errorMessage: String?
@@ -142,6 +150,7 @@ final class PostComposerViewModel: ObservableObject {
         // (StickerConfig sanitizes on decode; ranges live there too).
         self.stickerScale = cfg.scale
         self.stickerPos = CGPoint(x: cfg.posX, y: cfg.posY)
+        self.stickerRotation = Angle(degrees: cfg.rotation)
         // Seed a pre-chosen photo (mid-run snap) AFTER all stored properties
         // are initialized — the @Published setter touches self.
         self.pickedImage = initialImage
@@ -174,6 +183,7 @@ final class PostComposerViewModel: ObservableObject {
             showSticker: stickerEnabled,
             stickerPos: stickerPos,
             stickerScale: stickerScale,
+            stickerRotation: stickerRotation,
             input: stats,
             config: config
         )
@@ -232,6 +242,7 @@ final class PostComposerViewModel: ObservableObject {
                 toSave.scale = stickerScale
                 toSave.posX = stickerPos.x
                 toSave.posY = stickerPos.y
+                toSave.rotation = stickerRotation.degrees
                 toSave.save()
             }
             return true
@@ -262,6 +273,7 @@ struct PostCanvas: View {
     let showSticker: Bool
     let stickerPos: CGPoint
     let stickerScale: CGFloat
+    var stickerRotation: Angle = .zero
     let input: RunStatsInput
     let config: StickerConfig
 
@@ -277,12 +289,91 @@ struct PostCanvas: View {
                 if showSticker {
                     RunStatsStickerView(input: input, config: config)
                         .scaleEffect(stickerScale)
+                        .rotationEffect(stickerRotation)
                         .position(x: stickerPos.x * geo.size.width, y: stickerPos.y * geo.size.height)
                 }
             }
             .frame(width: geo.size.width, height: geo.size.height)
             .clipped()
         }
+    }
+}
+
+/// The live, manipulable sticker in the composer editor. Holds the in-flight
+/// drag / pinch / twist as transient `@GestureState` and applies it directly to
+/// the sticker, committing to the bindings ONLY on `.onEnded`. Because the
+/// committed VM values aren't touched mid-gesture, the rest of the composer
+/// never re-renders during a manipulation — this is what makes it feel as
+/// smooth as Instagram instead of re-laying-out the whole screen every frame.
+/// The sticker is wrapped in `.equatable()` (outside the transforms) so its own
+/// body — drop shadow, number formatting — is rendered once and only its cheap
+/// transform matrix changes per frame.
+private struct StickerEditorLayer: View {
+    let input: RunStatsInput
+    let config: StickerConfig
+    /// Canvas size in points — the SAME value `flatten()` renders at, so the
+    /// live sticker and the baked image land pixel-identically.
+    let canvas: CGSize
+    @Binding var pos: CGPoint      // normalized 0…1 center (committed)
+    @Binding var scale: CGFloat    // committed
+    @Binding var rotation: Angle   // committed
+
+    // Identity-at-rest transients — SwiftUI auto-resets these when the gesture
+    // ends, in the same transaction the `.onEnded` commit lands, so there's no
+    // jump between "committed ∘ transient" and the new committed value.
+    @GestureState private var dragTranslation: CGSize = .zero
+    @GestureState private var magnifyFactor: CGFloat = 1
+    @GestureState private var twist: Angle = .zero
+
+    var body: some View {
+        RunStatsStickerView(input: input, config: config)
+            .equatable()                       // MUST stay OUTSIDE the transforms
+            .scaleEffect(liveScale)
+            .rotationEffect(liveRotation)
+            // Generous, invisible hit margin so a shrunk-down sticker stays easy
+            // to grab. After the transforms → a fixed screen-space margin.
+            .padding(20)
+            .contentShape(Rectangle())
+            .gesture(manipulation)             // BEFORE .position → grab the sticker itself
+            .position(liveCenter)
+    }
+
+    // Live = committed ∘ transient, clamped IDENTICALLY to the `.onEnded` commit
+    // so releasing never snaps the sticker to a different spot/size.
+    private var liveScale: CGFloat {
+        (scale * magnifyFactor).clamped(to: StickerConfig.scaleRange)
+    }
+    private var liveRotation: Angle { rotation + twist }
+    private var liveCenter: CGPoint {
+        CGPoint(x: committedX(addingDrag: dragTranslation.width) * canvas.width,
+                y: committedY(addingDrag: dragTranslation.height) * canvas.height)
+    }
+
+    private func committedX(addingDrag dx: CGFloat) -> CGFloat {
+        (pos.x + dx / max(canvas.width, 1)).clamped(to: StickerConfig.posXRange)
+    }
+    private func committedY(addingDrag dy: CGFloat) -> CGFloat {
+        (pos.y + dy / max(canvas.height, 1)).clamped(to: StickerConfig.posYRange)
+    }
+
+    private var manipulation: some Gesture {
+        let drag = DragGesture()
+            .updating($dragTranslation) { value, state, _ in state = value.translation }
+            .onEnded { value in
+                pos = CGPoint(x: committedX(addingDrag: value.translation.width),
+                              y: committedY(addingDrag: value.translation.height))
+            }
+        let magnify = MagnifyGesture()
+            .updating($magnifyFactor) { value, state, _ in state = value.magnification }
+            .onEnded { value in
+                scale = (scale * value.magnification).clamped(to: StickerConfig.scaleRange)
+            }
+        let rotate = RotateGesture()
+            .updating($twist) { value, state, _ in state = value.rotation }
+            .onEnded { value in
+                rotation = rotation + value.rotation
+            }
+        return drag.simultaneously(with: magnify).simultaneously(with: rotate)
     }
 }
 
@@ -309,10 +400,6 @@ struct PostComposerView: View {
     /// time a fullScreenCover dismisses, and re-opening on each pass would
     /// trap the user in the camera with no way back.
     @State private var didAutoOpenCamera = false
-    @State private var gestureBaseScale: CGFloat = 1.0
-    /// Sticker position at drag start (normalized) — drags apply translation
-    /// relative to this instead of jumping to the touch point.
-    @State private var gestureBasePos: CGPoint? = nil
     /// "Saved to Photos" confirmation for the canvas Save button.
     @State private var showSavedToPhotos = false
     @FocusState private var captionFocused: Bool
@@ -540,16 +627,29 @@ struct PostComposerView: View {
             Group {
                 if let image = vm.pickedImage {
                     ZStack {
+                        // Photo only. The sticker is a SEPARATE, isolated layer
+                        // (StickerEditorLayer) so dragging/pinching/rotating it
+                        // never re-renders this canvas or the rest of the
+                        // composer — the key to an Instagram-smooth feel.
                         PostCanvas(
                             image: image,
-                            showSticker: vm.stickerEnabled,
+                            showSticker: false,
                             stickerPos: vm.stickerPos,
                             stickerScale: vm.stickerScale,
                             input: vm.stats,
                             config: vm.config
                         )
                         if vm.stickerEnabled {
-                            stickerGestureLayer(canvas: CGSize(width: width, height: height))
+                            // Pass geo.size — the exact value flatten() renders
+                            // at (via vm.canvasSize) — for pixel-perfect parity.
+                            StickerEditorLayer(
+                                input: vm.stats,
+                                config: vm.config,
+                                canvas: geo.size,
+                                pos: $vm.stickerPos,
+                                scale: $vm.stickerScale,
+                                rotation: $vm.stickerRotation
+                            )
                         }
                     }
                     .frame(width: width, height: height)
@@ -609,7 +709,7 @@ struct PostComposerView: View {
                     }
                     .overlay(alignment: .bottom) {
                         if vm.stickerEnabled {
-                            Text("Drag to move · pinch to resize")
+                            Text("Drag · pinch · twist")
                                 .font(.system(size: 10, weight: .semibold, design: .rounded))
                                 .foregroundColor(.white.opacity(0.65))
                                 .padding(.horizontal, 10).padding(.vertical, 4)
@@ -675,39 +775,6 @@ struct PostComposerView: View {
         }
         .buttonStyle(.plain)
         .disabled(!MADCameraView.isAvailable)
-    }
-
-    private func stickerGestureLayer(canvas: CGSize) -> some View {
-        Color.clear
-            .contentShape(Rectangle())
-            // Base the first pinch on the RESTORED scale — the default 1.0
-            // would make a remembered smaller/larger sticker jump on touch.
-            .onAppear { gestureBaseScale = vm.stickerScale }
-            .gesture(
-                SimultaneousGesture(
-                    DragGesture()
-                        .onChanged { value in
-                            // Move RELATIVE to where the sticker started — a
-                            // location-based move teleports the sticker to
-                            // wherever the finger first lands on the canvas.
-                            let base = gestureBasePos ?? vm.stickerPos
-                            if gestureBasePos == nil { gestureBasePos = vm.stickerPos }
-                            let x = base.x + value.translation.width / canvas.width
-                            let y = base.y + value.translation.height / canvas.height
-                            vm.stickerPos = CGPoint(
-                                x: x.clamped(to: StickerConfig.posXRange),
-                                y: y.clamped(to: StickerConfig.posYRange)
-                            )
-                        }
-                        .onEnded { _ in gestureBasePos = nil },
-                    MagnificationGesture()
-                        .onChanged { value in
-                            vm.stickerScale = (gestureBaseScale * value)
-                                .clamped(to: StickerConfig.scaleRange)
-                        }
-                        .onEnded { _ in gestureBaseScale = vm.stickerScale }
-                )
-            )
     }
 
     // MARK: - Overlay editor

--- a/app/Mile A Day/Views/Feed/RunStatsStickerView.swift
+++ b/app/Mile A Day/Views/Feed/RunStatsStickerView.swift
@@ -94,6 +94,10 @@ struct StickerConfig: Equatable, Codable {
     var scale: CGFloat = 1.0
     var posX: CGFloat = 0.5
     var posY: CGFloat = 0.82
+    /// Remembered rotation in degrees. Added after v1 — absent from older
+    /// configs, which decode to 0 (no tilt). Not clamped: rotation can't push
+    /// the sticker off-canvas (the position clamp handles bounds).
+    var rotation: CGFloat = 0
 
     init() {}
 
@@ -113,6 +117,7 @@ struct StickerConfig: Equatable, Codable {
             .clamped(to: Self.posXRange)
         posY = ((try? c.decode(CGFloat.self, forKey: .posY)) ?? defaults.posY)
             .clamped(to: Self.posYRange)
+        rotation = (try? c.decode(CGFloat.self, forKey: .rotation)) ?? defaults.rotation
     }
 
     func isOn(_ kind: RunStatKind) -> Bool { enabled.contains(kind) }
@@ -155,7 +160,7 @@ struct RunStatDatum: Identifiable {
 /// Config-driven run-stats overlay. Renders only the stats the user enabled, in
 /// the chosen style + accent. Used live in the composer (draggable/scalable) and
 /// baked into the photo via ImageRenderer.
-struct RunStatsStickerView: View {
+struct RunStatsStickerView: View, Equatable {
     let input: RunStatsInput
     let config: StickerConfig
 

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -36,10 +36,8 @@ struct SocialFeedView: View {
     @StateObject private var profileFriendService = FriendService()
     /// Fresh-post window: drives the compose FAB / rail countdown ring and the
     /// "Fresh" badge on the viewer's own in-window posts. Never gates posting.
+    /// The rings self-tick via `TimelineView`, so no feed-level timer is needed.
     @StateObject private var freshWindow = FreshPostWindowManager.shared
-    /// Bumped 1 Hz while the window is open so the ring shrinks and unmounts at
-    /// expiry — gated to `freshWindow.isOpen`, never a permanent timer.
-    @State private var windowTick = Date()
 
     @State private var feed: [FeedEntry] = []
     @State private var stories: [StoryGroup] = []
@@ -258,7 +256,7 @@ struct SocialFeedView: View {
                         canPost: mileDone,
                         hasSharedWorkout: alreadySharedWorkout,
                         windowOpen: freshWindow.isOpen,
-                        windowFraction: freshWindow.fractionRemaining,
+                        windowOpenedAt: freshWindow.windowOpenedAt,
                         isGroupViewable: { canViewStories(of: $0) },
                         isGroupUnviewed: { isGroupUnviewed(of: $0) },
                         onTapAdd: handleCompose,
@@ -335,16 +333,6 @@ struct SocialFeedView: View {
         .background(MADTheme.Colors.appBackgroundGradient)
         .toolbar(.hidden, for: .navigationBar)
         .overlay(alignment: .bottomTrailing) { composeButton }
-        // Drive the countdown rings' 1 Hz shrink (and their unmount at expiry)
-        // only while a window is open — no permanent timer on the feed. Kept on
-        // the root, not the FAB, so the rail ring keeps ticking after the FAB
-        // hides (once the workout is shared).
-        .background {
-            if freshWindow.isOpen {
-                Color.clear
-                    .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { windowTick = $0 }
-            }
-        }
         .overlay(alignment: .top) {
             if showHypeLimitBanner {
                 hypeLimitBanner
@@ -576,9 +564,8 @@ struct SocialFeedView: View {
                     )
                     // Fresh-window countdown ring around the FAB while open.
                     .overlay {
-                        if mileDone && freshWindow.isOpen {
-                            FreshWindowRing(fraction: freshWindow.fractionRemaining,
-                                            color: .white, lineWidth: 3)
+                        if mileDone && freshWindow.isOpen, let openedAt = freshWindow.windowOpenedAt {
+                            FreshWindowRing(openedAt: openedAt, color: .white, lineWidth: 3)
                                 .padding(-5)
                         }
                     }

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -34,6 +34,12 @@ struct SocialFeedView: View {
     /// FriendService inside the sheet closure re-instantiated it on every feed
     /// state change, wiping the loaded friends list mid-view.
     @StateObject private var profileFriendService = FriendService()
+    /// Fresh-post window: drives the compose FAB / rail countdown ring and the
+    /// "Fresh" badge on the viewer's own in-window posts. Never gates posting.
+    @StateObject private var freshWindow = FreshPostWindowManager.shared
+    /// Bumped 1 Hz while the window is open so the ring shrinks and unmounts at
+    /// expiry — gated to `freshWindow.isOpen`, never a permanent timer.
+    @State private var windowTick = Date()
 
     @State private var feed: [FeedEntry] = []
     @State private var stories: [StoryGroup] = []
@@ -251,6 +257,8 @@ struct SocialFeedView: View {
                         myImageURL: userManager.currentUser.profileImageUrl,
                         canPost: mileDone,
                         hasSharedWorkout: alreadySharedWorkout,
+                        windowOpen: freshWindow.isOpen,
+                        windowFraction: freshWindow.fractionRemaining,
                         isGroupViewable: { canViewStories(of: $0) },
                         isGroupUnviewed: { isGroupUnviewed(of: $0) },
                         onTapAdd: handleCompose,
@@ -327,6 +335,16 @@ struct SocialFeedView: View {
         .background(MADTheme.Colors.appBackgroundGradient)
         .toolbar(.hidden, for: .navigationBar)
         .overlay(alignment: .bottomTrailing) { composeButton }
+        // Drive the countdown rings' 1 Hz shrink (and their unmount at expiry)
+        // only while a window is open — no permanent timer on the feed. Kept on
+        // the root, not the FAB, so the rail ring keeps ticking after the FAB
+        // hides (once the workout is shared).
+        .background {
+            if freshWindow.isOpen {
+                Color.clear
+                    .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { windowTick = $0 }
+            }
+        }
         .overlay(alignment: .top) {
             if showHypeLimitBanner {
                 hypeLimitBanner
@@ -518,6 +536,8 @@ struct SocialFeedView: View {
             PostCardView(
                 post: post,
                 storyPhotoURL: entry.storyPhotoURL,
+                isFresh: entry.is_self
+                    && freshWindow.wasPostedLive(postId: post.post_id, workoutId: post.workout_id),
                 isHyping: hypingIds.contains(entry.id),
                 isOutOfHypes: isOutOfHypes,
                 onHype: { Task { await hype(entry) } },
@@ -554,6 +574,14 @@ struct SocialFeedView: View {
                     .background(
                         Circle().fill(mileDone ? AnyShapeStyle(MADTheme.Colors.redGradient) : AnyShapeStyle(Color.gray.opacity(0.6)))
                     )
+                    // Fresh-window countdown ring around the FAB while open.
+                    .overlay {
+                        if mileDone && freshWindow.isOpen {
+                            FreshWindowRing(fraction: freshWindow.fractionRemaining,
+                                            color: .white, lineWidth: 3)
+                                .padding(-5)
+                        }
+                    }
                     .shadow(color: .black.opacity(0.3), radius: 8, y: 4)
             }
             .padding(.trailing, MADTheme.Spacing.lg)

--- a/app/Mile A Day/Views/Feed/StoriesRailView.swift
+++ b/app/Mile A Day/Views/Feed/StoriesRailView.swift
@@ -14,9 +14,9 @@ struct StoriesRailView: View {
     var hasSharedWorkout: Bool = false
     /// Fresh-post window state (owned by the feed). When open, the "Your story"
     /// cell wears a shrinking countdown ring — an in-the-moment nudge, never a
-    /// gate. `windowFraction` is 0…1 of the window remaining.
+    /// gate. `windowOpenedAt` anchors the self-ticking ring.
     var windowOpen: Bool = false
-    var windowFraction: Double = 0
+    var windowOpenedAt: Date? = nil
     /// Per-group viewing gate: viewing is earned per story DAY (yesterday's
     /// stories stay open for a viewer who completed yesterday; a new today
     /// story locks until today's mile is done). The feed owns the rule.
@@ -83,8 +83,8 @@ struct StoriesRailView: View {
                     // Fresh-window countdown ring, just outside the avatar —
                     // only while there's still something to post this window.
                     .overlay {
-                        if windowOpen && canPost && !hasSharedWorkout {
-                            FreshWindowRing(fraction: windowFraction,
+                        if windowOpen && canPost && !hasSharedWorkout, let openedAt = windowOpenedAt {
+                            FreshWindowRing(openedAt: openedAt,
                                             color: MADTheme.Colors.madRed,
                                             lineWidth: 2.5)
                                 .padding(-3)

--- a/app/Mile A Day/Views/Feed/StoriesRailView.swift
+++ b/app/Mile A Day/Views/Feed/StoriesRailView.swift
@@ -12,6 +12,11 @@ struct StoriesRailView: View {
     /// The viewer has already shared this workout — the "+" add badge hides
     /// (one post per walk/run); the ring still opens their own story.
     var hasSharedWorkout: Bool = false
+    /// Fresh-post window state (owned by the feed). When open, the "Your story"
+    /// cell wears a shrinking countdown ring — an in-the-moment nudge, never a
+    /// gate. `windowFraction` is 0…1 of the window remaining.
+    var windowOpen: Bool = false
+    var windowFraction: Double = 0
     /// Per-group viewing gate: viewing is earned per story DAY (yesterday's
     /// stories stay open for a viewer who completed yesterday; a new today
     /// story locks until today's mile is done). The feed owns the rule.
@@ -74,6 +79,16 @@ struct StoriesRailView: View {
                 ZStack(alignment: .bottomTrailing) {
                     ring(unviewed: myGroup?.has_unviewed ?? false, dashed: myGroup == nil) {
                         AvatarView(name: myName, imageURL: myImageURL, size: 64)
+                    }
+                    // Fresh-window countdown ring, just outside the avatar —
+                    // only while there's still something to post this window.
+                    .overlay {
+                        if windowOpen && canPost && !hasSharedWorkout {
+                            FreshWindowRing(fraction: windowFraction,
+                                            color: MADTheme.Colors.madRed,
+                                            lineWidth: 2.5)
+                                .padding(-3)
+                        }
                     }
                     // No add/lock badge once they've shared this workout — the
                     // ring still opens their own story, there's just nothing new


### PR DESCRIPTION
This branch bundles two feed-composer improvements.

---

## 1. Fresh-post window (post-run countdown + "Fresh" reward)

**Reframe:** feed posts are *already* goal-gated (client `mileDone` + server `mile_not_completed`), identical to stories. What looks unblocked is the raw walk/run activity card the feed auto-surfaces from the `workouts` table — the activity itself, not a deliberate post. So this doesn't add a new block; it adds a **soft 10-minute "fresh window"** that celebrates in-the-moment sharing (never locks posting).

- `FreshPostWindowManager` (new, `Core/State/`): day-stamped, anchored to *observation time* so a late Apple Watch sync still gets a full window; reopens per extra qualifying workout. Kept out of the widget App Group. Opened from the existing goal-completion hooks in `DashboardView`.
- Countdown pill on the post-run prompt; a shrinking `TimelineView` ring on the compose FAB and the "Your story" cell (self-ticking — no feed-level timer).
- "Fresh" badge on the poster's own in-window posts (client-derived; friend-visible badge left as a future additive `posted_live` field).
- Sub-goal photo (0.75 mi) is preserved (the start-of-workout stash clear is gated to already-completed days) and re-offered when a later workout finishes the mile, with a "photo waiting" dashboard nudge.

## 2. Instagram-smooth stats sticker (drag / pinch / rotate)

The composer sticker's transform lived on `@Published` VM props written on **every** gesture frame, so each drag/pinch re-rendered the entire composer (photo, both `GeometryReader`s, toolbar, caption, cards) 60+×/sec.

- New `StickerEditorLayer` holds the live transform as transient `@GestureState` and commits to the VM **only on `.onEnded`** — nothing else re-renders mid-gesture.
- Sticker wrapped in `.equatable()` (outside the transforms) + shared `NumberFormatter`, so its body (drop shadow, formatting) renders once and only the transform matrix changes per frame.
- Adds two-finger **rotation** (`DragGesture` + `MagnifyGesture` + `RotateGesture`, combined simultaneously; iOS 17 target), persisted in `StickerConfig` (backwards-compatible — older configs decode rotation 0) and baked into the shared image via `PostCanvas` so preview and post match. Padded `contentShape` keeps a shrunk sticker easy to grab.

---

## Testing

iOS builds via Xcode only (no CLI build in this environment), so both changes were verified by careful static review + an adversarial `/code-review` pass rather than a compile. Before merging, build in Xcode and exercise: the post-run window (in-app finish, a synced workout with an old `endDate`, sub-goal case, relaunch mid-window); and the sticker (drag/pinch/rotate smoothness via `Self._printChanges()`, no snap-back on release, grab-ability at min scale, save/share pixel-parity with the preview, rotation persistence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY