### PR TITLE
iOS fixes: dup photo saves, sticker drag, Feed refresh, stale cold-launch state

### DIFF
--- a/app/Mile A Day/Core/State/MidRunPhotoStash.swift
+++ b/app/Mile A Day/Core/State/MidRunPhotoStash.swift
@@ -43,30 +43,33 @@ enum MidRunPhotoStash {
 
     /// Save a snap. Downscaled to a sane pixel size before writing — the
     /// composer flattens to 1080 wide anyway, and full 48MP camera output
-    /// would burn sandbox space for nothing.
+    /// would burn sandbox space for nothing. Returns the created `Entry`
+    /// (nil on failure) so callers can correlate a camera-roll save with this
+    /// snap's stable id.
     @discardableResult
-    static func add(_ image: UIImage) -> Bool {
+    static func add(_ image: UIImage) -> Entry? {
         let fm = FileManager.default
         try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
 
         let sized = downscaled(image, maxDimension: 2160)
-        guard let data = sized.jpegData(compressionQuality: 0.85) else { return false }
+        guard let data = sized.jpegData(compressionQuality: 0.85) else { return nil }
 
         let name = String(format: "%.3f", Date().timeIntervalSince1970)
+        let url = directory.appendingPathComponent("\(name).jpg")
         do {
-            try data.write(to: directory.appendingPathComponent("\(name).jpg"))
+            try data.write(to: url)
         } catch {
-            return false
+            return nil
         }
 
         // Enforce the cap: drop the oldest beyond maxPhotos.
         let files = fileURLs()
         if files.count > maxPhotos {
-            for url in files.prefix(files.count - maxPhotos) {
-                try? fm.removeItem(at: url)
+            for old in files.prefix(files.count - maxPhotos) {
+                try? fm.removeItem(at: old)
             }
         }
-        return true
+        return Entry(url: url, image: sized)
     }
 
     /// A stashed snap with a stable identity, so galleries can page and

--- a/app/Mile A Day/Core/State/SavedPhotoLibraryLedger.swift
+++ b/app/Mile A Day/Core/State/SavedPhotoLibraryLedger.swift
@@ -1,0 +1,53 @@
+import Combine
+import Foundation
+
+/// Remembers which mid-run snaps are already in the user's photo library, so
+/// the review gallery can show "Saved" and refuse to save the same shot twice.
+///
+/// Keyed by `MidRunPhotoStash.Entry.id` (the snap's stash filename). Every
+/// in-app capture auto-saves to the camera roll at shutter time and every
+/// library import obviously already lives there — this ledger is how the UI
+/// knows which entries are covered without re-hitting Photos. Persisted so the
+/// state survives the mid-run → post-run-prompt hop and an app relaunch;
+/// pruned to the live stash on read so it can't grow without bound.
+final class SavedPhotoLibraryLedger: ObservableObject {
+    static let shared = SavedPhotoLibraryLedger()
+
+    private static let storeKey = "savedPhotoLibraryLedger.v1"
+    /// Backstop cap — the stash tops out at 5 and is cleared each run, so this
+    /// is only reached if pruning never runs (e.g. a capture-heavy session
+    /// that never opens the gallery).
+    private static let maxKeys = 500
+
+    @Published private(set) var savedIds: Set<String>
+
+    private init() {
+        let stored = UserDefaults.standard.stringArray(forKey: Self.storeKey) ?? []
+        savedIds = Set(stored)
+    }
+
+    /// Whether this snap is known to already be in the photo library.
+    func contains(_ id: String) -> Bool { savedIds.contains(id) }
+
+    /// Record that this snap landed in the photo library.
+    func markSaved(_ id: String) {
+        guard !savedIds.contains(id) else { return }
+        savedIds.insert(id)
+        persist()
+    }
+
+    /// Drop keys no longer backed by a live stash entry. Call with the current
+    /// stash ids (e.g. when the gallery appears) to keep the store bounded.
+    func prune(keeping liveIds: [String]) {
+        let trimmed = savedIds.intersection(liveIds)
+        guard trimmed != savedIds else { return }
+        savedIds = trimmed
+        persist()
+    }
+
+    private func persist() {
+        var ids = Array(savedIds)
+        if ids.count > Self.maxKeys { ids = Array(ids.suffix(Self.maxKeys)) }
+        UserDefaults.standard.set(ids, forKey: Self.storeKey)
+    }
+}

--- a/app/Mile A Day/Managers/CelebrationManager.swift
+++ b/app/Mile A Day/Managers/CelebrationManager.swift
@@ -353,6 +353,25 @@ class CelebrationManager: ObservableObject {
     /// Tracks whether goal completion has been shown today (to prevent duplicates)
     @AppStorage("lastGoalCelebrationDate") private var lastGoalCelebrationDateString: String = ""
 
+    /// Workout ids that have already been offered the post-run photo prompt.
+    /// Persisted (newline-joined) so a cold relaunch — which starts with an empty
+    /// in-memory queue and can't dedup against it — never re-prompts for a mile
+    /// already handled. Bounded to the most recent `maxPromptedPhotoIds`.
+    @AppStorage("promptedPhotoWorkoutIdsV1") private var promptedPhotoWorkoutIdsRaw: String = ""
+    private let maxPromptedPhotoIds = 200
+
+    private func hasPromptedPhoto(for workoutId: String) -> Bool {
+        promptedPhotoWorkoutIdsRaw.split(separator: "\n").contains(where: { String($0) == workoutId })
+    }
+
+    private func markPromptedPhoto(for workoutId: String) {
+        var ids = promptedPhotoWorkoutIdsRaw.split(separator: "\n").map(String.init)
+        guard !ids.contains(workoutId) else { return }
+        ids.append(workoutId)
+        if ids.count > maxPromptedPhotoIds { ids = Array(ids.suffix(maxPromptedPhotoIds)) }
+        promptedPhotoWorkoutIdsRaw = ids.joined(separator: "\n")
+    }
+
     /// Backing store for the extra-mile workout-count baseline. Scoped to a single
     /// day via `lastPostGoalDateString` — see `lastPostGoalWorkoutCount`.
     @AppStorage("lastPostGoalWorkoutCount") private var storedPostGoalWorkoutCount: Int = 0
@@ -415,6 +434,16 @@ class CelebrationManager: ObservableObject {
             print("[CelebrationManager] ✅ Goal celebration queued (last shown: \(lastGoalCelebrationDateString.isEmpty ? "never" : lastGoalCelebrationDateString), today: \(formatDate(Date())))")
             // Note: markGoalCelebrationShown() is called in showNextCelebration() when it's actually displayed,
             // not here, to prevent marking as "shown" while the app is in the background.
+        }
+
+        // One photo prompt per workout, ever — persisted so a relaunch can't
+        // re-offer it for a mile already handled (the id is marked as shown in
+        // showNextCelebration(), same as the goal celebration).
+        if case .postRunPhotoPrompt(let workoutId, _) = celebration {
+            guard !hasPromptedPhoto(for: workoutId) else {
+                print("[CelebrationManager] ⏭️  Photo prompt already shown for workout \(workoutId), skipping")
+                return
+            }
         }
 
         // Avoid duplicates in queue
@@ -513,6 +542,11 @@ class CelebrationManager: ObservableObject {
         // Mark goal celebration as shown now that the user will actually see it
         if case .goalCompleted = next {
             markGoalCelebrationShown()
+        }
+        // Same for the photo prompt — record the workout so it's never re-offered,
+        // even across a relaunch.
+        if case .postRunPhotoPrompt(let workoutId, _) = next {
+            markPromptedPhoto(for: workoutId)
         }
 
         currentCelebration = next

--- a/app/Mile A Day/Models/HealthKitManager.swift
+++ b/app/Mile A Day/Models/HealthKitManager.swift
@@ -362,6 +362,21 @@ class HealthKitManager: ObservableObject {
     var hasTodaysDistanceLoaded: Bool = false
     var hasIndexOrStreakLoaded: Bool = false
 
+    /// True once fetchTodaysDistance() has actually SUCCEEDED this session — not
+    /// merely been attempted. Distinct from `hasTodaysDistanceLoaded`, which flips
+    /// true even when the query ERRORS (locked device) so `hasLoadedInitialData`
+    /// never hangs. Celebrations gate on THIS: on a cold launch behind a locked
+    /// screen the query errors, `todaysDistance` keeps the value `loadCachedData()`
+    /// seeded from last night, and firing on it re-showed "mile complete / streak
+    /// safe" + the photo prompt for yesterday's already-posted mile until a second
+    /// launch refreshed the cache.
+    @Published var hasFreshTodaysDistance: Bool = false
+
+    /// True once fetchRecentWorkouts() has SUCCEEDED at least once this session.
+    /// Lets the UI tell "still loading / query erroring" apart from a genuine
+    /// empty list, so a locked-device launch stops flashing "No recent workouts".
+    @Published var hasLoadedRecentWorkoutsOnce: Bool = false
+
     func checkInitialDataReady() {
         if hasTodaysDistanceLoaded && hasIndexOrStreakLoaded && !hasLoadedInitialData {
             hasLoadedInitialData = true
@@ -768,6 +783,13 @@ class HealthKitManager: ObservableObject {
                 return
             }
 
+            // Reached only on a SUCCESSFUL query (locked-device errors returned
+            // above). Now `todaysDistance` is about to reflect a value we just
+            // fetched, not the cached one init seeded — so celebrations may fire.
+            DispatchQueue.main.async {
+                self.hasFreshTodaysDistance = true
+            }
+
             #if os(watchOS)
             let workouts = ((samples as? [HKWorkout]) ?? [])
             #else
@@ -855,6 +877,9 @@ class HealthKitManager: ObservableObject {
                 print("[HealthKit] ✅ fetchRecentWorkouts → \(workouts.count) workouts")
                 self.recentWorkoutsRetriesLeft = 3
                 self.recentWorkouts = workouts
+                // Only NOW is an empty list meaningful — before the first success
+                // the UI must show "loading", not "no recent workouts".
+                self.hasLoadedRecentWorkoutsOnce = true
             }
         }
 

--- a/app/Mile A Day/Views/Components/ImagePicker.swift
+++ b/app/Mile A Day/Views/Components/ImagePicker.swift
@@ -54,16 +54,34 @@ struct ImagePicker: UIViewControllerRepresentable {
 /// camera roll. Best-effort: a denied permission or save failure never
 /// interrupts the capture flow.
 enum PhotoRollSaver {
-    static func save(_ image: UIImage) {
+    /// Saves `image` to the photo library (add-only). `completion` reports —
+    /// on the main queue — whether the asset actually landed in the library, so
+    /// callers can reflect a real "Saved" state (a denied permission or write
+    /// failure reports `false`, never `true`).
+    static func save(_ image: UIImage, completion: ((Bool) -> Void)? = nil) {
         PHPhotoLibrary.requestAuthorization(for: .addOnly) { status in
-            guard status == .authorized || status == .limited else { return }
+            guard status == .authorized || status == .limited else {
+                DispatchQueue.main.async { completion?(false) }
+                return
+            }
             PHPhotoLibrary.shared().performChanges {
                 PHAssetChangeRequest.creationRequestForAsset(from: image)
-            } completionHandler: { _, error in
+            } completionHandler: { ok, error in
                 if let error {
                     print("[PhotoRollSaver] Save failed: \(error.localizedDescription)")
                 }
+                DispatchQueue.main.async { completion?(ok && error == nil) }
             }
+        }
+    }
+
+    /// As `save`, but records `ledgerKey` in `SavedPhotoLibraryLedger` on a
+    /// confirmed save so a review gallery can show "Saved" and refuse a
+    /// duplicate. `ledgerKey` is a `MidRunPhotoStash.Entry.id`.
+    static func save(_ image: UIImage, ledgerKey: String, completion: ((Bool) -> Void)? = nil) {
+        save(image) { ok in
+            if ok { SavedPhotoLibraryLedger.shared.markSaved(ledgerKey) }
+            completion?(ok)
         }
     }
 }

--- a/app/Mile A Day/Views/Components/MADCameraView.swift
+++ b/app/Mile A Day/Views/Components/MADCameraView.swift
@@ -8,10 +8,17 @@ import UIKit
 /// reaching for: full flash control (off / auto / on — not just auto) and a
 /// self-timer (3s / 10s) for propped-up group shots. Camera-only by design —
 /// no library picking — so shared walks/runs stay captured in the moment.
-/// Every capture is also saved to the user's camera roll (PhotoRollSaver),
-/// same as the picker it replaces.
+/// By default every capture is also saved to the user's camera roll
+/// (PhotoRollSaver), same as the picker it replaces. Callers that need to
+/// control the camera-roll save themselves (e.g. to key it to a stash id for
+/// duplicate-prevention) pass `autoSaveToPhotos: false` and save the returned
+/// image on their own.
 struct MADCameraView: View {
     @Binding var image: UIImage?
+    /// When true (default), the raw shot is saved straight to the camera roll
+    /// at capture. Mid-run capture turns this off so it can save keyed by the
+    /// snap's stash id instead (see SavedPhotoLibraryLedger).
+    var autoSaveToPhotos: Bool = true
     @Environment(\.dismiss) private var dismiss
     @State private var camera = MADCameraController()
     /// Seconds left on a running self-timer; nil when idle.
@@ -343,8 +350,12 @@ struct MADCameraView: View {
             }
             image = captured
             // Every in-app capture also lands in the camera roll — the user's
-            // own copy, independent of what happens to the post.
-            PhotoRollSaver.save(captured)
+            // own copy, independent of what happens to the post. The mid-run
+            // path opts out (autoSaveToPhotos == false) so it can save keyed to
+            // the snap's stash id and avoid a duplicate on re-save.
+            if autoSaveToPhotos {
+                PhotoRollSaver.save(captured)
+            }
             dismiss()
         }
     }

--- a/app/Mile A Day/Views/Components/SnapGalleryView.swift
+++ b/app/Mile A Day/Views/Components/SnapGalleryView.swift
@@ -15,6 +15,7 @@ struct SnapGalleryView: View {
     var onStashChanged: () -> Void = {}
 
     @Environment(\.dismiss) private var dismiss
+    @ObservedObject private var savedLedger = SavedPhotoLibraryLedger.shared
     @State private var entries: [MidRunPhotoStash.Entry] = []
     @State private var selectedId: String?
     @State private var showSavedToast = false
@@ -62,6 +63,7 @@ struct SnapGalleryView: View {
         }
         .onAppear {
             entries = MidRunPhotoStash.entries()
+            savedLedger.prune(keeping: entries.map(\.id))
             if entries.indices.contains(initialIndex) {
                 selectedId = entries[initialIndex].id
             } else {
@@ -107,22 +109,39 @@ struct SnapGalleryView: View {
         .padding(.top, MADTheme.Spacing.md)
     }
 
-    /// Save / Use / Delete for the photo on screen. Every capture already
-    /// auto-saved to the camera roll at shutter time — Save is the explicit,
-    /// visible version of that (and covers a denied-then-granted permission).
+    /// Whether the photo on screen is already in the user's photo library —
+    /// true for every capture (auto-saved at shutter time) and every library
+    /// import, unless the capture's auto-save was blocked by a denied
+    /// permission that has since been granted.
+    private var isCurrentSaved: Bool {
+        guard let current else { return false }
+        return savedLedger.contains(current.id)
+    }
+
+    /// Save / Use / Delete for the photo on screen. Photos already in the
+    /// library show a disabled "Saved" — Save only stays active to cover a
+    /// capture whose auto-save was blocked by a denied-then-granted permission.
     private var actionBar: some View {
-        HStack(spacing: MADTheme.Spacing.sm) {
-            galleryAction(icon: "square.and.arrow.down", label: "Save") {
-                guard let current else { return }
-                PhotoRollSaver.save(current.image)
-                UINotificationFeedbackGenerator().notificationOccurred(.success)
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
-                    showSavedToast = true
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.8) {
-                    withAnimation(.easeOut(duration: 0.25)) { showSavedToast = false }
+        let saved = isCurrentSaved
+        return HStack(spacing: MADTheme.Spacing.sm) {
+            galleryAction(
+                icon: saved ? "checkmark.circle.fill" : "square.and.arrow.down",
+                label: saved ? "Saved" : "Save",
+                tint: saved ? .green : .white
+            ) {
+                guard let current, !saved else { return }
+                PhotoRollSaver.save(current.image, ledgerKey: current.id) { ok in
+                    guard ok else { return }
+                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                    withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                        showSavedToast = true
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.8) {
+                        withAnimation(.easeOut(duration: 0.25)) { showSavedToast = false }
+                    }
                 }
             }
+            .disabled(saved)
 
             if let onUse {
                 Button {

--- a/app/Mile A Day/Views/Dashboard/DashboardStatsViews.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardStatsViews.swift
@@ -246,10 +246,24 @@ struct RecentWorkoutsPreviewCard: View {
                 }
 
                 if preview.isEmpty {
-                    Text("No recent workouts yet — log a run to see it here.")
-                        .font(.system(size: 13, weight: .medium, design: .rounded))
-                        .foregroundColor(.secondary)
+                    if healthManager.hasLoadedRecentWorkoutsOnce {
+                        // A successful query genuinely returned nothing.
+                        Text("No recent workouts yet — log a run to see it here.")
+                            .font(.system(size: 13, weight: .medium, design: .rounded))
+                            .foregroundColor(.secondary)
+                            .padding(.vertical, MADTheme.Spacing.sm)
+                    } else {
+                        // Not loaded yet (or a locked-device query is still
+                        // retrying) — show loading, never the "no workouts" copy,
+                        // which read as "your workouts vanished" on a cold launch.
+                        HStack(spacing: 8) {
+                            ProgressView().controlSize(.small)
+                            Text("Loading recent workouts…")
+                                .font(.system(size: 13, weight: .medium, design: .rounded))
+                                .foregroundColor(.secondary)
+                        }
                         .padding(.vertical, MADTheme.Spacing.sm)
+                    }
                 } else {
                     VStack(spacing: MADTheme.Spacing.sm) {
                         ForEach(preview, id: \.uuid) { workout in

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -217,6 +217,17 @@ struct DashboardView: View {
             print("[Dashboard] ⏳ Skipping celebration check - initial data not yet loaded")
             return
         }
+        // Celebrate only on a today's-distance we FRESHLY fetched this session.
+        // hasLoadedInitialData can flip true off a locked-device query that ERRORED
+        // (see fetchTodaysDistance), leaving todaysDistance at the value init cached
+        // from last night — which re-fired the "mile complete / streak safe" screen
+        // and photo prompt for yesterday's already-posted mile every morning until a
+        // second launch refreshed it. The onChange(of: hasFreshTodaysDistance) below
+        // re-runs this once the real fetch lands.
+        guard healthManager.hasFreshTodaysDistance else {
+            print("[Dashboard] ⏳ Skipping celebration check - today's distance not freshly fetched yet")
+            return
+        }
         // Defer while the workout tracker covers the dashboard — the celebration
         // overlay lives on this view, so it would play hidden behind the cover.
         // The cover's onDismiss re-runs this check once the dashboard is visible.
@@ -557,6 +568,13 @@ struct DashboardView: View {
                 if wasShowing && !isShowing {
                     maybePresentPendingSheet()
                 }
+            }
+            .onChange(of: healthManager.hasFreshTodaysDistance) { _, isFresh in
+                // On a locked-device launch the initial fetch errors and the
+                // celebration check bails; when the real fetch finally lands this
+                // re-runs it against fresh data (fires a genuine completion, stays
+                // silent for yesterday's already-handled mile).
+                if isFresh { checkAndShowGoalCelebration() }
             }
             .onChange(of: healthManager.hasLoadedInitialData) { _, isLoaded in
                 if isLoaded {

--- a/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
@@ -441,11 +441,13 @@ struct WorkoutTrackingView: View {
         switch result {
         case .accepted(let image):
             Task.detached(priority: .utility) {
-                let saved = MidRunPhotoStash.add(image)
+                guard let entry = MidRunPhotoStash.add(image) else { return }
                 let count = MidRunPhotoStash.count
                 let thumb = MidRunPhotoStash.latestThumbnail()
-                guard saved else { return }
                 await MainActor.run {
+                    // Imported straight from the photo library — it already
+                    // lives there, so mark it saved and never offer to re-save.
+                    SavedPhotoLibraryLedger.shared.markSaved(entry.id)
                     midRunSnapCount = count
                     lastSnapThumb = thumb
                     showImportToast("Added to your \(activityNoun)", ok: true)
@@ -482,7 +484,9 @@ struct WorkoutTrackingView: View {
         }
         .buttonStyle(PlainButtonStyle())
         .fullScreenCover(isPresented: $showMidRunCamera) {
-            MADCameraView(image: $midRunImage)
+            // Camera-roll save is handled below, keyed to the stash id, so the
+            // review gallery can show "Saved" and never duplicate the shot.
+            MADCameraView(image: $midRunImage, autoSaveToPhotos: false)
         }
         .onChange(of: midRunImage) { _, newImage in
             guard let image = newImage else { return }
@@ -490,11 +494,20 @@ struct WorkoutTrackingView: View {
             // Downscale + JPEG-encode off the main thread — doing it inline
             // stutters the camera dismissal animation on big sensor images.
             Task.detached(priority: .utility) {
-                let saved = MidRunPhotoStash.add(image)
+                let entry = MidRunPhotoStash.add(image)
                 let count = MidRunPhotoStash.count
                 let thumb = MidRunPhotoStash.latestThumbnail()
-                guard saved else { return }
                 await MainActor.run {
+                    // Keep the user's own full-res copy in the camera roll no
+                    // matter what (the camera no longer auto-saves this path).
+                    // When it made it into the stash, key the save to that snap
+                    // so the gallery shows "Saved" instead of a duplicate.
+                    if let entry {
+                        PhotoRollSaver.save(image, ledgerKey: entry.id)
+                    } else {
+                        PhotoRollSaver.save(image)
+                    }
+                    guard entry != nil else { return }
                     midRunSnapCount = count
                     lastSnapThumb = thumb
                     UINotificationFeedbackGenerator().notificationOccurred(.success)

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -357,7 +357,14 @@ private struct StickerEditorLayer: View {
     }
 
     private var manipulation: some Gesture {
-        let drag = DragGesture()
+        // Measure the drag in GLOBAL (screen) space, not the default `.local`.
+        // The sticker is moved every frame by `.position(liveCenter)` and sits
+        // below `.scaleEffect`/`.rotationEffect`, so its local space moves AND
+        // rotates with it — a local-space translation feeds back on itself and
+        // makes the sticker jitter (and drags along the rotated axis). Global
+        // space is fixed to the screen, so `translation` is the true finger
+        // delta: smooth, straight, and rotation-independent.
+        let drag = DragGesture(coordinateSpace: .global)
             .updating($dragTranslation) { value, state, _ in state = value.translation }
             .onEnded { value in
                 pos = CGPoint(x: committedX(addingDrag: value.translation.width),

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -28,6 +28,12 @@ enum FeedDeepLink {
 /// photo posts AND raw walk/run activity. Posting and viewing friends' stories
 /// are both gated on completing today's mile (the server re-verifies posting).
 struct SocialFeedView: View {
+    /// True while the Feed tab is the selected one. TabView keeps tab views
+    /// alive, so `.onAppear`/`.task` don't re-fire on tab switches — this lets
+    /// the feed silently refresh when the user returns to it (e.g. after
+    /// completing a mile) instead of showing stale posts until a manual pull.
+    var isActiveTab: Bool = false
+
     @StateObject private var healthManager = HealthKitManager.shared
     @StateObject private var userManager = UserManager.shared
     /// One stable service for profiles opened from the feed. Creating a fresh
@@ -352,6 +358,19 @@ struct SocialFeedView: View {
                 await refresh()
                 await loadTermsStatus()
                 loadMemories()
+                await loadHypeStatus()
+            }
+        }
+        // Returning to the Feed tab silently pulls fresh posts so a mile just
+        // completed (or a friend's new post) shows up without a manual pull —
+        // no more "the feed looks locked" after finishing a run. Guarded by
+        // `loadedOnce` so it never races the initial `.task` into a double
+        // fetch; `refresh()` keeps the current cards on screen while data swaps
+        // in (it only shows a spinner when the feed is empty).
+        .onChange(of: isActiveTab) { _, active in
+            guard active, loadedOnce else { return }
+            Task {
+                await refresh()
                 await loadHypeStatus()
             }
         }

--- a/app/Mile A Day/Views/MainTabView.swift
+++ b/app/Mile A Day/Views/MainTabView.swift
@@ -54,7 +54,10 @@ struct MainTabView: View {
             .badge(competitionService.invites.count)
 
             NavigationStack {
-                SocialFeedView()
+                // `isActiveTab` lets the feed refresh itself on tab re-entry —
+                // TabView keeps it alive, so its own .task can't (same reason
+                // Compete/Friends refresh in the onChange below).
+                SocialFeedView(isActiveTab: selectedTab == 2)
             }
             .tabItem {
                 Label("Feed", systemImage: "square.stack.fill")


### PR DESCRIPTION
Four independent iOS fixes.

---

## 1. Show "Saved" & prevent duplicate camera-roll saves

**Problem:** In-app camera snaps auto-save to the camera roll at shutter time (and library imports already live there), but the snap review gallery's **Save** button re-saved unconditionally — so viewing a photo already on the phone and tapping Save created a **duplicate**.

**Fix:** Per-snap `SavedPhotoLibraryLedger` (persistent, pruned to the live stash). `PhotoRollSaver.save` reports *actual* success and gains a `ledgerKey` variant that records only on a confirmed write. Mid-run capture opts out of `MADCameraView`'s blind auto-save and saves keyed to its stash id; library imports mark the ledger immediately. Gallery shows a disabled **"Saved"** for anything already in the library; **Save** only stays active to cover a denied-then-granted permission. No new permissions/Info.plist strings.

## 2. Fix composer sticker drag jitter

**Problem:** Dragging the stats sticker jittered/shook (rotation was fine). It's moved every frame by `.position` and sits below `.scaleEffect`/`.rotationEffect`, so the default `.local` gesture space moved/rotated with it → feedback loop.

**Fix:** Measure the drag in `.global` space so `translation` is the true finger delta — smooth, straight, scale/rotation-independent.

## 3. Auto-refresh the Feed on tab re-entry

**Problem:** After completing a mile and switching to the Feed, it showed stale posts (looked "locked") until a manual pull. TabView keeps tab views alive, so `SocialFeedView`'s initial `.task` never re-fired.

**Fix:** Pass `isActiveTab` (`selectedTab == 2`) into `SocialFeedView` and silently refresh when it flips true, guarded by `loadedOnce` so it never double-fetches. `refresh()` keeps current cards on screen while fresh data swaps in.

## 4. Stop stale cold-launch HealthKit data from re-firing celebrations / hiding workouts

**Problem:** The morning after completing (and already posting) a mile, a cold launch re-showed "mile complete / streak safe" and re-prompted "take a picture" for **yesterday's** workout, and the recent-workouts list flashed "No recent workouts" — a second full launch fixed it. Root cause: behind a locked screen HealthKit queries error; `fetchTodaysDistance` correctly keeps the last-good value (never writes 0) **but still flips `hasLoadedInitialData` true on that error**, opening the celebration gate while `todaysDistance` still holds the value `loadCachedData()` seeded from last night.

**Fix (additive guards — no streak math changed):**
- `hasFreshTodaysDistance`, set true **only on a successful** `fetchTodaysDistance` (not an errored/attempted one). `checkAndShowGoalCelebration` gates on it and re-runs via `.onChange` when the real fetch lands — celebrations fire on verified-fresh data and stay silent for a previous day's already-handled mile.
- **Persistent** per-workout post-run photo-prompt dedup (`promptedPhotoWorkoutIdsV1`, marked when shown) — the in-memory queue check is empty on relaunch, so this stops re-prompting an already-posted mile.
- `hasLoadedRecentWorkoutsOnce`, set true only on a successful `fetchRecentWorkouts`; the Recent Workouts card shows a loading state until then instead of the empty copy.

---

## Testing
iOS builds via Xcode only (per project rules), so this was reviewed by hand rather than CLI-compiled. Suggested manual checks:
- **Photos:** snap mid-run → gallery shows disabled **"Saved"**, one camera-roll copy. Deny photo-add, capture, then grant → **"Save"** stays active, saves once, flips to **"Saved."**
- **Sticker:** drag the stats sticker — no jitter; tracks the finger 1:1 even when scaled/rotated.
- **Feed:** complete a mile, switch away and back to the Feed tab — new posts appear without a manual pull.
- **Cold launch:** complete + post a mile, next morning open the app behind a locked screen — no re-prompt, no "streak safe" re-show, Recent Workouts shows "Loading…" (not "No recent workouts") until the query succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uanj9zJRRY9bvmEpybozGK