### PR TITLE
iOS: friendlier handling when in-app workout can't save to HealthKit

### DIFF
--- a/app/Mile A Day/Models/HealthKitManager.swift
+++ b/app/Mile A Day/Models/HealthKitManager.swift
@@ -728,7 +728,19 @@ class HealthKitManager: ObservableObject {
             }
         }
     }
-    
+
+    /// Whether the user has explicitly turned OFF *write* access to Workouts for
+    /// this app. Unlike reads (which Apple hides — a denied read just returns no
+    /// samples), share-authorization status is reliable, so an in-app workout
+    /// that fails to save can distinguish "user denied Health access"
+    /// (actionable — send them to Settings) from a transient save failure.
+    /// `.notDetermined` and `.sharingAuthorized` both return false: the former
+    /// will prompt on the next save attempt, the latter is already fine.
+    func isWorkoutSharingDenied() -> Bool {
+        guard HKHealthStore.isHealthDataAvailable() else { return false }
+        return healthStore.authorizationStatus(for: HKObjectType.workoutType()) == .sharingDenied
+    }
+
     // Enable background delivery for HealthKit data
     private func enableBackgroundDelivery() {
         let workoutType = HKObjectType.workoutType()

--- a/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
@@ -50,8 +50,14 @@ struct WorkoutTrackingView: View {
     /// system started deferring updates (frozen activity on the lock screen).
     @State private var lastActivityPushDate: Date = .distantPast
     @State private var lastPushedDistance: Double = -1
-    @State private var showEndWorkoutError = false // Show error alert when end fails
-    @State private var endWorkoutErrorMessage = "" // Error message for end workout failure
+    @State private var showEndWorkoutError = false // Show error alert when starting fails (workout lock)
+    @State private var endWorkoutErrorMessage = "" // Error message for the start-failure alert
+    /// Health WRITE access is off — the save fails every time until re-enabled,
+    /// so we offer an actionable path to Settings instead of a dead-end error.
+    @State private var showHealthAccessAlert = false
+    /// Quiet, non-blocking confirmation for a transient save failure where the
+    /// mile still counts (Health access is fine) — no scary blocking alert.
+    @State private var showSaveFallbackToast = false
     @State private var endWorkoutTimeoutTask: DispatchWorkItem? // Timeout for end workout flow
     @State private var trackingMetricsHeight: CGFloat = 0 // Measured height of the scrollable metrics area
     @State private var workoutSession: HKWorkoutSession?
@@ -328,6 +334,7 @@ struct WorkoutTrackingView: View {
         .overlay(goalCompletionOverlay)
         .overlay(alignment: .top) { snapSavedToast }
         .overlay(alignment: .top) { importToastView }
+        .overlay(alignment: .top) { saveFallbackToast }
     }
 
     // MARK: - Mid-Run Photo Capture
@@ -572,6 +579,42 @@ struct WorkoutTrackingView: View {
             .transition(.move(edge: .top).combined(with: .opacity))
             .allowsHitTesting(false)
         }
+    }
+
+    /// Shown when the workout couldn't be written to Apple Health for a reason
+    /// OTHER than denied access — the mile still counts via sync, so this is a
+    /// calm reassurance rather than a blocking error.
+    @ViewBuilder
+    private var saveFallbackToast: some View {
+        if showSaveFallbackToast {
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 15, weight: .bold))
+                    .foregroundColor(.green)
+                Text("Your mile still counts — it'll sync on your next update.")
+                    .font(.system(size: 14, weight: .bold, design: .rounded))
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(
+                Capsule()
+                    .fill(Color.black.opacity(0.78))
+                    .overlay(Capsule().strokeBorder(Color.white.opacity(0.15), lineWidth: 1))
+            )
+            .padding(.top, 72)
+            .padding(.horizontal, MADTheme.Spacing.lg)
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .allowsHitTesting(false)
+        }
+    }
+
+    /// Deep-link to this app's Settings page, where the user can reach the
+    /// Health access toggles for Mile A Day.
+    private func openAppSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
     }
 
     /// Vertical spacing between the metric blocks, tightened on shorter screens.
@@ -894,13 +937,24 @@ struct WorkoutTrackingView: View {
         } message: {
             Text("Are you sure you want to end this workout? Your progress will be saved to HealthKit.")
         }
-        .alert("Couldn't Save Workout", isPresented: $showEndWorkoutError) {
+        .alert("Couldn't Start Workout", isPresented: $showEndWorkoutError) {
             Button("OK") {
                 // Dismiss back to dashboard since the workout state is already cleared
                 dismiss()
             }
         } message: {
             Text(endWorkoutErrorMessage)
+        }
+        .alert("Save Workouts to Apple Health?", isPresented: $showHealthAccessAlert) {
+            Button("Open Settings") {
+                openAppSettings()
+                dismiss()
+            }
+            Button("Not Now", role: .cancel) {
+                dismiss()
+            }
+        } message: {
+            Text("Your mile still counts toward your streak. To also save your workouts to Apple Health, turn on Workouts access for Mile A Day in Settings.")
         }
         .onAppear {
             // Workout recovery: if there's a persisted in-progress workout, restore it.
@@ -1235,12 +1289,22 @@ struct WorkoutTrackingView: View {
         isStopping = false
         isTracking = false
 
-        // Show result to user
+        // Show result to user. The mile counts via GPS/pedometer sync whether
+        // or not the HealthKit write succeeded, so a failed save is never a lost
+        // workout — tailor the messaging to the cause instead of alarming.
         if workoutSaved {
             withAnimation { showRecap = true }
+        } else if healthManager.isWorkoutSharingDenied() {
+            // Health write access is turned off — this fails on EVERY workout
+            // until the user re-enables it, so give them a way to fix it.
+            showHealthAccessAlert = true
         } else {
-            endWorkoutErrorMessage = "Your workout couldn't be saved to HealthKit. The distance you covered will still count from GPS/pedometer data on your next sync."
-            showEndWorkoutError = true
+            // Transient save failure with Health access intact. Don't block —
+            // show a quiet toast and slip back to the dashboard.
+            withAnimation { showSaveFallbackToast = true }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.6) {
+                dismiss()
+            }
         }
     }
 


### PR DESCRIPTION
## What & why

A user reported repeatedly hitting the **"Couldn't Save Workout"** alert in the in-app mile tracker (screenshot: `0.00 mi`, `00:21`, blocking alert).

That alert fired from the single failure branch in `finishCleanup(workoutSaved:)` whenever `HKWorkoutBuilder.finishWorkout` came back without a saved workout. There are really two very different causes behind it:

1. **HealthKit *write* access is denied** — `requestAuthorization`'s `success` flag only means "the prompt completed," not "access was granted" (the code already documents this for reads). Apple *enforces* write denials at save time, so with Workouts write turned off the save fails on **every** workout, with no path to fix it. This is the persistent case the reporter is in.
2. **A transient failure** (Health access fine) — the mile still counts via the GPS/pedometer sync path, so the old blocking, alarming alert was overkill.

This PR tailors the response to the cause instead of showing one scary alert for both.

## Changes

- **`HealthKitManager.isWorkoutSharingDenied()`** — reliable write-authorization check via `authorizationStatus(for: .workoutType())` (share status is not hidden by Apple, unlike reads).
- **`WorkoutTrackingView.finishCleanup`** now branches on the failure cause:
  - **Denied write access** → actionable alert *"Save Workouts to Apple Health?"* with an **Open Settings** button (deep-links via `UIApplication.openSettingsURLString`) and a **Not Now** option. Reassures that the mile still counts.
  - **Any other failure** → quiet, non-blocking `saveFallbackToast` ("Your mile still counts — it'll sync on your next update.") then returns to the dashboard. No blocking alert.
- Retitled the start-failure (workout-lock) alert from *"Couldn't Save Workout"* to *"Couldn't Start Workout"* — it was always a start failure, so the old title was misleading.

## Compliance / safety

- Additive UI only; no API, schema, or entitlement changes.
- App Review-safe: public `openSettingsURLString`/`UIApplication.shared.open`, no private APIs, no medical/placeholder/beta copy.
- No behavior change to the success path (recap) or to the workout-lock guard.

## Testing notes

- iOS builds via Xcode only (per repo conventions) — **not** compiled from CLI. Please build/run in Xcode.
- Suggested manual checks:
  - Turn **off** Workouts write for the app in Settings → Health → track & stop a mile → expect the *"Save Workouts to Apple Health?"* alert; **Open Settings** should deep-link to the app's settings.
  - With Health access **on**, force a transient save failure (or verify the success path is unchanged → recap still shows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhZCNSzoEfJtHUXYFYq7Gg

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhZCNSzoEfJtHUXYFYq7Gg)_