### PR TITLE
Workout visibility controls; fix photo lock, HealthKit auth, and friend/own detail parity

### DIFF
--- a/app/Mile A Day/Core/Services/MADBackgroundService.swift
+++ b/app/Mile A Day/Core/Services/MADBackgroundService.swift
@@ -132,7 +132,8 @@ final class MADBackgroundService: NSObject, ObservableObject {
 
     @MainActor
     private func handleNewWorkoutData() async {
-        guard await requestHealthKitAuthorizationIfNeeded() else { return }
+        // performBackgroundSync establishes authorization for every reason now,
+        // so this path no longer needs its own check.
         await performBackgroundSync(reason: .healthKitObserver)
     }
     
@@ -166,6 +167,16 @@ final class MADBackgroundService: NSObject, ObservableObject {
         // Only run if user has authenticated.
         guard UserDefaults.standard.bool(forKey: "MAD_IsAuthenticated") else {
             print("[MADBackgroundService] Skipping sync — user not authenticated")
+            return false
+        }
+
+        // Establish HealthKit authorization BEFORE any read. Only the observer
+        // path (handleNewWorkoutData) used to do this, so a background launch,
+        // BGTask, or silent push ran the entire sync with `isAuthorized` still
+        // false — every query returned instantly having done nothing, which is
+        // the "❌ Not authorized to access HealthKit" a background launch logs.
+        guard await requestHealthKitAuthorizationIfNeeded() else {
+            print("[MADBackgroundService] Skipping sync — HealthKit not authorized")
             return false
         }
 
@@ -214,20 +225,22 @@ final class MADBackgroundService: NSObject, ObservableObject {
     }
     
     private func requestHealthKitAuthorizationIfNeeded() async -> Bool {
-        return await withCheckedContinuation { [weak self] continuation in
-            guard let self = self else {
-                continuation.resume(returning: false)
-                return
-            }
-            
-            if self.healthManager.isAuthorized {
-                continuation.resume(returning: true)
-                return
-            }
-            
-            self.healthManager.requestAuthorization { success in
-                continuation.resume(returning: success)
-            }
+        if healthManager.isAuthorized { return true }
+
+        // Resolve WITHOUT prompting first. This service holds its own
+        // HealthKitManager, so its flag starts false in every process no matter
+        // what the UI's instance already knows — and in a background launch
+        // there's no UI to prompt with anyway. A user who granted access long
+        // ago needs no prompt, just a fresh process asking the right question.
+        let resolved = await withCheckedContinuation { continuation in
+            healthManager.refreshAuthorizationStatus { continuation.resume(returning: $0) }
+        }
+        if resolved { return true }
+
+        // Genuinely undetermined (first run) — fall back to the real request,
+        // which prompts if there's UI to prompt with.
+        return await withCheckedContinuation { continuation in
+            healthManager.requestAuthorization { continuation.resume(returning: $0) }
         }
     }
     

--- a/app/Mile A Day/Models/Competition.swift
+++ b/app/Mile A Day/Models/Competition.swift
@@ -870,6 +870,9 @@ struct NotificationSettingsResponse: Codable {
     let quiet_hours_end: Int?
     // Optional: absent on older server builds.
     let h2h_close_friends_only: Bool?
+    /// "public" | "friends" | "private" — who may see my routes and photos.
+    /// Optional: absent on older server builds (treat as "friends").
+    let workout_visibility: String?
 }
 
 struct FriendNotificationSetting: Codable, Identifiable {

--- a/app/Mile A Day/Models/HealthKitManager.swift
+++ b/app/Mile A Day/Models/HealthKitManager.swift
@@ -441,6 +441,13 @@ class HealthKitManager: ObservableObject {
         // shuttles authoritative iOS data (streak, today's distance, goal,
         // name) to the watch so the two never disagree.
         MADWatchBridge.shared.activate()
+
+        // Resolve real authorization immediately. Nothing else here does: the
+        // flag is set by requestAuthorization, which only the UI calls, so a
+        // background-launched process read HealthKit with it still false and
+        // every query no-opped. This never prompts, and its callback is
+        // deferred to the main queue, so it can't re-enter this init.
+        refreshAuthorizationStatus()
     }
     
     // MARK: - Caching Methods
@@ -616,41 +623,92 @@ class HealthKitManager: ObservableObject {
         return nil
     }
     
-    // Request authorization to access HealthKit data
-    func requestAuthorization(completion: @escaping (Bool) -> Void) {
-        guard HKHealthStore.isHealthDataAvailable() else {
-            completion(false)
-            return
-        }
-        
-        // Define the types we want to read from HealthKit
-        let readTypes: Set = [
+    /// The types we read from HealthKit. Shared by the authorization request and
+    /// the non-prompting status check so the two can never drift apart.
+    private var healthKitReadTypes: Set<HKObjectType> {
+        [
             HKObjectType.workoutType(),
             HKObjectType.quantityType(forIdentifier: .distanceWalkingRunning)!,
             HKObjectType.quantityType(forIdentifier: .activeEnergyBurned)!,
             HKObjectType.quantityType(forIdentifier: .stepCount)!,
             HKSeriesType.workoutRoute()
         ]
+    }
 
-        // Define the types we want to write to HealthKit (for workout tracking).
-        // workoutRoute share access lets in-app GPS workouts save their route,
-        // which is what the feed's route maps are built from at sync time.
-        let writeTypes: Set = [
+    /// The types we write (for workout tracking). workoutRoute share access lets
+    /// in-app GPS workouts save their route, which is what the feed's route maps
+    /// are built from at sync time.
+    private var healthKitWriteTypes: Set<HKSampleType> {
+        [
             HKObjectType.workoutType(),
             HKObjectType.quantityType(forIdentifier: .distanceWalkingRunning)!,
             HKObjectType.quantityType(forIdentifier: .activeEnergyBurned)!,
             HKSeriesType.workoutRoute()
         ]
+    }
 
-        healthStore.requestAuthorization(toShare: writeTypes, read: readTypes) { success, error in
+    /// Resolve authorization WITHOUT prompting, so a process that never shows UI
+    /// can still read HealthKit.
+    ///
+    /// `isAuthorized` only ever became true inside `requestAuthorization`'s
+    /// completion — a UI path — which made it really mean "did someone ask
+    /// during THIS process", not "is this app authorized". It starts false in
+    /// every new process, and HealthKit's own background delivery launches this
+    /// app with no UI constantly, so in those processes every read guarded on
+    /// the flag silently no-opped: the index logged "❌ Not authorized" and
+    /// `recentWorkouts` stayed empty even though the user had granted access
+    /// long ago.
+    ///
+    /// `.unnecessary` means every type we use has already been answered for, so
+    /// queries can run. That is exactly what `requestAuthorization`'s `success`
+    /// already meant — neither reports whether READ access was *granted*, which
+    /// Apple hides by design (a denied read just returns no samples).
+    func refreshAuthorizationStatus(completion: ((Bool) -> Void)? = nil) {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            completion?(false)
+            return
+        }
+        healthStore.getRequestStatusForAuthorization(
+            toShare: healthKitWriteTypes,
+            read: healthKitReadTypes
+        ) { [weak self] status, _ in
+            DispatchQueue.main.async {
+                guard let self else {
+                    completion?(false)
+                    return
+                }
+                // Only ever promote to true — never clobber a live grant from an
+                // in-flight requestAuthorization. Deliberately no other side
+                // effects: this is a question, not a request. Background
+                // delivery stays owned by requestAuthorization, which the UI
+                // runs on every foreground launch.
+                if status == .unnecessary && !self.isAuthorized {
+                    self.isAuthorized = true
+                }
+                completion?(self.isAuthorized)
+            }
+        }
+    }
+
+    // Request authorization to access HealthKit data
+    func requestAuthorization(completion: @escaping (Bool) -> Void) {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            completion(false)
+            return
+        }
+
+        healthStore.requestAuthorization(
+            toShare: healthKitWriteTypes,
+            read: healthKitReadTypes
+        ) { success, error in
             DispatchQueue.main.async {
                 self.isAuthorized = success
-                
+
                 // Enable background delivery for workouts when authorized
                 if success {
                     self.enableBackgroundDelivery()
                 }
-                
+
                 completion(success)
             }
         }
@@ -745,6 +803,11 @@ class HealthKitManager: ObservableObject {
         healthStore.execute(query)
     }
     
+    /// Retries left for a `fetchRecentWorkouts` that errored out. A locked
+    /// device is the common case and it resolves on its own, so a couple of
+    /// spaced retries recover the list without waiting for the next refresh.
+    private var recentWorkoutsRetriesLeft = 3
+
     // Fetch recent running/walking workouts (last 30 days, capped at 50).
     // The date predicate keeps HealthKit from scanning all-time history just to
     // pull the most recent samples — far cheaper for users with long histories.
@@ -766,15 +829,42 @@ class HealthKitManager: ObservableObject {
             predicate: predicate,
             limit: 50,
             sortDescriptors: [sortDescriptor]
-        ) { [weak self] _, samples, _ in
-            guard let self = self, let workouts = samples as? [HKWorkout] else { return }
+        ) { [weak self] _, samples, error in
+            guard let self = self else { return }
 
+            // Query failed — most commonly because the device is locked
+            // (HealthKit data is protected while locked, so the query errors
+            // rather than returning). Same rule as fetchTodaysDistance: this is
+            // "no answer", NOT "no workouts". Keep the last good list and retry,
+            // because swallowing the error left the list empty until something
+            // else happened to call fetchAllWorkoutData again.
+            guard error == nil, let workouts = samples as? [HKWorkout] else {
+                self.retryFetchRecentWorkouts()
+                return
+            }
+
+            // Successful query: trust the result, empty or not (a real zero).
             DispatchQueue.main.async {
+                self.recentWorkoutsRetriesLeft = 3
                 self.recentWorkouts = workouts
             }
         }
 
         healthStore.execute(query)
+    }
+
+    /// Re-run a failed recent-workouts query a few times, backing off, so a
+    /// launch behind a locked screen still fills the list once it unlocks.
+    private func retryFetchRecentWorkouts() {
+        DispatchQueue.main.async {
+            guard self.recentWorkoutsRetriesLeft > 0 else { return }
+            let attempt = 4 - self.recentWorkoutsRetriesLeft
+            self.recentWorkoutsRetriesLeft -= 1
+            let delay = Double(attempt) * 2.0
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                self?.fetchRecentWorkouts()
+            }
+        }
     }
     
     // Helper method to check if user has completed their mile goal today

--- a/app/Mile A Day/Models/NotificationPreferences.swift
+++ b/app/Mile A Day/Models/NotificationPreferences.swift
@@ -1,5 +1,47 @@
 import Foundation
 
+/// Who may see my workout CONTENT — routes and photos. Mirrors the backend's
+/// `workout_visibility` on /notifications/preferences; the raw values must stay
+/// exactly these three strings (the DB has a CHECK constraint on them).
+///
+/// This is the coarse gate: it decides WHO gets in at all. The sharing toggles
+/// below it (`shareRouteMaps`, `shareWorkoutsToFeed`) decide WHAT those people
+/// then see. Both apply.
+enum WorkoutVisibility: String, Codable, CaseIterable, Identifiable {
+    case `public`
+    case friends
+    case `private`
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .public: return "Everyone"
+        case .friends: return "Friends only"
+        case .private: return "Only me"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .public:
+            return "Any Mile A Day user can open your profile and see your runs, routes and photos."
+        case .friends:
+            return "Only friends you've accepted. People you block never see them."
+        case .private:
+            return "Nobody but you. Your posts leave your friends' feeds too."
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .public: return "globe.americas.fill"
+        case .friends: return "person.2.fill"
+        case .private: return "lock.fill"
+        }
+    }
+}
+
 struct NotificationPreferences: Codable {
     var dailyReminderEnabled: Bool = true
     var dailyReminderHour: Int = 18 // 24-hour format
@@ -54,6 +96,15 @@ struct NotificationPreferences: Codable {
     var weeklyRecapEnabled: Bool {
         get { weeklyRecapEnabledRaw ?? true }
         set { weeklyRecapEnabledRaw = newValue }
+    }
+
+    /// Who can see my routes and photos. Same optional-backing pattern, and an
+    /// unrecognised stored value falls back to `.friends` rather than to
+    /// something more exposed.
+    private var workoutVisibilityRaw: String?
+    var workoutVisibility: WorkoutVisibility {
+        get { workoutVisibilityRaw.flatMap(WorkoutVisibility.init(rawValue:)) ?? .friends }
+        set { workoutVisibilityRaw = newValue.rawValue }
     }
 
     // Do Not Disturb schedule

--- a/app/Mile A Day/Services/FriendService.swift
+++ b/app/Mile A Day/Services/FriendService.swift
@@ -587,6 +587,24 @@ class FriendService: ObservableObject {
         return response
     }
 
+    /// One of a friend's workouts' GPS trace, for the detail screen's map.
+    ///
+    /// Your own detail reads its route from HealthKit, which only holds your own
+    /// runs — this is the equivalent for someone else's. Returns nil when there
+    /// is no route OR when the author's "Share route maps" setting hides it;
+    /// the server answers `{ "route": null }` either way, so the map simply
+    /// isn't drawn rather than erroring.
+    func fetchWorkoutRoute(for friendId: String, workoutId: String) async throws -> [[Double]]? {
+        let encodedId = workoutId.addingPercentEncoding(
+            withAllowedCharacters: .urlPathAllowed
+        ) ?? workoutId
+        let response: WorkoutRouteResponse = try await makeRequest(
+            endpoint: "/workouts/\(friendId)/workout/\(encodedId)/route",
+            responseType: WorkoutRouteResponse.self
+        )
+        return response.route
+    }
+
     /// Fetch stats for a friend
     func fetchFriendStats(for friendId: String) async throws -> FriendStats {
         let endpoint = "/workouts/\(friendId)/stats"
@@ -780,6 +798,14 @@ struct FeedWorkoutItem: Codable, Identifiable {
 // MARK: - Friend Workout Models
 
 /// Workout data for a friend
+/// `{ "route": [[lat, lng], ...] | null }` from
+/// `/workouts/:userId/workout/:workoutId/route`. Codable (not just Decodable)
+/// because `makeRequest` is generic over one `Codable` type for both body and
+/// response.
+struct WorkoutRouteResponse: Codable {
+    let route: [[Double]]?
+}
+
 struct FriendWorkout: Codable, Identifiable {
     let id: String
     let userId: String
@@ -790,6 +816,11 @@ struct FriendWorkout: Codable, Identifiable {
     let deviceEndDate: String?
     let calories: Double?
     let source: String?
+    /// This run carries a stored GPS trace. Optional: absent from older servers.
+    let hasRoute: Bool?
+    /// This run has a real (non-auto) photo post — never a generated route/stats
+    /// card. Optional: absent from older servers. Existence only, never a url.
+    let hasPhoto: Bool?
 
     var isManualOrEdited: Bool {
         source == "manual" || source == "edited"
@@ -805,6 +836,8 @@ struct FriendWorkout: Codable, Identifiable {
         case deviceEndDate = "device_end_date"
         case calories
         case source
+        case hasRoute = "has_route"
+        case hasPhoto = "has_photo"
     }
 
     var formattedDate: String {

--- a/app/Mile A Day/Utils/Extensions.swift
+++ b/app/Mile A Day/Utils/Extensions.swift
@@ -209,24 +209,31 @@ extension HKWorkout {
         return "\(deviceTimeString) (\(timezoneAbbrev) - device timezone)"
     }
     
+    // For the average pace display, we use the workout's total duration and distance
+    // This gives us the average pace for the entire workout, which is appropriate for workout summaries
+    // NOTE: For fastest mile calculations, use HealthKitManager.getWorkoutSplitTimes() to get per-mile splits
     var pace: String {
-        guard let distance = totalDistance,
-              distance.doubleValue(for: HKUnit.mile()) > 0 else { return "N/A" }
-        
-        let miles = distance.doubleValue(for: HKUnit.mile())
-        
-        // For the average pace display, we use the workout's total duration and distance
-        // This gives us the average pace for the entire workout, which is appropriate for workout summaries
-        // NOTE: For fastest mile calculations, use HealthKitManager.getWorkoutSplitTimes() to get per-mile splits
-        let minutesPerMile = duration / 60.0 / miles
-        
-        guard minutesPerMile > 0 && minutesPerMile < 60 else { return "N/A" } // Sanity check
-        
-        let minutes = Int(minutesPerMile)
-        let seconds = Int((minutesPerMile - Double(minutes)) * 60)
-        
-        return String(format: "%d:%02d /mi", minutes, seconds)
+        guard let distance = totalDistance else { return "N/A" }
+        return workoutPaceText(
+            distanceMiles: distance.doubleValue(for: HKUnit.mile()),
+            durationSeconds: duration
+        )
     }
+}
+
+/// Average pace for a workout summary — "8:12 /mi", or "N/A" when the numbers
+/// can't produce a believable one.
+///
+/// ONE definition, because a friend's detail screen used to compute this itself
+/// WITHOUT the sanity guard: a 0.04 mi stroll read "884:34 /mi" on their screen
+/// and "N/A" on your own, for the same kind of run.
+func workoutPaceText(distanceMiles: Double, durationSeconds: TimeInterval) -> String {
+    guard distanceMiles > 0 else { return "N/A" }
+    let minutesPerMile = durationSeconds / 60.0 / distanceMiles
+    guard minutesPerMile > 0, minutesPerMile < 60 else { return "N/A" } // Sanity check
+    let minutes = Int(minutesPerMile)
+    let seconds = Int((minutesPerMile - Double(minutes)) * 60)
+    return String(format: "%d:%02d /mi", minutes, seconds)
 }
 
 // MARK: - Progress Calculation Utilities

--- a/app/Mile A Day/Views/Components/FriendWorkoutsSection.swift
+++ b/app/Mile A Day/Views/Components/FriendWorkoutsSection.swift
@@ -79,13 +79,13 @@ struct FriendWorkoutRow: View {
                     Text(verb)
                         .font(.system(size: 14, weight: .bold, design: .rounded))
                         .foregroundColor(MADTheme.Colors.secondaryText)
+                        .lineLimit(1)
                     Text(workout.distance.milesFormatted)
                         .font(.system(size: 17, weight: .black, design: .rounded))
                         .monospacedDigit()
                         .foregroundColor(MADTheme.Colors.primaryText)
-                    if workout.isManualOrEdited {
-                        ManualWorkoutBadgeFromString(source: workout.source)
-                    }
+                        .lineLimit(1)
+                        .layoutPriority(1)
                 }
                 HStack(spacing: 5) {
                     Image(systemName: "clock.fill")
@@ -97,10 +97,22 @@ struct FriendWorkoutRow: View {
                         .font(.system(size: 12, weight: .semibold, design: .rounded))
                         .monospacedDigit()
                         .foregroundColor(MADTheme.Colors.secondaryText)
+                        .lineLimit(1)
                 }
+
+                // Identical chips to the owner's own WorkoutRow — a friend's run
+                // reads the same as yours. Route/photo come from the server
+                // (`has_route`/`has_photo`); older servers omit them and the
+                // chips simply don't draw.
+                WorkoutRowTags(
+                    source: WorkoutSource(rawValue: workout.source ?? "") ?? .healthkit,
+                    hasRoute: workout.hasRoute == true,
+                    hasPhoto: workout.hasPhoto == true,
+                    routeColor: workoutColor
+                )
             }
 
-            Spacer()
+            Spacer(minLength: MADTheme.Spacing.sm)
 
             VStack(alignment: .trailing, spacing: 2) {
                 Text(dateLabel)
@@ -112,6 +124,8 @@ struct FriendWorkoutRow: View {
                         .foregroundColor(MADTheme.Colors.secondaryText)
                 }
             }
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
 
             if showChevron {
                 Image(systemName: "chevron.right")

--- a/app/Mile A Day/Views/Components/ManualWorkoutBadge.swift
+++ b/app/Mile A Day/Views/Components/ManualWorkoutBadge.swift
@@ -47,7 +47,13 @@ extension ManualWorkoutBanner {
 
 // MARK: - Inline Capsule Badge (for rows and cards)
 
-/// Capsule badge for workout rows — clearly visible next to workout type
+/// Capsule badge for workout rows — clearly visible next to workout type.
+///
+/// `lineLimit(1)` + `fixedSize` are load-bearing: in a row this sits in a
+/// title line that competes with the distance and a trailing date column, and
+/// without them a narrow screen compressed the capsule until "Manual" wrapped
+/// to two lines inside it ("Man / ual"). The badge is a fixed-size atom — the
+/// row gives it room rather than squeezing it.
 struct ManualWorkoutBadge: View {
     let source: WorkoutSource
 
@@ -58,7 +64,9 @@ struct ManualWorkoutBadge: View {
                     .font(.system(size: 9))
                 Text(source == .manual ? "Manual" : "Edited")
                     .font(.system(size: 10, weight: .bold, design: .rounded))
+                    .lineLimit(1)
             }
+            .fixedSize(horizontal: true, vertical: false)
             .foregroundColor(.white)
             .padding(.horizontal, 7)
             .padding(.vertical, 3)

--- a/app/Mile A Day/Views/Components/WorkoutDetailSections.swift
+++ b/app/Mile A Day/Views/Components/WorkoutDetailSections.swift
@@ -1,0 +1,215 @@
+import SwiftUI
+
+/// The building blocks of a workout's detail screen, defined ONCE and shared by
+/// your own `WorkoutDetailView` and a friend's `FriendWorkoutDetailSheet`.
+///
+/// The two screens were assembled separately and drifted: a friend's run showed
+/// no route/photo tags, a bare stat row with no header, and no timeline at all,
+/// so the same workout read as a different thing depending on whose it was.
+/// Composing both from these means they can't drift again.
+
+/// The red-gradient header above each detail card ("Stats", "Timeline", …).
+struct WorkoutDetailSectionHeader: View {
+    let icon: String
+    let title: String
+
+    var body: some View {
+        HStack(spacing: MADTheme.Spacing.sm) {
+            Image(systemName: icon)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(MADTheme.Colors.redGradient)
+            Text(title)
+                .font(MADTheme.Typography.headline)
+                .foregroundColor(.primary)
+            Spacer()
+        }
+    }
+}
+
+/// A "Route" / "Photo" pill in the hero — the detail-sized sibling of the row's
+/// `WorkoutTagChip`.
+struct WorkoutHeroTag: View {
+    let icon: String
+    let label: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: icon)
+                .font(.system(size: 11, weight: .bold))
+            Text(label)
+                .font(.system(size: 12, weight: .heavy, design: .rounded))
+                .lineLimit(1)
+        }
+        .fixedSize(horizontal: true, vertical: false)
+        .foregroundColor(color)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(Capsule().fill(color.opacity(0.15)))
+    }
+}
+
+/// The detail's hero: how it was recorded, the activity type, the hero distance,
+/// the date, and what the run carries.
+///
+/// Deliberately un-animated. The route probe and post fetch land a beat after
+/// the screen opens, and animating the tags in made the whole card resize under
+/// the reader — the same reflow `WorkoutRow` already learned to avoid ("a crisp
+/// appearance reads cleaner"). The tags simply appear.
+struct WorkoutHeroCard<Banner: View>: View {
+    private let icon: String
+    private let typeLabel: String
+    private let color: Color
+    private let distanceText: String
+    private let dateText: String
+    private let source: WorkoutSource
+    private let hasRoute: Bool
+    private let hasPhoto: Bool
+    private let banner: Banner
+
+    init(
+        icon: String,
+        typeLabel: String,
+        color: Color,
+        distanceText: String,
+        dateText: String,
+        source: WorkoutSource = .healthkit,
+        hasRoute: Bool = false,
+        hasPhoto: Bool = false,
+        @ViewBuilder banner: () -> Banner
+    ) {
+        self.icon = icon
+        self.typeLabel = typeLabel
+        self.color = color
+        self.distanceText = distanceText
+        self.dateText = dateText
+        self.source = source
+        self.hasRoute = hasRoute
+        self.hasPhoto = hasPhoto
+        self.banner = banner()
+    }
+
+    var body: some View {
+        VStack(spacing: MADTheme.Spacing.md) {
+            // How it was recorded, first — a manual entry says so before it
+            // says anything else.
+            ManualWorkoutBanner(source: source)
+
+            // Caller-supplied warnings (e.g. the vehicle-speed notice on your
+            // own runs), inside the card with the rest of the header.
+            banner
+
+            HStack(spacing: MADTheme.Spacing.sm) {
+                Image(systemName: icon)
+                    .font(.system(size: 14, weight: .semibold))
+                Text(typeLabel)
+                    .font(MADTheme.Typography.smallBold)
+            }
+            .foregroundColor(color)
+            .padding(.horizontal, MADTheme.Spacing.md)
+            .padding(.vertical, MADTheme.Spacing.xs + 2)
+            .background(Capsule().fill(color.opacity(0.15)))
+
+            Text(distanceText)
+                .font(.system(size: 52, weight: .bold, design: .rounded))
+                .foregroundColor(.primary)
+
+            Text(dateText)
+                .font(MADTheme.Typography.body)
+                .foregroundColor(.secondary)
+
+            if hasRoute || hasPhoto {
+                HStack(spacing: MADTheme.Spacing.sm) {
+                    if hasRoute {
+                        WorkoutHeroTag(icon: "map.fill", label: "Route", color: color)
+                    }
+                    if hasPhoto {
+                        WorkoutHeroTag(icon: "photo.fill", label: "Photo", color: .pink)
+                    }
+                }
+                .padding(.top, MADTheme.Spacing.xs)
+            }
+        }
+        .padding(MADTheme.Spacing.lg)
+        .frame(maxWidth: .infinity)
+        .madLiquidGlass()
+    }
+}
+
+extension WorkoutHeroCard where Banner == EmptyView {
+    init(
+        icon: String,
+        typeLabel: String,
+        color: Color,
+        distanceText: String,
+        dateText: String,
+        source: WorkoutSource = .healthkit,
+        hasRoute: Bool = false,
+        hasPhoto: Bool = false
+    ) {
+        self.init(
+            icon: icon,
+            typeLabel: typeLabel,
+            color: color,
+            distanceText: distanceText,
+            dateText: dateText,
+            source: source,
+            hasRoute: hasRoute,
+            hasPhoto: hasPhoto,
+            banner: { EmptyView() }
+        )
+    }
+}
+
+/// The run's headline numbers. Distance lives in the hero; everything else
+/// lives here, once.
+struct WorkoutStatsCard: View {
+    let duration: String
+    let pace: String
+    /// Omitted entirely when absent — never rendered as a zero.
+    var calories: Int? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
+            WorkoutDetailSectionHeader(icon: "chart.bar.fill", title: "Stats")
+            HStack(spacing: MADTheme.Spacing.sm) {
+                DashboardStatBox(
+                    title: "Duration",
+                    value: duration,
+                    icon: "clock.fill",
+                    color: .orange
+                )
+                DashboardStatBox(
+                    title: "Pace",
+                    value: pace,
+                    icon: "speedometer",
+                    color: .green
+                )
+                if let calories {
+                    DashboardStatBox(
+                        title: "Calories",
+                        value: "\(calories)",
+                        icon: "flame.fill",
+                        color: MADTheme.Colors.madRed
+                    )
+                }
+            }
+        }
+    }
+}
+
+/// When the run started and ended.
+struct WorkoutTimelineCard: View {
+    let startText: String
+    let endText: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
+            WorkoutDetailSectionHeader(icon: "clock.arrow.2.circlepath", title: "Timeline")
+            DetailRow(icon: "play.fill", iconColor: .green, title: "Start", value: startText)
+            DetailRow(icon: "stop.fill", iconColor: MADTheme.Colors.madRed, title: "End", value: endText)
+        }
+        .padding(MADTheme.Spacing.md)
+        .madLiquidGlass()
+    }
+}

--- a/app/Mile A Day/Views/Components/WorkoutRowTags.swift
+++ b/app/Mile A Day/Views/Components/WorkoutRowTags.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// One metadata chip on a workout row — "Route", "Photo".
+///
+/// Fixed-size by construction: a row's chips must never be the thing that
+/// gives when space runs short, or the label wraps mid-word inside its capsule.
+struct WorkoutTagChip: View {
+    let icon: String
+    let label: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Image(systemName: icon)
+                .font(.system(size: 9, weight: .bold))
+            Text(label)
+                .font(.system(size: 10, weight: .heavy, design: .rounded))
+                .lineLimit(1)
+        }
+        .fixedSize(horizontal: true, vertical: false)
+        .foregroundColor(color)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(Capsule().fill(color.opacity(0.15)))
+    }
+}
+
+/// The chips under a workout row's headline: how it was recorded, and what
+/// tapping in will reveal. ONE definition shared by the dashboard's own
+/// `WorkoutRow` and a friend's `FriendWorkoutRow`, so a workout reads
+/// identically no matter whose it is.
+///
+/// They sit on their own line rather than beside the distance because the
+/// badges can't shrink: a title line carrying verb + hero distance + badge,
+/// competing with a trailing date column, ran out of room on narrow screens and
+/// wrapped both the distance and the badge mid-word.
+struct WorkoutRowTags: View {
+    var source: WorkoutSource = .healthkit
+    var hasRoute: Bool = false
+    var hasPhoto: Bool = false
+    /// Accent for the Route chip — the workout's own type color.
+    var routeColor: Color
+
+    private var isManualOrEdited: Bool { source == .manual || source == .edited }
+
+    var body: some View {
+        if isManualOrEdited || hasRoute || hasPhoto {
+            HStack(spacing: 6) {
+                ManualWorkoutBadge(source: source)
+                if hasRoute {
+                    WorkoutTagChip(icon: "map.fill", label: "Route", color: routeColor)
+                }
+                if hasPhoto {
+                    WorkoutTagChip(icon: "photo.fill", label: "Photo", color: .pink)
+                }
+            }
+            .padding(.top, 1)
+        }
+    }
+}

--- a/app/Mile A Day/Views/Dashboard/DashboardStatsViews.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardStatsViews.swift
@@ -210,11 +210,14 @@ struct RecentWorkoutsView: View {
 // MARK: - Recent Workouts Preview (dashboard)
 
 /// Compact dashboard card: a peek at the few most-recent workouts with a
-/// "See All" that opens the full Workouts screen (calendar + history + swipeable
-/// detail). Replaces the old buried collapsible list.
+/// "See All" that PUSHES the full Workouts screen (calendar + history +
+/// swipeable detail) as its own page. Replaces the old buried collapsible list.
+///
+/// The flag is owned by DashboardView so its `navigationDestination` can sit on
+/// the stack root; this card only sets it.
 struct RecentWorkoutsPreviewCard: View {
     @ObservedObject var healthManager: HealthKitManager
-    @State private var showWorkouts = false
+    @Binding var showWorkouts: Bool
 
     private var preview: [HKWorkout] { Array(healthManager.recentWorkouts.prefix(3)) }
 
@@ -262,8 +265,5 @@ struct RecentWorkoutsPreviewCard: View {
             .cardStyle()
         }
         .buttonStyle(.plain)
-        .sheet(isPresented: $showWorkouts) {
-            WorkoutsView(healthManager: healthManager)
-        }
     }
 }

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -27,6 +27,10 @@ struct DashboardView: View {
     @State private var showConfetti = false
     @State private var showGoalSheet = false
     @State private var showDashboardSettings = false
+    /// "See All" on the Recent Workouts card. Lives here, not on the card, so
+    /// the destination is registered on the stack's root — a
+    /// navigationDestination declared inside the scroll content can miss.
+    @State private var showWorkouts = false
     @State private var newGoalMiles: Double = 1.0
     @State private var isRefreshing = false
     @State private var showWorkoutUploadAlert = false
@@ -417,6 +421,9 @@ struct DashboardView: View {
                 currentGoal: userManager.currentUser.goalMiles,
                 onSetGoal: { showGoalSheet = true }
             )
+        }
+        .navigationDestination(isPresented: $showWorkouts) {
+            WorkoutsView(healthManager: healthManager)
         }
             .sheet(isPresented: $showManualWorkoutEntry) {
                 ManualWorkoutEntryView()
@@ -1359,7 +1366,7 @@ struct DashboardView: View {
 
             // Recent Workouts now lives behind a clean preview card that opens
             // the full Workouts screen (calendar + history + swipeable detail).
-            RecentWorkoutsPreviewCard(healthManager: healthManager)
+            RecentWorkoutsPreviewCard(healthManager: healthManager, showWorkouts: $showWorkouts)
         }
     }
 }

--- a/app/Mile A Day/Views/Dashboard/WorkoutDetailView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutDetailView.swift
@@ -30,8 +30,6 @@ struct WorkoutDetailView: View {
     @State private var showPostDeleteConfirm = false
     @State private var isAddingToFeed = false
     @State private var addToFeedError: String?
-    /// Drives the staggered fade-in of the detail's sections.
-    @State private var revealed = false
     @EnvironmentObject var healthManager: HealthKitManager
 
     private let workoutService = WorkoutService()
@@ -102,45 +100,43 @@ struct WorkoutDetailView: View {
                 MADTheme.Colors.appBackgroundGradient
                     .ignoresSafeArea()
 
+                // No entrance animation here on purpose. The sheet's own
+                // presentation IS the animation; fading + sliding the content in
+                // on top of it read as a second, mushier motion — and in the
+                // pager it was inconsistent besides, since TabView builds
+                // adjacent pages off-screen, so the reveal fired where nobody
+                // could see it and swiped-to pages just appeared.
                 ScrollView {
                     VStack(spacing: MADTheme.Spacing.lg) {
                         // Hero — type, hero distance, date, and route/photo tags.
                         heroCard
-                            .workoutReveal(revealed, index: 0)
 
                         // The run's feed/story post, rendered exactly like the
                         // feed shows it (photo, route + stats, caption). Owner
                         // actions — edit caption, add to feed, delete — live
                         // in the card's menu + header pill.
                         linkedPostSection
-                            .workoutReveal(revealed, index: 1)
 
                         // Route — pulled up front so a run with a GPS trace leads
                         // with the map (hidden when the post card above already
                         // carries the run's visuals — no double map).
                         if linkedPost == nil {
                             routeMapSection
-                                .workoutReveal(revealed, index: 2)
                         }
 
                         // The numbers — one home, no repeats across cards.
                         statsSection
-                            .workoutReveal(revealed, index: 3)
 
                         // Mile splits as a pace bar chart.
                         mileSplitsSection
-                            .workoutReveal(revealed, index: 4)
 
                         // When it started and ended.
                         timelineCard
-                            .workoutReveal(revealed, index: 5)
 
                         // Delete — remove an accidental / vehicle workout.
                         deleteButton
-                            .workoutReveal(revealed, index: 6)
                     }
                     .padding(MADTheme.Spacing.md)
-                    .onAppear { revealed = true }
                 }
             }
             .alert("Delete this workout?", isPresented: $showDeleteConfirm) {
@@ -419,62 +415,21 @@ struct WorkoutDetailView: View {
     // MARK: - Hero Card
 
     private var heroCard: some View {
-        VStack(spacing: MADTheme.Spacing.md) {
-            // Manual/edited warning banner
-            if workoutSource != .healthkit {
-                ManualWorkoutBanner(source: workoutSource)
-            }
-
+        WorkoutHeroCard(
+            icon: workoutIcon,
+            typeLabel: workoutTypeString,
+            color: workoutColor,
+            distanceText: workout.formattedDistance,
+            dateText: correctedEndTime.formattedDate,
+            source: workoutSource,
+            hasRoute: heroHasRoute,
+            hasPhoto: heroHasPhoto
+        ) {
             // Vehicle-speed warning — surfaces a likely drive so the user can remove it.
             if vehicleSuspicion != .none {
                 vehicleWarningBanner
             }
-
-            // Workout type badge
-            HStack(spacing: MADTheme.Spacing.sm) {
-                Image(systemName: workoutIcon)
-                    .font(.system(size: 14, weight: .semibold))
-                Text(workoutTypeString)
-                    .font(MADTheme.Typography.smallBold)
-            }
-            .foregroundColor(workoutColor)
-            .padding(.horizontal, MADTheme.Spacing.md)
-            .padding(.vertical, MADTheme.Spacing.xs + 2)
-            .background(
-                Capsule()
-                    .fill(workoutColor.opacity(0.15))
-            )
-
-            // Distance — the hero number
-            Text(workout.formattedDistance)
-                .font(.system(size: 52, weight: .bold, design: .rounded))
-                .foregroundColor(.primary)
-
-            // Date
-            Text(correctedEndTime.formattedDate)
-                .font(MADTheme.Typography.body)
-                .foregroundColor(.secondary)
-
-            // Route / photo tags — makes it obvious at a glance that this run
-            // carries a map or a picture, without scrolling to find them.
-            if heroHasRoute || heroHasPhoto {
-                HStack(spacing: MADTheme.Spacing.sm) {
-                    if heroHasRoute {
-                        heroTag(icon: "map.fill", label: "Route", color: workoutColor)
-                    }
-                    if heroHasPhoto {
-                        heroTag(icon: "photo.fill", label: "Photo", color: .pink)
-                    }
-                }
-                .padding(.top, MADTheme.Spacing.xs)
-                .transition(.opacity.combined(with: .scale(scale: 0.9)))
-            }
         }
-        .padding(MADTheme.Spacing.lg)
-        .frame(maxWidth: .infinity)
-        .madLiquidGlass()
-        .animation(.easeInOut(duration: 0.3), value: heroHasRoute)
-        .animation(.easeInOut(duration: 0.3), value: heroHasPhoto)
     }
 
     /// Does this run have a drawable GPS trace (drives the hero "Route" tag).
@@ -490,31 +445,10 @@ struct WorkoutDetailView: View {
         return post.is_auto != true && !post.media_url.isEmpty
     }
 
-    private func heroTag(icon: String, label: String, color: Color) -> some View {
-        HStack(spacing: 5) {
-            Image(systemName: icon)
-                .font(.system(size: 11, weight: .bold))
-            Text(label)
-                .font(.system(size: 12, weight: .heavy, design: .rounded))
-        }
-        .foregroundColor(color)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 5)
-        .background(Capsule().fill(color.opacity(0.15)))
-    }
-
     // MARK: - Section header (shared across the detail's cards)
 
     private func sectionHeader(_ icon: String, _ title: String) -> some View {
-        HStack(spacing: MADTheme.Spacing.sm) {
-            Image(systemName: icon)
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(MADTheme.Colors.redGradient)
-            Text(title)
-                .font(MADTheme.Typography.headline)
-                .foregroundColor(.primary)
-            Spacer()
-        }
+        WorkoutDetailSectionHeader(icon: icon, title: title)
     }
 
     // MARK: - Stats
@@ -523,46 +457,20 @@ struct WorkoutDetailView: View {
     /// everything else lives here (no more repeating pace/calories in a second
     /// "Performance" card).
     private var statsSection: some View {
-        VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
-            sectionHeader("chart.bar.fill", "Stats")
-            HStack(spacing: MADTheme.Spacing.sm) {
-                DashboardStatBox(
-                    title: "Duration",
-                    value: workout.formattedDuration,
-                    icon: "clock.fill",
-                    color: .orange
-                )
-
-                DashboardStatBox(
-                    title: "Pace",
-                    value: workout.pace,
-                    icon: "speedometer",
-                    color: .green
-                )
-
-                if let calories = calories {
-                    DashboardStatBox(
-                        title: "Calories",
-                        value: "\(Int(calories))",
-                        icon: "flame.fill",
-                        color: MADTheme.Colors.madRed
-                    )
-                }
-            }
-        }
+        WorkoutStatsCard(
+            duration: workout.formattedDuration,
+            pace: workout.pace,
+            calories: calories.map { Int($0) }
+        )
     }
 
     // MARK: - Timeline Card
 
     private var timelineCard: some View {
-        VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
-            sectionHeader("clock.arrow.2.circlepath", "Timeline")
-
-            DetailRow(icon: "play.fill", iconColor: .green, title: "Start", value: correctedStartTime.formattedTime)
-            DetailRow(icon: "stop.fill", iconColor: MADTheme.Colors.madRed, title: "End", value: correctedEndTime.formattedTime)
-        }
-        .padding(MADTheme.Spacing.md)
-        .madLiquidGlass()
+        WorkoutTimelineCard(
+            startText: correctedStartTime.formattedTime,
+            endText: correctedEndTime.formattedTime
+        )
     }
 
     // MARK: - Mile Splits
@@ -848,20 +756,5 @@ struct SplitBarRow: View {
                 grown = true
             }
         }
-    }
-}
-
-// MARK: - Staggered reveal
-
-private extension View {
-    /// A single, cohesive fade-in for the detail's sections. The old per-index
-    /// cascade (each card delayed a beat) read as clunky, so everything now
-    /// settles together with one quick, gentle motion. `index` is kept for the
-    /// call sites but no longer staggers the timing.
-    func workoutReveal(_ shown: Bool, index: Int) -> some View {
-        self
-            .opacity(shown ? 1 : 0)
-            .offset(y: shown ? 0 : 6)
-            .animation(.easeOut(duration: 0.28), value: shown)
     }
 }

--- a/app/Mile A Day/Views/Dashboard/WorkoutsView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutsView.swift
@@ -4,10 +4,10 @@ import HealthKit
 /// A dedicated home for a user's runs: a month calendar (completed days lit in
 /// the same language as the streak calendar) plus the selected day's workouts.
 /// Tapping a workout opens a swipeable detail (WorkoutPagerView) so you can flick
-/// through that day's runs. Reached from the Dashboard's "Recent Workouts" card.
+/// through that day's runs. PUSHED from the Dashboard's "Recent Workouts" card,
+/// so it owns no NavigationStack of its own and gets the standard back button.
 struct WorkoutsView: View {
     @ObservedObject var healthManager: HealthKitManager
-    @Environment(\.dismiss) private var dismiss
 
     private enum Mode: Hashable { case calendar, list }
     @State private var mode: Mode = .calendar
@@ -22,49 +22,40 @@ struct WorkoutsView: View {
     private let calendar = Calendar.current
 
     var body: some View {
-        NavigationStack {
-            ZStack {
-                MADTheme.Colors.appBackgroundGradient.ignoresSafeArea()
-                ScrollView {
-                    VStack(spacing: MADTheme.Spacing.lg) {
-                        Picker("View", selection: $mode) {
-                            Text("Calendar").tag(Mode.calendar)
-                            Text("List").tag(Mode.list)
-                        }
-                        .pickerStyle(.segmented)
-
-                        if mode == .calendar {
-                            calendarCard
-                            selectedDaySection
-                        } else {
-                            RecentWorkoutsView(workouts: healthManager.recentWorkouts)
-                        }
+        ZStack {
+            MADTheme.Colors.appBackgroundGradient.ignoresSafeArea()
+            ScrollView {
+                VStack(spacing: MADTheme.Spacing.lg) {
+                    Picker("View", selection: $mode) {
+                        Text("Calendar").tag(Mode.calendar)
+                        Text("List").tag(Mode.list)
                     }
-                    .padding(MADTheme.Spacing.md)
+                    .pickerStyle(.segmented)
+
+                    if mode == .calendar {
+                        calendarCard
+                        selectedDaySection
+                    } else {
+                        RecentWorkoutsView(workouts: healthManager.recentWorkouts)
+                    }
                 }
+                .padding(MADTheme.Spacing.md)
             }
-            .navigationTitle("Workouts")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbarColorScheme(.dark, for: .navigationBar)
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") { dismiss() }
-                        .foregroundColor(MADTheme.Colors.madRed)
-                        .fontWeight(.semibold)
-                }
-            }
-            .task {
-                pickDefaultDayIfNeeded()
-                await loadLinkedPosts()
-            }
-            .sheet(item: $selectedWorkout) { identifiable in
-                let list = workouts(on: selectedDay ?? Date())
-                WorkoutPagerView(
-                    workouts: list,
-                    startIndex: list.firstIndex { $0.uuid == identifiable.workout.uuid } ?? 0,
-                    preloadedPosts: postsByWorkout
-                )
-            }
+        }
+        .navigationTitle("Workouts")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .task {
+            pickDefaultDayIfNeeded()
+            await loadLinkedPosts()
+        }
+        .sheet(item: $selectedWorkout) { identifiable in
+            let list = workouts(on: selectedDay ?? Date())
+            WorkoutPagerView(
+                workouts: list,
+                startIndex: list.firstIndex { $0.uuid == identifiable.workout.uuid } ?? 0,
+                preloadedPosts: postsByWorkout
+            )
         }
         // Keep the shared HealthKit manager available to WorkoutRow / the pager's
         // detail views regardless of how this screen was presented.
@@ -74,24 +65,34 @@ struct WorkoutsView: View {
     // MARK: - Calendar
 
     private var calendarCard: some View {
-        VStack(spacing: MADTheme.Spacing.md) {
+        // One pass for the whole month, then every cell just reads its facts.
+        let info = monthInfo
+        return VStack(spacing: MADTheme.Spacing.md) {
             HStack {
                 Button { changeMonth(-1) } label: {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 15, weight: .bold))
                         .foregroundColor(.white)
                         .frame(width: 36, height: 36)
+                        .contentShape(Rectangle())
                 }
                 Spacer()
-                Text(monthTitle)
-                    .font(.system(size: 17, weight: .heavy, design: .rounded))
-                    .foregroundColor(.white)
+                VStack(spacing: 1) {
+                    Text(monthTitle)
+                        .font(.system(size: 17, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+                    Text(monthSummary(info))
+                        .font(.system(size: 11, weight: .semibold, design: .rounded))
+                        .monospacedDigit()
+                        .foregroundColor(.white.opacity(0.5))
+                }
                 Spacer()
                 Button { changeMonth(1) } label: {
                     Image(systemName: "chevron.right")
                         .font(.system(size: 15, weight: .bold))
                         .foregroundColor(canGoNext ? .white : .white.opacity(0.2))
                         .frame(width: 36, height: 36)
+                        .contentShape(Rectangle())
                 }
                 .disabled(!canGoNext)
             }
@@ -105,38 +106,105 @@ struct WorkoutsView: View {
                 }
             }
 
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 4), count: 7), spacing: 8) {
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 4), count: 7), spacing: 6) {
                 ForEach(Array(monthCells.enumerated()), id: \.offset) { _, cell in
                     if let date = cell {
-                        dayCell(date)
+                        dayCell(
+                            date,
+                            status: dayStatus(date),
+                            info: info[calendar.startOfDay(for: date)] ?? DayInfo()
+                        )
                     } else {
-                        Color.clear.frame(height: 38)
+                        Color.clear.frame(height: Self.cellHeight)
                     }
                 }
             }
+
+            calendarLegend
         }
         .padding()
         .cardStyle()
     }
 
-    private func dayCell(_ date: Date) -> some View {
-        let status = dayStatus(date)
+    /// Height of a day cell: the 36pt disc plus the type-dot strip under it.
+    private static let cellHeight: CGFloat = 47
+
+    /// Without this, the dots and the camera badge are just decoration nobody
+    /// can decode — the legend is what makes the month readable at a glance.
+    private var calendarLegend: some View {
+        HStack(spacing: MADTheme.Spacing.md) {
+            legendItem(color: MADTheme.workoutColor("running"), label: "Run")
+            legendItem(color: MADTheme.workoutColor("walking"), label: "Walk")
+            HStack(spacing: 4) {
+                Image(systemName: "camera.fill")
+                    .font(.system(size: 7, weight: .black))
+                    .foregroundColor(.white)
+                    .padding(2.5)
+                    .background(Circle().fill(Color.pink))
+                Text("Photo")
+                    .font(.system(size: 10, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.6))
+            }
+            Spacer()
+        }
+        .padding(.top, 2)
+    }
+
+    private func legendItem(color: Color, label: String) -> some View {
+        HStack(spacing: 4) {
+            Circle().fill(color).frame(width: 6, height: 6)
+            Text(label)
+                .font(.system(size: 10, weight: .bold, design: .rounded))
+                .foregroundColor(.white.opacity(0.6))
+        }
+    }
+
+    /// A day: the goal-status disc (same language as the streak calendar), a dot
+    /// per activity type under it — two dots is a run-AND-walk day — and a
+    /// camera badge when one of that day's runs carries a photo.
+    private func dayCell(_ date: Date, status: DayStatus, info: DayInfo) -> some View {
         let isToday = calendar.isDateInToday(date)
         let isSelected = selectedDay.map { calendar.isDate($0, inSameDayAs: date) } ?? false
         return Button {
             withAnimation(.easeInOut(duration: 0.15)) { selectedDay = date }
         } label: {
-            Text("\(calendar.component(.day, from: date))")
-                .font(.system(size: 14, weight: .bold, design: .rounded))
-                .foregroundColor(status == .none ? .white.opacity(0.45) : .white)
-                .frame(width: 38, height: 38)
-                .background(Circle().fill(status.fill))
-                .overlay(
-                    Circle().strokeBorder(
-                        isSelected ? Color.white : (isToday ? MADTheme.Colors.madRed : .clear),
-                        lineWidth: isSelected ? 2 : 1.5
+            VStack(spacing: 4) {
+                Text("\(calendar.component(.day, from: date))")
+                    .font(.system(size: 14, weight: .bold, design: .rounded))
+                    .foregroundColor(status == .none ? .white.opacity(0.45) : .white)
+                    .frame(width: 36, height: 36)
+                    .background(Circle().fill(status.fill))
+                    .overlay(
+                        Circle().strokeBorder(
+                            isSelected ? Color.white : (isToday ? MADTheme.Colors.madRed : .clear),
+                            lineWidth: isSelected ? 2 : 1.5
+                        )
                     )
-                )
+                    .overlay(alignment: .topTrailing) {
+                        if info.hasPhoto {
+                            Image(systemName: "camera.fill")
+                                .font(.system(size: 6, weight: .black))
+                                .foregroundColor(.white)
+                                .padding(2.5)
+                                .background(Circle().fill(Color.pink))
+                                .overlay(Circle().strokeBorder(Color.black.opacity(0.4), lineWidth: 1))
+                                .offset(x: 2, y: -2)
+                        }
+                    }
+
+                // Reserved strip: dots or not, every cell is the same height, so
+                // the grid never reflows row-to-row.
+                HStack(spacing: 3) {
+                    ForEach(info.types, id: \.self) { type in
+                        Circle()
+                            .fill(MADTheme.workoutColor(type))
+                            .frame(width: 5, height: 5)
+                    }
+                }
+                .frame(height: 5)
+            }
+            .frame(height: Self.cellHeight)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }
@@ -234,6 +302,70 @@ struct WorkoutsView: View {
             case .complete: return MADTheme.Colors.success
             }
         }
+    }
+
+    /// The decoration a single calendar day carries. Goal status is NOT in here
+    /// — it stays with `dayStatus`, which reads the timezone-aware index, so the
+    /// disc's fill keeps matching the streak calendar exactly even when the
+    /// workout cache and the index disagree.
+    private struct DayInfo {
+        /// Distinct activity types that day, run first — one dot each, so a
+        /// run-AND-walk day reads as two dots without any extra chrome.
+        var types: [String] = []
+        var hasPhoto: Bool = false
+    }
+
+    /// The visible month's type dots and photo flags, bucketed in ONE pass over
+    /// the workout cache and keyed by start-of-day.
+    ///
+    /// Deliberately not `workouts(on:)` per cell: that re-filters the entire
+    /// cache for each of the 42 cells, and for a day with no indexed workouts it
+    /// takes the expensive corrected-time fallback — 40k+ calendar comparisons
+    /// per body evaluation on a long history, on every day tap. Bucketing by
+    /// `getCorrectedLocalTime` groups by the same local day that function does.
+    private var monthInfo: [Date: DayInfo] {
+        guard let interval = calendar.dateInterval(of: .month, for: month) else { return [:] }
+        var out: [Date: DayInfo] = [:]
+        for workout in healthManager.cachedWorkouts {
+            let day = calendar.startOfDay(for: healthManager.getCorrectedLocalTime(for: workout))
+            guard day >= interval.start, day < interval.end else { continue }
+            var info = out[day] ?? DayInfo()
+            let key = workout.workoutActivityType.madTypeKey
+            if !info.types.contains(key) { info.types.append(key) }
+            if hasRealPhoto(postsByWorkout[workout.uuid.uuidString]) { info.hasPhoto = true }
+            out[day] = info
+        }
+        for (day, info) in out {
+            out[day] = DayInfo(
+                types: info.types.sorted { typeRank($0) < typeRank($1) },
+                hasPhoto: info.hasPhoto
+            )
+        }
+        return out
+    }
+
+    /// Run before walk before anything else, so a both-day's dots never swap
+    /// order between renders.
+    private func typeRank(_ type: String) -> Int {
+        switch type {
+        case "running": return 0
+        case "walking": return 1
+        default: return 2
+        }
+    }
+
+    /// "12 of 31 days · 38.4 mi" — the month at a glance under its title. Only
+    /// days that actually have workouts are priced, so this costs one index
+    /// lookup per active day rather than a scan per cell.
+    private func monthSummary(_ info: [Date: DayInfo]) -> String {
+        let days = calendar.range(of: .day, in: .month, for: month)?.count ?? 30
+        var complete = 0
+        var total = 0.0
+        for day in info.keys {
+            if dayStatus(day) == .complete { complete += 1 }
+            total += miles(on: day)
+        }
+        return String(format: "%d of %d days \u{00B7} %.1f mi", complete, days, total)
     }
 
     private func dayStatus(_ date: Date) -> DayStatus {

--- a/app/Mile A Day/Views/Feed/PostCardView.swift
+++ b/app/Mile A Day/Views/Feed/PostCardView.swift
@@ -153,12 +153,14 @@ struct PostCardView: View {
 
     /// Image slides, real moment first: when the run has a story photo it
     /// leads, and the post media (photo or route/stats card) becomes the
-    /// second slide — never a cramped corner thumbnail.
-    private var photoURLs: [URL?] {
+    /// second slide — never a cramped corner thumbnail. Photos the server
+    /// withheld arrive blank and drop out here; `mediaSlides` puts a single
+    /// lock in their place, ahead of whatever survived.
+    private var photoURLs: [URL] {
         if let storyPhotoURL {
-            return [storyPhotoURL, post.mediaURL]
+            return [storyPhotoURL, post.mediaURL].compactMap { $0 }
         }
-        return [post.mediaURL]
+        return [post.mediaURL].compactMap { $0 }
     }
 
     /// Whether to append a branded workout-stats card as the run's second
@@ -198,19 +200,10 @@ struct PostCardView: View {
         celebrateAndHype()
     }
 
-    /// The media block: a lock card when the server withheld today's photo
-    /// (the viewer hasn't run yet), otherwise the real photo/route carousel.
-    @ViewBuilder
-    private var media: some View {
-        if post.isPhotoLocked {
-            lockedMediaCard
-        } else {
-            unlockedMedia
-        }
-    }
-
-    /// Shown in place of the photo when it's locked — a frosted "run to unlock"
-    /// card, matching the app's earn-to-view story gate.
+    /// Shown in place of a WITHHELD PHOTO — a frosted "run to unlock" card,
+    /// matching the app's earn-to-view story gate. It's one slide among the
+    /// rest, so it clips like a photo slide rather than squaring off next to
+    /// them.
     private var lockedMediaCard: some View {
         ZStack {
             LinearGradient(
@@ -233,42 +226,81 @@ struct PostCardView: View {
         }
         .frame(maxWidth: .infinity)
         .aspectRatio(4.0 / 5.0, contentMode: .fit)
-        .clipped()
+        .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
     }
 
-    /// A single photo, or a full-size swipeable carousel:
-    /// photo → route/stats card → route map. The hype burst plays centered
-    /// over whichever slide is showing.
+    /// One page of the media carousel.
+    private enum MediaSlide {
+        /// Stands in for the photo(s) the server withheld.
+        case locked
+        case photo(url: URL, badged: Bool)
+        case route(coords: [CLLocationCoordinate2D])
+        case statsCard(stats: PostStats)
+    }
+
+    /// The carousel's pages in swipe order: the lock (standing in for ANY
+    /// withheld photo, however many were held back) → the photos that survived
+    /// the gate → the route map, or the stats card when there's no route.
+    ///
+    /// The lock only ever replaces a picture. An auto route/stats card, a route
+    /// map, and the page dots all survive it — so a viewer who hasn't run yet
+    /// can still swipe a friend's run, just not see their photo.
+    private var mediaSlides: [MediaSlide] {
+        var slides: [MediaSlide] = []
+        if post.isPhotoLocked { slides.append(.locked) }
+        for url in photoURLs {
+            // Badge an auto route/stats card that trails a photo (or its lock)
+            // so the swipe reads "photo → stats".
+            slides.append(.photo(url: url, badged: !slides.isEmpty && post.is_auto == true))
+        }
+        if let coords = routeSlideCoordinates {
+            slides.append(.route(coords: coords))
+        } else if let stats = workoutCardStats {
+            slides.append(.statsCard(stats: stats))
+        }
+        return slides
+    }
+
     @ViewBuilder
-    private var unlockedMedia: some View {
-        let slides = photoURLs
-        let coords = routeSlideCoordinates
-        let cardStats = workoutCardStats
+    private func slideView(_ slide: MediaSlide) -> some View {
+        switch slide {
+        case .locked:
+            lockedMediaCard
+        case .photo(let url, let badged):
+            ZoomablePhotoSlide(
+                url: url,
+                badge: badged ? ("Stats", "chart.bar.fill") : nil,
+                onDoubleTap: post.is_self ? nil : doubleTapHype
+            )
+        case .route(let coords):
+            routeSlide(coords)
+        case .statsCard(let stats):
+            workoutCardSlide(stats)
+        }
+    }
+
+    /// A single slide, or a full-size swipeable carousel. The hype burst plays
+    /// centered over whichever slide is showing.
+    @ViewBuilder
+    private var media: some View {
+        let slides = mediaSlides
         Group {
-            if slides.count > 1 || coords != nil || cardStats != nil {
+            if slides.count > 1 {
                 TabView {
-                    ForEach(Array(slides.enumerated()), id: \.offset) { index, url in
-                        // When the story photo leads, badge the trailing auto
-                        // route/stats card so the swipe reads as "photo → stats".
-                        ZoomablePhotoSlide(
-                            url: url,
-                            badge: index > 0 && post.is_auto == true ? ("Stats", "chart.bar.fill") : nil,
-                            onDoubleTap: post.is_self ? nil : doubleTapHype
-                        )
-                    }
-                    if let coords {
-                        routeSlide(coords)
-                    } else if let cardStats {
-                        workoutCardSlide(cardStats)
+                    ForEach(Array(slides.enumerated()), id: \.offset) { _, slide in
+                        slideView(slide)
                     }
                 }
                 .tabViewStyle(.page(indexDisplayMode: .always))
                 .indexViewStyle(.page(backgroundDisplayMode: .interactive))
                 .frame(maxWidth: .infinity)
                 .aspectRatio(4.0 / 5.0, contentMode: .fit)
+            } else if let only = slides.first {
+                slideView(only)
             } else {
+                // No media at all — the empty-state placeholder.
                 ZoomablePhotoSlide(
-                    url: post.mediaURL,
+                    url: nil,
                     badge: nil,
                     onDoubleTap: post.is_self ? nil : doubleTapHype
                 )

--- a/app/Mile A Day/Views/Feed/ProfilePostsGridView.swift
+++ b/app/Mile A Day/Views/Feed/ProfilePostsGridView.swift
@@ -195,15 +195,17 @@ struct ProfilePostsGridView: View {
     }
 
     private func thumbnail(_ post: PostItem) -> some View {
-        Color.clear
+        // The real picture leads when the run has one; the workout card is only
+        // the face of the post when no photo exists.
+        let url = post.storyPhotoURL ?? post.mediaURL
+        return Color.clear
             .aspectRatio(1, contentMode: .fit)
             .overlay(
-                // The real picture leads when the run has one; the workout
-                // card is only the face of the post when no photo exists. When
-                // the server locks today's photo (viewer hasn't run), show a
-                // lock tile instead — tapping it opens the same locked card.
+                // The lock tile is for when the withheld photo WAS the tile —
+                // an auto route/stats card that survived the gate still shows
+                // its face, since only the picture is locked.
                 Group {
-                    if post.isPhotoLocked {
+                    if url == nil, post.isPhotoLocked {
                         ZStack {
                             LinearGradient(
                                 colors: [MADTheme.Colors.madRed.opacity(0.30), Color.black.opacity(0.6)],
@@ -214,7 +216,7 @@ struct ProfilePostsGridView: View {
                                 .foregroundColor(.white.opacity(0.9))
                         }
                     } else {
-                        AsyncImage(url: post.storyPhotoURL ?? post.mediaURL) { phase in
+                        AsyncImage(url: url) { phase in
                             switch phase {
                             case .success(let image): image.resizable().scaledToFill()
                             case .failure:
@@ -325,6 +327,15 @@ struct ProfilePostsFeedSheet: View {
     @State private var deletingPost: PostItem?
     @State private var reportingPost: PostItem?
     @State private var hypingIds: Set<String> = []
+    /// The list starts at the TOP and only then scrolls to the tapped post, so
+    /// the first frames show whoever is newest — reading as a flash of someone
+    /// else's card (a lock card, when today's photo is still unearned) before
+    /// settling. Stay invisible until we're parked on the right post.
+    @State private var didPosition = false
+
+    /// Tapping the newest post needs no scroll at all — show it immediately
+    /// rather than fading in after a settle delay it doesn't need.
+    private var needsScroll: Bool { posts.first?.post_id != initialPostId }
 
     var body: some View {
         NavigationStack {
@@ -345,14 +356,24 @@ struct ProfilePostsFeedSheet: View {
                         .padding(MADTheme.Spacing.md)
                         .padding(.bottom, MADTheme.Spacing.xl)
                     }
+                    // Held invisible (not unbuilt — opacity doesn't affect
+                    // layout, so the LazyVStack still lays out and scrollTo
+                    // still lands) until we're parked on the tapped post.
+                    .opacity(didPosition ? 1 : 0)
                     .onAppear {
+                        guard needsScroll else {
+                            didPosition = true
+                            return
+                        }
                         // LazyVStack hasn't laid out far-down cards yet when
                         // onAppear fires, so a single scrollTo can land short
                         // for deep taps — jump, then correct once layout has
-                        // caught up.
+                        // caught up. Reveal only after the correction, which
+                        // lands while the sheet is still animating in.
                         proxy.scrollTo(initialPostId, anchor: .top)
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                             proxy.scrollTo(initialPostId, anchor: .top)
+                            withAnimation(.easeOut(duration: 0.12)) { didPosition = true }
                         }
                     }
                 }

--- a/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
+++ b/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import CoreLocation
 
 /// Detailed view for displaying a user's profile information
 struct UserProfileDetailView: View {
@@ -123,7 +124,7 @@ struct UserProfileDetailView: View {
             }
         }
         .sheet(item: $selectedWorkout) { workout in
-            FriendWorkoutDetailSheet(workout: workout)
+            FriendWorkoutDetailSheet(workout: workout, friendService: friendService)
         }
         .sheet(isPresented: $showCompeteSheet) {
             CreateCompetitionView(
@@ -1101,14 +1102,85 @@ struct UserProfileDetailView: View {
 
 struct FriendWorkoutDetailSheet: View {
     let workout: FriendWorkout
+    /// Passed down rather than constructed here — FriendService has no shared
+    /// instance, and a View struct is rebuilt constantly.
+    @ObservedObject var friendService: FriendService
     @Environment(\.dismiss) private var dismiss
 
+    /// The run's post, so this shows the actual photo — not just a chip saying
+    /// one exists. Same card the feed draws (and the same lock when today's
+    /// photo hasn't been earned yet).
+    @State private var linkedPost: PostItem?
+    /// The run's GPS trace from the server — the owner's own detail gets this
+    /// from HealthKit, which never holds someone else's runs.
+    @State private var routeCoordinates: [CLLocationCoordinate2D]?
+    @State private var isLoadingRoute = false
+
+    /// The same rule your own detail uses, sanity guard included.
     private var pace: String {
-        guard workout.distance > 0, workout.totalDuration > 0 else { return "N/A" }
-        let minutesPerMile = (workout.totalDuration / 60.0) / workout.distance
-        let minutes = Int(minutesPerMile)
-        let seconds = Int((minutesPerMile - Double(minutes)) * 60)
-        return String(format: "%d:%02d /mi", minutes, seconds)
+        workoutPaceText(distanceMiles: workout.distance, durationSeconds: workout.totalDuration)
+    }
+
+    /// The run's post, headed like your own detail's "On the Feed" section but
+    /// without the owner's edit/delete/add-to-feed controls.
+    private func linkedPostSection(_ post: PostItem) -> some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+            WorkoutDetailSectionHeader(icon: "photo.on.rectangle.angled", title: "On the Feed")
+            PostCardView(
+                post: post,
+                storyPhotoURL: post.storyPhotoURL,
+                onHype: {},
+                onReport: {},
+                onBlock: {},
+                onDelete: {}
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var routeMapSection: some View {
+        if let routeCoordinates, !routeCoordinates.isEmpty {
+            VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
+                WorkoutDetailSectionHeader(icon: "map.fill", title: "Route")
+                WorkoutRouteMapView(
+                    coordinates: routeCoordinates,
+                    routeColor: workoutColor
+                )
+                .frame(height: 260)
+                .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
+                        .strokeBorder(Color.white.opacity(0.08), lineWidth: 1)
+                )
+            }
+            .padding(MADTheme.Spacing.md)
+            .madLiquidGlass()
+        }
+    }
+
+    /// The run's post, found by workout id among the author's posts — the same
+    /// lookup your own detail does, just for someone else's id. The server
+    /// scopes it to your circle and applies the photo gate.
+    private func loadLinkedPost() async {
+        guard linkedPost == nil else { return }
+        let post = try? await PostService.fetchOwnPostForWorkout(
+            workoutId: workout.id, userId: workout.userId
+        )
+        await MainActor.run { linkedPost = post }
+    }
+
+    /// Only when the server said there's a route to draw — no point asking
+    /// otherwise, and `has_route` is already consent-gated.
+    private func loadRoute() async {
+        guard workout.hasRoute == true, routeCoordinates == nil, !isLoadingRoute else { return }
+        await MainActor.run { isLoadingRoute = true }
+        let raw = try? await friendService.fetchWorkoutRoute(
+            for: workout.userId, workoutId: workout.id
+        )
+        await MainActor.run {
+            routeCoordinates = decodeRouteCoordinates(raw)
+            isLoadingRoute = false
+        }
     }
 
     private var workoutColor: Color {
@@ -1125,77 +1197,75 @@ struct FriendWorkoutDetailSheet: View {
         }
     }
 
+    /// End − duration, the same way FriendWorkoutRow derives it. Nil when the
+    /// server has no device timestamp, which is the only reason the timeline
+    /// card is ever missing here.
+    private var startDate: Date? {
+        guard let end = workout.deviceEndDate, let d = RelativeTime.date(from: end) else { return nil }
+        return d.addingTimeInterval(-workout.totalDuration)
+    }
+
+    private var endDate: Date? {
+        guard let end = workout.deviceEndDate else { return nil }
+        return RelativeTime.date(from: end)
+    }
+
     var body: some View {
         NavigationStack {
             ZStack {
                 MADTheme.Colors.appBackgroundGradient
                     .ignoresSafeArea()
 
+                // Same sections, same order, same components as your own
+                // WorkoutDetailView — a friend's run reads exactly like yours.
+                // Splits, the route map and the post card are the only things
+                // missing, because the server doesn't hand those over for
+                // someone else's workout.
                 ScrollView {
                     VStack(spacing: MADTheme.Spacing.lg) {
-                        // Hero card
-                        VStack(spacing: MADTheme.Spacing.md) {
-                            // Manual/edited warning banner
-                            if workout.isManualOrEdited {
-                                ManualWorkoutBanner(source: workout.source)
-                            }
+                        WorkoutHeroCard(
+                            icon: workoutIcon,
+                            typeLabel: workout.workoutType.capitalized,
+                            color: workoutColor,
+                            distanceText: workout.formattedDistance,
+                            dateText: workout.formattedDate,
+                            source: WorkoutSource(rawValue: workout.source ?? "") ?? .healthkit,
+                            hasRoute: workout.hasRoute == true,
+                            hasPhoto: workout.hasPhoto == true
+                        )
 
-                            // Workout type badge
-                            HStack(spacing: MADTheme.Spacing.sm) {
-                                Image(systemName: workoutIcon)
-                                    .font(.system(size: 14, weight: .semibold))
-                                Text(workout.workoutType.capitalized)
-                                    .font(MADTheme.Typography.smallBold)
-                            }
-                            .foregroundColor(workoutColor)
-                            .padding(.horizontal, MADTheme.Spacing.md)
-                            .padding(.vertical, MADTheme.Spacing.xs + 2)
-                            .background(
-                                Capsule()
-                                    .fill(workoutColor.opacity(0.15))
-                            )
-
-                            // Distance
-                            Text(workout.formattedDistance)
-                                .font(.system(size: 52, weight: .bold, design: .rounded))
-                                .foregroundColor(.primary)
-
-                            // Date
-                            Text(workout.formattedDate)
-                                .font(MADTheme.Typography.body)
-                                .foregroundColor(.secondary)
+                        // The run's post — the real photo, exactly as the feed
+                        // renders it. Read-only: hyping and reporting live on
+                        // the feed, and none of the owner actions apply here.
+                        if let post = linkedPost {
+                            linkedPostSection(post)
                         }
-                        .padding(MADTheme.Spacing.lg)
-                        .frame(maxWidth: .infinity)
-                        .madLiquidGlass()
 
-                        // Stats row
-                        HStack(spacing: MADTheme.Spacing.sm) {
-                            DashboardStatBox(
-                                title: "Duration",
-                                value: workout.formattedDuration,
-                                icon: "clock.fill",
-                                color: .orange
+                        // The map, on the same rule as your own detail: hidden
+                        // when the post card above already carries the run's
+                        // visuals, so there's never a double map.
+                        if linkedPost == nil {
+                            routeMapSection
+                        }
+
+                        WorkoutStatsCard(
+                            duration: workout.formattedDuration,
+                            pace: pace,
+                            calories: workout.calories.flatMap { $0 > 0 ? Int($0) : nil }
+                        )
+
+                        if let start = startDate, let end = endDate {
+                            WorkoutTimelineCard(
+                                startText: start.formattedTime,
+                                endText: end.formattedTime
                             )
-
-                            DashboardStatBox(
-                                title: "Pace",
-                                value: pace,
-                                icon: "speedometer",
-                                color: .green
-                            )
-
-                            if let calories = workout.calories, calories > 0 {
-                                DashboardStatBox(
-                                    title: "Calories",
-                                    value: "\(Int(calories))",
-                                    icon: "flame.fill",
-                                    color: MADTheme.Colors.madRed
-                                )
-                            }
                         }
                     }
                     .padding(MADTheme.Spacing.md)
+                }
+                .task {
+                    await loadLinkedPost()
+                    await loadRoute()
                 }
             }
             .navigationTitle("")

--- a/app/Mile A Day/Views/NotificationSettingsView.swift
+++ b/app/Mile A Day/Views/NotificationSettingsView.swift
@@ -141,6 +141,23 @@ struct NotificationSettingsView: View {
                         settingsToggle("Friend nudges", isOn: $prefs.friendNudgeEnabled)
                     }
 
+                    // Privacy — the coarse gate. Sits above the sharing toggles
+                    // because it decides WHO gets in at all; those decide what
+                    // they then see.
+                    settingsSection(title: "WHO CAN SEE MY WORKOUTS", icon: "eye.fill", iconColor: .purple) {
+                        VStack(spacing: 0) {
+                            ForEach(Array(WorkoutVisibility.allCases.enumerated()), id: \.element.id) { index, option in
+                                if index > 0 { settingsDivider }
+                                visibilityOption(option)
+                            }
+                        }
+                        Text("Applies to your routes, photos and posts. Blocked people never see them, whatever you pick.")
+                            .font(.system(size: 11, design: .rounded))
+                            .foregroundColor(.white.opacity(0.35))
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.top, 2)
+                    }
+
                     // Feed & Stories (v2)
                     settingsSection(title: "FEED & STORIES", icon: "square.stack.fill", iconColor: MADTheme.Colors.madRed) {
                         settingsToggle("Share my walks & runs to the feed", isOn: $prefs.shareWorkoutsToFeed,
@@ -340,6 +357,7 @@ struct NotificationSettingsView: View {
         .task {
             await friendService.refreshAllData()
             await loadFriendSettingsAsync()
+            await loadVisibilityFromServer()
         }
     }
 
@@ -389,6 +407,66 @@ struct NotificationSettingsView: View {
         Divider().overlay(Color.white.opacity(0.06))
     }
 
+    // MARK: - Visibility picker
+
+    /// Accent per option — green reads "open", red reads "shut". The tint is
+    /// what carries the state at a glance, before you read a word.
+    private func visibilityTint(_ option: WorkoutVisibility) -> Color {
+        switch option {
+        case .public: return .green
+        case .friends: return .blue
+        case .private: return MADTheme.Colors.madRed
+        }
+    }
+
+    /// One choice in the visibility picker. A row rather than a segmented
+    /// control because each option needs a sentence to be honest about what it
+    /// does — nobody should have to guess what "Everyone" reaches.
+    private func visibilityOption(_ option: WorkoutVisibility) -> some View {
+        let selected = prefs.workoutVisibility == option
+        let tint = visibilityTint(option)
+        return Button {
+            guard !selected else { return }
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            withAnimation(.easeInOut(duration: 0.15)) {
+                prefs.workoutVisibility = option
+            }
+        } label: {
+            HStack(spacing: MADTheme.Spacing.md) {
+                ZStack {
+                    Circle()
+                        .fill(selected ? tint.opacity(0.22) : Color.white.opacity(0.06))
+                        .frame(width: 34, height: 34)
+                    Image(systemName: option.icon)
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundColor(selected ? tint : .white.opacity(0.4))
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(option.title)
+                        .font(MADTheme.Typography.body)
+                        .foregroundColor(.white)
+                    Text(option.subtitle)
+                        .font(.system(size: 11, design: .rounded))
+                        .foregroundColor(.white.opacity(0.35))
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: MADTheme.Spacing.sm)
+
+                Image(systemName: selected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundColor(selected ? tint : .white.opacity(0.2))
+            }
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(selected ? [.isButton, .isSelected] : .isButton)
+    }
+
     // MARK: - Friend Notification List
     private var friendNotificationList: some View {
         VStack(spacing: MADTheme.Spacing.sm) {
@@ -435,6 +513,7 @@ struct NotificationSettingsView: View {
                     "friend_posts_enabled": prefs.friendPostsEnabled,
                     "share_route_maps": prefs.shareRouteMaps,
                     "weekly_recap_enabled": prefs.weeklyRecapEnabled,
+                    "workout_visibility": prefs.workoutVisibility.rawValue,
                 ]
                 _ = try await friendService.updateNotificationSettings(backendSettings)
             } catch {
@@ -446,6 +525,26 @@ struct NotificationSettingsView: View {
         withAnimation(.easeInOut(duration: 0.2)) { savedFeedback = true }
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
             withAnimation(.easeInOut(duration: 0.2)) { savedFeedback = false }
+        }
+    }
+
+    /// Pull the visibility the SERVER actually enforces.
+    ///
+    /// Every other setting on this screen is local-first, which is fine for a
+    /// notification preference — but this one is a privacy control, and showing
+    /// "Friends only" to someone the server has as "Everyone" would be a lie
+    /// about who can see their photos. The server is the authority here.
+    private func loadVisibilityFromServer() async {
+        guard let settings = try? await friendService.getNotificationSettings(),
+              let raw = settings.workout_visibility,
+              let visibility = WorkoutVisibility(rawValue: raw)
+        else { return }
+        await MainActor.run {
+            guard prefs.workoutVisibility != visibility else { return }
+            prefs.workoutVisibility = visibility
+            // Keep the local copy honest too, so a later Save of some unrelated
+            // toggle can't push the stale value back over the server's.
+            prefs.save()
         }
     }
 

--- a/app/Mile A Day/Views/Profile/MostMilesDetailView.swift
+++ b/app/Mile A Day/Views/Profile/MostMilesDetailView.swift
@@ -314,11 +314,13 @@ struct WorkoutRow: View {
                     Text(verb)
                         .font(.system(size: 14, weight: .bold, design: .rounded))
                         .foregroundColor(MADTheme.Colors.secondaryText)
+                        .lineLimit(1)
                     Text(workoutDistance)
                         .font(.system(size: 17, weight: .black, design: .rounded))
                         .monospacedDigit()
                         .foregroundColor(MADTheme.Colors.primaryText)
-                    ManualWorkoutBadge(source: workoutSource)
+                        .lineLimit(1)
+                        .layoutPriority(1)
                 }
                 HStack(spacing: 5) {
                     Image(systemName: "clock.fill")
@@ -328,23 +330,19 @@ struct WorkoutRow: View {
                         .font(.system(size: 12, weight: .semibold, design: .rounded))
                         .monospacedDigit()
                         .foregroundColor(MADTheme.Colors.secondaryText)
+                        .lineLimit(1)
                 }
 
-                // Route / photo chips — surfaces at a glance that tapping in
-                // reveals a map or a picture, so those runs stand out.
-                if hasRoute || hasPhoto {
-                    HStack(spacing: 6) {
-                        if hasRoute {
-                            rowTag(icon: "map.fill", label: "Route", color: workoutColor)
-                        }
-                        if hasPhoto {
-                            rowTag(icon: "photo.fill", label: "Photo", color: .pink)
-                        }
-                    }
-                    .padding(.top, 1)
-                }
+                // How it was recorded + what tapping in reveals — so a manual
+                // entry, a mapped route, or a photo stands out at a glance.
+                WorkoutRowTags(
+                    source: workoutSource,
+                    hasRoute: hasRoute,
+                    hasPhoto: hasPhoto,
+                    routeColor: workoutColor
+                )
             }
-            Spacer()
+            Spacer(minLength: MADTheme.Spacing.sm)
             VStack(alignment: .trailing, spacing: 2) {
                 if showDate {
                     Text(workoutDateString)
@@ -355,6 +353,8 @@ struct WorkoutRow: View {
                     .font(.system(size: 12, weight: .medium, design: .rounded))
                     .foregroundColor(MADTheme.Colors.secondaryText)
             }
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
         }
         .task(id: workout.uuid) {
             // Cheap existence probe (limit 1) — never enumerates route points.
@@ -363,20 +363,6 @@ struct WorkoutRow: View {
             let found = await healthManager.hasRouteData(for: workout)
             await MainActor.run { hasRoute = found }
         }
-    }
-
-    /// Small rounded chip used for the route/photo indicators.
-    private func rowTag(icon: String, label: String, color: Color) -> some View {
-        HStack(spacing: 3) {
-            Image(systemName: icon)
-                .font(.system(size: 9, weight: .bold))
-            Text(label)
-                .font(.system(size: 10, weight: .heavy, design: .rounded))
-        }
-        .foregroundColor(color)
-        .padding(.horizontal, 7)
-        .padding(.vertical, 3)
-        .background(Capsule().fill(color.opacity(0.15)))
     }
 
     /// Feed-style verb ("Ran", "Walked") for the headline.

--- a/backend/scripts/ci-smoke.mjs
+++ b/backend/scripts/ci-smoke.mjs
@@ -8,14 +8,21 @@
 import assert from "node:assert/strict";
 
 const { PostgresService } = await import("../dist/services/DbService.js");
-const { uploadWorkouts, getUserRoutes } =
+const { uploadWorkouts, getUserRoutes, getRecentWorkouts, getWorkoutRoute } =
   await import("../dist/services/workoutService.js");
-const { createPost, getUnifiedFeed, getStoriesRail, getUserPosts } =
-  await import("../dist/services/postService.js");
+const {
+  createPost,
+  getUnifiedFeed,
+  getStoriesRail,
+  getUserPosts,
+  lockUnearnedPhotos,
+} = await import("../dist/services/postService.js");
 const { canonicalizeMileContext, logHypeIfUnderLimit, hasHypedMile } =
   await import("../dist/services/hypeService.js");
 const { signMediaUrl, verifyPostsMediaAccess, stripMediaQuery } =
   await import("../dist/services/mediaSigningService.js");
+const { getNotificationPreferences, updateNotificationPreferences } =
+  await import("../dist/services/notificationSettingsService.js");
 
 const db = PostgresService.getInstance();
 
@@ -27,6 +34,9 @@ const nowIso = new Date().toISOString();
 async function cleanup() {
   // CI always runs on a fresh database; this makes local re-runs work too.
   await db.query(`DELETE FROM hype_log WHERE sender_id LIKE 'ci-%'`);
+  // The route-privacy assertions block a user mid-run; a failed run must not
+  // leave that block behind to poison the next one.
+  await db.query(`DELETE FROM user_blocks WHERE blocker_id LIKE 'ci-%'`);
   await db.query(`DELETE FROM posts WHERE user_id LIKE 'ci-%'`);
   await db.query(
     `DELETE FROM workout_routes WHERE workout_id LIKE 'ci-workout-%'`,
@@ -166,7 +176,11 @@ assert.ok(feedAfterHype.length >= 1, "feed still reads after hype");
 const hypedFeedPost = feedAfterHype.find(
   (r) => r.kind === "post" && r.id === post.post_id,
 );
-assert.equal(hypedFeedPost?.is_hyped, true, "exact workout hype marks post hyped");
+assert.equal(
+  hypedFeedPost?.is_hyped,
+  true,
+  "exact workout hype marks post hyped",
+);
 
 // Signed media urls: sign, verify via the real middleware, and reject tampering.
 process.env.MEDIA_SIGNING_SECRET ||= "ci-signing-secret";
@@ -199,6 +213,347 @@ assert.equal(
   403,
   "unsigned request rejected",
 );
+
+// Earn-to-view gate: a viewer who hasn't run yet loses today's PHOTOS and
+// nothing else. Both halves matter — leaking a photo breaks the promise, and
+// over-flagging hides auto route/stats cards the viewer is meant to swipe.
+const openGate = { completed: false, localDate };
+const row = (over) => ({
+  user_id: BOB,
+  local_date: localDate,
+  is_auto: false,
+  media_url: "/uploads/posts/ci-bob-photo.jpg",
+  story_photo_url: null,
+  ...over,
+});
+const gated = lockUnearnedPhotos(
+  [
+    row({ is_auto: true, media_url: "/uploads/posts/ci-auto-card.jpg" }),
+    row({
+      is_auto: true,
+      media_url: "/uploads/posts/ci-auto-card.jpg",
+      story_photo_url: "/uploads/posts/ci-story.jpg",
+    }),
+    row({}),
+    row({ user_id: ALICE }),
+    row({ local_date: "2000-01-01" }),
+  ],
+  ALICE,
+  openGate,
+);
+const [autoOnly, autoWithStory, userPhoto, own, older] = gated;
+assert.equal(
+  autoOnly.media_url,
+  "/uploads/posts/ci-auto-card.jpg",
+  "auto card survives the gate",
+);
+assert.ok(
+  !autoOnly.photo_locked,
+  "auto card with nothing withheld is NOT flagged locked",
+);
+assert.equal(
+  autoWithStory.story_photo_url,
+  null,
+  "today's story photo withheld",
+);
+assert.equal(
+  autoWithStory.media_url,
+  "/uploads/posts/ci-auto-card.jpg",
+  "auto card still swipeable behind a locked story photo",
+);
+assert.equal(
+  autoWithStory.photo_locked,
+  true,
+  "withheld story photo flags the row",
+);
+assert.equal(userPhoto.media_url, "", "today's real photo withheld");
+assert.equal(userPhoto.photo_locked, true, "withheld photo flags the row");
+assert.equal(
+  own.media_url,
+  "/uploads/posts/ci-bob-photo.jpg",
+  "own photo never gated",
+);
+assert.ok(!own.photo_locked, "own post never flagged");
+assert.equal(
+  older.media_url,
+  "/uploads/posts/ci-bob-photo.jpg",
+  "older photo never gated",
+);
+assert.ok(!older.photo_locked, "older post never flagged");
+
+const earned = lockUnearnedPhotos([row({})], ALICE, {
+  completed: true,
+  localDate,
+});
+assert.equal(
+  earned[0].media_url,
+  "/uploads/posts/ci-bob-photo.jpg",
+  "finishing the mile unlocks today's photos",
+);
+assert.ok(!earned[0].photo_locked, "completed viewer sees no lock");
+
+// Recent workouts carry has_route / has_photo, so a friend's workout row can
+// show the same Route/Photo chips the owner sees. Bob's run has a GPS route and
+// a real photo post; Alice's has neither.
+const bobRecent = await getRecentWorkouts(BOB, 10);
+assert.equal(bobRecent.length, 1, "Bob has one recent workout");
+assert.equal(bobRecent[0].workout_id, "ci-workout-bob");
+assert.equal(bobRecent[0].has_route, true, "Bob's run reports its GPS route");
+assert.equal(bobRecent[0].has_photo, true, "Bob's run reports its real photo");
+assert.equal(bobRecent[0].distance, 1.5, "the workout's own columns survive");
+
+const aliceRecent = await getRecentWorkouts(ALICE, 10);
+assert.equal(aliceRecent.length, 1, "Alice has one recent workout");
+assert.equal(aliceRecent[0].has_route, false, "no route → has_route false");
+assert.equal(aliceRecent[0].has_photo, false, "no post → has_photo false");
+
+// An auto route/stats card is NOT a photo — only a deliberate one counts.
+await db.query(
+  `INSERT INTO posts (user_id, media_url, workout_id, local_date, share_to_feed, share_to_story, is_auto)
+	 VALUES ($1, $2, $3, $4, TRUE, FALSE, TRUE)`,
+  [ALICE, "/uploads/posts/ci-alice-auto.jpg", "ci-workout-alice", localDate],
+);
+const aliceAfterAuto = await getRecentWorkouts(ALICE, 10);
+assert.equal(
+  aliceAfterAuto.length,
+  1,
+  "auto post doesn't duplicate the workout",
+);
+assert.equal(
+  aliceAfterAuto[0].has_photo,
+  false,
+  "an auto route/stats card must not count as a photo",
+);
+
+// A workout with BOTH a feed post and a separate story-only post must still
+// yield exactly one row — the guard against the LEFT JOIN multiplying rows.
+await db.query(
+  `INSERT INTO posts (user_id, media_url, workout_id, local_date, share_to_feed, share_to_story, is_auto)
+	 VALUES ($1, $2, $3, $4, FALSE, TRUE, FALSE)`,
+  [BOB, "/uploads/posts/ci-bob-story.jpg", "ci-workout-bob", localDate],
+);
+const bobTwoPosts = await getRecentWorkouts(BOB, 10);
+assert.equal(bobTwoPosts.length, 1, "two posts on one workout → still one row");
+assert.equal(bobTwoPosts[0].has_photo, true);
+
+// The controller passes null when ?limit is absent — LIMIT NULL means "all".
+const bobNoLimit = await getRecentWorkouts(BOB, null);
+assert.equal(bobNoLimit.length, 1, "a null limit returns rows, not zero");
+
+// --- Route privacy. Routes start at people's homes; these are the assertions
+// that keep them from leaking. Alice and Bob are accepted friends (seed).
+const CI_ROUTE_LEN = 3;
+
+// A friend may see the route, and the owner always may.
+assert.equal(
+  (await getWorkoutRoute(BOB, "ci-workout-bob", ALICE))?.length,
+  CI_ROUTE_LEN,
+  "a friend sees the route by default",
+);
+assert.equal(
+  (await getWorkoutRoute(BOB, "ci-workout-bob", BOB))?.length,
+  CI_ROUTE_LEN,
+  "the owner always sees their own route",
+);
+
+// A STRANGER may not — authentication alone is not access.
+await db.query(
+  `INSERT INTO users (user_id, email, apple_sub, username, first_name)
+	 VALUES ($1, $2, $3, $4, $5) ON CONFLICT (user_id) DO NOTHING`,
+  [
+    "ci-stranger",
+    "stranger@ci.local",
+    "ci-sub-stranger",
+    "ci_stranger",
+    "stranger",
+  ],
+);
+assert.equal(
+  await getWorkoutRoute(BOB, "ci-workout-bob", "ci-stranger"),
+  null,
+  "a non-friend gets NO route, however authenticated they are",
+);
+
+// A blocked friend may not, in either direction.
+await db.query(
+  `INSERT INTO user_blocks (blocker_id, blocked_id) VALUES ($1, $2)
+	 ON CONFLICT DO NOTHING`,
+  [BOB, ALICE],
+);
+assert.equal(
+  await getWorkoutRoute(BOB, "ci-workout-bob", ALICE),
+  null,
+  "blocking hides the route from the blocked friend",
+);
+await db.query(`DELETE FROM user_blocks WHERE blocker_id LIKE 'ci-%'`);
+
+// share_route_maps = false hides it from friends, but never from the owner.
+await db.query(
+  `UPDATE notification_settings SET share_route_maps = FALSE WHERE user_id = $1`,
+  [BOB],
+);
+assert.equal(
+  await getWorkoutRoute(BOB, "ci-workout-bob", ALICE),
+  null,
+  "share_route_maps=false hides the route from friends",
+);
+assert.equal(
+  (await getWorkoutRoute(BOB, "ci-workout-bob", BOB))?.length,
+  CI_ROUTE_LEN,
+  "share_route_maps=false still shows the owner their own route",
+);
+// ...and it must not even ADMIT a route exists to anyone else.
+assert.equal(
+  (await getRecentWorkouts(BOB, 10, ALICE))[0].has_route,
+  false,
+  "share_route_maps=false hides route EXISTENCE from friends too",
+);
+assert.equal(
+  (await getRecentWorkouts(BOB, 10, BOB))[0].has_route,
+  true,
+  "share_route_maps=false still reports the route to the owner",
+);
+// A missing viewer is a stranger, not a free pass.
+assert.equal(
+  (await getRecentWorkouts(BOB, 10, null))[0].has_route,
+  false,
+  "no viewer id → fail closed, not open",
+);
+await db.query(
+  `UPDATE notification_settings SET share_route_maps = TRUE WHERE user_id = $1`,
+  [BOB],
+);
+assert.equal(
+  (await getRecentWorkouts(BOB, 10, ALICE))[0].has_route,
+  true,
+  "consent restored → friends see the route again",
+);
+
+// A workout id that isn't the named owner's must never resolve.
+assert.equal(
+  await getWorkoutRoute(ALICE, "ci-workout-bob", ALICE),
+  null,
+  "a workout id belonging to someone else resolves to nothing",
+);
+
+// --- workout_visibility: 'friends' (default) | 'public' | 'private'.
+// A setting that doesn't actually gate is worse than no setting, so assert all
+// three states on the surfaces they govern.
+const setVisibility = (userId, value) =>
+  db.query(
+    `UPDATE notification_settings SET workout_visibility = $2 WHERE user_id = $1`,
+    [userId, value],
+  );
+
+// The column ships defaulted to 'friends' — nothing changes for existing users.
+const defaultVis = await db.query(
+  `SELECT workout_visibility FROM notification_settings WHERE user_id = $1`,
+  [BOB],
+);
+assert.equal(
+  defaultVis[0].workout_visibility,
+  "friends",
+  "workout_visibility defaults to friends",
+);
+
+// The CHECK constraint rejects anything else.
+await assert.rejects(
+  () => setVisibility(BOB, "everyone"),
+  "an invalid visibility is rejected by the DB, not silently stored",
+);
+
+// 'private': gone from a friend's profile grid, gone from their feed, no route.
+await setVisibility(BOB, "private");
+assert.equal(
+  (await getUserPosts(ALICE, BOB, 24)).length,
+  0,
+  "private hides the profile grid from friends",
+);
+assert.equal(
+  (await getUnifiedFeed(ALICE, 20)).filter((e) => e.user_id === BOB).length,
+  0,
+  "private removes the user from friends' feeds",
+);
+assert.equal(
+  await getWorkoutRoute(BOB, "ci-workout-bob", ALICE),
+  null,
+  "private hides routes from friends",
+);
+assert.equal(
+  (await getRecentWorkouts(BOB, 10, ALICE))[0].has_photo,
+  false,
+  "private hides photo existence from friends",
+);
+// ...but never from the owner.
+assert.ok(
+  (await getUserPosts(BOB, BOB, 24)).length >= 1,
+  "private never hides your own posts from you",
+);
+assert.equal(
+  (await getWorkoutRoute(BOB, "ci-workout-bob", BOB))?.length,
+  CI_ROUTE_LEN,
+  "private never hides your own route from you",
+);
+
+// 'public': a stranger may see the profile grid; blocks still win.
+await setVisibility(BOB, "public");
+assert.ok(
+  (await getUserPosts("ci-stranger", BOB, 24)).length >= 1,
+  "public lets a non-friend see the profile grid",
+);
+assert.equal(
+  (await getWorkoutRoute(BOB, "ci-workout-bob", "ci-stranger"))?.length,
+  CI_ROUTE_LEN,
+  "public lets a non-friend see the route",
+);
+await db.query(
+  `INSERT INTO user_blocks (blocker_id, blocked_id) VALUES ($1, $2)
+	 ON CONFLICT DO NOTHING`,
+  [BOB, "ci-stranger"],
+);
+assert.equal(
+  (await getUserPosts("ci-stranger", BOB, 24)).length,
+  0,
+  "a block beats 'public'",
+);
+await db.query(`DELETE FROM user_blocks WHERE blocker_id LIKE 'ci-%'`);
+
+// 'friends' (default): friend yes, stranger no.
+await setVisibility(BOB, "friends");
+assert.ok(
+  (await getUserPosts(ALICE, BOB, 24)).length >= 1,
+  "friends lets an accepted friend see the profile grid",
+);
+assert.equal(
+  (await getUserPosts("ci-stranger", BOB, 24)).length,
+  0,
+  "friends hides the profile grid from a non-friend",
+);
+
+// The settings round-trip the app actually uses. updateNotificationPreferences
+// silently skips keys it doesn't recognise, so a typo in the field name would
+// no-op rather than fail — assert the value really comes back changed.
+const afterPut = await updateNotificationPreferences(BOB, {
+  workout_visibility: "public",
+});
+assert.equal(
+  afterPut.workout_visibility,
+  "public",
+  "PUT /notifications/preferences persists workout_visibility",
+);
+assert.equal(
+  (await getNotificationPreferences(BOB)).workout_visibility,
+  "public",
+  "GET /notifications/preferences reports workout_visibility",
+);
+// An unrelated update must not disturb it.
+await updateNotificationPreferences(BOB, { share_route_maps: true });
+assert.equal(
+  (await getNotificationPreferences(BOB)).workout_visibility,
+  "public",
+  "updating another preference leaves visibility alone",
+);
+await updateNotificationPreferences(BOB, { workout_visibility: "friends" });
 
 console.log("ci-smoke: all assertions passed");
 process.exit(0);

--- a/backend/src/controllers/notificationSettingsController.ts
+++ b/backend/src/controllers/notificationSettingsController.ts
@@ -7,6 +7,10 @@ import {
   updateFriendNotificationSettings,
 } from "../services/notificationSettingsService.js";
 import { getCloseFriendIds } from "../services/closeFriendsService.js";
+import {
+  isWorkoutVisibility,
+  WORKOUT_VISIBILITY_VALUES,
+} from "../services/visibilityService.js";
 
 export async function getPreferences(req: AuthenticatedRequest, res: Response) {
   try {
@@ -28,7 +32,18 @@ export async function updatePreferences(
       quiet_hours_end,
       daily_reminder_hour,
       timezone_offset_minutes,
+      workout_visibility,
     } = req.body;
+    // The DB has a CHECK for this too; validating here turns a would-be 500
+    // into a clear 400.
+    if (
+      workout_visibility !== undefined &&
+      !isWorkoutVisibility(workout_visibility)
+    ) {
+      return res.status(400).json({
+        error: `workout_visibility must be one of: ${WORKOUT_VISIBILITY_VALUES.join(", ")}`,
+      });
+    }
     if (
       quiet_hours_start !== undefined &&
       quiet_hours_start !== null &&

--- a/backend/src/controllers/workoutController.ts
+++ b/backend/src/controllers/workoutController.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { AuthenticatedRequest } from "../middleware/auth.js";
 import { PostgresService } from "../services/DbService.js";
 import hasRequiredKeys from "../utils/hasRequiredKeys.js";
 import { getUser } from "../services/userService.js";
@@ -20,6 +21,7 @@ import {
   type RaceDistanceKey,
   getUserLocalToday,
   getUserRoutes,
+  getWorkoutRoute as getWorkoutRouteDb,
 } from "../services/workoutService.js";
 import { checkRaceCompletions } from "../services/competitionService.js";
 import { softDeleteWorkout } from "../services/workoutDeletionService.js";
@@ -372,7 +374,9 @@ export async function getRaceHistoryController(req: Request, res: Response) {
 
   const distance = req.params.distance;
   if (!RACE_DISTANCES.some((d) => d.key === distance)) {
-    return res.status(400).json({ error: `Unknown race distance: ${distance}` });
+    return res
+      .status(400)
+      .json({ error: `Unknown race distance: ${distance}` });
   }
 
   try {
@@ -444,7 +448,10 @@ export async function deleteWorkout(req: Request, res: Response) {
 
 export async function getWorkoutRange() {}
 
-export async function getRecentWorkouts(req: Request, res: Response) {
+export async function getRecentWorkouts(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
   if (!hasRequiredKeys(["userId"], req, res)) return;
 
   const limitParam = typeof req.query.limit === "string" ? req.query.limit : "";
@@ -461,7 +468,9 @@ export async function getRecentWorkouts(req: Request, res: Response) {
       return res.status(400).send({ error: `No user found with ID ${userId}` });
     }
 
-    const results = await getRecentWorkoutsDb(userId, resultLimit);
+    // The viewer decides whether `has_route` may be reported: the author's
+    // "Share route maps" setting hides it from everyone but themselves.
+    const results = await getRecentWorkoutsDb(userId, resultLimit, req.userId);
 
     return res.status(200).json(results);
   } catch (error: any) {
@@ -469,6 +478,31 @@ export async function getRecentWorkouts(req: Request, res: Response) {
     res
       .status(500)
       .json({ error: "Error getting recent workouts: " + error.message });
+  }
+}
+
+/**
+ * GET /workouts/:userId/workout/:workoutId/route — one workout's GPS trace, so
+ * a friend's workout detail can draw the same map the owner sees. Honors the
+ * author's `share_route_maps` consent; returns `{ route: null }` (never a 403)
+ * when it's off, so the client simply draws no map.
+ */
+export async function getWorkoutRouteController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  if (!hasRequiredKeys(["userId", "workoutId"], req, res)) return;
+
+  try {
+    const route = await getWorkoutRouteDb(
+      req.params.userId,
+      req.params.workoutId,
+      req.userId!,
+    );
+    return res.status(200).json({ route });
+  } catch (error: any) {
+    console.error("Error getting workout route:", error.message);
+    res.status(500).json({ error: "Error getting workout route" });
   }
 }
 

--- a/backend/src/db/drizzle/0019_white_odin.sql
+++ b/backend/src/db/drizzle/0019_white_odin.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "notification_settings" ADD COLUMN "workout_visibility" text DEFAULT 'friends' NOT NULL;--> statement-breakpoint
+ALTER TABLE "notification_settings" ADD CONSTRAINT "notification_settings_workout_visibility_check" CHECK (workout_visibility = ANY (ARRAY['public'::text, 'friends'::text, 'private'::text]));

--- a/backend/src/db/drizzle/meta/0019_snapshot.json
+++ b/backend/src/db/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,3987 @@
+{
+  "id": "fd81dbb8-fa8c-4afd-8092-9da84674094f",
+  "prevId": "8ac5a07c-6766-45d8-90c9-d8f3bab16cdf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.android_waitlist": {
+      "name": "android_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'website'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "android_waitlist_email_unique": {
+          "name": "android_waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_badges_category": {
+          "name": "idx_badges_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "badges_rarity_check": {
+          "name": "badges_rarity_check",
+          "value": "rarity = ANY (ARRAY['common'::text, 'rare'::text, 'legendary'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.close_friends": {
+      "name": "close_friends",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_friend_id": {
+          "name": "close_friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_close_friends_friend": {
+          "name": "idx_close_friends_friend",
+          "columns": [
+            {
+              "expression": "close_friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "close_friends_pkey": {
+          "name": "close_friends_pkey",
+          "columns": [
+            "user_id",
+            "close_friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_users": {
+      "name": "competition_users",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_rank": {
+          "name": "last_known_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_score": {
+          "name": "last_known_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rank_updated_at": {
+          "name": "last_rank_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_competition_users_comp": {
+          "name": "idx_competition_users_comp",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_competition": {
+          "name": "idx_competition_users_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_rank_cache": {
+          "name": "idx_competition_users_rank_cache",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_known_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((invite_status)::text = 'accepted'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user": {
+          "name": "idx_competition_users_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user_status": {
+          "name": "idx_competition_users_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invite_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_users_user_id_fkey": {
+          "name": "competition_users_user_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_users_competition_id_fkey": {
+          "name": "competition_users_competition_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_users_pkey": {
+          "name": "competition_users_pkey",
+          "columns": [
+            "competition_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_users_invite_status_check": {
+          "name": "competition_users_invite_status_check",
+          "value": "(invite_status)::text = ANY ((ARRAY['pending'::character varying, 'accepted'::character varying, 'declined'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workouts": {
+          "name": "workouts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_winner": {
+          "name": "idx_competitions_winner",
+          "columns": [
+            {
+              "expression": "winner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(winner IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_winner_fkey": {
+          "name": "competitions_winner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "competitions_owner_fkey": {
+          "name": "competitions_owner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitions_type_check": {
+          "name": "competitions_type_check",
+          "value": "(type)::text = ANY ((ARRAY['streaks'::character varying, 'apex'::character varying, 'clash'::character varying, 'targets'::character varying, 'race'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_challenges": {
+      "name": "daily_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_template": {
+          "name": "description_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_start": {
+          "name": "gradient_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_end": {
+          "name": "gradient_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rotation_index": {
+          "name": "rotation_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_challenges_rotation_index_key": {
+          "name": "daily_challenges_rotation_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rotation_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daily_challenges_type_check": {
+          "name": "daily_challenges_type_check",
+          "value": "type = ANY (ARRAY['pace'::text, 'distance'::text, 'time'::text, 'activity'::text, 'steps'::text, 'social'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_steps": {
+      "name": "daily_steps",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_steps_user_date": {
+          "name": "idx_daily_steps_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_steps_user_id_fkey": {
+          "name": "daily_steps_user_id_fkey",
+          "tableFrom": "daily_steps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_steps_pkey": {
+          "name": "daily_steps_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "daily_steps_steps_check": {
+          "name": "daily_steps_steps_check",
+          "value": "steps >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token": {
+          "name": "device_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_tokens_user_id": {
+          "name": "idx_device_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_user_id_fkey": {
+          "name": "device_tokens_user_id_fkey",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_user_id_device_token_key": {
+          "name": "device_tokens_user_id_device_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_log": {
+      "name": "error_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_error_log_created_at": {
+          "name": "idx_error_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_error_log_category": {
+          "name": "idx_error_log_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flex_log": {
+      "name": "flex_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flex_log_lookup": {
+          "name": "idx_flex_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_notification_settings": {
+      "name": "friend_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted": {
+          "name": "muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nudges_muted": {
+          "name": "nudges_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "activity_muted": {
+          "name": "activity_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "friend_notification_settings_pkey": {
+          "name": "friend_notification_settings_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_nudge_log": {
+      "name": "friend_nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_nudge_log_lookup": {
+          "name": "idx_friend_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_friendships_friend_status": {
+          "name": "idx_friendships_friend_status",
+          "columns": [
+            {
+              "expression": "friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_friendships_user_status": {
+          "name": "idx_friendships_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_user_id_fkey": {
+          "name": "friendships_user_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_friend_id_fkey": {
+          "name": "friendships_friend_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendships_pkey": {
+          "name": "friendships_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_friendship_pair": {
+          "name": "unique_friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.h2h_matchups": {
+      "name": "h2h_matchups",
+      "schema": "",
+      "columns": {
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rival_id": {
+          "name": "rival_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mutual": {
+          "name": "mutual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "won": {
+          "name": "won",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "h2h_matchups_user_id_fkey": {
+          "name": "h2h_matchups_user_id_fkey",
+          "tableFrom": "h2h_matchups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "h2h_matchups_rival_id_fkey": {
+          "name": "h2h_matchups_rival_id_fkey",
+          "tableFrom": "h2h_matchups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "rival_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "h2h_matchups_pkey": {
+          "name": "h2h_matchups_pkey",
+          "columns": [
+            "local_date",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hype_log": {
+      "name": "hype_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_label": {
+          "name": "context_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hype_log_context_dedupe_idx": {
+          "name": "hype_log_context_dedupe_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_lookup": {
+          "name": "idx_hype_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_app_notifications": {
+      "name": "in_app_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_in_app_notifications_unread": {
+          "name": "idx_in_app_notifications_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_read = false)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_app_notifications_user": {
+          "name": "idx_in_app_notifications_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_app_notifications_user_id_fkey": {
+          "name": "in_app_notifications_user_id_fkey",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_notifications": {
+      "name": "milestone_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_key": {
+          "name": "milestone_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_notifications_milestone_key_key": {
+          "name": "milestone_notifications_milestone_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_audience_settings": {
+      "name": "notification_audience_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_audience_settings_pkey": {
+          "name": "notification_audience_settings_pkey",
+          "columns": [
+            "user_id",
+            "direction",
+            "event_type",
+            "activity_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_audience_settings_direction_check": {
+          "name": "notification_audience_settings_direction_check",
+          "value": "direction = ANY (ARRAY['outgoing'::text, 'incoming'::text])"
+        },
+        "notification_audience_settings_audience_check": {
+          "name": "notification_audience_settings_audience_check",
+          "value": "audience = ANY (ARRAY['none'::text, 'close'::text, 'all'::text, 'ask'::text, 'match_run'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_user_date": {
+          "name": "idx_notification_log_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nudges_enabled": {
+          "name": "nudges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "flexes_enabled": {
+          "name": "flexes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_activity_enabled": {
+          "name": "friend_activity_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_invites_enabled": {
+          "name": "competition_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_updates_enabled": {
+          "name": "competition_updates_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_milestones_enabled": {
+          "name": "competition_milestones_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "hypes_enabled": {
+          "name": "hypes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "step_goal_enabled": {
+          "name": "step_goal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "friend_personal_best_enabled": {
+          "name": "friend_personal_best_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_enabled": {
+          "name": "daily_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_hour": {
+          "name": "daily_reminder_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 18
+        },
+        "h2h_close_friends_only": {
+          "name": "h2h_close_friends_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone_offset_minutes": {
+          "name": "timezone_offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_workouts_to_feed": {
+          "name": "share_workouts_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_posts_enabled": {
+          "name": "friend_posts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "share_route_maps": {
+          "name": "share_route_maps",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "weekly_recap_enabled": {
+          "name": "weekly_recap_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "workout_visibility": {
+          "name": "workout_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'friends'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_settings_workout_visibility_check": {
+          "name": "notification_settings_workout_visibility_check",
+          "value": "workout_visibility = ANY (ARRAY['public'::text, 'friends'::text, 'private'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.nudge_log": {
+      "name": "nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_nudge_log_lookup": {
+          "name": "idx_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nudge_log_rate_limit": {
+          "name": "idx_nudge_log_rate_limit",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_friend_notifications": {
+      "name": "pending_friend_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "send_after_at": {
+          "name": "send_after_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_friend_notif_user": {
+          "name": "idx_pending_friend_notif_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_pending_friend_notif_workout": {
+          "name": "uq_pending_friend_notif_workout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((workout_id IS NOT NULL) AND (status = 'pending'::text))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pending_friend_notifications_status_check": {
+          "name": "pending_friend_notifications_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'sent'::text, 'dismissed'::text, 'expired'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_notifications": {
+      "name": "pending_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_notifications_unsent": {
+          "name": "idx_pending_notifications_unsent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(sent_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_notifications_user_id_fkey": {
+          "name": "pending_notifications_user_id_fkey",
+          "tableFrom": "pending_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_reports": {
+      "name": "post_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_reports_dedupe_idx": {
+          "name": "post_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_reports_status": {
+          "name": "idx_post_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_reports_post_id_fkey": {
+          "name": "post_reports_post_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_reports_reporter_id_fkey": {
+          "name": "post_reports_reporter_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_reports_reason_check": {
+          "name": "post_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_snapshot": {
+          "name": "stats_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_to_feed": {
+          "name": "share_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_to_story": {
+          "name": "share_to_story",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "story_expires_at": {
+          "name": "story_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto": {
+          "name": "is_auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_route": {
+          "name": "include_route",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_posts_user_created": {
+          "name": "idx_posts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_feed": {
+          "name": "idx_posts_feed",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_story_active": {
+          "name": "idx_posts_story_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "story_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_story)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_active": {
+          "name": "uq_posts_workout_active",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_story": {
+          "name": "uq_posts_workout_story",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_story AND NOT share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_fkey": {
+          "name": "posts_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_workout_id_fkey": {
+          "name": "posts_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_family_id": {
+          "name": "token_family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_hash": {
+          "name": "replaced_by_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "token_family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_revoked_at": {
+          "name": "idx_refresh_tokens_revoked_at",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(revoked_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_token_hash": {
+          "name": "idx_refresh_tokens_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_fkey": {
+          "name": "refresh_tokens_user_id_fkey",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_key": {
+          "name": "refresh_tokens_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_reactions": {
+      "name": "story_reactions",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_reactions_post_id_fkey": {
+          "name": "story_reactions_post_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_reactions_user_id_fkey": {
+          "name": "story_reactions_user_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_reactions_pkey": {
+          "name": "story_reactions_pkey",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_views": {
+      "name": "story_views",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_views_post_id_fkey": {
+          "name": "story_views_post_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_views_viewer_id_fkey": {
+          "name": "story_views_viewer_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_views_pkey": {
+          "name": "story_views_pkey",
+          "columns": [
+            "post_id",
+            "viewer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggering_workout_id": {
+          "name": "triggering_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_snapshot": {
+          "name": "progress_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_slot": {
+          "name": "pin_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_badges_user": {
+          "name": "idx_user_badges_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_new": {
+          "name": "idx_user_badges_user_new",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_new = true)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_pin_slot": {
+          "name": "idx_user_badges_user_pin_slot",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(pin_slot IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_workout": {
+          "name": "idx_user_badges_workout",
+          "columns": [
+            {
+              "expression": "triggering_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_badges_user_id_fkey": {
+          "name": "user_badges_user_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_fkey": {
+          "name": "user_badges_badge_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "badge_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_triggering_workout_id_fkey": {
+          "name": "user_badges_triggering_workout_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "triggering_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_badges_user_id_badge_id_key": {
+          "name": "user_badges_user_id_badge_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "badge_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_badges_pin_slot_range": {
+          "name": "user_badges_pin_slot_range",
+          "value": "(pin_slot IS NULL) OR ((pin_slot >= 0) AND (pin_slot <= 2))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_blocks_blocked": {
+          "name": "idx_user_blocks_blocked",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_fkey": {
+          "name": "user_blocks_blocker_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_blocks_blocked_id_fkey": {
+          "name": "user_blocks_blocked_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_pkey": {
+          "name": "user_blocks_pkey",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenge_completions": {
+      "name": "user_challenge_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completing_workout_id": {
+          "name": "completing_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ucc_user": {
+          "name": "idx_ucc_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ucc_user_date": {
+          "name": "idx_ucc_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenge_completions_user_id_fkey": {
+          "name": "user_challenge_completions_user_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_challenge_key_fkey": {
+          "name": "user_challenge_completions_challenge_key_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "daily_challenges",
+          "columnsFrom": [
+            "challenge_key"
+          ],
+          "columnsTo": [
+            "challenge_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_completing_workout_id_fkey": {
+          "name": "user_challenge_completions_completing_workout_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "completing_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_challenge_completions_user_id_local_date_key": {
+          "name": "user_challenge_completions_user_id_local_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_sub": {
+          "name": "apple_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "goal_miles": {
+          "name": "goal_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_source": {
+          "name": "referral_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_detail": {
+          "name": "referral_detail",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signup_goal": {
+          "name": "signup_goal",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience_level": {
+          "name": "experience_level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_current_streak_desc": {
+          "name": "idx_users_current_streak_desc",
+          "columns": [
+            {
+              "expression": "current_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email_trgm": {
+          "name": "idx_users_email_trgm",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_username_trgm": {
+          "name": "idx_users_username_trgm",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_apple_id_key": {
+          "name": "users_apple_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_apple_sub_key": {
+          "name": "users_apple_sub_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "apple_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_recap_log": {
+      "name": "weekly_recap_log",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "weekly_recap_log_pkey": {
+          "name": "weekly_recap_log_pkey",
+          "columns": [
+            "user_id",
+            "week_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_completion_notifications": {
+      "name": "workout_completion_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_date": {
+          "name": "notified_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_completion_notifications_user_id_notified_date_key": {
+          "name": "workout_completion_notifications_user_id_notified_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "notified_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_routes": {
+      "name": "workout_routes",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "point_count": {
+          "name": "point_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workout_routes_workout_id_fkey": {
+          "name": "workout_routes_workout_id_fkey",
+          "tableFrom": "workout_routes",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_splits": {
+      "name": "workout_splits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_number": {
+          "name": "split_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_duration": {
+          "name": "split_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_distance": {
+          "name": "split_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_pace": {
+          "name": "split_pace",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_splits_time": {
+          "name": "idx_splits_time",
+          "columns": [
+            {
+              "expression": "split_duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_splits_workout": {
+          "name": "idx_splits_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_splits_workout_id_fkey": {
+          "name": "workout_splits_workout_id_fkey",
+          "tableFrom": "workout_splits",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_splits_workout_id_split_number_key": {
+          "name": "workout_splits_workout_id_split_number_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "split_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workouts": {
+      "name": "workouts",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_end_date": {
+          "name": "device_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthkit'"
+        },
+        "original_distance": {
+          "name": "original_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_duration": {
+          "name": "original_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_flagged": {
+          "name": "speed_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_workouts_local_date_user_id": {
+          "name": "idx_workouts_local_date_user_id",
+          "columns": [
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_device_end": {
+          "name": "idx_workouts_user_device_end",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_local_date": {
+          "name": "idx_workouts_user_local_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workouts_user_workout_unique": {
+          "name": "workouts_user_workout_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/drizzle/meta/_journal.json
+++ b/backend/src/db/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1784150224132,
       "tag": "0018_aberrant_sersi",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1784229100218,
+      "tag": "0019_white_odin",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/drizzle/schema.ts
+++ b/backend/src/db/drizzle/schema.ts
@@ -244,56 +244,74 @@ export const workoutRoutes = pgTable(
   ],
 );
 
-export const notificationSettings = pgTable("notification_settings", {
-  userId: text("user_id").primaryKey().notNull(),
-  nudgesEnabled: boolean("nudges_enabled").default(true),
-  flexesEnabled: boolean("flexes_enabled").default(true),
-  friendActivityEnabled: boolean("friend_activity_enabled").default(true),
-  competitionInvitesEnabled: boolean("competition_invites_enabled").default(
-    true,
-  ),
-  competitionUpdatesEnabled: boolean("competition_updates_enabled").default(
-    true,
-  ),
-  competitionMilestonesEnabled: boolean(
-    "competition_milestones_enabled",
-  ).default(true),
-  quietHoursStart: integer("quiet_hours_start"),
-  quietHoursEnd: integer("quiet_hours_end"),
-  createdAt: timestamp("created_at", {
-    withTimezone: true,
-    mode: "string",
-  }).defaultNow(),
-  updatedAt: timestamp("updated_at", {
-    withTimezone: true,
-    mode: "string",
-  }).defaultNow(),
-  hypesEnabled: boolean("hypes_enabled").default(true).notNull(),
-  stepGoalEnabled: boolean("step_goal_enabled").default(true).notNull(),
-  friendPersonalBestEnabled: boolean("friend_personal_best_enabled").default(
-    true,
-  ),
-  dailyReminderEnabled: boolean("daily_reminder_enabled").default(true),
-  dailyReminderHour: integer("daily_reminder_hour").default(18),
-  // Head-to-Head rivals drawn only from the user's close-friends list.
-  // Not a notification pref, but this table is the de-facto per-user
-  // preferences row (see share_workouts_to_feed / share_route_maps).
-  h2hCloseFriendsOnly: boolean("h2h_close_friends_only")
-    .default(false)
-    .notNull(),
-  timezoneOffsetMinutes: integer("timezone_offset_minutes"),
-  // Social feed settings (added v2). share_workouts_to_feed: include my raw
-  // walks/runs as activity cards in friends' unified feed. friend_posts_enabled:
-  // notify me when a friend shares a new photo post.
-  shareWorkoutsToFeed: boolean("share_workouts_to_feed").default(true),
-  friendPostsEnabled: boolean("friend_posts_enabled").default(true),
-  // share_route_maps: expose my GPS route maps (workout_routes traces) on my
-  // feed entries/posts. Explicit consent surface — when off, friends see the
-  // cards without the route slide/map.
-  shareRouteMaps: boolean("share_route_maps").default(true),
-  // weekly_recap_enabled: Sunday-evening "Your week" recap push + story card.
-  weeklyRecapEnabled: boolean("weekly_recap_enabled").default(true),
-});
+export const notificationSettings = pgTable(
+  "notification_settings",
+  {
+    userId: text("user_id").primaryKey().notNull(),
+    nudgesEnabled: boolean("nudges_enabled").default(true),
+    flexesEnabled: boolean("flexes_enabled").default(true),
+    friendActivityEnabled: boolean("friend_activity_enabled").default(true),
+    competitionInvitesEnabled: boolean("competition_invites_enabled").default(
+      true,
+    ),
+    competitionUpdatesEnabled: boolean("competition_updates_enabled").default(
+      true,
+    ),
+    competitionMilestonesEnabled: boolean(
+      "competition_milestones_enabled",
+    ).default(true),
+    quietHoursStart: integer("quiet_hours_start"),
+    quietHoursEnd: integer("quiet_hours_end"),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+    updatedAt: timestamp("updated_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+    hypesEnabled: boolean("hypes_enabled").default(true).notNull(),
+    stepGoalEnabled: boolean("step_goal_enabled").default(true).notNull(),
+    friendPersonalBestEnabled: boolean("friend_personal_best_enabled").default(
+      true,
+    ),
+    dailyReminderEnabled: boolean("daily_reminder_enabled").default(true),
+    dailyReminderHour: integer("daily_reminder_hour").default(18),
+    // Head-to-Head rivals drawn only from the user's close-friends list.
+    // Not a notification pref, but this table is the de-facto per-user
+    // preferences row (see share_workouts_to_feed / share_route_maps).
+    h2hCloseFriendsOnly: boolean("h2h_close_friends_only")
+      .default(false)
+      .notNull(),
+    timezoneOffsetMinutes: integer("timezone_offset_minutes"),
+    // Social feed settings (added v2). share_workouts_to_feed: include my raw
+    // walks/runs as activity cards in friends' unified feed. friend_posts_enabled:
+    // notify me when a friend shares a new photo post.
+    shareWorkoutsToFeed: boolean("share_workouts_to_feed").default(true),
+    friendPostsEnabled: boolean("friend_posts_enabled").default(true),
+    // share_route_maps: expose my GPS route maps (workout_routes traces) on my
+    // feed entries/posts. Explicit consent surface — when off, friends see the
+    // cards without the route slide/map.
+    shareRouteMaps: boolean("share_route_maps").default(true),
+    // weekly_recap_enabled: Sunday-evening "Your week" recap push + story card.
+    weeklyRecapEnabled: boolean("weekly_recap_enabled").default(true),
+    // workout_visibility: who may see my workout CONTENT — routes and photos.
+    // 'friends' (the default, and what every user effectively has today) =
+    // accepted friends only, the same circle the feed uses. 'public' = any
+    // signed-in user. 'private' = nobody but me.
+    //
+    // This is a coarser, content-level gate that sits ABOVE share_route_maps:
+    // visibility decides WHO, share_route_maps decides WHETHER routes are part
+    // of what they get. Both must pass.
+    workoutVisibility: text("workout_visibility").default("friends").notNull(),
+  },
+  (table) => [
+    check(
+      "notification_settings_workout_visibility_check",
+      sql`workout_visibility = ANY (ARRAY['public'::text, 'friends'::text, 'private'::text])`,
+    ),
+  ],
+);
 
 // One row per (user, week) the recap push was sent for — the cron runs hourly
 // to catch every timezone's Sunday evening, so this is what makes it fire

--- a/backend/src/routes/workoutRoutes.ts
+++ b/backend/src/routes/workoutRoutes.ts
@@ -9,6 +9,7 @@ import {
   recalibrateStreak,
   deleteWorkout,
   getUserRoutesController,
+  getWorkoutRouteController,
   getRaceRecords,
   getRaceHistoryController,
 } from "../controllers/workoutController.js";
@@ -39,6 +40,10 @@ router.get(
   requireSelfAccess("userId"),
   getUserRoutesController,
 );
+// ONE workout's trace, readable by any authenticated user so a friend's workout
+// detail can draw its map — the same share_route_maps consent the feed applies
+// gates it, and it can never become the full-history dump above.
+router.get("/:userId/workout/:workoutId/route", getWorkoutRouteController);
 router.get("/:userId/streak", getStreak);
 router.get("/:userId/range", getWorkoutRange);
 router.get("/:userId/recent", getRecentWorkouts);

--- a/backend/src/services/notificationSettingsService.ts
+++ b/backend/src/services/notificationSettingsService.ts
@@ -1,4 +1,9 @@
 import { PostgresService } from "./DbService.js";
+import {
+  DEFAULT_WORKOUT_VISIBILITY,
+  isWorkoutVisibility,
+  type WorkoutVisibility,
+} from "./visibilityService.js";
 
 const db = PostgresService.getInstance();
 
@@ -24,6 +29,10 @@ export interface NotificationPreferences {
   share_route_maps: boolean; // show my GPS route maps on my feed entries/posts
   weekly_recap_enabled: boolean; // Sunday-evening weekly recap push + story card
   h2h_close_friends_only: boolean; // Head-to-Head rivals only from my close friends
+  // Who may see my workout content (routes + photos): 'public' | 'friends' |
+  // 'private'. Coarser than share_route_maps — that one decides WHETHER routes
+  // are included, this decides WHO gets in at all. Both must pass.
+  workout_visibility: WorkoutVisibility;
 }
 
 const DEFAULT_PREFERENCES: NotificationPreferences = {
@@ -46,6 +55,7 @@ const DEFAULT_PREFERENCES: NotificationPreferences = {
   share_route_maps: true,
   weekly_recap_enabled: true,
   h2h_close_friends_only: false,
+  workout_visibility: DEFAULT_WORKOUT_VISIBILITY,
 };
 
 export async function getNotificationPreferences(
@@ -79,6 +89,11 @@ export async function getNotificationPreferences(
     share_route_maps: row.share_route_maps ?? true,
     weekly_recap_enabled: row.weekly_recap_enabled ?? true,
     h2h_close_friends_only: row.h2h_close_friends_only ?? false,
+    // Anything unrecognised reads as the safe default rather than being
+    // handed to the client as-is.
+    workout_visibility: isWorkoutVisibility(row.workout_visibility)
+      ? row.workout_visibility
+      : DEFAULT_WORKOUT_VISIBILITY,
   };
 }
 
@@ -124,6 +139,7 @@ export async function updateNotificationPreferences(
     { key: "share_route_maps", value: prefs.share_route_maps },
     { key: "weekly_recap_enabled", value: prefs.weekly_recap_enabled },
     { key: "h2h_close_friends_only", value: prefs.h2h_close_friends_only },
+    { key: "workout_visibility", value: prefs.workout_visibility },
   ];
 
   for (const field of fields) {

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -2,6 +2,10 @@ import { PostgresService } from "./DbService.js";
 import { sendPush } from "./pushNotificationService.js";
 import { shouldSendNotification } from "./notificationSettingsService.js";
 import {
+  VIEWER_MAY_SEE_WORKOUT_CONTENT_SQL,
+  OWNER_NOT_PRIVATE_SQL,
+} from "./visibilityService.js";
+import {
   postHypeMatchSql,
   postHypedByViewerMatchSql,
   runHypeMatchSql,
@@ -340,6 +344,7 @@ export async function getStoriesRail(viewerId: string): Promise<StoryGroup[]> {
 			AND p.deleted_at IS NULL
 			AND p.story_expires_at > NOW()
 			AND p.user_id NOT IN (SELECT uid FROM blocked)
+			AND ${OWNER_NOT_PRIVATE_SQL("p.user_id")}
 		ORDER BY p.created_at ASC
 		`,
     [viewerId],
@@ -423,6 +428,7 @@ export async function getUserActiveStories(
 			AND p.deleted_at IS NULL
 			AND p.story_expires_at > NOW()
 			AND p.user_id NOT IN (SELECT uid FROM blocked)
+			AND ${OWNER_NOT_PRIVATE_SQL("p.user_id")}
 		ORDER BY p.created_at ASC
 		`,
     [viewerId, authorId],
@@ -701,6 +707,8 @@ export interface ViewerGoalGate {
  *
  * media_url is blanked to "" rather than nulled so existing (non-optional)
  * clients still decode; new clients read `photo_locked` to draw the lock state.
+ * `photo_locked` marks a row that LOST a photo here — not merely one that fell
+ * under the gate — so a row whose every slide survived never renders as locked.
  */
 export function lockUnearnedPhotos<
   T extends {
@@ -716,10 +724,20 @@ export function lockUnearnedPhotos<
   for (const r of rows) {
     if (r.user_id === viewerId) continue;
     if ((r.local_date ?? null) !== gate.localDate) continue;
-    if (r.story_photo_url) r.story_photo_url = null;
+    let withheld = false;
+    if (r.story_photo_url) {
+      r.story_photo_url = null;
+      withheld = true;
+    }
     // Leave auto route/stats cards visible; only real photos are locked.
-    if (r.is_auto !== true && r.media_url) r.media_url = "";
-    r.photo_locked = true;
+    if (r.is_auto !== true && r.media_url) {
+      r.media_url = "";
+      withheld = true;
+    }
+    // Only flag rows that actually LOST a photo. An auto route/stats card with
+    // no story photo has nothing withheld, so it must not read as locked —
+    // flagging it made clients hide a card they were meant to see.
+    if (withheld) r.photo_locked = true;
   }
   return rows;
 }
@@ -869,6 +887,7 @@ export async function getUnifiedFeed(
 			LEFT JOIN notification_settings nsp ON nsp.user_id = p.user_id
 			WHERE p.share_to_feed AND p.deleted_at IS NULL
 				AND p.user_id NOT IN (SELECT uid FROM blocked)
+				AND ${OWNER_NOT_PRIVATE_SQL("p.user_id")}
 
 			UNION ALL
 
@@ -910,6 +929,9 @@ export async function getUnifiedFeed(
 			LEFT JOIN notification_settings ns ON ns.user_id = w.user_id
 			WHERE w.user_id NOT IN (SELECT uid FROM blocked)
 				AND COALESCE(ns.share_workouts_to_feed, true) = true
+				-- The feed is always YOUR circle, so 'public' must not pour
+				-- strangers in; only the tightening direction applies here.
+				AND ${OWNER_NOT_PRIVATE_SQL("w.user_id")}
 				AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL
 				AND NOT EXISTS (
 					SELECT 1 FROM posts p2
@@ -943,9 +965,11 @@ export async function getUserPosts(
   before?: string | null,
   includeStoryOnly = false,
 ): Promise<PostRow[]> {
+  // No CIRCLE_CTE here: a profile read is exactly where `workout_visibility`
+  // decides who gets in, and a hardcoded circle join would have made 'public'
+  // impossible. The feed still uses the circle — that one IS friends-by-nature.
   const rows = await db.query<PostRow>(
     `
-		${CIRCLE_CTE}
 		SELECT ${POST_SELECT},
 			${URL_SAFE_CURSOR("p.created_at")} AS cursor,
 			-- The run's story photo, so the profile grid + detail cards lead
@@ -983,8 +1007,7 @@ export async function getUserPosts(
 					)
 				)
 			)
-			AND EXISTS (SELECT 1 FROM circle WHERE uid = $2)
-			AND $2 NOT IN (SELECT uid FROM blocked)
+			AND ${VIEWER_MAY_SEE_WORKOUT_CONTENT_SQL("$2", "$1")}
 			AND ($3::timestamptz IS NULL OR p.created_at < $3::timestamptz)
 		ORDER BY p.created_at DESC
 		LIMIT $4

--- a/backend/src/services/visibilityService.ts
+++ b/backend/src/services/visibilityService.ts
@@ -1,0 +1,87 @@
+/**
+ * Who may see one user's workout CONTENT — routes and photos.
+ *
+ * Before this, "friends only" was a property of individual queries: the feed,
+ * the profile grid and the stories rail each JOINed the circle, while
+ * /workouts/:userId/recent (and /stats, /streak, /race-records) were readable by
+ * any authenticated account. Same underlying runs, two different answers.
+ *
+ * `notification_settings.workout_visibility` makes it one decision:
+ *   'friends'  — accepted friends only (the DEFAULT, and what every existing
+ *                user effectively has today, so the column changes nothing on
+ *                its own)
+ *   'public'   — any signed-in user
+ *   'private'  — nobody but the owner
+ *
+ * Blocks always win, in both directions, whatever the visibility.
+ */
+export type WorkoutVisibility = "public" | "friends" | "private";
+
+export const WORKOUT_VISIBILITY_VALUES: WorkoutVisibility[] = [
+  "public",
+  "friends",
+  "private",
+];
+
+export const DEFAULT_WORKOUT_VISIBILITY: WorkoutVisibility = "friends";
+
+export function isWorkoutVisibility(v: unknown): v is WorkoutVisibility {
+  return (
+    typeof v === "string" && (WORKOUT_VISIBILITY_VALUES as string[]).includes(v)
+  );
+}
+
+/**
+ * SQL predicate: may `viewerParam` see `ownerCol`'s workout content?
+ *
+ * `ownerCol` is any SQL expression naming the owner (a column like `p.user_id`
+ * or a parameter like `$1`); `viewerParam` names the viewer. Both are spliced
+ * as SQL, so they must ALWAYS be literals you wrote — never user input.
+ *
+ * Fail-closed by construction: an unknown visibility value and a NULL viewer
+ * both fall through to false, and a missing settings row reads as the
+ * 'friends' default rather than as open.
+ */
+export const VIEWER_MAY_SEE_WORKOUT_CONTENT_SQL = (
+  ownerCol: string,
+  viewerParam: string,
+) => `(
+	${ownerCol} = ${viewerParam}
+	OR (
+		NOT EXISTS (
+			SELECT 1 FROM user_blocks b
+			WHERE (b.blocker_id = ${viewerParam} AND b.blocked_id = ${ownerCol})
+				OR (b.blocker_id = ${ownerCol} AND b.blocked_id = ${viewerParam})
+		)
+		AND CASE COALESCE(
+			(SELECT nsv.workout_visibility FROM notification_settings nsv
+				WHERE nsv.user_id = ${ownerCol}),
+			'${DEFAULT_WORKOUT_VISIBILITY}'
+		)
+			WHEN 'public' THEN true
+			WHEN 'friends' THEN EXISTS (
+				SELECT 1 FROM friendships f
+				WHERE f.user_id = ${viewerParam}
+					AND f.friend_id = ${ownerCol}
+					AND f.status = 'accepted'
+			)
+			ELSE false
+		END
+	)
+)`;
+
+/**
+ * SQL predicate: is `ownerCol` NOT fully private?
+ *
+ * The feed is always your own circle — 'public' must never pour strangers into
+ * it — so the feed doesn't use the full predicate above. It only needs to honor
+ * the one direction that tightens: a user who went 'private' disappears from
+ * their friends' feeds.
+ */
+export const OWNER_NOT_PRIVATE_SQL = (ownerCol: string) => `(
+	COALESCE(
+		(SELECT nsp2.workout_visibility FROM notification_settings nsp2
+			WHERE nsp2.user_id = ${ownerCol}),
+		'${DEFAULT_WORKOUT_VISIBILITY}'
+	) <> 'private'
+)`;

--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -1,5 +1,6 @@
 import { Workout } from "../types/workouts.js";
 import { PostgresService } from "./DbService.js";
+import { VIEWER_MAY_SEE_WORKOUT_CONTENT_SQL } from "./visibilityService.js";
 
 const db = PostgresService.getInstance();
 
@@ -368,19 +369,114 @@ export async function getBestSplit(userId: string, startDate?: string) {
   return { best_split_time, workout };
 }
 
+/**
+ * A user's recent workouts, newest first, each tagged with whether it carries a
+ * GPS route and whether it has a real photo — so a friend's workout row can
+ * show the same "Route"/"Photo" chips the owner sees on their own rows. Both
+ * flags are ADDITIVE: older clients simply ignore them.
+ *
+ * Both flags obey `workout_visibility` (who may see this user's content at all)
+ * AND, for routes, the author's "Share route maps" consent — an author who
+ * turned either off must not even have the EXISTENCE of a route advertised to
+ * others, only to themselves. `viewerId` is what makes "the owner always sees
+ * their own" work; omit it and everyone is treated as a stranger (fail-closed).
+ *
+ * `has_photo` means a DELIBERATE photo (`is_auto = false`), never a generated
+ * route/stats card — the same "real photo" test the feed uses. It reports mere
+ * existence, never a url, so it reveals nothing `lockUnearnedPhotos` protects:
+ * a gated viewer already sees a lock card on today's photo posts in the feed.
+ *
+ * The photo lookup is a per-user CTE rather than a correlated EXISTS per row:
+ * `posts` has no plain `workout_id` index (only partial uniques that a
+ * `is_auto = false` predicate can't use), so a subquery per row would seq-scan
+ * `posts` once per workout. Keyed on user_id it rides `idx_posts_user_created`.
+ *
+ * Routes themselves are NOT shipped here — 50 polylines per page is a lot of
+ * jsonb for a list that draws none of them. The detail screen pulls the one it
+ * needs from `getWorkoutRoute`.
+ */
 export async function getRecentWorkouts(
   userId: string,
   limit: number | null = 10,
+  viewerId?: string | null,
 ) {
   const recentWorkoutsQuery = `
-	SELECT * FROM workouts
-	WHERE user_id = $1
-	AND deleted_at IS NULL
-	ORDER BY device_end_date DESC
-	LIMIT $2
+	WITH recent AS (
+		SELECT * FROM workouts
+		WHERE user_id = $1
+		AND deleted_at IS NULL
+		ORDER BY device_end_date DESC
+		LIMIT $2
+	),
+	photo_workouts AS (
+		SELECT DISTINCT workout_id
+		FROM posts
+		WHERE user_id = $1
+		AND deleted_at IS NULL
+		AND workout_id IN (SELECT workout_id FROM recent)
+		AND is_auto = FALSE
+		AND media_url <> ''
+	),
+	route_consent AS (
+		SELECT (COALESCE(ns.share_route_maps, true) OR $1 = $3) AS allowed
+		FROM users u
+		LEFT JOIN notification_settings ns ON ns.user_id = u.user_id
+		WHERE u.user_id = $1
+	)
+	SELECT r.*,
+		(
+			wr.workout_id IS NOT NULL
+			AND COALESCE((SELECT allowed FROM route_consent), false)
+			AND ${VIEWER_MAY_SEE_WORKOUT_CONTENT_SQL("$1", "$3")}
+		) AS has_route,
+		(
+			pw.workout_id IS NOT NULL
+			AND ${VIEWER_MAY_SEE_WORKOUT_CONTENT_SQL("$1", "$3")}
+		) AS has_photo
+	FROM recent r
+	LEFT JOIN workout_routes wr ON wr.workout_id = r.workout_id
+	LEFT JOIN photo_workouts pw ON pw.workout_id = r.workout_id
+	ORDER BY r.device_end_date DESC
 	`;
 
-  return await db.query(recentWorkoutsQuery, [userId, limit]);
+  return await db.query(recentWorkoutsQuery, [userId, limit, viewerId ?? null]);
+}
+
+/**
+ * ONE workout's stored GPS trace, or null — what a workout DETAIL screen needs
+ * to draw its map.
+ *
+ * The owner's own detail reads its route from HealthKit, which only ever holds
+ * their own runs, so a friend's detail had no way to draw the map it was being
+ * told existed. Two independent gates, BOTH required:
+ *   1. `workout_visibility` — who may see this user's content at all.
+ *      Authentication alone is NOT access: without this, any account
+ *      (including one the owner blocked) could pull a stranger's polyline by
+ *      guessing an id. Routes are the most sensitive thing here; they start at
+ *      people's homes.
+ *   2. `share_route_maps` — whether routes are part of what those people get.
+ *      Owner exempt.
+ * Deliberately per-workout — never the full-history dump `/routes` keeps
+ * self-only.
+ */
+export async function getWorkoutRoute(
+  userId: string,
+  workoutId: string,
+  viewerId: string,
+): Promise<[number, number][] | null> {
+  const rows = await db.query<{ route: [number, number][] | null }>(
+    `SELECT wr.route
+		 FROM workouts w
+		 LEFT JOIN notification_settings ns ON ns.user_id = w.user_id
+		 JOIN workout_routes wr ON wr.workout_id = w.workout_id
+		 WHERE w.workout_id = $2
+			 AND w.user_id = $1
+			 AND w.deleted_at IS NULL
+			 AND ${VIEWER_MAY_SEE_WORKOUT_CONTENT_SQL("w.user_id", "$3")}
+			 AND (COALESCE(ns.share_route_maps, true) OR w.user_id = $3)`,
+    [userId, workoutId, viewerId],
+  );
+  return rows[0]?.route ?? null;
 }
 
 /**


### PR DESCRIPTION
Started as "the feed photo lock hides too much" and grew as each fix uncovered the next thing. **Backend must deploy before the app ships** — iOS reads new fields.

## Privacy (the important part)

`workout_visibility` — `public` | `friends` | `private`, **default `friends`**, on `notification_settings`. One shared predicate (`backend/src/services/visibilityService.ts`) enforces it across routes, photo existence, the profile grid, the feed and stories. Settings ride the existing `GET/PUT /notifications/preferences` — no new endpoints. New iOS picker in Notification Settings.

**Safe to deploy:** `friends` is what routes/photos already were, so the default changes nothing for existing users.

Two deliberate calls:

- **The feed only honors the tightening direction.** `private` removes you from friends' feeds; `public` does *not* pour strangers in — a feed is your circle by definition. `public` only opens profile-level reads.
- **`/recent`, `/stats`, `/streak`, `/race-records` are still readable by any authenticated user** — left as-is on purpose so non-friend profiles don't silently empty. The model now exists, so putting them behind it is a one-line predicate.

### Privacy bugs found and fixed

- `lockUnearnedPhotos` flagged **every** one of today's posts, not just ones that lost a photo — so clients hid auto route/stats cards that were never withheld.
- `has_route` advertised route **existence** regardless of the author's `share_route_maps` setting.
- The new per-workout route endpoint is circle-gated (accepted friends + self, blocks both ways). Authentication alone is not access — routes start at people's homes.

## Fixes

**Recent Workouts loading intermittently.** `isAuthorized` was a per-process session flag set only inside `requestAuthorization` (a UI path). HealthKit's own background delivery launches the app with no UI constantly, so those processes read HealthKit with it `false` and every query no-opped — the `[WorkoutIndex] ❌ Not authorized` in the logs. It now resolves against real authorization without prompting, and `performBackgroundSync` establishes auth for all four reasons instead of only the observer path. `fetchRecentWorkouts` also swallowed its query error, so a locked-device launch left the list empty with nothing to retry it.

**Photo lock hid too much.** The lock is now one slide in the carousel rather than a replacement for it — the route map, stats card and page dots survive.

**Friend workouts didn't match your own.** Shared `WorkoutRowTags` + `WorkoutDetailSections` so rows and detail can't drift again. A friend's detail now shows the real photo and route map.

**Workout detail animation.** Content was fading + sliding in *on top of* the sheet's own presentation, and the hero card animated its own size when the route/photo probes landed a beat later. Both removed — same lesson `WorkoutRow` already learned ("a crisp appearance reads cleaner").

**Also:** Manual badge wrapped mid-word on narrow rows (moved to the chips line); See All pushes a page; calendar shows run/walk/both + photo per day; one `workoutPaceText` (a friend's detail lacked the sanity guard — a 0.04 mi stroll read `884:34 /mi` there and `N/A` on your own).

## Verification

`tsc` builds, `drizzle-kit check` passes, migration `0019` is purely additive (`ADD COLUMN` + `CHECK`).

`ci-smoke.mjs` gained coverage for the photo gate, route privacy (stranger / blocked / consent / fail-closed on a null viewer), all three visibility states, block precedence over `public`, and the settings round-trip — that last one because `updateNotificationPreferences` silently skips unknown keys, so a typo would no-op rather than fail.

**CI is the first place this SQL ever executes** — no Docker/psql was available locally, so the smoke test never ran on my machine.

## Reviewer notes

- **iOS is parse-checked only, never built.** Needs Xcode. `WorkoutHeroCard`'s generic `@ViewBuilder banner` slot (so the vehicle-speed warning stays inside your hero while a friend's has none) is the most likely thing to complain.
- Three separate `HealthKitManager` instances exist (`RootView` makes one and injects it as an `environmentObject`, `MainTabView` uses `.shared`, `MADBackgroundService` makes a third) — triple queries and index builds per launch. Left alone deliberately; that path has scar tissue and deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
