### PR TITLE
Shareable achievement cards (badges + personal records)

### DIFF
--- a/app/Mile A Day/Views/BadgeDetailView.swift
+++ b/app/Mile A Day/Views/BadgeDetailView.swift
@@ -16,6 +16,8 @@ struct BadgeDetailView: View {
     @State private var shimmerOffset: CGFloat = -300
     @State private var glowPulse = false
     @State private var ribbonDrop = false
+    /// Rendered badge card presented in the system share sheet.
+    @State private var shareItem: ShareableImage?
 
     private var trackedBadgeIds: Set<String> {
         Set(trackedBadgeIdsRaw.split(separator: ",").map(String.init))
@@ -321,6 +323,30 @@ struct BadgeDetailView: View {
                     Capsule()
                         .stroke(Color.cyan.opacity(0.3), lineWidth: isTracked ? 0 : 1)
                 )
+            }
+
+            // Share button — only for earned medals.
+            if !badge.isLocked {
+                Button {
+                    if let image = renderAchievementShareImage(BadgeShareCardView(badge: badge)) {
+                        shareItem = ShareableImage(image: image)
+                    }
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "square.and.arrow.up")
+                            .font(.system(size: 14, weight: .semibold))
+                        Text("Share")
+                            .font(.system(size: 14, weight: .bold, design: .rounded))
+                    }
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 10)
+                    .background(Capsule().fill(Color.white.opacity(0.14)))
+                    .overlay(Capsule().stroke(Color.white.opacity(0.25), lineWidth: 1))
+                }
+                .sheet(item: $shareItem) { item in
+                    ShareSheet(items: [item.image])
+                }
             }
 
             // Your progress (when we have user stats)

--- a/app/Mile A Day/Views/Celebrations/AchievementShareCards.swift
+++ b/app/Mile A Day/Views/Celebrations/AchievementShareCards.swift
@@ -1,0 +1,186 @@
+import SwiftUI
+
+/// Branded, shareable achievement cards (badge unlock + personal record),
+/// rendered to a crisp image for the system share sheet. Deliberately share the
+/// same dark-gradient / radial-glow / MADLogoMark language as
+/// `CelebrationShareCardView` and `RunStatsCardView` so every card the app
+/// produces reads as one family. Fixed 600×900 (4:5-ish portrait) at @3x.
+
+/// Render a fixed-size share card to a crisp @3x image (a 600×900 card → an
+/// 1800×2700 export), matching the existing celebration share pipeline
+/// (`GoalCompletedCelebrationView.generateShareCardImage`).
+@MainActor
+func renderAchievementShareImage<Card: View>(_ card: Card) -> UIImage? {
+    let renderer = ImageRenderer(content: card)
+    renderer.scale = 3.0
+    renderer.isOpaque = false
+    return renderer.uiImage
+}
+
+// MARK: - Shared chrome
+
+/// The dark gradient + a rarity/accent-tinted glow shared by every card.
+private struct ShareCardBackground: View {
+    let glow: Color
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    Color(red: 0.15, green: 0.08, blue: 0.10),
+                    Color(red: 0.12, green: 0.06, blue: 0.08),
+                    Color(red: 0.05, green: 0.02, blue: 0.04),
+                ],
+                startPoint: .top, endPoint: .bottom
+            )
+            RadialGradient(
+                colors: [glow.opacity(0.5), glow.opacity(0.14), .clear],
+                center: UnitPoint(x: 0.5, y: 0.2),
+                startRadius: 10, endRadius: 320
+            )
+        }
+    }
+}
+
+private struct ShareCardFooter: View {
+    var body: some View {
+        HStack(spacing: 10) {
+            MADLogoMark(size: 34)
+            Text("Mile A Day")
+                .font(.system(size: 20, weight: .black, design: .rounded))
+                .foregroundColor(.white.opacity(0.85))
+        }
+    }
+}
+
+// MARK: - Badge share card
+
+struct BadgeShareCardView: View {
+    let badge: Badge
+
+    private let cardWidth: CGFloat = 600
+    private let cardHeight: CGFloat = 900
+
+    var body: some View {
+        ZStack {
+            ShareCardBackground(glow: badge.rarity.color)
+
+            VStack(spacing: 22) {
+                Spacer()
+
+                Text("BADGE UNLOCKED")
+                    .font(.system(size: 15, weight: .black, design: .rounded))
+                    .tracking(3)
+                    .foregroundColor(.white.opacity(0.6))
+
+                ZStack {
+                    Circle()
+                        .fill(LinearGradient(colors: medalGradientColors(for: badge),
+                                             startPoint: .topLeading, endPoint: .bottomTrailing))
+                        .frame(width: 220, height: 220)
+                        .shadow(color: badge.rarity.color.opacity(0.6), radius: 30)
+                    Circle()
+                        .strokeBorder(Color.white.opacity(0.35), lineWidth: 3)
+                        .frame(width: 220, height: 220)
+                    Image(systemName: iconName(for: badge))
+                        .font(.system(size: 96, weight: .bold))
+                        .foregroundColor(.white)
+                        .shadow(color: .black.opacity(0.25), radius: 8, y: 3)
+                }
+
+                Text(badge.rarity.rawValue.uppercased())
+                    .font(.system(size: 14, weight: .black, design: .rounded))
+                    .tracking(2)
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 16).padding(.vertical, 7)
+                    .background(
+                        Capsule().fill(badge.rarity.color.opacity(0.35))
+                            .overlay(Capsule().strokeBorder(badge.rarity.color, lineWidth: 1))
+                    )
+
+                VStack(spacing: 10) {
+                    Text(badge.name)
+                        .font(.system(size: 40, weight: .black, design: .rounded))
+                        .foregroundColor(.white)
+                        .multilineTextAlignment(.center)
+                    Text(badge.description)
+                        .font(.system(size: 20, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.7))
+                        .multilineTextAlignment(.center)
+                }
+                .padding(.horizontal, 40)
+
+                Spacer()
+                ShareCardFooter().padding(.bottom, 40)
+            }
+        }
+        .frame(width: cardWidth, height: cardHeight)
+    }
+}
+
+// MARK: - Personal-record share card
+
+/// A generic "big number" record card — reused for race PRs, best day, fastest
+/// mile, etc. Callers format the value/unit/caption for their record type.
+struct PRShareRecord {
+    var icon: String
+    var banner: String          // e.g. "PERSONAL RECORD"
+    var value: String           // e.g. "6:42" or "5.20"
+    var unit: String            // e.g. "/mi" or "mi"
+    var title: String           // e.g. "Fastest Mile"
+    var caption: String         // e.g. "Mar 3, 2026"
+    var accent: Color = MADTheme.Colors.madRed
+}
+
+struct PRShareCardView: View {
+    let record: PRShareRecord
+
+    private let cardWidth: CGFloat = 600
+    private let cardHeight: CGFloat = 900
+
+    var body: some View {
+        ZStack {
+            ShareCardBackground(glow: record.accent)
+
+            VStack(spacing: 20) {
+                Spacer()
+
+                Image(systemName: record.icon)
+                    .font(.system(size: 84, weight: .bold))
+                    .foregroundStyle(LinearGradient(colors: [.white, record.accent],
+                                                    startPoint: .top, endPoint: .bottom))
+                    .shadow(color: record.accent.opacity(0.6), radius: 16)
+
+                Text(record.banner)
+                    .font(.system(size: 15, weight: .black, design: .rounded))
+                    .tracking(3)
+                    .foregroundColor(record.accent)
+
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text(record.value)
+                        .font(.system(size: 96, weight: .black, design: .rounded))
+                        .foregroundColor(.white)
+                        .monospacedDigit()
+                    Text(record.unit)
+                        .font(.system(size: 30, weight: .bold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.8))
+                }
+                .shadow(color: record.accent.opacity(0.4), radius: 8)
+
+                VStack(spacing: 6) {
+                    Text(record.title)
+                        .font(.system(size: 30, weight: .black, design: .rounded))
+                        .foregroundColor(.white)
+                    Text(record.caption)
+                        .font(.system(size: 18, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.65))
+                }
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+
+                Spacer()
+                ShareCardFooter().padding(.bottom, 40)
+            }
+        }
+        .frame(width: cardWidth, height: cardHeight)
+    }
+}

--- a/app/Mile A Day/Views/Celebrations/BadgeUnlockCelebrationView.swift
+++ b/app/Mile A Day/Views/Celebrations/BadgeUnlockCelebrationView.swift
@@ -24,6 +24,8 @@ struct BadgeUnlockCelebrationView: View {
     @State private var showContent = false
     @State private var showButtons = false
     @State private var hasStartedAnimation: Bool = false
+    /// Rendered badge card presented in the system share sheet.
+    @State private var shareItem: ShareableImage?
     
     // Haptic generators
     private let impactGenerator = UIImpactFeedbackGenerator(style: .heavy)
@@ -259,6 +261,34 @@ struct BadgeUnlockCelebrationView: View {
                                             )
                                     )
                                     .shadow(color: rarityColor.opacity(0.4), radius: 15, x: 0, y: 8)
+                                }
+
+                                Button {
+                                    triggerHaptic()
+                                    if let image = renderAchievementShareImage(BadgeShareCardView(badge: badge)) {
+                                        shareItem = ShareableImage(image: image)
+                                    }
+                                } label: {
+                                    HStack(spacing: 10) {
+                                        Image(systemName: "square.and.arrow.up")
+                                            .font(.system(size: 17, weight: .semibold))
+                                        Text("Share")
+                                            .font(.system(size: 17, weight: .semibold, design: .rounded))
+                                    }
+                                    .foregroundColor(.white)
+                                    .frame(maxWidth: .infinity)
+                                    .frame(height: 52)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 14)
+                                            .fill(.white.opacity(0.12))
+                                            .overlay(
+                                                RoundedRectangle(cornerRadius: 14)
+                                                    .stroke(.white.opacity(0.2), lineWidth: 1)
+                                            )
+                                    )
+                                }
+                                .sheet(item: $shareItem) { item in
+                                    ShareSheet(items: [item.image])
                                 }
 
                                 Button {

--- a/app/Mile A Day/Views/Profile/RaceRecordsView.swift
+++ b/app/Mile A Day/Views/Profile/RaceRecordsView.swift
@@ -76,6 +76,8 @@ struct RaceHistoryView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var history: [RaceRecord] = []
     @State private var isLoading = true
+    /// Rendered PR card presented in the system share sheet.
+    @State private var shareItem: ShareableImage?
 
     private var best: RaceRecord? {
         history.min(by: { $0.durationSec < $1.durationSec })
@@ -101,12 +103,38 @@ struct RaceHistoryView: View {
             .navigationTitle(distance.name)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
+                if let best {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button {
+                            if let image = renderAchievementShareImage(PRShareCardView(record: prShareRecord(best))) {
+                                shareItem = ShareableImage(image: image)
+                            }
+                        } label: {
+                            Image(systemName: "square.and.arrow.up")
+                        }
+                    }
+                }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") { dismiss() }
                 }
             }
+            .sheet(item: $shareItem) { item in
+                ShareSheet(items: [item.image])
+            }
         }
         .task { await load() }
+    }
+
+    /// Build the shareable-card model for this distance's best run.
+    private func prShareRecord(_ rec: RaceRecord) -> PRShareRecord {
+        PRShareRecord(
+            icon: "stopwatch.fill",
+            banner: "PERSONAL RECORD",
+            value: RaceCatalog.formatTime(rec.durationSec),
+            unit: "",
+            title: "\(distance.name) PR",
+            caption: "\(RaceCatalog.formatPace(seconds: rec.durationSec, miles: rec.distanceMiles)) · \(formatDate(rec.achievedDate))"
+        )
     }
 
     private func prHeader(_ rec: RaceRecord) -> some View {


### PR DESCRIPTION
First of three planned feature PRs (cards → friend streaks → streak freeze). This is the smallest, lowest-risk one — **iOS-only, fully additive.**

## What

Let users share a branded card of their wins via the system share sheet, reusing the app's existing SwiftUI→image pipeline (no new infra).

- **`AchievementShareCards.swift`** (new): `BadgeShareCardView` and a generic `PRShareCardView`, plus `renderAchievementShareImage()`. They share the same dark-gradient / radial-glow / `MADLogoMark` language as `CelebrationShareCardView` and render at the same @3x (600×900 → 1800×2700), so every card the app produces reads as one family.
- **Badge sharing** — a "Share" button on the **badge-unlock celebration** (`BadgeUnlockCelebrationView`) and on the **badge detail** screen (earned medals only), reusing the existing `ShareSheet` + `ShareableImage`.
- **PR sharing** — a Share button on the **race-PR detail** (`RaceHistoryView`) that renders the distance's best time as a PR card.
- **Weekly recap** already had its own share card (`WeeklyRecapView.shareCard()`) — no change needed.

## Reuse

`ImageRenderer` + `renderer.scale` idiom (from `RunPostService.renderStatsCard` / `GoalCompletedCelebrationView.generateShareCardImage`), `ShareSheet` (`DashboardShareViews`), `ShareableImage`, `iconName(for:)` / `medalGradientColors(for:)`, `MADLogoMark`. No new dependencies.

## App Review

System share sheet only (Instagram/Messages are just targets); Photos add-only permission is already used elsewhere. Nothing new to declare.

## Testing

iOS builds via Xcode only (no CLI build here), so this was verified by static review against the proven `GoalCompletedCelebrationView` share pattern. Before merge, in Xcode: unlock a badge → Share → correct card in the sheet and it saves to Photos crisp (not tiny); open a race PR → Share → correct time/pace/date card; a non-earned/locked badge shows no Share button.

Follow-ups (noted, not in this PR): a Share button on the best-day (`MostMilesDetailView`) surface using the same `PRShareCardView`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY

---
_Generated by [Claude Code](https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY)_