### PR TITLE
Fix has_route/has_photo returning null instead of false

### DIFF
--- a/backend/scripts/ci-smoke.mjs
+++ b/backend/scripts/ci-smoke.mjs
@@ -295,14 +295,16 @@ assert.ok(!earned[0].photo_locked, "completed viewer sees no lock");
 // Recent workouts carry has_route / has_photo, so a friend's workout row can
 // show the same Route/Photo chips the owner sees. Bob's run has a GPS route and
 // a real photo post; Alice's has neither.
-const bobRecent = await getRecentWorkouts(BOB, 10);
+// Read as ALICE, Bob's friend — the flags are viewer-dependent, so who's
+// asking is part of the question.
+const bobRecent = await getRecentWorkouts(BOB, 10, ALICE);
 assert.equal(bobRecent.length, 1, "Bob has one recent workout");
 assert.equal(bobRecent[0].workout_id, "ci-workout-bob");
 assert.equal(bobRecent[0].has_route, true, "Bob's run reports its GPS route");
 assert.equal(bobRecent[0].has_photo, true, "Bob's run reports its real photo");
 assert.equal(bobRecent[0].distance, 1.5, "the workout's own columns survive");
 
-const aliceRecent = await getRecentWorkouts(ALICE, 10);
+const aliceRecent = await getRecentWorkouts(ALICE, 10, ALICE);
 assert.equal(aliceRecent.length, 1, "Alice has one recent workout");
 assert.equal(aliceRecent[0].has_route, false, "no route → has_route false");
 assert.equal(aliceRecent[0].has_photo, false, "no post → has_photo false");
@@ -313,7 +315,7 @@ await db.query(
 	 VALUES ($1, $2, $3, $4, TRUE, FALSE, TRUE)`,
   [ALICE, "/uploads/posts/ci-alice-auto.jpg", "ci-workout-alice", localDate],
 );
-const aliceAfterAuto = await getRecentWorkouts(ALICE, 10);
+const aliceAfterAuto = await getRecentWorkouts(ALICE, 10, ALICE);
 assert.equal(
   aliceAfterAuto.length,
   1,
@@ -332,12 +334,12 @@ await db.query(
 	 VALUES ($1, $2, $3, $4, FALSE, TRUE, FALSE)`,
   [BOB, "/uploads/posts/ci-bob-story.jpg", "ci-workout-bob", localDate],
 );
-const bobTwoPosts = await getRecentWorkouts(BOB, 10);
+const bobTwoPosts = await getRecentWorkouts(BOB, 10, ALICE);
 assert.equal(bobTwoPosts.length, 1, "two posts on one workout → still one row");
 assert.equal(bobTwoPosts[0].has_photo, true);
 
 // The controller passes null when ?limit is absent — LIMIT NULL means "all".
-const bobNoLimit = await getRecentWorkouts(BOB, null);
+const bobNoLimit = await getRecentWorkouts(BOB, null, ALICE);
 assert.equal(bobNoLimit.length, 1, "a null limit returns rows, not zero");
 
 // --- Route privacy. Routes start at people's homes; these are the assertions

--- a/backend/src/controllers/workoutController.ts
+++ b/backend/src/controllers/workoutController.ts
@@ -519,7 +519,7 @@ export async function getUserRoutesController(req: Request, res: Response) {
   }
 }
 
-export async function getUserStats(req: Request, res: Response) {
+export async function getUserStats(req: AuthenticatedRequest, res: Response) {
   if (!hasRequiredKeys(["userId"], req, res)) return;
 
   try {
@@ -544,7 +544,10 @@ export async function getUserStats(req: Request, res: Response) {
       getTotalMiles(userId, startDateParam),
       getBestMilesDay(userId, startDateParam),
       getBestSplit(userId, startDateParam),
-      getRecentWorkoutsDb(userId, 10),
+      // Viewer matters here too: this payload's recent_workouts carry
+      // has_route/has_photo, and without it they'd report nothing to anyone —
+      // including the owner looking at their own stats.
+      getRecentWorkoutsDb(userId, 10, req.userId),
       getTodayMiles(userId),
     ]);
 

--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -424,14 +424,21 @@ export async function getRecentWorkouts(
 		WHERE u.user_id = $1
 	)
 	SELECT r.*,
-		(
+		-- COALESCE the WHOLE expression, not just its parts: with no viewer,
+		-- '$1 = $3' is NULL and the visibility predicate evaluates to NULL
+		-- rather than false, so 'true AND NULL' made these columns come back
+		-- JSON null instead of a boolean. NULL is fail-closed in a WHERE but
+		-- meaningless as a value — these must always be a real true/false.
+		COALESCE(
 			wr.workout_id IS NOT NULL
 			AND COALESCE((SELECT allowed FROM route_consent), false)
-			AND ${VIEWER_MAY_SEE_WORKOUT_CONTENT_SQL("$1", "$3")}
+			AND ${VIEWER_MAY_SEE_WORKOUT_CONTENT_SQL("$1", "$3")},
+			false
 		) AS has_route,
-		(
+		COALESCE(
 			pw.workout_id IS NOT NULL
-			AND ${VIEWER_MAY_SEE_WORKOUT_CONTENT_SQL("$1", "$3")}
+			AND ${VIEWER_MAY_SEE_WORKOUT_CONTENT_SQL("$1", "$3")},
+			false
 		) AS has_photo
 	FROM recent r
 	LEFT JOIN workout_routes wr ON wr.workout_id = r.workout_id


### PR DESCRIPTION
Fixes the red backend CI on `main` (from #222). **Production is functional** — the failure is a real but narrow defect plus a stale test.

## The defect

The visibility predicate evaluates to `NULL`, not `false`, when there's no viewer:

```
'$1 = $3'                                    -> NULL   (owner = NULL)
'NULL OR (not_blocked AND friendship)'       -> NULL   (NULL OR false = NULL)
'wr.workout_id IS NOT NULL AND ... AND NULL' -> NULL   (true AND NULL = NULL)
```

`NULL` is fail-closed in a `WHERE` clause — which is what I reasoned about — but meaningless as a **selected value**: these columns were reaching clients as JSON `null` instead of a boolean. Now `COALESCE`d as a whole expression, so they're always a real `true`/`false`.

## The second call site

`getUserStats` built its `recent_workouts` payload via `getRecentWorkoutsDb(userId, 10)` with **no viewer**, so its `has_route`/`has_photo` reported nothing to anyone — including the owner reading their own stats. It passes `req.userId` now.

Blast radius was limited: `/workouts/:userId/recent` (the friend-rows path, and the one that actually draws the chips) always passed the viewer correctly, so the shipped feature works. `/stats` just carried two null fields that iOS decodes as `nil`.

## The stale test

The assertions that caught this were written *before* the visibility gate existed, when "no viewer" still returned the owner's answer. The flags are viewer-dependent now — who's asking is part of the question — so they read as ALICE (Bob's friend). The deliberate `getRecentWorkouts(BOB, 10, null)` fail-closed check stays, and now genuinely gets `false` rather than `null`.

Worth noting the test did its job: this is exactly the class of bug I couldn't catch locally without a database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)