### PR TITLE
Improve marketing site SEO discoverability

### DIFF
--- a/website/app/admin/page.tsx
+++ b/website/app/admin/page.tsx
@@ -4,7 +4,7 @@ import { AdminLogin } from "./login";
 import { AdminDashboard } from "./dashboard";
 
 export const metadata: Metadata = {
-  title: "Admin — Mile A Day",
+  title: "Admin",
   robots: { index: false, follow: false },
 };
 

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -18,12 +18,39 @@ const bebasNeue = Bebas_Neue({
 })
 
 export const metadata: Metadata = {
-  title: 'Mile A Day - Walk or Run a Mile Every Single Day',
-  description: 'Build an unbreakable habit. Track your streak, compete with friends, and Go the Extra Mile. Available on iOS and Apple Watch.',
-  keywords: ['mile a day', 'running app', 'walking app', 'fitness tracker', 'streak tracker', 'daily mile'],
+  metadataBase: new URL('https://mileaday.run'),
+  title: {
+    default: 'Mile A Day - Walk or Run a Mile Every Single Day',
+    template: '%s | Mile A Day',
+  },
+  description:
+    'Mile A Day is the free iOS & Apple Watch app that turns one mile a day into an unbreakable habit. Track your streak, compete with friends, earn badges, and go the extra mile.',
+  applicationName: 'Mile A Day',
+  keywords: [
+    'mile a day',
+    'mile a day app',
+    'run a mile a day',
+    'walk a mile a day',
+    'daily mile',
+    'running app',
+    'walking app',
+    'fitness tracker',
+    'streak tracker',
+    'habit tracker',
+    'apple watch running app',
+    'run streak',
+  ],
+  authors: [{ name: 'Rob Wiscount' }, { name: 'David Simmerman' }],
+  creator: 'Mile A Day',
+  publisher: 'Mile A Day',
+  category: 'health',
+  alternates: {
+    canonical: '/',
+  },
   openGraph: {
     title: 'Mile A Day - Walk or Run a Mile Every Single Day',
     description: 'Build an unbreakable habit. Track your streak, compete with friends, and Go the Extra Mile.',
+    url: '/',
     type: 'website',
     siteName: 'Mile A Day',
     locale: 'en_US',
@@ -33,10 +60,25 @@ export const metadata: Metadata = {
     title: 'Mile A Day - Walk or Run a Mile Every Single Day',
     description: 'Build an unbreakable habit. Track your streak, compete with friends, and Go the Extra Mile.',
   },
-  metadataBase: new URL('https://mileaday.run'),
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+      'max-video-preview': -1,
+    },
+  },
   icons: {
     icon: '/images/mad-circle-icon.png',
     apple: '/images/mad-circle-icon.png',
+  },
+  // Set NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION in the Vercel project env to the
+  // token from Search Console and the tag renders automatically. Omitted when unset.
+  verification: {
+    google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
   },
 }
 

--- a/website/app/opengraph-image.tsx
+++ b/website/app/opengraph-image.tsx
@@ -1,0 +1,89 @@
+import { ImageResponse } from "next/og";
+
+// Branded social-share card, generated at build time. Used for both OpenGraph
+// and Twitter (Next reuses opengraph-image when no twitter-image is present),
+// so links to mileaday.run render a real preview instead of a blank card.
+export const alt = "Mile A Day — Walk or run a mile every single day";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    <div
+      style={{
+        height: "100%",
+        width: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        backgroundColor: "#0a0a0a",
+        backgroundImage:
+          "radial-gradient(circle at 78% 22%, rgba(199,37,84,0.28) 0%, rgba(10,10,10,0) 55%)",
+        padding: "90px",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "18px",
+          fontSize: 30,
+          fontWeight: 700,
+          letterSpacing: "4px",
+          color: "#c72554",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            height: "20px",
+            width: "20px",
+            borderRadius: "50%",
+            backgroundColor: "#c72554",
+          }}
+        />
+        MILE A DAY
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          marginTop: "36px",
+          fontSize: 122,
+          fontWeight: 800,
+          lineHeight: 1,
+          letterSpacing: "-3px",
+        }}
+      >
+        <div style={{ display: "flex", color: "#f5f5f5" }}>ONE MILE.</div>
+        <div style={{ display: "flex", color: "#c72554" }}>EVERY DAY.</div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          marginTop: "48px",
+          fontSize: 40,
+          color: "#a0a0a0",
+        }}
+      >
+        Track your streak. Compete with friends.
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          marginTop: "20px",
+          fontSize: 28,
+          fontWeight: 600,
+          letterSpacing: "1px",
+          color: "#f5f5f5",
+        }}
+      >
+        Free on iOS &amp; Apple Watch
+      </div>
+    </div>,
+    { ...size },
+  );
+}

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -15,6 +15,60 @@ import { CtaSection } from "@/components/cta-section";
 import { Footer } from "@/components/footer";
 import { ScrollReveal } from "@/components/scroll-reveal";
 
+const SITE_URL = "https://mileaday.run";
+const APP_STORE_URL = "https://apps.apple.com/us/app/mile-a-day/id6746970905";
+
+// Structured data (schema.org) so Google can render a rich result and
+// understand that mileaday.run is the home of a free iOS/Apple Watch app.
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": `${SITE_URL}/#organization`,
+      name: "Mile A Day",
+      url: SITE_URL,
+      logo: `${SITE_URL}/images/mad-circle-icon.png`,
+      founder: [
+        { "@type": "Person", name: "Rob Wiscount" },
+        { "@type": "Person", name: "David Simmerman" },
+      ],
+      sameAs: [
+        "https://www.instagram.com/mileadayapp",
+        "https://www.tiktok.com/@mileadayapp",
+        "https://x.com/mileadayapp",
+      ],
+    },
+    {
+      "@type": "WebSite",
+      "@id": `${SITE_URL}/#website`,
+      url: SITE_URL,
+      name: "Mile A Day",
+      description:
+        "Mile A Day is the free iOS & Apple Watch app that turns one mile a day into an unbreakable habit.",
+      publisher: { "@id": `${SITE_URL}/#organization` },
+    },
+    {
+      "@type": "MobileApplication",
+      "@id": `${SITE_URL}/#app`,
+      name: "Mile A Day",
+      operatingSystem: "iOS, watchOS",
+      applicationCategory: "HealthApplication",
+      description:
+        "Run or walk a mile every day, build streaks, earn badges, and compete with friends. Free on iPhone and Apple Watch.",
+      url: SITE_URL,
+      downloadUrl: APP_STORE_URL,
+      installUrl: APP_STORE_URL,
+      publisher: { "@id": `${SITE_URL}/#organization` },
+      offers: {
+        "@type": "Offer",
+        price: "0",
+        priceCurrency: "USD",
+      },
+    },
+  ],
+};
+
 // Section order tells the story top to bottom: hook (hero) → live proof the
 // community is real (stats band) → what the app does (features) → the new
 // social experience (feed, then friends/nudges) → the competitive layer
@@ -23,6 +77,10 @@ import { ScrollReveal } from "@/components/scroll-reveal";
 export default function Home() {
   return (
     <main className="relative min-h-screen overflow-x-hidden bg-[#0a0a0a]">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
       <ScrollReveal />
       <Navbar />
       <HeroSection />

--- a/website/app/privacy/page.tsx
+++ b/website/app/privacy/page.tsx
@@ -2,8 +2,9 @@ import type { Metadata } from 'next';
 import { LegalPage, Section } from '@/components/legal-page';
 
 export const metadata: Metadata = {
-	title: 'Privacy Policy - Mile A Day',
-	description: 'How Mile A Day collects, uses, and protects your data.'
+	title: 'Privacy Policy',
+	description: 'How Mile A Day collects, uses, and protects your data.',
+	alternates: { canonical: '/privacy' }
 };
 
 export default function PrivacyPage() {

--- a/website/app/robots.ts
+++ b/website/app/robots.ts
@@ -1,0 +1,18 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://mileaday.run";
+
+// Generates /robots.txt. Allow crawling of the marketing pages, keep crawlers
+// out of the admin console and the noindex utility routes, and point them at
+// the sitemap so Google can discover everything in one hop.
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/admin", "/admin/", "/users"],
+    },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+    host: BASE_URL,
+  };
+}

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -1,0 +1,31 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://mileaday.run";
+
+// Generates /sitemap.xml. Only the indexable marketing + legal pages are
+// listed. Dynamic /u/<username> profiles and the noindex /admin and /users
+// routes are intentionally excluded.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
+  return [
+    {
+      url: `${BASE_URL}/`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${BASE_URL}/privacy`,
+      lastModified,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${BASE_URL}/terms`,
+      lastModified,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+  ];
+}

--- a/website/app/terms/page.tsx
+++ b/website/app/terms/page.tsx
@@ -2,8 +2,9 @@ import type { Metadata } from 'next';
 import { LegalPage, Section } from '@/components/legal-page';
 
 export const metadata: Metadata = {
-	title: 'Terms of Use - Mile A Day',
-	description: 'The terms and conditions for using the Mile A Day app.'
+	title: 'Terms of Use',
+	description: 'The terms and conditions for using the Mile A Day app.',
+	alternates: { canonical: '/terms' }
 };
 
 export default function TermsPage() {

--- a/website/app/u/[username]/page.tsx
+++ b/website/app/u/[username]/page.tsx
@@ -45,19 +45,21 @@ export async function generateMetadata({
   const profile = await getProfile(username)
 
   if (!profile) {
-    return { title: 'Mile A Day' }
+    return { title: { absolute: 'Mile A Day' } }
   }
 
-  const title = `@${profile.username} on Mile A Day`
+  const socialTitle = `@${profile.username} on Mile A Day`
   const description = `${displayName(profile)} is building a daily mile habit${
     profile.current_streak > 0 ? ` — ${profile.current_streak} day streak and counting` : ''
   }. Add them on Mile A Day and keep each other moving.`
 
   return {
-    title,
+    // Document <title> gets the '| Mile A Day' template suffix; the social
+    // cards use the fuller phrasing.
+    title: `@${profile.username}`,
     description,
-    openGraph: { title, description, type: 'profile', siteName: 'Mile A Day' },
-    twitter: { card: 'summary', title, description },
+    openGraph: { title: socialTitle, description, type: 'profile', siteName: 'Mile A Day' },
+    twitter: { card: 'summary', title: socialTitle, description },
     // Smart App Banner: iOS Safari shows an "Open in app" banner, which is
     // the fallback path when the universal link opens in the browser.
     itunes: { appId: '6746970905' },

--- a/website/app/users/page.tsx
+++ b/website/app/users/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { LiveCounter } from './live-counter';
 
 export const metadata: Metadata = {
-	title: 'Users — Mile A Day',
+	title: 'Users',
 	description: 'Live Mile A Day user counter.',
 	robots: { index: false, follow: false }
 };


### PR DESCRIPTION
## Why

Searching "Mile A Day" on Google surfaces nothing. The site already had good per-page `<head>` metadata, but it was missing the crawl/indexing infrastructure and rich signals search engines rely on to discover and rank a site. This PR adds that foundation. All changes are on the **website** only — no backend, API, or iOS changes.

## What changed

- **`app/robots.ts` → `/robots.txt`** — allows crawling, blocks `/admin` and the `noindex` utility routes, and points crawlers at the sitemap.
- **`app/sitemap.ts` → `/sitemap.xml`** — lists the indexable pages (`/`, `/privacy`, `/terms`).
- **`app/opengraph-image.tsx`** — a branded 1200×630 social-share card generated at build time, used for both OpenGraph and Twitter. Links to the site previously rendered a **blank** card (the `summary_large_image` tag had no image).
- **JSON-LD structured data on the homepage** — `Organization`, `WebSite`, and `MobileApplication` schema so Google understands mileaday.run is the home of a free iOS/Apple Watch app (links the App Store listing, social profiles, and founders).
- **Richer root metadata** (`app/layout.tsx`) — canonical URLs, explicit `robots`/`googlebot` directives (`max-image-preview:large`, etc.), an expanded keyword set, a `%s | Mile A Day` title template, and a Google Search Console verification hook wired to `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION`.
- **Per-page canonicals** on `/privacy` and `/terms`, and trimmed page titles so they compose cleanly with the new title template.

## Verification

- `next build` passes; `/robots.txt`, `/sitemap.xml`, and `/opengraph-image` all generate as static routes.
- Ran the production server and confirmed: the OG image returns a valid 1200×630 PNG, the homepage `<head>` emits canonical + robots + populated OG/Twitter image tags, and the JSON-LD parses (`Organization`, `WebSite`, `MobileApplication`).
- Diffs to existing files are metadata-only; the legal-page bodies are untouched (original tabs/quotes preserved).

## ⚠️ Required manual step (this is the real reason nothing shows up)

Code alone can't get a site indexed. After this deploys:

1. Add the property `https://mileaday.run` in [Google Search Console](https://search.google.com/search-console).
2. Verify ownership — easiest path: set `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` in the Vercel project env to the token GSC gives you (this PR already renders the tag when that var is set), then redeploy and click Verify.
3. Submit `https://mileaday.run/sitemap.xml` under Sitemaps, and use "Request indexing" on the homepage URL.

Indexing typically takes anywhere from a few days to ~2 weeks after verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPEkhtdH2bdMSxso3PP2Ab)_