### PR TITLE
Log fetchRecentWorkouts outcomes so an empty list has a cause

### DIFF
--- a/app/Mile A Day/Models/HealthKitManager.swift
+++ b/app/Mile A Day/Models/HealthKitManager.swift
@@ -812,7 +812,13 @@ class HealthKitManager: ObservableObject {
     // The date predicate keeps HealthKit from scanning all-time history just to
     // pull the most recent samples — far cheaper for users with long histories.
     func fetchRecentWorkouts() {
-        guard isAuthorized else { return }
+        // print, not log(): log() is a no-op stub, so this path had no voice at
+        // all — an empty Recent Workouts list looked identical whether the query
+        // was skipped, errored, or genuinely returned nothing.
+        guard isAuthorized else {
+            print("[HealthKit] ⏭️ fetchRecentWorkouts skipped — isAuthorized == false")
+            return
+        }
 
         let runningPredicate = HKQuery.predicateForWorkouts(with: .running)
         let walkingPredicate = HKQuery.predicateForWorkouts(with: .walking)
@@ -839,12 +845,14 @@ class HealthKitManager: ObservableObject {
             // because swallowing the error left the list empty until something
             // else happened to call fetchAllWorkoutData again.
             guard error == nil, let workouts = samples as? [HKWorkout] else {
+                print("[HealthKit] ⚠️ fetchRecentWorkouts failed: \(error?.localizedDescription ?? "nil samples") — will retry")
                 self.retryFetchRecentWorkouts()
                 return
             }
 
             // Successful query: trust the result, empty or not (a real zero).
             DispatchQueue.main.async {
+                print("[HealthKit] ✅ fetchRecentWorkouts → \(workouts.count) workouts")
                 self.recentWorkoutsRetriesLeft = 3
                 self.recentWorkouts = workouts
             }


### PR DESCRIPTION
Diagnostic only — no behavior change.

`HealthKitManager.log()` is a no-op stub:

```swift
func log(_ message: String) {}
```

So every `log(...)` call in that file prints nothing, and `fetchRecentWorkouts` had no voice at all. An empty Recent Workouts list looks identical whether the query was **skipped** (`isAuthorized == false`), **errored** (locked device), or **genuinely returned zero** — and I've been guessing between those three.

This uses `print()` like the paths that actually report (`[WorkoutIndex]`, `[APIClient]`, `[AppDelegate]`) and says which one happened:

- `[HealthKit] ⏭️ fetchRecentWorkouts skipped — isAuthorized == false`
- `[HealthKit] ⚠️ fetchRecentWorkouts failed: <error> — will retry`
- `[HealthKit] ✅ fetchRecentWorkouts → N workouts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)