### PR TITLE
Lock today's feed/profile photos until you run; persist story reactions

### DIFF
--- a/app/Mile A Day/Services/PostService.swift
+++ b/app/Mile A Day/Services/PostService.swift
@@ -51,8 +51,18 @@ struct PostItem: Codable, Identifiable {
     /// Story rows only: does this run already have a live feed post? Hides the
     /// story viewer's "Add to feed" when the workout is already on the feed.
     var workout_on_feed: Bool?
+    /// Server withheld this post's photo because it's from the viewer's local
+    /// today and they haven't finished their own mile yet — the client draws a
+    /// lock instead of a broken image. Absent/false = unlocked.
+    var photo_locked: Bool? = nil
+    /// The viewer's own emoji reaction to this story, hydrated on load so a
+    /// re-view shows the reaction they already left. nil = not reacted.
+    var viewer_reaction: String? = nil
 
     var id: String { post_id }
+
+    /// Whether the server locked this post's photo (viewer hasn't run today).
+    var isPhotoLocked: Bool { photo_locked == true }
 
     /// Decoded route polyline (nil when absent or degenerate).
     var routeCoordinates: [CLLocationCoordinate2D]? { decodeRouteCoordinates(route) }
@@ -155,6 +165,9 @@ struct FeedEntry: Codable, Identifiable {
     let is_self: Bool
     var is_hyped: Bool
     var hype_count: Int?
+    /// Server withheld this post's photo (viewer hasn't run today) — carried
+    /// into the rendered PostItem so the card draws a lock.
+    let photo_locked: Bool?
 
     enum CodingKeys: String, CodingKey {
         case kind
@@ -162,7 +175,7 @@ struct FeedEntry: Codable, Identifiable {
         case sort_ts, user_id, username, first_name, last_name, profile_image_url
         case media_url, caption, stats_snapshot, story_photo_url, is_auto
         case workout_id, workout_type, distance, total_duration, calories, steps, route
-        case is_self, is_hyped, hype_count
+        case is_self, is_hyped, hype_count, photo_locked
     }
 
     var id: String { "\(kind)-\(entryId)" }
@@ -196,7 +209,8 @@ struct FeedEntry: Codable, Identifiable {
             created_at: sort_ts, is_auto: is_auto, workout_type: workout_type,
             route: route, story_photo_url: story_photo_url,
             is_self: is_self, is_hyped: is_hyped,
-            hype_count: hype_count, is_viewed: nil, workout_on_feed: nil
+            hype_count: hype_count, is_viewed: nil, workout_on_feed: nil,
+            photo_locked: photo_locked
         )
     }
 }
@@ -229,6 +243,30 @@ struct StoryViewer: Codable, Identifiable {
 
 struct StoryViewersResponse: Decodable {
     let viewers: [StoryViewer]
+    let count: Int
+}
+
+/// One person who reacted to a story, for the bubble row shown to all viewers.
+struct StoryReactor: Codable, Identifiable {
+    let user_id: String
+    let username: String?
+    let first_name: String?
+    let last_name: String?
+    let profile_image_url: String?
+    let emoji: String
+    let created_at: String
+
+    var id: String { user_id }
+
+    var displayName: String {
+        if let username, !username.isEmpty { return username }
+        if let first_name, !first_name.isEmpty { return first_name }
+        return "Someone"
+    }
+}
+
+struct StoryReactorsResponse: Decodable {
+    let reactors: [StoryReactor]
     let count: Int
 }
 
@@ -386,6 +424,15 @@ enum PostService {
         try await APIClient.fancyFetch(
             endpoint: "/posts/stories/\(postId)/viewers",
             responseType: StoryViewersResponse.self
+        )
+    }
+
+    /// Everyone who reacted to a story — visible to any circle viewer, for the
+    /// reaction-bubble row (not just the author's private viewers list).
+    static func storyReactors(postId: String) async throws -> StoryReactorsResponse {
+        try await APIClient.fancyFetch(
+            endpoint: "/posts/stories/\(postId)/reactions",
+            responseType: StoryReactorsResponse.self
         )
     }
 

--- a/app/Mile A Day/Views/Feed/PostCardView.swift
+++ b/app/Mile A Day/Views/Feed/PostCardView.swift
@@ -198,11 +198,49 @@ struct PostCardView: View {
         celebrateAndHype()
     }
 
+    /// The media block: a lock card when the server withheld today's photo
+    /// (the viewer hasn't run yet), otherwise the real photo/route carousel.
+    @ViewBuilder
+    private var media: some View {
+        if post.isPhotoLocked {
+            lockedMediaCard
+        } else {
+            unlockedMedia
+        }
+    }
+
+    /// Shown in place of the photo when it's locked — a frosted "run to unlock"
+    /// card, matching the app's earn-to-view story gate.
+    private var lockedMediaCard: some View {
+        ZStack {
+            LinearGradient(
+                colors: [MADTheme.Colors.madRed.opacity(0.30), Color.black.opacity(0.65)],
+                startPoint: .topLeading, endPoint: .bottomTrailing
+            )
+            VStack(spacing: 10) {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 32, weight: .bold))
+                    .foregroundColor(.white)
+                Text("Finish your mile to unlock")
+                    .font(.system(size: 15, weight: .heavy, design: .rounded))
+                    .foregroundColor(.white)
+                Text("Today's photos open up once you complete your own mile.")
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundColor(.white.opacity(0.8))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 28)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .aspectRatio(4.0 / 5.0, contentMode: .fit)
+        .clipped()
+    }
+
     /// A single photo, or a full-size swipeable carousel:
     /// photo → route/stats card → route map. The hype burst plays centered
     /// over whichever slide is showing.
     @ViewBuilder
-    private var media: some View {
+    private var unlockedMedia: some View {
         let slides = photoURLs
         let coords = routeSlideCoordinates
         let cardStats = workoutCardStats

--- a/app/Mile A Day/Views/Feed/ProfilePostsGridView.swift
+++ b/app/Mile A Day/Views/Feed/ProfilePostsGridView.swift
@@ -199,14 +199,30 @@ struct ProfilePostsGridView: View {
             .aspectRatio(1, contentMode: .fit)
             .overlay(
                 // The real picture leads when the run has one; the workout
-                // card is only the face of the post when no photo exists.
-                AsyncImage(url: post.storyPhotoURL ?? post.mediaURL) { phase in
-                    switch phase {
-                    case .success(let image): image.resizable().scaledToFill()
-                    case .failure:
-                        ZStack { Color.white.opacity(0.05); Image(systemName: "photo").foregroundColor(.white.opacity(0.3)) }
-                    default:
-                        ZStack { Color.white.opacity(0.05); ProgressView().tint(.white) }
+                // card is only the face of the post when no photo exists. When
+                // the server locks today's photo (viewer hasn't run), show a
+                // lock tile instead — tapping it opens the same locked card.
+                Group {
+                    if post.isPhotoLocked {
+                        ZStack {
+                            LinearGradient(
+                                colors: [MADTheme.Colors.madRed.opacity(0.30), Color.black.opacity(0.6)],
+                                startPoint: .topLeading, endPoint: .bottomTrailing
+                            )
+                            Image(systemName: "lock.fill")
+                                .font(.system(size: 20, weight: .bold))
+                                .foregroundColor(.white.opacity(0.9))
+                        }
+                    } else {
+                        AsyncImage(url: post.storyPhotoURL ?? post.mediaURL) { phase in
+                            switch phase {
+                            case .success(let image): image.resizable().scaledToFill()
+                            case .failure:
+                                ZStack { Color.white.opacity(0.05); Image(systemName: "photo").foregroundColor(.white.opacity(0.3)) }
+                            default:
+                                ZStack { Color.white.opacity(0.05); ProgressView().tint(.white) }
+                            }
+                        }
                     }
                 }
             )

--- a/app/Mile A Day/Views/Feed/StoryViewerView.swift
+++ b/app/Mile A Day/Views/Feed/StoryViewerView.swift
@@ -31,8 +31,12 @@ struct StoryViewerView: View {
     /// the auto-advance can never re-target a destructive action mid-dialog.
     @State private var optionsPost: PostItem?
     @State private var showOptions = false
-    /// postId → emoji the viewer sent this session (server keeps one per story).
+    /// postId → the viewer's own emoji (hydrated from the server on load, so a
+    /// re-view shows the reaction they already left; the server keeps one/story).
     @State private var myReactions: [String: String] = [:]
+    /// postId → everyone who reacted, for the Instagram-style bubble row shown
+    /// to ALL viewers (not just the author).
+    @State private var reactors: [String: [StoryReactor]] = [:]
     /// Own-story extras: seen-by counts per post + the viewers sheet.
     @State private var viewerCounts: [String: Int] = [:]
     @State private var viewersSheetFor: PostItem?
@@ -108,6 +112,13 @@ struct StoryViewerView: View {
             guard let post = current, post.is_self else { return }
             if let resp = try? await PostService.storyViewers(postId: post.post_id) {
                 viewerCounts[post.post_id] = resp.count
+            }
+        }
+        .task(id: current?.post_id) {
+            // Everyone's reactions for the current story → the bubble row.
+            guard let post = current else { return }
+            if let resp = try? await PostService.storyReactors(postId: post.post_id) {
+                reactors[post.post_id] = resp.reactors
             }
         }
         .alert("Couldn't add to feed", isPresented: Binding(
@@ -254,6 +265,8 @@ struct StoryViewerView: View {
     @ViewBuilder
     private func footer(_ post: PostItem) -> some View {
         VStack(alignment: .leading, spacing: 12) {
+            reactorBubbles(post)
+
             if let caption = post.caption, !caption.isEmpty {
                 Text(caption)
                     .font(.system(size: 15, weight: .semibold, design: .rounded))
@@ -309,6 +322,40 @@ struct StoryViewerView: View {
             Spacer(minLength: 0)
         }
         .animation(.spring(response: 0.3, dampingFraction: 0.6), value: myReactions)
+    }
+
+    /// Instagram-style row of who reacted — overlapping avatars, each badged
+    /// with their emoji. Shown to every viewer (per the product decision).
+    @ViewBuilder
+    private func reactorBubbles(_ post: PostItem) -> some View {
+        let list = reactors[post.post_id] ?? []
+        if !list.isEmpty {
+            HStack(spacing: -8) {
+                ForEach(list.prefix(6)) { reactor in
+                    ZStack(alignment: .bottomTrailing) {
+                        AvatarView(
+                            name: reactor.displayName,
+                            imageURL: reactor.profile_image_url,
+                            size: 30
+                        )
+                        .overlay(Circle().strokeBorder(Color.black.opacity(0.55), lineWidth: 1.5))
+                        Text(reactor.emoji)
+                            .font(.system(size: 12))
+                            .padding(2)
+                            .background(Circle().fill(Color.black.opacity(0.6)))
+                            .offset(x: 5, y: 4)
+                    }
+                }
+                if list.count > 6 {
+                    Text("+\(list.count - 6)")
+                        .font(.system(size: 12, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+                        .padding(.leading, 14)
+                }
+                Spacer(minLength: 0)
+            }
+            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: list.count)
+        }
     }
 
     private func seenByPill(_ post: PostItem) -> some View {
@@ -436,6 +483,13 @@ struct StoryViewerView: View {
             }
             await MainActor.run {
                 stories = loaded
+                // Hydrate the viewer's prior reactions so re-opening a story
+                // shows the emoji they already picked (server keeps one/story).
+                for story in loaded {
+                    if let emoji = story.viewer_reaction, !emoji.isEmpty {
+                        myReactions[story.post_id] = emoji
+                    }
+                }
                 isLoading = false
                 if loaded.isEmpty {
                     // The group's stories expired/vanished since the rail
@@ -458,7 +512,13 @@ struct StoryViewerView: View {
         // idempotent, so a failed call just means no push went out.
         myReactions[post.post_id] = emoji
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-        Task { try? await PostService.reactToStory(postId: post.post_id, emoji: emoji) }
+        Task {
+            try? await PostService.reactToStory(postId: post.post_id, emoji: emoji)
+            // Reconcile the bubble row with the server (adds/updates my bubble).
+            if let resp = try? await PostService.storyReactors(postId: post.post_id) {
+                await MainActor.run { reactors[post.post_id] = resp.reactors }
+            }
+        }
     }
 
     private func promoteToFeed(_ post: PostItem) async {

--- a/backend/src/controllers/postsController.ts
+++ b/backend/src/controllers/postsController.ts
@@ -257,13 +257,17 @@ export async function getUserStoriesController(
   res: Response,
 ) {
   try {
-    res
-      .status(200)
-      .json(
-        signMediaUrlsDeep(
-          await getUserActiveStories(req.userId!, req.params.userId),
-        ),
-      );
+    const stories = await getUserActiveStories(req.userId!, req.params.userId);
+    // Gate today's story photos the same way the feed/profile do — a viewer who
+    // hasn't finished their own mile can't pull a friend's today photo. (The
+    // client already hides today's stories pre-completion; this closes the
+    // server-side bypass so the photo bytes are never handed over.)
+    lockUnearnedPhotos(
+      stories,
+      req.userId!,
+      await viewerPhotoGate(req.userId!),
+    );
+    res.status(200).json(signMediaUrlsDeep(stories));
   } catch (error: any) {
     console.error("Error fetching user stories:", error.message);
     res.status(500).json({ error: "Error fetching stories" });

--- a/backend/src/controllers/postsController.ts
+++ b/backend/src/controllers/postsController.ts
@@ -20,11 +20,14 @@ import {
   hasAcceptedTerms,
   acceptTerms,
   getStoryViewers,
+  getStoryReactors,
   reactToStory,
   getOwnPostMemories,
   userOwnsWorkout,
+  lockUnearnedPhotos,
   ALLOWED_STORY_REACTIONS,
   PostStatsSnapshot,
+  type ViewerGoalGate,
 } from "../services/postService.js";
 import {
   reportPost,
@@ -303,6 +306,29 @@ export async function getStoryViewersController(
   }
 }
 
+/**
+ * Who reacted to a story, for the reaction-bubble row shown to ALL circle
+ * viewers (not just the author). 404 when the caller can't see the story.
+ */
+export async function getStoryReactorsController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  try {
+    if (!isUuid(req.params.postId)) {
+      return res.status(404).json({ error: "story_not_found" });
+    }
+    const reactors = await getStoryReactors(req.userId!, req.params.postId);
+    if (reactors === null) {
+      return res.status(404).json({ error: "story_not_found" });
+    }
+    res.json({ reactors, count: reactors.length });
+  } catch (error: any) {
+    console.error("Error getting story reactors:", error.message);
+    res.status(500).json({ error: "Error getting story reactors" });
+  }
+}
+
 /** Emoji-react to a friend's active story. Re-reacting swaps the emoji. */
 export async function reactToStoryController(
   req: AuthenticatedRequest,
@@ -365,6 +391,21 @@ function repairBeforeCursor(req: AuthenticatedRequest): string | null {
   return raw.replace(/ (\d{2}(:?\d{2})?)$/, "+$1");
 }
 
+/**
+ * The viewer's mile status, used to gate today's photos. Fail-OPEN: a stats
+ * hiccup returns `completed:true` so a glitch never blanks the whole feed
+ * (better to briefly over-show than to break the surface).
+ */
+async function viewerPhotoGate(userId: string): Promise<ViewerGoalGate> {
+  try {
+    const goal = await getDailyGoalStatus(userId);
+    return { completed: goal.completed, localDate: goal.localDate };
+  } catch (e: any) {
+    console.error("[viewerPhotoGate] goal status failed:", e?.message ?? e);
+    return { completed: true, localDate: "" };
+  }
+}
+
 export async function getFeedController(
   req: AuthenticatedRequest,
   res: Response,
@@ -376,6 +417,7 @@ export async function getFeedController(
       : DEFAULT_FEED_LIMIT;
     const before = repairBeforeCursor(req);
     const items = await getFeed(req.userId!, limit, before);
+    lockUnearnedPhotos(items, req.userId!, await viewerPhotoGate(req.userId!));
     // `cursor` is the microsecond-precise URL-safe timestamp; created_at
     // (a ms-truncated JS Date) would skip same-millisecond rows at boundaries.
     const last = items[items.length - 1];
@@ -402,6 +444,7 @@ export async function getUnifiedFeedController(
       : DEFAULT_FEED_LIMIT;
     const before = repairBeforeCursor(req);
     const items = await getUnifiedFeed(req.userId!, limit, before);
+    lockUnearnedPhotos(items, req.userId!, await viewerPhotoGate(req.userId!));
     const last = items[items.length - 1];
     const nextBefore =
       items.length === limit ? (last.cursor ?? last.sort_ts) : null;
@@ -442,6 +485,7 @@ export async function getUserPostsController(
       before,
       includeStoryOnly,
     );
+    lockUnearnedPhotos(items, req.userId!, await viewerPhotoGate(req.userId!));
     const last = items[items.length - 1];
     const nextBefore =
       items.length === limit ? (last.cursor ?? last.created_at) : null;

--- a/backend/src/routes/postsRoutes.ts
+++ b/backend/src/routes/postsRoutes.ts
@@ -7,6 +7,7 @@ import {
   getUserStoriesController,
   markStoryViewedController,
   getStoryViewersController,
+  getStoryReactorsController,
   reactToStoryController,
   getPostMemoriesController,
   getFeedController,
@@ -47,6 +48,7 @@ router.get("/stories", getStoriesRailController);
 router.get("/stories/:userId", getUserStoriesController);
 router.post("/stories/:postId/view", markStoryViewedController);
 router.get("/stories/:postId/viewers", getStoryViewersController);
+router.get("/stories/:postId/reactions", getStoryReactorsController);
 router.post("/stories/:postId/react", reactToStoryController);
 
 // "On this day" — the caller's own past post photos.

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -56,6 +56,13 @@ export interface PostRow {
   is_hyped: boolean;
   hype_count: number;
   is_viewed?: boolean;
+  // The viewer's own emoji reaction to this story (getUserActiveStories only),
+  // so re-opening a story they already reacted to shows the reaction. null/absent
+  // = they haven't reacted.
+  viewer_reaction?: string | null;
+  // Set by lockUnearnedPhotos: this post's photo is withheld because it's from
+  // the viewer's local today and they haven't finished their own mile yet.
+  photo_locked?: boolean;
   // Microsecond-precise created_at (Postgres text form) for keyset pagination.
   // node-pg parses timestamptz to a ms-truncated JS Date, and a truncated
   // `before` cursor silently skips same-millisecond rows at page boundaries.
@@ -396,6 +403,10 @@ export async function getUserActiveStories(
 			EXISTS (
 				SELECT 1 FROM story_views sv WHERE sv.post_id = p.post_id AND sv.viewer_id = $1
 			) AS is_viewed,
+			(
+				SELECT sr.emoji FROM story_reactions sr
+				WHERE sr.post_id = p.post_id AND sr.user_id = $1
+			) AS viewer_reaction,
 			EXISTS (
 				SELECT 1 FROM posts pf
 				WHERE pf.workout_id = p.workout_id
@@ -505,6 +516,59 @@ export async function getStoryViewers(
 		LIMIT 200
 		`,
     [postId, authorId],
+  );
+}
+
+export interface StoryReactorRow {
+  user_id: string;
+  username: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  profile_image_url: string | null;
+  emoji: string;
+  created_at: string;
+}
+
+/**
+ * Everyone who reacted to a story, for the Instagram-style bubble row shown to
+ * ALL circle viewers (not just the author, unlike getStoryViewers). Returns
+ * null when the caller can't see the story (author/accepted-friend, no block) —
+ * the controller maps that to 404. Includes the caller's own reaction.
+ */
+export async function getStoryReactors(
+  viewerId: string,
+  postId: string,
+): Promise<StoryReactorRow[] | null> {
+  const allowed = await db.query(
+    `SELECT 1 FROM posts p
+			 WHERE p.post_id = $1 AND p.share_to_story AND p.deleted_at IS NULL
+				 AND (
+					 p.user_id = $2
+					 OR EXISTS (
+						 SELECT 1 FROM friendships f
+						 WHERE f.user_id = $2 AND f.friend_id = p.user_id AND f.status = 'accepted'
+					 )
+				 )
+				 AND NOT EXISTS (
+					 SELECT 1 FROM user_blocks b
+					 WHERE (b.blocker_id = $2 AND b.blocked_id = p.user_id)
+							OR (b.blocker_id = p.user_id AND b.blocked_id = $2)
+				 )`,
+    [postId, viewerId],
+  );
+  if (allowed.length === 0) return null;
+
+  return db.query<StoryReactorRow>(
+    `
+		SELECT u.user_id, u.username, u.first_name, u.last_name, u.profile_image_url,
+			sr.emoji, sr.created_at
+		FROM story_reactions sr
+		JOIN users u ON u.user_id = sr.user_id
+		WHERE sr.post_id = $1
+		ORDER BY sr.created_at DESC
+		LIMIT 200
+		`,
+    [postId],
   );
 }
 
@@ -618,6 +682,48 @@ export async function getOwnPostMemories(
   );
 }
 
+/** The viewer's mile status for a feed read — drives the photo gate. */
+export interface ViewerGoalGate {
+  completed: boolean;
+  localDate: string;
+}
+
+/**
+ * Withhold TODAY's real photos from a viewer who hasn't finished their own mile
+ * yet — "run to see your friends' pictures". Mutates and returns the rows.
+ *
+ * Rules (per the product decision):
+ *  - Only the viewer's LOCAL today is gated; older posts always show.
+ *  - Own posts are never gated (you can always see your own).
+ *  - PHOTOS ONLY: a real user photo (media_url on a non-auto post) and any
+ *    story_photo_url are withheld; auto route/stats cards stay visible.
+ *  - Once the viewer completes their mile, nothing is gated.
+ *
+ * media_url is blanked to "" rather than nulled so existing (non-optional)
+ * clients still decode; new clients read `photo_locked` to draw the lock state.
+ */
+export function lockUnearnedPhotos<
+  T extends {
+    user_id: string;
+    local_date?: string | null;
+    is_auto?: boolean | null;
+    media_url?: string | null;
+    story_photo_url?: string | null;
+    photo_locked?: boolean;
+  },
+>(rows: T[], viewerId: string, gate: ViewerGoalGate): T[] {
+  if (gate.completed || !gate.localDate) return rows;
+  for (const r of rows) {
+    if (r.user_id === viewerId) continue;
+    if ((r.local_date ?? null) !== gate.localDate) continue;
+    if (r.story_photo_url) r.story_photo_url = null;
+    // Leave auto route/stats cards visible; only real photos are locked.
+    if (r.is_auto !== true && r.media_url) r.media_url = "";
+    r.photo_locked = true;
+  }
+  return rows;
+}
+
 /**
  * Persistent feed: photo posts from the viewer's circle, newest first, keyset
  * paginated on created_at. Pass `before` (an ISO timestamp) to fetch older.
@@ -667,6 +773,11 @@ export interface FeedEntryRow {
   story_photo_url: string | null;
   // post-only: system-generated route/stats card vs deliberate user post.
   is_auto: boolean | null;
+  // post-only: the author's local date ("YYYY-MM-DD"), so the viewer's today can
+  // be gated. Null for raw workout entries (they carry no photo to gate).
+  local_date: string | null;
+  // Set by lockUnearnedPhotos when this post's photo is withheld.
+  photo_locked?: boolean;
   // The entry's workout: the linked workout for posts (null when unlinked),
   // the workout itself for workout entries. Lets the client know which of
   // today's runs already carry a deliberate post.
@@ -710,6 +821,7 @@ export async function getUnifiedFeed(
 				p.created_at AS sort_ts,
 				p.user_id, u.username, u.first_name, u.last_name, u.profile_image_url,
 				p.media_url, p.caption, p.stats_snapshot,
+				p.local_date::text AS local_date,
 				-- Owner's decision: the 24h expiry only ends the STORY (rail/viewer).
 				-- A photo riding on the run's feed card stays permanently — only
 				-- deleting the story removes it.
@@ -766,6 +878,7 @@ export async function getUnifiedFeed(
 				w.device_end_date AS sort_ts,
 				w.user_id, u.username, u.first_name, u.last_name, u.profile_image_url,
 				NULL::text AS media_url, NULL::text AS caption, NULL::jsonb AS stats_snapshot,
+				NULL::text AS local_date,
 				NULL::text AS story_photo_url,
 				NULL::boolean AS is_auto,
 				w.workout_id,


### PR DESCRIPTION
## What & why

Two feed asks:
1. **You could still see today's feed/profile photos without doing your mile.** Now today's photos are locked until you complete your own mile (older photos always show). This extends the app's existing "earn-to-view" story gate to feed posts and profile grids.
2. **Story reactions didn't stick** — re-opening a story forgot you'd reacted, and there was no shared "who reacted" display. Now your reaction persists on re-view, and everyone sees an Instagram-style bubble row of who reacted.

Both are **additive and backwards-compatible**. The live App Store build has no feed/stories UI, so only feed-enabled (TestFlight/dev) builds are affected — but nothing here changes existing response types in a breaking way.

## Feature A — earn-to-view photos (server-enforced)
- `lockUnearnedPhotos()` withholds a post's **real photo** when the post is from the **viewer's local today** and they haven't finished their mile. Rules: older posts always show; **your own posts never lock**; **photos only** (a user photo, and any story photo) are withheld — **auto route/stats cards stay visible**; completing your mile unlocks everything.
- Enforcement is at the response layer: `media_url` is blanked to `""` (so existing non-optional clients still decode — no crash), `story_photo_url` nulled, both **before** signing; a new `photo_locked` flag tells the client to draw a lock. Applied to `getFeed`, `getUnifiedFeed`, `getUserPosts`.
- The viewer's completion comes from the existing timezone-aware `getDailyGoalStatus`, wrapped **fail-open** so a stats hiccup never blanks the feed. Added `local_date` to unified-feed post rows so "today" can be evaluated.
- **iOS:** `PostCardView` shows a frosted "Finish your mile to unlock" card; the profile grid shows a lock tile instead of a broken image. Tapping a locked thumbnail opens the same locked card.

## Feature B — story reactions that stick
- `getUserActiveStories` now returns the viewer's own emoji as `viewer_reaction`, so re-opening a story shows the reaction you already left. One-reaction-per-story was already enforced by the `story_reactions` primary key; the client now reflects it.
- New `GET /posts/stories/:postId/reactions` returns everyone who reacted (visible to any circle viewer, not just the author), driving an **Instagram-style bubble row** — overlapping avatars each badged with their emoji — shown to all viewers.
- **iOS:** hydrate reactions on load, render the bubble row above the caption, and re-fetch to reconcile after you react.

## Safety
- No DB migration (`story_reactions`/`story_views` already exist).
- No breaking API changes: new fields are additive; `media_url` stays a decodable string; new endpoint is net-new.
- No streak/write paths touched. Backend `tsc` build is clean.
- iOS builds via Xcode only (can't compile in CI here) — changes reuse shipping components (`PostCardView`, `AvatarView`, `StoryViewersSheet` patterns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY)_