### PR TITLE
Friend streaks 🔥 (shared consecutive-day streaks)

### DIFF
--- a/app/Mile A Day/Models/Competition.swift
+++ b/app/Mile A Day/Models/Competition.swift
@@ -857,6 +857,11 @@ struct NudgeStatusBatchResponse: Codable {
     let statuses: [String: NudgeStatusResponse]
 }
 
+/// Friend-streak counts keyed by friend id (from `/friends/shared-streaks`).
+struct SharedStreaksResponse: Codable {
+    let shared_streaks: [String: Int]
+}
+
 // MARK: - Notification Settings Models
 
 struct NotificationSettingsResponse: Codable {

--- a/app/Mile A Day/Services/FriendService.swift
+++ b/app/Mile A Day/Services/FriendService.swift
@@ -13,6 +13,11 @@ class FriendService: ObservableObject {
     /// not in view @State — so every refresh trigger (app foreground, tab switch,
     /// push, pull-to-refresh) updates the same data all friend rows read.
     @Published var nudgeStatuses: [String: NudgeStatusResponse] = [:]
+    /// Friend-streak count (consecutive days both the viewer and the friend
+    /// completed their mile) per friend id. Populated only by the feature build
+    /// via the `/friends/shared-streaks` endpoint; empty by default so friend
+    /// rows simply omit the shared-streak badge when there's no data.
+    @Published var sharedStreaks: [String: Int] = [:]
     @Published var isLoading = false
     @Published var errorMessage: String?
     
@@ -422,13 +427,18 @@ class FriendService: ObservableObject {
         let friendIds = friends.map { $0.user_id }
         guard !friendIds.isEmpty else {
             nudgeStatuses = [:]
+            sharedStreaks = [:]
             return
         }
+        // Friend streaks load alongside nudge statuses (same friend ids) so
+        // every row has both when it renders. Concurrent; best-effort.
+        async let sharedTask: Void = loadSharedStreaks(friendIds: friendIds)
         do {
             nudgeStatuses = try await checkNudgeStatusBatch(friendIds: friendIds)
         } catch {
             print("[FriendService] ❌ refreshNudgeStatuses failed: \(error)")
         }
+        await sharedTask
     }
     
     /// Get current user ID from UserDefaults
@@ -492,6 +502,25 @@ class FriendService: ObservableObject {
             responseType: NudgeStatusBatchResponse.self
         )
         return response.statuses
+    }
+
+    /// Fetch friend streaks (shared consecutive-day streaks) for the given
+    /// friends and publish them into `sharedStreaks`. Best-effort: failures are
+    /// swallowed so a friend-streak hiccup never blocks the friends list.
+    func loadSharedStreaks(friendIds: [String]) async {
+        guard !friendIds.isEmpty else { return }
+        do {
+            let body = try JSONSerialization.data(withJSONObject: ["friend_ids": friendIds])
+            let response: SharedStreaksResponse = try await makeRequest(
+                endpoint: "/friends/shared-streaks",
+                method: .POST,
+                body: body,
+                responseType: SharedStreaksResponse.self
+            )
+            sharedStreaks.merge(response.shared_streaks) { _, new in new }
+        } catch {
+            print("[FriendService] loadSharedStreaks failed: \(error)")
+        }
     }
 
     // MARK: - Notification Settings

--- a/app/Mile A Day/Views/Friends/FriendsListView.swift
+++ b/app/Mile A Day/Views/Friends/FriendsListView.swift
@@ -1000,6 +1000,27 @@ struct FriendsListView: View {
                         }
                         .foregroundColor(.orange)
                     }
+                    // Shared "friend streak" — days you BOTH completed in a row.
+                    // A bordered pill in a distinct pink-red so it never reads as
+                    // the friend's own (orange) streak next to it.
+                    if let shared = friendService.sharedStreaks[friend.user_id], shared > 0 {
+                        HStack(spacing: 2) {
+                            Image(systemName: "flame.fill")
+                                .font(.system(size: 9, weight: .bold))
+                            Text("\(shared)")
+                                .font(.system(size: 10, weight: .heavy, design: .rounded))
+                        }
+                        .foregroundStyle(
+                            LinearGradient(
+                                colors: [Color(red: 1.0, green: 0.5, blue: 0.7), MADTheme.Colors.madRed],
+                                startPoint: .top, endPoint: .bottom
+                            )
+                        )
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1.5)
+                        .background(Capsule().fill(Color.white.opacity(0.08)))
+                        .overlay(Capsule().strokeBorder(Color.white.opacity(0.15), lineWidth: 0.5))
+                    }
                 }
 
                 Text(rowSubtitle(isCompleted: isCompleted, todayMiles: todayMiles, goal: goalMiles))

--- a/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
+++ b/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
@@ -159,6 +159,9 @@ struct UserProfileDetailView: View {
             // distance never loaded.
             await friendService.refreshAllData()
             await loadNudgeStatus()
+            if friendService.isFriend(user) {
+                await friendService.loadSharedStreaks(friendIds: [user.user_id])
+            }
         }
         .task {
             await closeFriends.loadIfNeeded()
@@ -637,6 +640,24 @@ struct UserProfileDetailView: View {
                         : String(format: "%d%% of today's mile", Int(progress * 100)))
                         .font(.system(size: 11, weight: .medium, design: .rounded))
                         .foregroundColor(.white.opacity(0.5))
+
+                    // Friend streak — days you BOTH completed in a row. Labeled
+                    // explicitly so it's never confused with their own streak.
+                    if let shared = friendService.sharedStreaks[user.user_id], shared > 0 {
+                        HStack(spacing: 4) {
+                            Image(systemName: "flame.fill")
+                                .font(.system(size: 10, weight: .bold))
+                            Text("\(shared)-day streak with you")
+                                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                        }
+                        .foregroundStyle(
+                            LinearGradient(
+                                colors: [Color(red: 1.0, green: 0.5, blue: 0.7), MADTheme.Colors.madRed],
+                                startPoint: .leading, endPoint: .trailing
+                            )
+                        )
+                        .padding(.top, 1)
+                    }
                 }
 
                 Spacer()

--- a/backend/src/controllers/sharedStreakController.ts
+++ b/backend/src/controllers/sharedStreakController.ts
@@ -1,0 +1,36 @@
+import { Response } from "express";
+import { AuthenticatedRequest } from "../middleware/auth.js";
+import { getSharedStreaks } from "../services/sharedStreakService.js";
+
+/**
+ * Batch "friend streaks" for the authenticated viewer against a set of friend
+ * ids. New endpoint (no existing behavior touched) that only the feature build
+ * calls — older App Store clients never hit it, so the live app is unaffected.
+ */
+export async function getSharedStreaksBatch(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  const viewerId = req.userId!;
+  const friendIds = req.body?.friend_ids;
+
+  if (!Array.isArray(friendIds) || friendIds.length === 0) {
+    return res
+      .status(400)
+      .json({ error: "friend_ids must be a non-empty array" });
+  }
+
+  // Bound the batch and drop non-strings so a crafted request can't balloon the
+  // query.
+  const ids = friendIds
+    .filter((x: unknown): x is string => typeof x === "string")
+    .slice(0, 200);
+
+  try {
+    const shared = await getSharedStreaks(viewerId, ids);
+    res.status(200).json({ shared_streaks: shared });
+  } catch (error: any) {
+    console.error("Error computing shared streaks:", error.message);
+    res.status(500).json({ error: "Error computing shared streaks" });
+  }
+}

--- a/backend/src/routes/friendshipsRoutes.ts
+++ b/backend/src/routes/friendshipsRoutes.ts
@@ -15,6 +15,7 @@ import {
   checkNudgeStatus,
   checkNudgeStatusBatch,
 } from "../controllers/friendNudgeController.js";
+import { getSharedStreaksBatch } from "../controllers/sharedStreakController.js";
 import {
   listCloseFriends,
   addCloseFriendHandler,
@@ -79,6 +80,10 @@ router.delete(
   requireSelfAccess("fromUser"),
   getFriendshipHandler("removed"),
 );
+
+// Friend streaks: shared consecutive-day streaks vs the viewer's friends.
+// New endpoint (touches no existing route) — only the feature build calls it.
+router.post("/shared-streaks", getSharedStreaksBatch);
 
 // Nudge routes
 router.post("/:friendId/nudge", nudgeFriend);

--- a/backend/src/services/sharedStreakService.ts
+++ b/backend/src/services/sharedStreakService.ts
@@ -1,0 +1,108 @@
+import { PostgresService } from "./DbService.js";
+import { getUserLocalToday, dateStringMinus } from "./workoutService.js";
+
+const db = PostgresService.getInstance();
+
+/**
+ * "Friend streaks" — the number of consecutive local days that BOTH the viewer
+ * and a friend completed their daily mile (SUM(distance) >= 0.95, the same
+ * qualifying-day rule as personal streaks in getActiveStreak). A shared day is
+ * one whose local_date label both users qualified on; the head has the same
+ * today/yesterday grace as a personal streak, anchored to the VIEWER's local
+ * today. (Cross-timezone friends: each user's local_date is stamped in their
+ * own tz, so we compare date labels — a reasonable v1 simplification.)
+ *
+ * Read-only and computed live — no new tables, no writes, no effect on the
+ * personal streak. Bounded to a LOOKBACK_DAYS window (far larger than any
+ * current streak — the app launched June 2026) so the query + walk stay cheap.
+ */
+
+const LOOKBACK_DAYS = 90;
+
+export async function getSharedStreaks(
+  viewerId: string,
+  friendIds: string[],
+): Promise<Record<string, number>> {
+  const result: Record<string, number> = {};
+  if (friendIds.length === 0) return result;
+
+  // Only compute for people who are actually accepted friends of the viewer — a
+  // shared streak with a non-friend is meaningless, and this avoids probing
+  // arbitrary users' activity.
+  const friendRows = await db.query<{ friend_id: string }>(
+    `SELECT friend_id FROM friendships
+     WHERE user_id = $1 AND status = 'accepted' AND friend_id = ANY($2::text[])`,
+    [viewerId, friendIds],
+  );
+  const acceptedFriendIds = friendRows.map((r) => r.friend_id);
+  if (acceptedFriendIds.length === 0) return result;
+
+  const today = await getUserLocalToday(viewerId);
+  const since = dateStringMinus(today, LOOKBACK_DAYS);
+  const userIds = [viewerId, ...acceptedFriendIds];
+
+  // One batched query for the viewer + all friends' qualifying days in the
+  // window. Mirrors getActiveStreak's rule (>= 0.95, exclude deleted /
+  // auto-excluded). idx_workouts_local_date_user_id covers this.
+  const rows = await db.query<{ user_id: string; local_date: string }>(
+    `SELECT user_id, to_char(local_date, 'YYYY-MM-DD') AS local_date
+     FROM workouts
+     WHERE user_id = ANY($1::text[])
+       AND local_date >= $2::date
+       AND deleted_at IS NULL AND exclusion_reason IS NULL
+     GROUP BY user_id, local_date
+     HAVING SUM(distance) >= 0.95`,
+    [userIds, since],
+  );
+
+  const daysByUser = new Map<string, Set<string>>();
+  for (const r of rows) {
+    let set = daysByUser.get(r.user_id);
+    if (!set) {
+      set = new Set<string>();
+      daysByUser.set(r.user_id, set);
+    }
+    set.add(r.local_date);
+  }
+
+  const viewerDays = daysByUser.get(viewerId) ?? new Set<string>();
+  const yesterday = dateStringMinus(today, 1);
+
+  for (const friendId of acceptedFriendIds) {
+    const friendDays = daysByUser.get(friendId);
+    if (!friendDays || viewerDays.size === 0) {
+      result[friendId] = 0;
+      continue;
+    }
+    result[friendId] = walkSharedStreak(
+      viewerDays,
+      friendDays,
+      today,
+      yesterday,
+    );
+  }
+
+  return result;
+}
+
+/** Consecutive shared days ending at today or yesterday (grace), else 0. */
+function walkSharedStreak(
+  viewerDays: Set<string>,
+  friendDays: Set<string>,
+  today: string,
+  yesterday: string,
+): number {
+  const isShared = (d: string) => viewerDays.has(d) && friendDays.has(d);
+
+  let cursor: string;
+  if (isShared(today)) cursor = today;
+  else if (isShared(yesterday)) cursor = yesterday;
+  else return 0;
+
+  let streak = 0;
+  while (isShared(cursor)) {
+    streak++;
+    cursor = dateStringMinus(cursor, 1);
+  }
+  return streak;
+}

--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -212,7 +212,7 @@ function classifyWorkoutSpeed(
   return { exclusionReason: null, speedFlagged: false };
 }
 
-function dateStringMinus(dateStr: string, days: number): string {
+export function dateStringMinus(dateStr: string, days: number): string {
   const [y, m, d] = dateStr.split("-").map(Number);
   const date = new Date(Date.UTC(y, m - 1, d));
   date.setUTCDate(date.getUTCDate() - days);


### PR DESCRIPTION
Second of the three planned feature PRs (cards #212 → **friend streaks** → streak saving). Display-only v1.

## What

A **friend streak** = the number of consecutive local days that two mutual friends **both** completed their mile (same `SUM(distance) >= 0.95` rule + today/yesterday grace as personal streaks). Shown as:
- a distinct **pink flame pill** on the friends list (visually separate from the friend's own orange streak flame), and
- a labeled **"N-day streak with you"** line on a friend's profile.

## Safe for the live app by construction

The user asked that nothing reach current live App Store users until this ships. This PR guarantees that with the **lowest-risk possible gate — a brand-new endpoint**:
- `POST /friends/shared-streaks` is entirely new; **no migration**, and **zero changes to any existing endpoint or behavior**. The only edit to existing backend code is adding `export` to a pure helper (`dateStringMinus`) — no behavior change.
- Only the feature build calls it (via `FriendService.loadSharedStreaks`). Old App Store clients never call it and have no UI for it, so the running app is untouched.

## How it works

- **Backend** (`sharedStreakService.getSharedStreaks`): one batched query for the viewer + all requested friends' qualifying days over a **90-day** window (far larger than any current streak — the app launched June 2026), intersect each friend's day-set with the viewer's, and walk from the today/yesterday grace head. Restricted to the viewer's **accepted friends**; batch bounded to 200. Read-only, no writes, no effect on personal streaks.
- **iOS**: `sharedStreaks` loads concurrently alongside nudge statuses (same friend ids) and renders the flame; the profile does a targeted load on appear.

**Cross-timezone note:** a "shared day D" means both users have a qualifying `local_date` labeled D (each stamped in their own tz) — a reasonable v1 simplification, anchored to the viewer's local today.

## Testing

Backend `tsc` build is clean (verified locally). iOS builds via Xcode only, so the UI was written against the existing personal-flame pattern and reviewed statically. Before merge: with two friend accounts, complete both for N days → friends list shows the pink "N" pill and the profile shows "N-day streak with you"; break one day → resets; a day only one completed doesn't count.

Follow-up (per plan): an at-risk "your friend streak is tonight" push (needs a small pair table + cron) — intentionally not in this display-only v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY

---
_Generated by [Claude Code](https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY)_