### PR TITLE
Match the mid-run camera & library photo buttons to one size

### DIFF
--- a/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
@@ -391,20 +391,27 @@ struct WorkoutTrackingView: View {
     /// Import a photo taken DURING this walk/run from the library. Camera-only
     /// authenticity is preserved by the time-window check in the picker — you
     /// can use a system-camera shot from this walk, but not an old photo.
+    /// Shared look for the mid-run photo buttons so the camera and library
+    /// controls are the exact same size and weight (they used to differ — 40 vs
+    /// 44, icon 15 vs 17). Both read as one matched pair sitting in the top bar.
+    private func midRunCircleIcon(_ systemName: String) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: 17, weight: .semibold))
+            .foregroundColor(.white)
+            .frame(width: 44, height: 44)
+            .background(
+                Circle()
+                    .fill(Color.white.opacity(0.18))
+                    .overlay(Circle().strokeBorder(Color.white.opacity(0.3), lineWidth: 1))
+            )
+    }
+
     private var midRunLibraryButton: some View {
         Button {
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
             showLibraryImport = true
         } label: {
-            Image(systemName: "photo.badge.plus")
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundColor(.white)
-                .frame(width: 40, height: 40)
-                .background(
-                    Circle()
-                        .fill(Color.white.opacity(0.14))
-                        .overlay(Circle().strokeBorder(Color.white.opacity(0.28), lineWidth: 1))
-                )
+            midRunCircleIcon("photo.badge.plus")
         }
         .buttonStyle(PlainButtonStyle())
         .fullScreenCover(isPresented: $showLibraryImport) {
@@ -471,15 +478,7 @@ struct WorkoutTrackingView: View {
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
             showMidRunCamera = true
         } label: {
-            Image(systemName: "camera.fill")
-                .font(.system(size: 17, weight: .semibold))
-                .foregroundColor(.white)
-                .frame(width: 44, height: 44)
-                .background(
-                    Circle()
-                        .fill(Color.white.opacity(0.18))
-                        .overlay(Circle().strokeBorder(Color.white.opacity(0.3), lineWidth: 1))
-                )
+            midRunCircleIcon("camera.fill")
         }
         .buttonStyle(PlainButtonStyle())
         .fullScreenCover(isPresented: $showMidRunCamera) {


### PR DESCRIPTION
## What & why

While tracking a run, the two photo buttons in the top bar were mismatched: the **"add from library"** button was `40×40` with a `15pt` icon, while the **camera** button was `44×44` with a `17pt` icon (and slightly different fill/stroke opacities). They read as an uneven pair.

## Change
- Extracted one shared `midRunCircleIcon(_:)` helper (44×44, 17pt semibold, matched `0.18` fill / `0.30` stroke) and routed **both** buttons through it, so they're now identical.
- They now sit as a clean matched set next to the existing 44×44 snap-tray chip.
- **No behavior change** — the camera button still opens `MADCameraView`; the library button still opens the time-windowed `WorkoutPhotoImportPicker` (which keeps the "photo must be from this run" authenticity gate).

iOS-only; builds via Xcode (can't compile in CI here). One small self-contained file (`WorkoutTrackingView.swift`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY)_