### PR TITLE
Feed fixes: hype sync, one post/story per workout, in-window photo picker

### DIFF
--- a/app/Mile A Day/Core/Services/MADNotificationService.swift
+++ b/app/Mile A Day/Core/Services/MADNotificationService.swift
@@ -467,7 +467,24 @@ extension MADNotificationService: UNUserNotificationCenterDelegate {
         }
 
         do {
-            let response = try await HypeService.sendHype(targetUserId: targetUserId)
+            // Send the SAME mile-hype context the feed and notifications inbox use
+            // (target:localDate) so this hype dedupes against them. A context-less
+            // hype has no run identity and lets the same daily mile be hyped twice
+            // (once here, once in the app). friend_activity pushes carry the
+            // runner's local_date; the sympathetic "streak broken" variant isn't
+            // hypeable, so fall back to a context-less hype there.
+            let response: HypeResponse
+            if data?["kind"] != "streak_broken",
+               let localDate = data?["local_date"], !localDate.isEmpty {
+                let context = HypeContext(
+                    contextType: "mile",
+                    contextId: "\(targetUserId):\(localDate)",
+                    contextLabel: "today's mile"
+                )
+                response = try await HypeService.sendHype(targetUserId: targetUserId, context: context)
+            } else {
+                response = try await HypeService.sendHype(targetUserId: targetUserId)
+            }
             let remaining = response.hypes_remaining
             let body: String
             if response.unlimited == true {
@@ -482,6 +499,13 @@ extension MADNotificationService: UNUserNotificationCenterDelegate {
             await postLocalToast(title: "🔥 Hype sent", body: body)
         } catch let error as APIError where error.isRateLimited {
             await postLocalToast(title: "Out of hypes", body: "You're out of hypes for today.")
+        } catch let error as APIError {
+            // Already hyped this run from the feed/inbox — the dedupe caught it.
+            if case .conflict = error {
+                await postLocalToast(title: "Already hyped", body: "You already hyped this one 🔥")
+            } else {
+                await postLocalToast(title: "Couldn't send hype", body: "Try opening the app.")
+            }
         } catch {
             await postLocalToast(title: "Couldn't send hype", body: "Try opening the app.")
         }

--- a/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
+++ b/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
@@ -148,11 +148,13 @@ struct PostRunPhotoPromptView: View {
                     composerLaunch = ComposerLaunch(image: image)
                 }
             }) {
-                WorkoutPhotoImportPicker(window: importWindow) { result in
+                WorkoutPhotoImportPicker(
+                    window: importWindow,
+                    activityNoun: isWalk ? "walk" : "run"
+                ) { result in
                     handleImportResult(result)
                     showLibraryImport = false
                 }
-                .ignoresSafeArea()
             }
         }
         .onAppear {
@@ -380,10 +382,6 @@ struct PostRunPhotoPromptView: View {
             // Deferred to the import cover's onDismiss (composer is a second
             // cover — presenting it now would race this one's dismissal).
             pendingUseImage = image
-        case .outsideWindow:
-            importError = "That photo wasn't taken on this \(isWalk ? "walk" : "run"). You can use a photo you snapped between starting and finishing."
-        case .noCaptureDate:
-            importError = "We couldn't confirm when that photo was taken, so we can't add it to this \(isWalk ? "walk" : "run")."
         case .failed:
             importError = "Couldn't load that photo. Try another one."
         case .cancelled:

--- a/app/Mile A Day/Views/Components/WorkoutPhotoImportPicker.swift
+++ b/app/Mile A Day/Views/Components/WorkoutPhotoImportPicker.swift
@@ -1,94 +1,319 @@
 import SwiftUI
-import PhotosUI
-import ImageIO
-import UniformTypeIdentifiers
+import Photos
+import UIKit
 
 /// Outcome of importing a library photo into a walk/run.
 enum WorkoutPhotoImportResult {
     case accepted(UIImage)
-    /// The photo's capture time is outside the workout window.
-    case outsideWindow
-    /// No embedded capture date (screenshot, stripped EXIF) — can't prove it
-    /// was taken on this walk, so we don't accept it.
-    case noCaptureDate
     case cancelled
     case failed
 }
 
 /// Library import that stays true to the app's "captured on this walk"
-/// authenticity: it uses the system photo picker (no library permission — the
-/// picker runs out of process) and ACCEPTS a photo only if its embedded EXIF
-/// capture time falls inside the workout's time window. So a user who shot a
-/// great photo mid-run with the system camera (better controls, Live Photo)
-/// can still use it, but a random selfie from last week can't slip in.
-struct WorkoutPhotoImportPicker: UIViewControllerRepresentable {
+/// authenticity by only ever SHOWING photos whose library creation time falls
+/// inside the workout window — the user can't pick something we'd reject, so
+/// there's no "you tapped a photo we won't allow" dead-end.
+///
+/// This reads the photo library directly (PHAsset), which needs
+/// `NSPhotoLibraryUsageDescription`, because Apple's out-of-process PHPicker
+/// can't filter what it displays by capture time. `creationDate` is the
+/// library's own trusted timestamp (the shutter moment for camera captures), so
+/// no post-selection EXIF re-check is needed. Screenshots are excluded — they
+/// have no real capture moment and the old EXIF path rejected them too.
+struct WorkoutPhotoImportPicker: View {
     /// Accepted capture-time window (absolute time). Callers add grace.
     let window: ClosedRange<Date>
+    /// "run" / "walk" for copy; defaults to a neutral noun.
+    var activityNoun: String = "workout"
     let onResult: (WorkoutPhotoImportResult) -> Void
 
-    func makeUIViewController(context: Context) -> PHPickerViewController {
-        var config = PHPickerConfiguration() // no photoLibrary → no permission
-        config.filter = .images
-        config.selectionLimit = 1
-        config.preferredAssetRepresentationMode = .current
-        let picker = PHPickerViewController(configuration: config)
-        picker.delegate = context.coordinator
-        return picker
+    @State private var status: PHAuthorizationStatus = .notDetermined
+    @State private var assets: [PHAsset] = []
+    @State private var isLoading = true
+    @State private var isFetchingFull = false
+    @State private var didFinish = false
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+            VStack(spacing: 0) {
+                header
+                Divider().overlay(Color.white.opacity(0.12))
+                content
+            }
+            if isFetchingFull {
+                Color.black.opacity(0.45).ignoresSafeArea()
+                ProgressView().tint(.white)
+            }
+        }
+        .task { await start() }
     }
 
-    func updateUIViewController(_ picker: PHPickerViewController, context: Context) {}
+    // MARK: - Chrome
 
-    func makeCoordinator() -> Coordinator { Coordinator(self) }
-
-    final class Coordinator: NSObject, PHPickerViewControllerDelegate {
-        let parent: WorkoutPhotoImportPicker
-        init(_ parent: WorkoutPhotoImportPicker) { self.parent = parent }
-
-        func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
-            guard let provider = results.first?.itemProvider else {
-                parent.onResult(.cancelled)
-                return
+    private var header: some View {
+        ZStack {
+            Text("Photos from your \(activityNoun)")
+                .font(.headline)
+                .foregroundStyle(.white)
+            HStack {
+                Button("Cancel") { finish(.cancelled) }
+                    .foregroundStyle(.white)
+                Spacer()
+                // Limited access → let the user add more of their photos so the
+                // in-window ones they want aren't hidden by the allowed subset.
+                if status == .limited {
+                    Button("Add") { presentLimitedPicker() }
+                        .foregroundStyle(.white)
+                }
             }
-            // Load the raw file so EXIF survives (loadObject(UIImage) strips it).
-            let types = provider.registeredTypeIdentifiers
-            let imageType = types.first { UTType($0)?.conforms(to: .image) == true }
-                ?? UTType.image.identifier
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
 
-            provider.loadDataRepresentation(forTypeIdentifier: imageType) { [weak self] data, _ in
-                guard let self else { return }
-                guard let data, let image = UIImage(data: data) else {
-                    DispatchQueue.main.async { self.parent.onResult(.failed) }
-                    return
+    @ViewBuilder private var content: some View {
+        switch status {
+        case .denied, .restricted:
+            infoState(
+                title: "Photo access is off",
+                message: "Turn on photo access in Settings to add a picture you took on your \(activityNoun).",
+                actionTitle: "Open Settings",
+                action: openSettings
+            )
+        case .notDetermined:
+            loadingState
+        default:
+            if isLoading {
+                loadingState
+            } else if assets.isEmpty {
+                infoState(
+                    title: "No photos from this \(activityNoun)",
+                    message: "We only show photos taken while you were moving. Snap one with the camera to add it.",
+                    actionTitle: nil,
+                    action: {}
+                )
+            } else {
+                grid
+            }
+        }
+    }
+
+    private var loadingState: some View {
+        VStack {
+            Spacer()
+            ProgressView().tint(.white)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private func infoState(
+        title: String,
+        message: String,
+        actionTitle: String?,
+        action: @escaping () -> Void
+    ) -> some View {
+        VStack(spacing: 12) {
+            Spacer()
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(.white)
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(.white.opacity(0.7))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+            if let actionTitle {
+                Button(actionTitle, action: action)
+                    .font(.subheadline.weight(.semibold))
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 10)
+                    .background(Color.white, in: Capsule())
+                    .foregroundStyle(.black)
+                    .padding(.top, 4)
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var grid: some View {
+        GeometryReader { geo in
+            let spacing: CGFloat = 2
+            let columnCount = 3
+            let side = (geo.size.width - spacing * CGFloat(columnCount - 1)) / CGFloat(columnCount)
+            ScrollView {
+                LazyVGrid(
+                    columns: Array(
+                        repeating: GridItem(.fixed(side), spacing: spacing),
+                        count: columnCount
+                    ),
+                    spacing: spacing
+                ) {
+                    ForEach(assets, id: \.localIdentifier) { asset in
+                        AssetThumbnailView(asset: asset, side: side)
+                            .onTapGesture { select(asset) }
+                    }
                 }
-                let result: WorkoutPhotoImportResult
-                if let taken = Self.captureDate(from: data) {
-                    result = self.parent.window.contains(taken) ? .accepted(image) : .outsideWindow
-                } else {
-                    result = .noCaptureDate
-                }
-                DispatchQueue.main.async { self.parent.onResult(result) }
+            }
+        }
+    }
+
+    // MARK: - Authorization + fetch
+
+    private func start() async {
+        var resolved = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        if resolved == .notDetermined {
+            resolved = await requestAuthorization()
+        }
+        await MainActor.run { status = resolved }
+        if resolved == .authorized || resolved == .limited {
+            await fetchAssets()
+        } else {
+            await MainActor.run { isLoading = false }
+        }
+    }
+
+    private func requestAuthorization() async -> PHAuthorizationStatus {
+        await withCheckedContinuation { continuation in
+            PHPhotoLibrary.requestAuthorization(for: .readWrite) { newStatus in
+                continuation.resume(returning: newStatus)
+            }
+        }
+    }
+
+    private func fetchAssets() async {
+        let options = PHFetchOptions()
+        options.predicate = NSPredicate(
+            format: "creationDate >= %@ AND creationDate <= %@",
+            window.lowerBound as NSDate,
+            window.upperBound as NSDate
+        )
+        options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+        let fetched = PHAsset.fetchAssets(with: .image, options: options)
+
+        var list: [PHAsset] = []
+        fetched.enumerateObjects { asset, _, _ in
+            // Screenshots have a creationDate but no real "taken on this walk"
+            // moment — the old EXIF check rejected them, so keep them out.
+            if !asset.mediaSubtypes.contains(.photoScreenshot) {
+                list.append(asset)
             }
         }
 
-        /// Read the embedded capture time. EXIF `DateTimeOriginal` (the shutter
-        /// moment) is tz-less wall-clock, parsed in the device's current tz —
-        /// which matches the phone's clock when the shot was taken.
-        static func captureDate(from data: Data) -> Date? {
-            guard let src = CGImageSourceCreateWithData(data as CFData, nil),
-                  let props = CGImageSourceCopyPropertiesAtIndex(src, 0, nil) as? [CFString: Any]
-            else { return nil }
+        await MainActor.run {
+            assets = list
+            isLoading = false
+        }
+    }
 
-            let fmt = DateFormatter()
-            fmt.locale = Locale(identifier: "en_US_POSIX")
-            fmt.dateFormat = "yyyy:MM:dd HH:mm:ss"
+    // MARK: - Selection
 
-            if let exif = props[kCGImagePropertyExifDictionary] as? [CFString: Any],
-               let dto = exif[kCGImagePropertyExifDateTimeOriginal] as? String,
-               let d = fmt.date(from: dto) { return d }
-            if let tiff = props[kCGImagePropertyTIFFDictionary] as? [CFString: Any],
-               let dt = tiff[kCGImagePropertyTIFFDateTime] as? String,
-               let d = fmt.date(from: dt) { return d }
-            return nil
+    private func select(_ asset: PHAsset) {
+        guard !isFetchingFull, !didFinish else { return }
+        isFetchingFull = true
+
+        let options = PHImageRequestOptions()
+        options.deliveryMode = .highQualityFormat
+        options.isNetworkAccessAllowed = true // download from iCloud if needed
+        options.resizeMode = .exact
+        // Large enough for a full-bleed post; the composer/upload compress.
+        let target = CGSize(width: 3024, height: 3024)
+
+        PHImageManager.default().requestImage(
+            for: asset,
+            targetSize: target,
+            contentMode: .aspectFit,
+            options: options
+        ) { image, info in
+            // highQualityFormat may still deliver a degraded placeholder first
+            // while downloading; wait for the final, full-quality delivery.
+            let degraded = (info?[PHImageResultIsDegradedKey] as? Bool) ?? false
+            if degraded { return }
+            DispatchQueue.main.async {
+                isFetchingFull = false
+                if let image {
+                    finish(.accepted(image))
+                } else {
+                    finish(.failed)
+                }
+            }
+        }
+    }
+
+    private func finish(_ result: WorkoutPhotoImportResult) {
+        guard !didFinish else { return }
+        didFinish = true
+        onResult(result)
+    }
+
+    // MARK: - System affordances
+
+    private func openSettings() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url)
+        }
+    }
+
+    private func presentLimitedPicker() {
+        guard let presenter = Self.topViewController() else { return }
+        PHPhotoLibrary.shared().presentLimitedLibraryPicker(from: presenter) { _ in
+            Task { await fetchAssets() }
+        }
+    }
+
+    private static func topViewController() -> UIViewController? {
+        let scene = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState == .foregroundActive }
+        var top = scene?.keyWindow?.rootViewController
+            ?? scene?.windows.first?.rootViewController
+        while let presented = top?.presentedViewController { top = presented }
+        return top
+    }
+}
+
+/// One square library thumbnail, loaded async from PhotoKit.
+private struct AssetThumbnailView: View {
+    let asset: PHAsset
+    let side: CGFloat
+
+    @State private var image: UIImage?
+
+    var body: some View {
+        ZStack {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                Rectangle().fill(Color.white.opacity(0.06))
+            }
+        }
+        .frame(width: side, height: side)
+        .clipped()
+        .contentShape(Rectangle())
+        .onAppear(perform: load)
+    }
+
+    private func load() {
+        guard image == nil else { return }
+        let scale = UIScreen.main.scale
+        let target = CGSize(width: side * scale, height: side * scale)
+        let options = PHImageRequestOptions()
+        options.deliveryMode = .opportunistic
+        options.isNetworkAccessAllowed = true
+        options.resizeMode = .fast
+        PHImageManager.default().requestImage(
+            for: asset,
+            targetSize: target,
+            contentMode: .aspectFill,
+            options: options
+        ) { img, _ in
+            guard let img else { return }
+            DispatchQueue.main.async { self.image = img }
         }
     }
 }

--- a/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
@@ -408,11 +408,13 @@ struct WorkoutTrackingView: View {
         }
         .buttonStyle(PlainButtonStyle())
         .fullScreenCover(isPresented: $showLibraryImport) {
-            WorkoutPhotoImportPicker(window: importWindow) { result in
+            WorkoutPhotoImportPicker(
+                window: importWindow,
+                activityNoun: activityNoun
+            ) { result in
                 showLibraryImport = false
                 handleImportResult(result)
             }
-            .ignoresSafeArea()
         }
         .onChange(of: isStopping) { _, stopping in
             if stopping { showLibraryImport = false }
@@ -442,10 +444,6 @@ struct WorkoutTrackingView: View {
                     showImportToast("Added to your \(activityNoun)", ok: true)
                 }
             }
-        case .outsideWindow:
-            showImportToast("That photo wasn't taken on this \(activityNoun)", ok: false)
-        case .noCaptureDate:
-            showImportToast("Couldn't confirm when that photo was taken", ok: false)
         case .failed:
             showImportToast("Couldn't load that photo", ok: false)
         case .cancelled:

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -160,6 +160,13 @@ struct SocialFeedView: View {
     /// own-story group) — a story share counts as that workout's one share.
     @State private var myStoryWorkoutIds: Set<String> = []
 
+    /// Workout ids just shared via the composer, held only until the next
+    /// refresh reflects them. Closes the window where the async refresh() hasn't
+    /// yet updated `feed`/`myStoryWorkoutIds`, which previously let the composer
+    /// re-open for a workout the user had just posted. Reconciled in refresh()
+    /// (cleared once the server state is authoritative) and on delete.
+    @State private var optimisticSharedWorkoutIds: Set<String> = []
+
     /// Workout ids of today's walks/runs that already carry the user's
     /// DELIBERATE share — a photo post on the feed or a story. The auto
     /// route/stats card doesn't count (a photo can still replace it).
@@ -169,6 +176,7 @@ struct SocialFeedView: View {
             return entry.workout_id
         })
         ids.formUnion(myStoryWorkoutIds)
+        ids.formUnion(optimisticSharedWorkoutIds)
         return ids
     }
 
@@ -365,7 +373,15 @@ struct SocialFeedView: View {
         }
         .sheet(isPresented: $presentingComposer) {
             PostComposerView(stats: statsInput) { outcome in
-                if case .published = outcome { Task { await refresh() } }
+                if case .published = outcome {
+                    // Lock this run's share slot immediately — refresh() is async
+                    // and its window previously let the composer re-open for the
+                    // same workout. (The backend also 409s a second share now.)
+                    if let wid = statsInput.workoutId {
+                        optimisticSharedWorkoutIds.insert(wid)
+                    }
+                    Task { await refresh() }
+                }
             }
         }
         .sheet(item: $reportingPost) { post in
@@ -782,6 +798,12 @@ struct SocialFeedView: View {
                 stories = storyGroups
                 myStoryWorkoutIds = storyWorkoutIds
             }
+            // Both fetches succeeded → feed + stories now reflect every real
+            // share, so the optimistic bridge can be dropped. Keep it on a failed
+            // fetch so a stale feed doesn't re-open an already-shared slot.
+            if feedResponse != nil, storyGroups != nil {
+                optimisticSharedWorkoutIds.removeAll()
+            }
             isLoading = false
             loadedOnce = true
         }
@@ -936,7 +958,14 @@ struct SocialFeedView: View {
     private func deletePost(_ entry: FeedEntry) async {
         do {
             try await PostService.deletePost(postId: entry.entryId)
-            await MainActor.run { feed.removeAll { $0.id == entry.id } }
+            await MainActor.run {
+                feed.removeAll { $0.id == entry.id }
+                // Deleting a share frees that run's slot — drop any optimistic
+                // lock so the composer can re-open for it.
+                if let wid = entry.workout_id {
+                    optimisticSharedWorkoutIds.remove(wid)
+                }
+            }
         } catch {}
     }
 

--- a/app/Mile-A-Day-Info.plist
+++ b/app/Mile-A-Day-Info.plist
@@ -23,6 +23,8 @@
 	<string>Mile A Day uses the camera to take photos for your walk and run posts and stories, and to scan a friend's profile QR code so you can add each other quickly.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Photos you take in Mile A Day are also saved to your photo library so you always keep your own copy.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Mile A Day shows the photos you took during a walk or run so you can pick one to share on that workout. Only photos taken while you were moving are shown, and nothing is accessed until you choose to add a picture.</string>
 	<key>NSHealthShareUsageDescription</key>
 	<string>Mile A Day reads your workouts, walking and running distance, active energy, step count, and workout routes to track your daily mile, calculate streaks, and show your progress. This data is synced to Mile A Day's servers so you can compete with friends and view your history across devices.</string>
 	<key>NSHealthUpdateUsageDescription</key>

--- a/backend/src/controllers/hypeController.ts
+++ b/backend/src/controllers/hypeController.ts
@@ -152,6 +152,31 @@ export async function sendHype(req: AuthenticatedRequest, res: Response) {
       });
     }
 
+    // A context-less hype — older clients' push-notification "🔥 Hype" button
+    // sends only target_user_id — has no run identity, so it would skip the
+    // per-run dedupe below and let the same daily mile be hyped again from the
+    // feed or inbox. Resolve it to the target's most recent daily-mile composite
+    // (the same key those surfaces use) so it dedupes and counts as one hype.
+    if (!context) {
+      const recent = await db.query<{ local_date: string }>(
+        `SELECT local_date::text AS local_date
+				FROM workouts
+				WHERE user_id = $1 AND deleted_at IS NULL AND exclusion_reason IS NULL
+					AND device_end_date >= NOW() - INTERVAL '36 hours'
+				ORDER BY device_end_date DESC
+				LIMIT 1`,
+        [targetUserId],
+      );
+      const localDate = recent[0]?.local_date;
+      if (localDate) {
+        context = {
+          contextType: "mile",
+          contextId: `${targetUserId}:${localDate}`,
+          contextLabel: "today's mile",
+        };
+      }
+    }
+
     // No event-occurred validation: the recipient only sees a hype affordance
     // when a real notification exists, so the notification itself is the proof.
     // Abuse is bounded by the friend/co-participant gate, per-context dedupe,

--- a/backend/src/controllers/inAppNotificationController.ts
+++ b/backend/src/controllers/inAppNotificationController.ts
@@ -135,9 +135,11 @@ export async function getInAppNotifications(req: Request, res: Response) {
       }));
 
     // Mile contexts use the unified RUN rule: the composite key's own 'mile'
-    // hypes PLUS 'post' hypes on posts linked to that runner+day's workouts —
-    // the same rule the feed queries use (see hypeService.runHypeMatchSql),
-    // so the inbox tally always equals the feed tally for the same run.
+    // hypes, 'mile' hypes the feed keyed by an exact workout id for that day,
+    // PLUS 'post' hypes on posts linked to that runner+day's workouts — the same
+    // rule the feed queries use (see hypeService.runHypeMatchSql). This keeps the
+    // inbox tally AND its "already hyped" state in sync with the feed for the
+    // same run, so a mile hyped from the feed can't be hyped again from here.
     const mileKeys = ctxKeys.filter((k) => k.type === "mile");
     const otherKeys = ctxKeys.filter((k) => k.type !== "mile");
 
@@ -148,7 +150,14 @@ export async function getInAppNotifications(req: Request, res: Response) {
     const mileIds = mileKeys.map((k) => k.id);
 
     const MILE_RUN_MATCH = `
-			(h.context_type = 'mile' AND h.context_id = t.context_id)
+			(h.context_type = 'mile' AND (
+				h.context_id = t.context_id
+				OR h.context_id IN (
+					SELECT w.workout_id::text FROM workouts w
+					WHERE w.user_id = t.target_id
+						AND (w.user_id || ':' || w.local_date::text) = t.context_id
+				)
+			))
 			OR (h.context_type = 'post' AND h.context_id IN (
 				SELECT p.post_id::text
 				FROM posts p

--- a/backend/src/services/friendshipService.ts
+++ b/backend/src/services/friendshipService.ts
@@ -362,8 +362,11 @@ export async function getFriendsWorkoutFeed(
 			w.calories::float AS calories,
 			w.steps,
 			(w.user_id = $1) AS is_self,
-			-- Exact workout/post rule for button state: don't let a different
-			-- same-day mile hype make this workout look already hyped.
+			-- Unified RUN rule for button state (matches the feed/inbox): this
+			-- run's mile hypes (day composite OR exact workout id) and its posts'
+			-- hypes are one pool, so a mile hyped from any surface shows hyped
+			-- here too and can't be hyped again. A different same-day workout
+			-- keyed by its own id stays independently hypeable.
 			EXISTS (
 				SELECT 1 FROM hype_log h
 				WHERE h.sender_id = $1

--- a/backend/src/services/hypeService.ts
+++ b/backend/src/services/hypeService.ts
@@ -241,19 +241,18 @@ export function runHypeMatchSql(h: string, w: string): string {
 }
 
 /**
- * Viewer/button-state predicate for one concrete workout. Unlike the tally
- * rule above, this does not let a legacy/date-keyed mile hype make a later
- * same-day workout look already hyped in the feed.
+ * Viewer/button-state + dedupe predicate for one concrete workout. This is now
+ * the SAME rule as the tally (runHypeMatchSql): a run's mile hypes (the day
+ * composite the inbox sends AND the exact workout id the feed sends) plus the
+ * hypes on any live post linked to it are ONE pool. Hyping a run from any
+ * surface therefore marks it hyped on every surface and blocks a second hype —
+ * previously this predicate matched the workout id only, so an inbox hype
+ * (composite) and a feed hype (workout id) on the SAME run slipped past each
+ * other and double-spent. A DIFFERENT same-day workout keyed by its own
+ * workout id stays independently hypeable (its id ≠ this run's id/composite).
  */
 export function runHypedByViewerMatchSql(h: string, w: string): string {
-  return `(
-		(${h}.context_type = 'mile' AND ${h}.context_id = ${w}.workout_id::text)
-		OR (${h}.context_type = 'post' AND ${h}.context_id IN (
-			SELECT p_.post_id::text FROM posts p_
-			WHERE p_.workout_id = ${w}.workout_id AND p_.user_id = ${w}.user_id
-				AND p_.deleted_at IS NULL
-		))
-	)`;
+  return runHypeMatchSql(h, w);
 }
 
 /**
@@ -281,17 +280,15 @@ export function postHypeMatchSql(h: string, p: string): string {
 	)`;
 }
 
-/** Exact post/workout predicate for "did I hype this card?" state. */
+/**
+ * Viewer/button-state + dedupe predicate for "did I hype this card?" — now the
+ * SAME rule as the post tally (postHypeMatchSql), so a post card and the run's
+ * mile hype (the inbox's day composite OR the feed's workout id) can't both be
+ * spent on one run. Previously it matched the workout id only, letting an inbox
+ * mile hype (composite) and this post's hype double-count for the same run.
+ */
 export function postHypedByViewerMatchSql(h: string, p: string): string {
-  return `(
-		(${h}.context_type = 'post' AND ${h}.context_id = ${p}.post_id::text)
-		OR (${p}.workout_id IS NOT NULL AND ${h}.context_type = 'mile' AND ${h}.context_id = ${p}.workout_id::text)
-		OR (${p}.workout_id IS NOT NULL AND ${h}.context_type = 'post' AND ${h}.context_id IN (
-			SELECT p2_.post_id::text FROM posts p2_
-			WHERE p2_.workout_id = ${p}.workout_id AND p2_.user_id = ${p}.user_id
-				AND p2_.deleted_at IS NULL
-		))
-	)`;
+  return postHypeMatchSql(h, p);
 }
 
 /**
@@ -362,7 +359,14 @@ export async function hasHypedRunContext(
   const matchSql =
     contextType === "mile" && isCompositeMile
       ? `(
-			(h.context_type = 'mile' AND h.context_id = $3)
+			(h.context_type = 'mile' AND (
+					h.context_id = $3
+					OR h.context_id IN (
+						SELECT w.workout_id::text FROM workouts w
+						WHERE w.user_id = $2
+							AND (w.user_id || ':' || w.local_date::text) = $3
+					)
+				))
 			OR (h.context_type = 'post' AND h.context_id IN (
 				SELECT p.post_id::text
 				FROM posts p

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -170,14 +170,16 @@ const CREATED_POST_SELECT = `
  * Insert a post and return it shaped as a PostRow (is_self=true, no hypes yet).
  * story_expires_at is set to now()+24h only when the post is shared to a story.
  *
- * One-post-per-workout rules (per destination — feed and story-only are
- * separate slots, enforced by partial unique indexes):
+ * One-deliberate-share-per-workout rules:
  * - Legacy clients (isAuto undefined) keep the original upsert-in-place.
  * - An AUTO post fills an empty slot or replaces an existing auto post; it
  *   never clobbers a deliberate user post (returns the existing post instead).
- * - A USER post fills an empty slot or replaces the auto post; if a live user
- *   post already exists for the workout it throws "workout_already_posted" —
- *   deleting the old post frees the slot again.
+ * - A USER post (feed OR story) is allowed once per workout, across BOTH the
+ *   feed and story-only slots: it fills an empty slot / replaces the auto post,
+ *   but if a live user share already exists for the run — in EITHER slot — it
+ *   throws "workout_already_posted". Deleting that share (or starting the next
+ *   workout) frees it again. The per-slot partial unique indexes enforce the
+ *   same-slot case; the cross-slot pre-check above closes the other-slot gap.
  */
 export async function createPost(input: CreatePostInput): Promise<PostRow> {
   // A workout can have ONE live feed post and ONE live story-only photo
@@ -199,6 +201,27 @@ export async function createPost(input: CreatePostInput): Promise<PostRow> {
     !input.shareToStory;
   const isAutoValue =
     input.isAuto === undefined ? legacyLooksAuto : input.isAuto === true;
+  // One deliberate share (a feed post OR a story) per workout — across BOTH
+  // destination slots. The per-slot unique indexes already stop a second post
+  // to the SAME slot; this closes the cross-slot gap where a feed post AND a
+  // separate story-only photo could both be created for one run ("posting
+  // again after I've posted"). Auto route/stats cards don't count as the user's
+  // share and never block (a real photo still replaces them). The slot frees
+  // when the existing share is deleted or the next workout starts.
+  if (!isAutoValue && input.workoutId) {
+    const otherSlotFilter = input.shareToFeed
+      ? `(p.share_to_story AND NOT p.share_to_feed)`
+      : `p.share_to_feed`;
+    const existingShare = await db.query<{ post_id: string }>(
+      `SELECT p.post_id FROM posts p
+			WHERE p.workout_id = $1 AND p.user_id = $2
+				AND p.deleted_at IS NULL AND NOT p.is_auto
+				AND ${otherSlotFilter}
+			LIMIT 1`,
+      [input.workoutId, input.userId],
+    );
+    if (existingShare[0]) throw new Error("workout_already_posted");
+  }
   // Only the slot's AUTO post may be overwritten in place — for legacy
   // requests too. Legacy upserts used to overwrite ANYTHING the caller owned,
   // which let an old build's background auto-card post silently DESTROY a


### PR DESCRIPTION
## Summary

Three feed/notification fixes:

1. **You can double-hype the same run** — hyping a friend's daily mile from the feed and again from the notification (inbox or push) both succeeded instead of syncing to one hype.
2. **You can post again after already posting** — a user could create a feed post *and* a separate story for the same workout. It should be one post **or** story per workout, locked until the share is deleted or another workout happens.
3. **The camera roll shows photos you can't post** — the library picker showed the whole roll and rejected any photo taken outside the workout's time window *after* you picked it. Now it only shows photos you can actually post for that walk/run.

## 1 — Double-hype

A `mile` hype is stored under two different keys depending on the surface: the **feed** keys by `workout_id`, the **notifications inbox** keys by the `user:date` composite. The *tally* predicates bridged both keys, but the *"already hyped" / dedupe* predicates matched only one — so neither the button state nor the write-dedupe synced across surfaces. Separately, the iOS push-notification "🔥 Hype" button sent a hype with **no context at all**, which skips dedupe entirely.

- `hypeService.ts` — `runHypedByViewerMatchSql`/`postHypedByViewerMatchSql` now return the unified RUN rule (identical to the tally); `hasHypedRunContext`'s composite branch also matches a mile hyped by exact `workout_id` for that day.
- `inAppNotificationController.ts` — `MILE_RUN_MATCH` bridges `workout_id` hypes too.
- `hypeController.ts` — a context-less hype resolves to the target's most recent daily-mile composite so it dedupes as one hype.
- iOS `MADNotificationService.swift` — the push-action hype now sends the mile composite context and treats a 409 as "already hyped".

A *different* same-day workout keyed by its own `workout_id` stays independently hypeable; only the *same* run collapses to one hype across surfaces.

## 2 — Post/story once per workout

The one-share rule was enforced *per destination* (separate feed and story-only unique indexes). `postService.createPost` now blocks a deliberate (non-auto) share when a live non-auto share already exists for the run in the *other* slot (409 `workout_already_posted`). Auto route/stats cards still don't count and stay replaceable. No schema/migration change — application-level cross-slot check, so existing rows are untouched. iOS `SocialFeedView` also locks the composer optimistically on publish.

## 3 — In-window photo picker (iOS)

Apple's out-of-process `PHPickerViewController` has no API to filter what it shows by capture time, so the old flow validated EXIF *after* selection and rejected out-of-window photos. Replaced with a custom `PHAsset` grid (`WorkoutPhotoImportPicker`) that fetches only photos whose `creationDate` falls in the workout window (screenshots excluded), so every photo shown is postable.

- Reading the library needs `NSPhotoLibraryUsageDescription` — added a purpose string. The privacy manifest already declares Photos/Videos collection and PhotoKit isn't a required-reason API, so no manifest change.
- Handles authorization, denied/empty states, iCloud download on selection, and a limited-access "Add" affordance.
- `creationDate` is the library's trusted timestamp, so the post-selection EXIF re-check (and `outsideWindow`/`noCaptureDate` outcomes) are removed.

## Verification
- Backend `tsc` build ✅ (pinned TS 5.8.3), `drizzle-kit check` ✅
- CI: **Backend (build + migrations + smoke) ✅**, **Website ✅**
- iOS is Xcode-only and wasn't compiled here; changes follow existing patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEE4x1dgf2HGWxhx5Tvaok