### PR TITLE
Fix Current Streak Stats showing wrong streak on WorkoutIndex hole

### DIFF
--- a/app/Mile A Day/Models/HealthKitManager+StreakCalculation.swift
+++ b/app/Mile A Day/Models/HealthKitManager+StreakCalculation.swift
@@ -96,9 +96,17 @@ extension HealthKitManager {
     // MARK: - Current Streak Stats Functions
 
     // Calculate current streak stats (total miles, most miles, fastest pace during current streak)
-    func calculateCurrentStreakStats() -> (totalMiles: Double, mostMiles: Double, fastestPace: TimeInterval, streakDays: Int) {
+    /// - Parameter displayedStreak: the vetted, user-facing streak — the value the
+    ///   dashboard's main streak card shows (`UserManager.currentUser.streak`). The
+    ///   streak window uses `max(retroactiveStreak, displayedStreak)` so these
+    ///   streak-scoped stats match the displayed streak rather than the raw local
+    ///   `retroactiveStreak`, which collapses to a tiny value when the WorkoutIndex
+    ///   has a hole (a qualifying day that reached HealthKit late / was deleted /
+    ///   never synced). See `UserManager.vettedHealthKitStreak` and the
+    ///   `max(hk, user.streak)` rule in `.claude/rules/ios.md`.
+    func calculateCurrentStreakStats(displayedStreak: Int = 0) -> (totalMiles: Double, mostMiles: Double, fastestPace: TimeInterval, streakDays: Int) {
 
-        let currentStreakDays = retroactiveStreak
+        let currentStreakDays = max(retroactiveStreak, displayedStreak)
         guard currentStreakDays > 0 else {
             return (0.0, 0.0, 0.0, 0)
         }
@@ -108,7 +116,7 @@ extension HealthKitManager {
             return cachedCurrentStreakStats
         }
 
-        let streakWorkouts = getWorkoutsForCurrentStreak()
+        let streakWorkouts = getWorkoutsForCurrentStreak(streakDays: currentStreakDays)
 
         // Calculate total miles and most miles (these are fast)
         let totalMiles = streakWorkouts.reduce(0.0) { total, workout in
@@ -134,7 +142,7 @@ extension HealthKitManager {
         }
 
         // Smart fastest pace calculation
-        let fastestPace = calculateSmartCurrentStreakFastestPace(streakWorkouts: streakWorkouts)
+        let fastestPace = calculateSmartCurrentStreakFastestPace(streakWorkouts: streakWorkouts, streakDays: currentStreakDays)
 
         let newStats = (totalMiles, mostMiles, fastestPace, currentStreakDays)
 
@@ -176,14 +184,14 @@ extension HealthKitManager {
         return true
     }
 
-    func calculateSmartCurrentStreakFastestPace(streakWorkouts: [HKWorkout]) -> TimeInterval {
+    func calculateSmartCurrentStreakFastestPace(streakWorkouts: [HKWorkout], streakDays: Int) -> TimeInterval {
         // OPTIMIZATION 1: Check if All Time fastest mile is within current streak
         if findWorkoutWithAllTimeFastestMile(in: streakWorkouts) != nil {
             return fastestMilePace
         }
 
         // OPTIMIZATION 2: Check if we have a cached value that's still valid for this streak
-        if cachedCurrentStreakFastestPace > 0 && cachedCurrentStreakStats.streakDays == retroactiveStreak {
+        if cachedCurrentStreakFastestPace > 0 && cachedCurrentStreakStats.streakDays == streakDays {
             // Check if any new qualifying workouts have been added since last calculation
             if !hasNewQualifyingWorkoutsSinceLastStreakCalculation(streakWorkouts: streakWorkouts) {
                 return cachedCurrentStreakFastestPace
@@ -304,7 +312,7 @@ extension HealthKitManager {
 
     /// Find workouts that achieved the current streak's fastest mile pace
     func findCurrentStreakFastestMileWorkouts() {
-        let streakWorkouts = getWorkoutsForCurrentStreak()
+        let streakWorkouts = getWorkoutsForCurrentStreak(streakDays: cachedCurrentStreakStats.streakDays)
         let currentStreakFastestPace = cachedCurrentStreakStats.fastestPace
 
         guard currentStreakFastestPace > 0 else {
@@ -340,12 +348,15 @@ extension HealthKitManager {
     }
 
     // Get workouts for the current streak period using timezone-aware calculation
-    func getWorkoutsForCurrentStreak() -> [HKWorkout] {
-        guard retroactiveStreak > 0 else { return [] }
+    /// - Parameter streakDays: streak length that bounds the window. Callers pass the
+    ///   vetted/effective streak (see `calculateCurrentStreakStats`), NOT raw
+    ///   `retroactiveStreak`, so the window doesn't collapse on a WorkoutIndex hole.
+    func getWorkoutsForCurrentStreak(streakDays: Int) -> [HKWorkout] {
+        guard streakDays > 0 else { return [] }
 
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
-        let streakStartDate = calendar.date(byAdding: .day, value: -retroactiveStreak, to: today) ?? today
+        let streakStartDate = calendar.date(byAdding: .day, value: -streakDays, to: today) ?? today
 
 
         // If cachedWorkouts is empty, we need to fetch workouts directly

--- a/app/Mile A Day/Views/Dashboard/StreakDetailViews.swift
+++ b/app/Mile A Day/Views/Dashboard/StreakDetailViews.swift
@@ -233,7 +233,7 @@ struct CurrentStreakFastestPaceDetailView: View {
 
     private func loadStreakWorkouts() async {
         isLoading = true
-        let allStreakWorkouts = healthManager.getWorkoutsForCurrentStreak()
+        let allStreakWorkouts = healthManager.getWorkoutsForCurrentStreak(streakDays: currentStreakStats.streakDays)
         let fastestMileWorkouts = healthManager.currentStreakFastestMileWorkouts
 
         var dayWorkouts: [HKWorkout] = []
@@ -421,7 +421,7 @@ struct CurrentStreakMostMilesDetailView: View {
 
     private func loadStreakWorkouts() async {
         isLoading = true
-        let allStreakWorkouts = healthManager.getWorkoutsForCurrentStreak()
+        let allStreakWorkouts = healthManager.getWorkoutsForCurrentStreak(streakDays: currentStreakStats.streakDays)
         let workoutsByDay = Dictionary(grouping: allStreakWorkouts) { workout in
             Calendar.current.startOfDay(for: workout.endDate)
         }

--- a/app/Mile A Day/Views/Dashboard/UnifiedStatsGrid.swift
+++ b/app/Mile A Day/Views/Dashboard/UnifiedStatsGrid.swift
@@ -247,6 +247,13 @@ struct UnifiedStatsGrid: View {
                 calculateCurrentStreakStats()
             }
         }
+        .onChange(of: user.streak) { _, _ in
+            // The displayed streak drives the stats window (max with retroactiveStreak);
+            // recompute when the backend/vetted value changes so the two stay in sync.
+            if statsType == .currentStreak {
+                calculateCurrentStreakStats()
+            }
+        }
         .onChange(of: statsType) { _, newType in
             if newType == .currentStreak {
                 calculateCurrentStreakStats()
@@ -353,8 +360,12 @@ struct UnifiedStatsGrid: View {
         guard !recomputeInFlight else { return }
         recomputeInFlight = true
 
+        // Pass the vetted, user-facing streak (the value the main streak card shows)
+        // so the stats window matches it instead of the raw retroactiveStreak, which
+        // collapses to a tiny value on a WorkoutIndex hole (see ios.md).
+        let displayedStreak = user.streak
         DispatchQueue.global(qos: .userInitiated).async {
-            let stats = healthManager.calculateCurrentStreakStats()
+            let stats = healthManager.calculateCurrentStreakStats(displayedStreak: displayedStreak)
 
             DispatchQueue.main.async {
                 self.statsData = stats


### PR DESCRIPTION
## Problem

On the Dashboard, the **"Your Stats → Current Streak"** section disagreed with the main streak card:

- Main **Current Streak** card: **433 days** (correct)
- **Current Streak Stats** section: badge **"8 days"**, plus every tile (Streak Miles 14.3 mi, 1.8 avg/day, Streak Days 8, Avg Per Day 1.79) computed over that wrong 8-day window.

## Root cause

The stats section calls `HealthKitManager.calculateCurrentStreakStats()`, which read the **raw** `retroactiveStreak` and bounded its stat window by it (`getWorkoutsForCurrentStreak()`). `retroactiveStreak` comes from `WorkoutIndex.activeStreak()`, which walks back from today and **stops at the first day missing a qualifying workout**. A WorkoutIndex hole — a run that reached HealthKit late (Watch sync latency), was deleted locally, or never synced — collapses it to a tiny value (here, 8).

The main streak card is immune because it reads `currentUser.streak`, guarded by `UserManager.vettedHealthKitStreak` (which refuses a 2+ day collapse unless the backend confirms). This one UI path bypassed that guard — violating the documented rule in `.claude/rules/ios.md`:

> Never write `hk.retroactiveStreak` raw to UI/widgets/watch — it flaps on index holes; route through … `max(hk, user.streak)`.

## Fix

Feed the vetted, user-facing streak into the streak-stats functions and use `max(retroactiveStreak, displayedStreak)` as both the reported streak length and the stat window. `cachedWorkouts` holds full history (fetched with no date limit), so widening the window produces correct totals.

- `calculateCurrentStreakStats(displayedStreak:)` — new parameter; window = `max(retroactiveStreak, displayedStreak)`.
- `getWorkoutsForCurrentStreak(streakDays:)` — window bounded by the passed streak length instead of raw `retroactiveStreak`.
- `calculateSmartCurrentStreakFastestPace(streakWorkouts:streakDays:)` — cache-validity keyed on the effective streak.
- `UnifiedStatsGrid` passes `user.streak` and recomputes on `user.streak` change.
- The two current-streak detail sheets thread the same corrected streak length.

The existing `repairWorkoutIndexIfStale` / `vettedHealthKitStreak` machinery still repairs the underlying index hole in the background; this change makes the stats card show the correct value immediately, matching the main card.

## Impact / compatibility

- iOS-only, client-side display fix. No backend, API, schema, or entitlement changes.
- No new permissions or data collection; App Review posture unchanged.
- Builds via Xcode (no CLI build gate for iOS); backend/website builds unaffected (no files touched there).

## Testing notes

Best verified on a device whose local WorkoutIndex has a hole (local streak ≪ backend streak): the Current Streak Stats badge and Streak Days should now match the main streak card, with miles/avg/fastest computed over the full streak window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01By4RMkRsSRpmwMEtfgCNH1)_