### PR TITLE
Streak tokens backend: Double Down, Streak Save, Streak Assist (ships dark)

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -5,6 +5,7 @@ globs: backend/**
 # Backend Conventions
 
 - Daily-mile completion checks must use `DAILY_GOAL_TOLERANCE` (0.95) from workoutService, never a raw `>= 1.0` — streaks/challenges count 0.95 days, and today_miles is displayed 2-decimal-rounded ("1.00" can be 0.996). iOS mirror: `ProgressCalculator.dailyGoalTolerance`.
+- Streak tokens (streak_coverage): any code that recomputes a streak MUST branch through `coverageActiveFor`/`computeCoveredStreak` (streakFeatureCore) like getActiveStreak + refreshCurrentStreak do — the 6h `reconcileStaleStreaks` cron rewrites `current_streak` via refreshCurrentStreak, so an unrouted walk silently erases token-saved streaks. Un-enrolled/env-off users must keep the byte-identical legacy loop. Meters are DERIVED from workouts since `*_last_used` (never stored counters).
 
 ## Architecture: Routes -> Controllers -> Services
 - `routes/` - Express Router definitions. Thin: just wire HTTP verbs to controller functions + middleware.
@@ -27,7 +28,6 @@ globs: backend/**
 - If two branches both add migrations, a merge silently corrupts `meta/_journal.json` (one side's entries vanish while its .sql files remain). Resolve by REGENERATING: restore one side's journal+snapshots, delete the other side's .sql, and `db:generate` its DDL back as the next index. `npx drizzle-kit check` must pass.
 - Existing prod schema was baselined via `scripts/drizzle-baseline.mjs` (records `0000` as applied without running it). Run it ONCE per environment before the first `db:migrate`.
 - `drizzle-kit pull` has introspection bugs to fix by hand after every pull: (1) some SQL-expression/empty-string defaults emit broken TS → fix with `.default(sql\`...\`)` / `.default('')`; (2) composite-index per-column opclasses get misaligned (text col tagged `timestamptz_ops` etc.) → these are all DEFAULT opclasses, so strip every `.op(...)` EXCEPT non-defaults like `gin_trgm_ops`; (3) `relations.ts` imports `./schema` without `.js` → add it. After fixing, regenerate the baseline (empty `meta/_journal.json` + `db:generate`) and confirm it says "No schema changes".
-
 - Never emit raw `timestamptz::text` in URL query params (pagination cursors): its `+00` offset decodes as a SPACE in Express's query parser and the `::timestamptz` cast 500s. Emit cursors via `URL_SAFE_CURSOR` (ISO `…Z`, postService.ts); iOS must percent-encode query values with a set that excludes `+` (`PostService.queryValueAllowed`).
 
 ## Auth Pattern

--- a/backend/src/controllers/streakFeaturesController.ts
+++ b/backend/src/controllers/streakFeaturesController.ts
@@ -1,0 +1,107 @@
+import { Response } from "express";
+import { AuthenticatedRequest } from "../middleware/auth.js";
+import {
+  enrollStreakFeatures,
+  getStreakFeaturesPayload,
+  getAssistableFriends,
+  giveStreakAssist,
+} from "../services/streakFeatureService.js";
+import {
+  streakFeaturesGloballyEnabled,
+  coverageActiveFor,
+} from "../services/streakFeatureCore.js";
+import { getActiveStreak } from "../services/workoutService.js";
+
+/**
+ * POST /users/streak-features/enable — idempotent enrollment stamp. Only the
+ * new app build calls this (once, on launch, fire-and-forget), which is what
+ * keeps every streak feature invisible to older builds: without the stamp the
+ * server omits all token fields and never runs token side-effects.
+ */
+export async function enableStreakFeaturesController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  try {
+    const result = await enrollStreakFeatures(req.userId!);
+    res.status(200).json(result);
+  } catch (error: any) {
+    console.error("Error enabling streak features:", error.message);
+    res.status(500).json({ error: "Error enabling streak features" });
+  }
+}
+
+/**
+ * GET /users/streak-features/status — the caller's meters, coverage, natural
+ * flag, plus friends they could currently rescue. `active:false` (and nothing
+ * else) until the env switch is on AND the caller enrolled.
+ */
+export async function streakFeaturesStatusController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  try {
+    const userId = req.userId!;
+    if (!(await coverageActiveFor(userId))) {
+      return res.status(200).json({ active: false });
+    }
+    const { streak, start } = await getActiveStreak(userId);
+    const payload = await getStreakFeaturesPayload(userId, streak, start);
+    if (!payload) return res.status(200).json({ active: false });
+
+    // Only surface rescuable friends to a caller actually holding an Assist —
+    // the friends-page CTA is meaningless (and noisy) otherwise.
+    const assistableFriends = payload.streak_assist.held
+      ? await getAssistableFriends(userId)
+      : [];
+
+    res.status(200).json({
+      active: true,
+      streak,
+      ...payload,
+      assistable_friends: assistableFriends,
+    });
+  } catch (error: any) {
+    console.error("Error getting streak-features status:", error.message);
+    res.status(500).json({ error: "Error getting streak features" });
+  }
+}
+
+/**
+ * POST /users/streak-features/assist/:friendId — spend a held Streak Assist
+ * to restore the friend's just-broken streak. Status strings map 1:1 to HTTP
+ * so the client can show a precise reason.
+ */
+export async function giveStreakAssistController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  try {
+    if (!streakFeaturesGloballyEnabled()) {
+      return res.status(403).json({ error: "not_available" });
+    }
+    const result = await giveStreakAssist(req.userId!, req.params.friendId);
+    switch (result.status) {
+      case "ok":
+        return res
+          .status(200)
+          .json({ ok: true, restored_streak: result.restored_streak });
+      case "already_saved":
+        return res.status(409).json({ error: "already_saved" });
+      case "no_token":
+        return res.status(409).json({ error: "no_token" });
+      case "no_recent_break":
+      case "window_passed":
+      case "gap_too_wide":
+        return res.status(409).json({ error: result.status });
+      case "disabled":
+      case "not_enrolled":
+      case "friend_not_enrolled":
+      case "forbidden":
+        return res.status(403).json({ error: result.status });
+    }
+  } catch (error: any) {
+    console.error("Error giving streak assist:", error.message);
+    res.status(500).json({ error: "Error giving streak assist" });
+  }
+}

--- a/backend/src/controllers/workoutController.ts
+++ b/backend/src/controllers/workoutController.ts
@@ -41,6 +41,10 @@ import {
   fanOutFriendRacePrPush,
 } from "../services/pushNotificationService.js";
 import { refreshCurrentStreak } from "../services/leaderboardService.js";
+import {
+  reconcileStreakFeaturesOnUpload,
+  getStreakFeaturesPayload,
+} from "../services/streakFeatureService.js";
 
 export async function uploadWorkouts(req: Request, res: Response) {
   if (!hasRequiredKeys(["userId"], req, res)) return;
@@ -99,6 +103,13 @@ export async function uploadWorkouts(req: Request, res: Response) {
     // user, so it's cheap, but blocking the response on it isn't worth it.
     refreshCurrentStreak(userId).catch((err) =>
       console.error("Error refreshing current_streak:", err.message),
+    );
+
+    // Streak tokens: detect a completed Double Down (missed yesterday, 2× goal
+    // today). Fire-and-forget and double-gated — instant no-op until the env
+    // switch is on AND this user enrolled via the new build.
+    reconcileStreakFeaturesOnUpload(userId).catch((err) =>
+      console.error("Error reconciling streak features:", err.message),
     );
 
     try {
@@ -554,6 +565,14 @@ export async function getUserStats(req: AuthenticatedRequest, res: Response) {
     // Default goal miles is 1.0 (can be updated when user preferences are stored)
     const goal_miles = 1.0;
 
+    // Streak tokens: null (→ field omitted, JSON byte-identical to today)
+    // unless the env switch is on AND this user enrolled via the new build.
+    const streak_features = await getStreakFeaturesPayload(
+      userId,
+      streak,
+      start,
+    );
+
     return res.status(200).json({
       streak,
       start_date: start,
@@ -563,6 +582,7 @@ export async function getUserStats(req: AuthenticatedRequest, res: Response) {
       recent_workouts,
       today_miles,
       goal_miles,
+      ...(streak_features ? { streak_features } : {}),
     });
   } catch (error: any) {
     console.error("Error getting user stats:", error.message);

--- a/backend/src/cron/streakFeaturesCron.ts
+++ b/backend/src/cron/streakFeaturesCron.ts
@@ -1,0 +1,30 @@
+import cron from "node-cron";
+import { runStreakFeaturesSweep } from "../services/streakFeatureService.js";
+import { streakFeaturesGloballyEnabled } from "../services/streakFeatureCore.js";
+
+/**
+ * Hourly streak-token sweep. Each run settles YESTERDAY for enrolled users
+ * currently in their local morning (6–11): waits out an open Double Down
+ * window, auto-consumes a held Streak Save, or stamps the break and offers
+ * the rescue to assist-holding friends. Runs at :10 so it never lands on the
+ * same tick as the :00 daily-reminder batch.
+ *
+ * Instant no-op while STREAK_FEATURES_ENABLED is unset — safe to deploy dark.
+ */
+export function startStreakFeaturesCron(): void {
+  cron.schedule("10 * * * *", async () => {
+    if (!streakFeaturesGloballyEnabled()) return;
+    try {
+      const { processed, saved, breaks } = await runStreakFeaturesSweep();
+      if (processed > 0) {
+        console.log(
+          `[CRON] Streak-features sweep: ${processed} users, ${saved} saves, ${breaks} breaks.`,
+        );
+      }
+    } catch (error: any) {
+      console.error("[CRON] Streak-features sweep failed:", error.message);
+    }
+  });
+
+  console.log("Streak-features cron scheduled (hourly sweep at :10).");
+}

--- a/backend/src/db/drizzle/0021_robust_plazm.sql
+++ b/backend/src/db/drizzle/0021_robust_plazm.sql
@@ -1,0 +1,25 @@
+CREATE TABLE "streak_coverage" (
+	"user_id" text NOT NULL,
+	"local_date" date NOT NULL,
+	"kind" varchar(32) NOT NULL,
+	"trigger_date" date,
+	"source_user" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "streak_coverage_pkey" PRIMARY KEY("user_id","local_date")
+);
+--> statement-breakpoint
+CREATE TABLE "streak_events" (
+	"user_id" text NOT NULL,
+	"local_date" date NOT NULL,
+	"kind" varchar(24) NOT NULL,
+	"prior_streak" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "streak_events_pkey" PRIMARY KEY("user_id","local_date","kind")
+);
+--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "streak_features_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "double_down_last_used" date;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "streak_save_last_used" date;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "streak_assist_last_used" date;--> statement-breakpoint
+ALTER TABLE "streak_coverage" ADD CONSTRAINT "streak_coverage_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("user_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "streak_events" ADD CONSTRAINT "streak_events_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("user_id") ON DELETE cascade ON UPDATE no action;

--- a/backend/src/db/drizzle/meta/0021_snapshot.json
+++ b/backend/src/db/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,4185 @@
+{
+  "id": "56def261-59b1-4e20-b801-5be7c3875cec",
+  "prevId": "502f02e3-b474-4955-86f9-c39446812d2d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.android_waitlist": {
+      "name": "android_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'website'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "android_waitlist_email_unique": {
+          "name": "android_waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_badges_category": {
+          "name": "idx_badges_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "badges_rarity_check": {
+          "name": "badges_rarity_check",
+          "value": "rarity = ANY (ARRAY['common'::text, 'rare'::text, 'legendary'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.close_friends": {
+      "name": "close_friends",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_friend_id": {
+          "name": "close_friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_close_friends_friend": {
+          "name": "idx_close_friends_friend",
+          "columns": [
+            {
+              "expression": "close_friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "close_friends_pkey": {
+          "name": "close_friends_pkey",
+          "columns": [
+            "user_id",
+            "close_friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_users": {
+      "name": "competition_users",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_rank": {
+          "name": "last_known_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_score": {
+          "name": "last_known_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rank_updated_at": {
+          "name": "last_rank_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_competition_users_comp": {
+          "name": "idx_competition_users_comp",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_competition": {
+          "name": "idx_competition_users_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_rank_cache": {
+          "name": "idx_competition_users_rank_cache",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_known_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((invite_status)::text = 'accepted'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user": {
+          "name": "idx_competition_users_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user_status": {
+          "name": "idx_competition_users_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invite_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_users_user_id_fkey": {
+          "name": "competition_users_user_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_users_competition_id_fkey": {
+          "name": "competition_users_competition_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_users_pkey": {
+          "name": "competition_users_pkey",
+          "columns": [
+            "competition_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_users_invite_status_check": {
+          "name": "competition_users_invite_status_check",
+          "value": "(invite_status)::text = ANY ((ARRAY['pending'::character varying, 'accepted'::character varying, 'declined'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workouts": {
+          "name": "workouts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_winner": {
+          "name": "idx_competitions_winner",
+          "columns": [
+            {
+              "expression": "winner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(winner IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_winner_fkey": {
+          "name": "competitions_winner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "competitions_owner_fkey": {
+          "name": "competitions_owner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitions_type_check": {
+          "name": "competitions_type_check",
+          "value": "(type)::text = ANY ((ARRAY['streaks'::character varying, 'apex'::character varying, 'clash'::character varying, 'targets'::character varying, 'race'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_challenges": {
+      "name": "daily_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_template": {
+          "name": "description_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_start": {
+          "name": "gradient_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_end": {
+          "name": "gradient_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rotation_index": {
+          "name": "rotation_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_challenges_rotation_index_key": {
+          "name": "daily_challenges_rotation_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rotation_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daily_challenges_type_check": {
+          "name": "daily_challenges_type_check",
+          "value": "type = ANY (ARRAY['pace'::text, 'distance'::text, 'time'::text, 'activity'::text, 'steps'::text, 'social'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_steps": {
+      "name": "daily_steps",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_steps_user_date": {
+          "name": "idx_daily_steps_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_steps_user_id_fkey": {
+          "name": "daily_steps_user_id_fkey",
+          "tableFrom": "daily_steps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_steps_pkey": {
+          "name": "daily_steps_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "daily_steps_steps_check": {
+          "name": "daily_steps_steps_check",
+          "value": "steps >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token": {
+          "name": "device_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_tokens_user_id": {
+          "name": "idx_device_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_user_id_fkey": {
+          "name": "device_tokens_user_id_fkey",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_user_id_device_token_key": {
+          "name": "device_tokens_user_id_device_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_log": {
+      "name": "error_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_error_log_created_at": {
+          "name": "idx_error_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_error_log_category": {
+          "name": "idx_error_log_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flex_log": {
+      "name": "flex_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flex_log_lookup": {
+          "name": "idx_flex_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_notification_settings": {
+      "name": "friend_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted": {
+          "name": "muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nudges_muted": {
+          "name": "nudges_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "activity_muted": {
+          "name": "activity_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "friend_notification_settings_pkey": {
+          "name": "friend_notification_settings_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_nudge_log": {
+      "name": "friend_nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_nudge_log_lookup": {
+          "name": "idx_friend_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_friendships_friend_status": {
+          "name": "idx_friendships_friend_status",
+          "columns": [
+            {
+              "expression": "friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_friendships_user_status": {
+          "name": "idx_friendships_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_user_id_fkey": {
+          "name": "friendships_user_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_friend_id_fkey": {
+          "name": "friendships_friend_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendships_pkey": {
+          "name": "friendships_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_friendship_pair": {
+          "name": "unique_friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.h2h_matchups": {
+      "name": "h2h_matchups",
+      "schema": "",
+      "columns": {
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rival_id": {
+          "name": "rival_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mutual": {
+          "name": "mutual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "won": {
+          "name": "won",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "h2h_matchups_user_id_fkey": {
+          "name": "h2h_matchups_user_id_fkey",
+          "tableFrom": "h2h_matchups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "h2h_matchups_rival_id_fkey": {
+          "name": "h2h_matchups_rival_id_fkey",
+          "tableFrom": "h2h_matchups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "rival_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "h2h_matchups_pkey": {
+          "name": "h2h_matchups_pkey",
+          "columns": [
+            "local_date",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hype_log": {
+      "name": "hype_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_label": {
+          "name": "context_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hype_log_context_dedupe_idx": {
+          "name": "hype_log_context_dedupe_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_lookup": {
+          "name": "idx_hype_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_target_context": {
+          "name": "idx_hype_log_target_context",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_app_notifications": {
+      "name": "in_app_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_in_app_notifications_unread": {
+          "name": "idx_in_app_notifications_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_read = false)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_app_notifications_user": {
+          "name": "idx_in_app_notifications_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_app_notifications_user_id_fkey": {
+          "name": "in_app_notifications_user_id_fkey",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_notifications": {
+      "name": "milestone_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_key": {
+          "name": "milestone_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_notifications_milestone_key_key": {
+          "name": "milestone_notifications_milestone_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_audience_settings": {
+      "name": "notification_audience_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_audience_settings_pkey": {
+          "name": "notification_audience_settings_pkey",
+          "columns": [
+            "user_id",
+            "direction",
+            "event_type",
+            "activity_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_audience_settings_direction_check": {
+          "name": "notification_audience_settings_direction_check",
+          "value": "direction = ANY (ARRAY['outgoing'::text, 'incoming'::text])"
+        },
+        "notification_audience_settings_audience_check": {
+          "name": "notification_audience_settings_audience_check",
+          "value": "audience = ANY (ARRAY['none'::text, 'close'::text, 'all'::text, 'ask'::text, 'match_run'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_user_date": {
+          "name": "idx_notification_log_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nudges_enabled": {
+          "name": "nudges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "flexes_enabled": {
+          "name": "flexes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_activity_enabled": {
+          "name": "friend_activity_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_invites_enabled": {
+          "name": "competition_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_updates_enabled": {
+          "name": "competition_updates_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_milestones_enabled": {
+          "name": "competition_milestones_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "hypes_enabled": {
+          "name": "hypes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "step_goal_enabled": {
+          "name": "step_goal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "friend_personal_best_enabled": {
+          "name": "friend_personal_best_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_enabled": {
+          "name": "daily_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_hour": {
+          "name": "daily_reminder_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 18
+        },
+        "h2h_close_friends_only": {
+          "name": "h2h_close_friends_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone_offset_minutes": {
+          "name": "timezone_offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_workouts_to_feed": {
+          "name": "share_workouts_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_posts_enabled": {
+          "name": "friend_posts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "share_route_maps": {
+          "name": "share_route_maps",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "weekly_recap_enabled": {
+          "name": "weekly_recap_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "workout_visibility": {
+          "name": "workout_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'friends'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_settings_workout_visibility_check": {
+          "name": "notification_settings_workout_visibility_check",
+          "value": "workout_visibility = ANY (ARRAY['public'::text, 'friends'::text, 'private'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.nudge_log": {
+      "name": "nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_nudge_log_lookup": {
+          "name": "idx_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nudge_log_rate_limit": {
+          "name": "idx_nudge_log_rate_limit",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_friend_notifications": {
+      "name": "pending_friend_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "send_after_at": {
+          "name": "send_after_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_friend_notif_user": {
+          "name": "idx_pending_friend_notif_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_pending_friend_notif_workout": {
+          "name": "uq_pending_friend_notif_workout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((workout_id IS NOT NULL) AND (status = 'pending'::text))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pending_friend_notifications_status_check": {
+          "name": "pending_friend_notifications_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'sent'::text, 'dismissed'::text, 'expired'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_notifications": {
+      "name": "pending_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_notifications_unsent": {
+          "name": "idx_pending_notifications_unsent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(sent_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_notifications_user_id_fkey": {
+          "name": "pending_notifications_user_id_fkey",
+          "tableFrom": "pending_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_reports": {
+      "name": "post_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_reports_dedupe_idx": {
+          "name": "post_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_reports_status": {
+          "name": "idx_post_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_reports_post_id_fkey": {
+          "name": "post_reports_post_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_reports_reporter_id_fkey": {
+          "name": "post_reports_reporter_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_reports_reason_check": {
+          "name": "post_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_snapshot": {
+          "name": "stats_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_to_feed": {
+          "name": "share_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_to_story": {
+          "name": "share_to_story",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "story_expires_at": {
+          "name": "story_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto": {
+          "name": "is_auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_route": {
+          "name": "include_route",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_posts_user_created": {
+          "name": "idx_posts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_feed": {
+          "name": "idx_posts_feed",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_story_active": {
+          "name": "idx_posts_story_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "story_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_story)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_active": {
+          "name": "uq_posts_workout_active",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_story": {
+          "name": "uq_posts_workout_story",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_story AND NOT share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_fkey": {
+          "name": "posts_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_workout_id_fkey": {
+          "name": "posts_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_family_id": {
+          "name": "token_family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_hash": {
+          "name": "replaced_by_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "token_family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_revoked_at": {
+          "name": "idx_refresh_tokens_revoked_at",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(revoked_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_token_hash": {
+          "name": "idx_refresh_tokens_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_fkey": {
+          "name": "refresh_tokens_user_id_fkey",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_key": {
+          "name": "refresh_tokens_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_reactions": {
+      "name": "story_reactions",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_reactions_post_id_fkey": {
+          "name": "story_reactions_post_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_reactions_user_id_fkey": {
+          "name": "story_reactions_user_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_reactions_pkey": {
+          "name": "story_reactions_pkey",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_views": {
+      "name": "story_views",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_views_post_id_fkey": {
+          "name": "story_views_post_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_views_viewer_id_fkey": {
+          "name": "story_views_viewer_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_views_pkey": {
+          "name": "story_views_pkey",
+          "columns": [
+            "post_id",
+            "viewer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streak_coverage": {
+      "name": "streak_coverage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_date": {
+          "name": "trigger_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_user": {
+          "name": "source_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "streak_coverage_user_id_fkey": {
+          "name": "streak_coverage_user_id_fkey",
+          "tableFrom": "streak_coverage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "streak_coverage_pkey": {
+          "name": "streak_coverage_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streak_events": {
+      "name": "streak_events",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prior_streak": {
+          "name": "prior_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "streak_events_user_id_fkey": {
+          "name": "streak_events_user_id_fkey",
+          "tableFrom": "streak_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "streak_events_pkey": {
+          "name": "streak_events_pkey",
+          "columns": [
+            "user_id",
+            "local_date",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggering_workout_id": {
+          "name": "triggering_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_snapshot": {
+          "name": "progress_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_slot": {
+          "name": "pin_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_badges_user": {
+          "name": "idx_user_badges_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_new": {
+          "name": "idx_user_badges_user_new",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_new = true)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_pin_slot": {
+          "name": "idx_user_badges_user_pin_slot",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(pin_slot IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_workout": {
+          "name": "idx_user_badges_workout",
+          "columns": [
+            {
+              "expression": "triggering_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_badges_user_id_fkey": {
+          "name": "user_badges_user_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_fkey": {
+          "name": "user_badges_badge_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "badge_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_triggering_workout_id_fkey": {
+          "name": "user_badges_triggering_workout_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "triggering_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_badges_user_id_badge_id_key": {
+          "name": "user_badges_user_id_badge_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "badge_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_badges_pin_slot_range": {
+          "name": "user_badges_pin_slot_range",
+          "value": "(pin_slot IS NULL) OR ((pin_slot >= 0) AND (pin_slot <= 2))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_blocks_blocked": {
+          "name": "idx_user_blocks_blocked",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_fkey": {
+          "name": "user_blocks_blocker_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_blocks_blocked_id_fkey": {
+          "name": "user_blocks_blocked_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_pkey": {
+          "name": "user_blocks_pkey",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenge_completions": {
+      "name": "user_challenge_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completing_workout_id": {
+          "name": "completing_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ucc_user": {
+          "name": "idx_ucc_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ucc_user_date": {
+          "name": "idx_ucc_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenge_completions_user_id_fkey": {
+          "name": "user_challenge_completions_user_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_challenge_key_fkey": {
+          "name": "user_challenge_completions_challenge_key_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "daily_challenges",
+          "columnsFrom": [
+            "challenge_key"
+          ],
+          "columnsTo": [
+            "challenge_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_completing_workout_id_fkey": {
+          "name": "user_challenge_completions_completing_workout_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "completing_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_challenge_completions_user_id_local_date_key": {
+          "name": "user_challenge_completions_user_id_local_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_sub": {
+          "name": "apple_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "goal_miles": {
+          "name": "goal_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_source": {
+          "name": "referral_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_detail": {
+          "name": "referral_detail",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signup_goal": {
+          "name": "signup_goal",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience_level": {
+          "name": "experience_level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "streak_features_at": {
+          "name": "streak_features_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "double_down_last_used": {
+          "name": "double_down_last_used",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streak_save_last_used": {
+          "name": "streak_save_last_used",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streak_assist_last_used": {
+          "name": "streak_assist_last_used",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_current_streak_desc": {
+          "name": "idx_users_current_streak_desc",
+          "columns": [
+            {
+              "expression": "current_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email_trgm": {
+          "name": "idx_users_email_trgm",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_username_trgm": {
+          "name": "idx_users_username_trgm",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_apple_id_key": {
+          "name": "users_apple_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_apple_sub_key": {
+          "name": "users_apple_sub_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "apple_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_recap_log": {
+      "name": "weekly_recap_log",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "weekly_recap_log_pkey": {
+          "name": "weekly_recap_log_pkey",
+          "columns": [
+            "user_id",
+            "week_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_completion_notifications": {
+      "name": "workout_completion_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_date": {
+          "name": "notified_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_completion_notifications_user_id_notified_date_key": {
+          "name": "workout_completion_notifications_user_id_notified_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "notified_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_routes": {
+      "name": "workout_routes",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "point_count": {
+          "name": "point_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workout_routes_workout_id_fkey": {
+          "name": "workout_routes_workout_id_fkey",
+          "tableFrom": "workout_routes",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_splits": {
+      "name": "workout_splits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_number": {
+          "name": "split_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_duration": {
+          "name": "split_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_distance": {
+          "name": "split_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_pace": {
+          "name": "split_pace",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_splits_time": {
+          "name": "idx_splits_time",
+          "columns": [
+            {
+              "expression": "split_duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_splits_workout": {
+          "name": "idx_splits_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_splits_workout_id_fkey": {
+          "name": "workout_splits_workout_id_fkey",
+          "tableFrom": "workout_splits",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_splits_workout_id_split_number_key": {
+          "name": "workout_splits_workout_id_split_number_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "split_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workouts": {
+      "name": "workouts",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_end_date": {
+          "name": "device_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthkit'"
+        },
+        "original_distance": {
+          "name": "original_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_duration": {
+          "name": "original_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_flagged": {
+          "name": "speed_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_workouts_local_date_user_id": {
+          "name": "idx_workouts_local_date_user_id",
+          "columns": [
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_device_end": {
+          "name": "idx_workouts_user_device_end",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_local_date": {
+          "name": "idx_workouts_user_local_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workouts_user_workout_unique": {
+          "name": "workouts_user_workout_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/drizzle/meta/_journal.json
+++ b/backend/src/db/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1784426667260,
       "tag": "0020_sparkling_centennial",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1784595653948,
+      "tag": "0021_robust_plazm",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/drizzle/schema.ts
+++ b/backend/src/db/drizzle/schema.ts
@@ -143,6 +143,21 @@ export const users = pgTable(
     })
       .defaultNow()
       .notNull(),
+    // Streak-features enrollment stamp (Double Down / Streak Save / Streak
+    // Assist). Only the new app build calls the enable endpoint, so null =
+    // legacy build → every streak feature is invisible AND inert for this user
+    // (their streak math runs the exact legacy path). Mirrors terms_accepted_at.
+    streakFeaturesAt: timestamp("streak_features_at", {
+      withTimezone: true,
+      mode: "string",
+    }),
+    // Token meters are DERIVED (counted from workouts since the matching
+    // last-used date), never stored — these anchors are the only state.
+    // Null = never used → the meter window opens at enrollment (with a
+    // bounded retroactive lookback).
+    doubleDownLastUsed: date("double_down_last_used"),
+    streakSaveLastUsed: date("streak_save_last_used"),
+    streakAssistLastUsed: date("streak_assist_last_used"),
   },
   (table) => [
     index("idx_users_current_streak_desc").using(
@@ -976,6 +991,71 @@ export const dailySteps = pgTable(
       name: "daily_steps_pkey",
     }),
     check("daily_steps_steps_check", sql`steps >= 0`),
+  ],
+);
+
+// One row = one missed local day that still counts toward the user's streak.
+// The SINGLE substrate all three streak tokens converge on: Double Down writes
+// kind 'double_down_recover', an auto-consumed Streak Save writes 'streak_save',
+// and a friend's rescue writes 'streak_assist' (source_user = the giver). The
+// composite PK makes every write idempotent (ON CONFLICT DO NOTHING) — the
+// upload-vs-sweep race defense — and means a day can only ever be covered once.
+export const streakCoverage = pgTable(
+  "streak_coverage",
+  {
+    userId: text("user_id").notNull(),
+    localDate: date("local_date").notNull(),
+    kind: varchar({ length: 32 }).notNull(),
+    // The local day whose activity triggered the coverage (e.g. the 2× run
+    // day for a Double Down, the giver's day for an Assist).
+    triggerDate: date("trigger_date"),
+    // Assist only: who rescued this user. Plain text (no FK) so a deleted
+    // giver never blocks the receiver's history.
+    sourceUser: text("source_user"),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.userId],
+      name: "streak_coverage_user_id_fkey",
+    }).onDelete("cascade"),
+    primaryKey({
+      columns: [table.userId, table.localDate],
+      name: "streak_coverage_pkey",
+    }),
+  ],
+);
+
+// Streak lifecycle events, currently just kind 'break': stamped once by the
+// sweep when an enrolled user's streak actually breaks (no token covered it).
+// Drives the "you can save your friend" flow — assist eligibility reads it,
+// and the ON CONFLICT-guarded insert doubles as the push de-dupe so hourly
+// sweep re-runs never re-notify.
+export const streakEvents = pgTable(
+  "streak_events",
+  {
+    userId: text("user_id").notNull(),
+    localDate: date("local_date").notNull(),
+    kind: varchar({ length: 24 }).notNull(),
+    // Length of the streak that ended (what an assist would restore).
+    priorStreak: integer("prior_streak").default(0).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.userId],
+      name: "streak_events_user_id_fkey",
+    }).onDelete("cascade"),
+    primaryKey({
+      columns: [table.userId, table.localDate, table.kind],
+      name: "streak_events_pkey",
+    }),
   ],
 );
 

--- a/backend/src/routes/usersRoutes.ts
+++ b/backend/src/routes/usersRoutes.ts
@@ -13,6 +13,11 @@ import {
   uploadProfileImage,
 } from "../controllers/usersController.js";
 import { requireSelfAccess } from "../middleware/auth.js";
+import {
+  enableStreakFeaturesController,
+  streakFeaturesStatusController,
+  giveStreakAssistController,
+} from "../controllers/streakFeaturesController.js";
 
 const upload = multer({
   storage: multer.memoryStorage(),
@@ -27,6 +32,13 @@ const upload = multer({
 });
 
 const router = Router();
+
+// Streak tokens (Double Down / Streak Save / Streak Assist). Self-scoped via
+// req.userId, so no :userId param — registered above the param routes so the
+// static paths can never be captured by /:userId.
+router.post("/streak-features/enable", enableStreakFeaturesController);
+router.get("/streak-features/status", streakFeaturesStatusController);
+router.post("/streak-features/assist/:friendId", giveStreakAssistController);
 
 router.get("/search", searchUsers);
 router.get("/check-username", checkUsername);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -34,6 +34,7 @@ import { startStoriesCron } from "./cron/storiesCron.js";
 import { startPendingSendCron } from "./cron/pendingSendCron.js";
 import { startWeeklyRecapCron } from "./cron/weeklyRecapCron.js";
 import { startH2hChallengeCron } from "./cron/h2hChallengeCron.js";
+import { startStreakFeaturesCron } from "./cron/streakFeaturesCron.js";
 import { seedExtraBadges } from "./services/badgeService.js";
 import { seedExtraChallenges } from "./services/dailyChallengeService.js";
 import { PostgresService } from "./services/DbService.js";
@@ -253,6 +254,7 @@ function startCrons() {
   startPendingSendCron();
   startWeeklyRecapCron();
   startH2hChallengeCron();
+  startStreakFeaturesCron();
   // Idempotently ensure the v2 social/app-function badges exist in the catalog.
   seedExtraBadges();
   // Idempotently ensure the v2 daily challenges (5K/10K/social) exist.

--- a/backend/src/services/leaderboardService.ts
+++ b/backend/src/services/leaderboardService.ts
@@ -1,4 +1,8 @@
 import { PostgresService } from "./DbService.js";
+import {
+  coverageActiveFor,
+  computeCoveredStreak,
+} from "./streakFeatureCore.js";
 
 const db = PostgresService.getInstance();
 
@@ -682,6 +686,21 @@ export async function refreshCurrentStreak(userId: string): Promise<number> {
       userId,
     ]);
     return 0;
+  }
+
+  // Streak-features gate. CRITICAL: this function is the ONLY writer of
+  // users.current_streak and is also invoked by the 6-hourly
+  // reconcileStaleStreaks cron — if it didn't honor coverage, that cron would
+  // silently erase every token-saved streak within hours. Enrolled users (new
+  // build + env switch on) get the coverage-aware walk; everyone else runs
+  // the untouched legacy loop below, byte-identical to before.
+  if (await coverageActiveFor(userId)) {
+    const covered = await computeCoveredStreak(userId, userToday);
+    await db.query(`UPDATE users SET current_streak = $1 WHERE user_id = $2`, [
+      covered.streak,
+      userId,
+    ]);
+    return covered.streak;
   }
 
   const days = await db.query(

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -716,7 +716,16 @@ export async function checkStreaksBroken(): Promise<void> {
 			SELECT us.user_id, u.username
 			FROM user_streaks us
 			JOIN users u ON u.user_id = us.user_id
-			WHERE us.last_active_date < $1`,
+			WHERE us.last_active_date < $1
+			-- Streak tokens: a covered day after the last workout day means the
+			-- streak did NOT break (a Save/Double Down/Assist bridged it) — don't
+			-- send this user a "streak broken" push. Coverage rows only exist for
+			-- enrolled users, so this is a no-op for everyone else.
+			AND NOT EXISTS (
+				SELECT 1 FROM streak_coverage sc
+				WHERE sc.user_id = us.user_id
+					AND sc.local_date > us.last_active_date
+			)`,
       [yesterdayStr],
     );
 

--- a/backend/src/services/pushNotificationService.ts
+++ b/backend/src/services/pushNotificationService.ts
@@ -130,7 +130,13 @@ export type NotificationType =
   | "friend_post"
   | "story_reaction"
   | "daily_reminder"
-  | "weekly_recap";
+  | "weekly_recap"
+  // Streak tokens (gated behind STREAK_FEATURES_ENABLED + per-user enrollment;
+  // none are high-priority, so quiet hours apply automatically).
+  | "streak_double_down"
+  | "streak_saved"
+  | "streak_assist_opportunity"
+  | "streak_assisted";
 
 interface PushPayload {
   title: string;

--- a/backend/src/services/streakFeatureCore.ts
+++ b/backend/src/services/streakFeatureCore.ts
@@ -1,0 +1,210 @@
+import { PostgresService } from "./DbService.js";
+
+const db = PostgresService.getInstance();
+
+/**
+ * Low-level streak-features plumbing shared by the streak walks. Deliberately
+ * imports ONLY DbService so both workoutService and leaderboardService can use
+ * it without an import cycle (the high-level token logic lives in
+ * streakFeatureService, which imports those services in turn).
+ *
+ * The safety contract of the whole feature lives here:
+ *   - streak features are DOUBLE-gated: the STREAK_FEATURES_ENABLED env switch
+ *     (fail-closed master kill switch) AND a per-user enrollment stamp that
+ *     only the new app build writes. Un-enrolled users' streak math runs the
+ *     EXACT legacy code path — the callers branch before any of this runs.
+ *   - a covered day (one streak_coverage row) counts as "not a miss" in the
+ *     walk, no matter WHICH token wrote it. The walks never branch per token.
+ */
+
+export function streakFeaturesGloballyEnabled(): boolean {
+  return process.env.STREAK_FEATURES_ENABLED === "true";
+}
+
+/** One users-row read of everything the token logic needs. */
+export interface StreakFeatureUserRow {
+  streak_features_at: string | null;
+  double_down_last_used: string | null;
+  streak_save_last_used: string | null;
+  streak_assist_last_used: string | null;
+  goal_miles: string | number;
+  current_streak: number;
+}
+
+export async function getStreakFeatureRow(
+  userId: string,
+): Promise<StreakFeatureUserRow | null> {
+  const rows = await db.query<StreakFeatureUserRow>(
+    `SELECT streak_features_at, double_down_last_used, streak_save_last_used,
+            streak_assist_last_used, goal_miles, current_streak
+     FROM users WHERE user_id = $1`,
+    [userId],
+  );
+  return rows[0] ?? null;
+}
+
+/**
+ * Should this user's streak walk honor coverage? False for everyone until the
+ * env switch flips AND the user's (new-build-only) enrollment stamp exists —
+ * the callers run their untouched legacy code in that case, so live users'
+ * streak output stays byte-identical.
+ */
+export async function coverageActiveFor(userId: string): Promise<boolean> {
+  if (!streakFeaturesGloballyEnabled()) return false;
+  const rows = await db.query<{ enrolled: boolean }>(
+    `SELECT (streak_features_at IS NOT NULL) AS enrolled FROM users WHERE user_id = $1`,
+    [userId],
+  );
+  return rows[0]?.enrolled === true;
+}
+
+/** All covered local dates for a user, newest first (tiny — days are rare). */
+export async function fetchCoverageDates(userId: string): Promise<string[]> {
+  const rows = await db.query<{ d: string }>(
+    `SELECT to_char(local_date, 'YYYY-MM-DD') AS d
+     FROM streak_coverage WHERE user_id = $1
+     ORDER BY local_date DESC`,
+    [userId],
+  );
+  return rows.map((r) => r.d);
+}
+
+/** Shared YYYY-MM-DD date arithmetic (UTC-safe, mirrors the legacy walks'). */
+export function dateStrMinus(dateStr: string, days: number): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const date = new Date(Date.UTC(y, m - 1, d));
+  date.setUTCDate(date.getUTCDate() - days);
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * The coverage-aware streak walk: identical anchor/grace/consecutive semantics
+ * to the legacy walks (today counts if present but isn't required; stop at the
+ * first uncovered miss), over the UNION of qualifying workout days and covered
+ * days. Paginates the same qualifying-days query the legacy walk uses.
+ *
+ * Only ever called for enrolled users with the env switch on.
+ */
+export async function computeCoveredStreak(
+  userId: string,
+  userToday: string,
+): Promise<{ streak: number; start: string | undefined }> {
+  const coverage = await fetchCoverageDates(userId); // DESC
+  const yesterday = dateStrMinus(userToday, 1);
+
+  const qualifyingDaysQuery = `
+    SELECT to_char(local_date, 'YYYY-MM-DD') AS local_date
+    FROM workouts
+    WHERE user_id = $1
+    AND deleted_at IS NULL AND exclusion_reason IS NULL
+    GROUP BY local_date
+    HAVING SUM(distance) >= 0.95
+    ORDER BY local_date DESC
+    LIMIT $2 OFFSET $3
+  `;
+  const LIMIT = 100;
+
+  // Lazily merge the paginated qualifying stream with the (small) coverage
+  // list, descending, de-duped — a backfilled workout can land on an
+  // already-covered day and must not count twice.
+  let pageIndex = 0;
+  let page: { local_date: string }[] = await db.query(qualifyingDaysQuery, [
+    userId,
+    LIMIT,
+    0,
+  ]);
+  let pi = 0; // cursor into page
+  let ci = 0; // cursor into coverage
+  let last: string | undefined;
+
+  const next = async (): Promise<string | undefined> => {
+    while (true) {
+      if (pi >= page.length && page.length === LIMIT) {
+        pageIndex++;
+        page = await db.query(qualifyingDaysQuery, [
+          userId,
+          LIMIT,
+          pageIndex * LIMIT,
+        ]);
+        pi = 0;
+      }
+      const q = pi < page.length ? page[pi].local_date : undefined;
+      const c = ci < coverage.length ? coverage[ci] : undefined;
+      let candidate: string | undefined;
+      if (q !== undefined && (c === undefined || q >= c)) {
+        candidate = q;
+        pi++;
+        if (c !== undefined && c === q) ci++; // dupe: consume both
+      } else if (c !== undefined) {
+        candidate = c;
+        ci++;
+      } else {
+        return undefined;
+      }
+      if (candidate === last) continue; // safety de-dupe
+      last = candidate;
+      return candidate;
+    }
+  };
+
+  let streak = 0;
+  let streakStartDay: string | undefined;
+  let expectedDate: string | undefined;
+
+  while (true) {
+    const date = await next();
+    if (date === undefined) break;
+
+    if (expectedDate === undefined) {
+      if (date !== userToday && date !== yesterday) {
+        return { streak: 0, start: undefined };
+      }
+      streak = 1;
+      streakStartDay = date;
+      expectedDate = dateStrMinus(date, 1);
+    } else if (date === expectedDate) {
+      streak++;
+      streakStartDay = date;
+      expectedDate = dateStrMinus(date, 1);
+    } else {
+      return { streak, start: streakStartDay };
+    }
+  }
+
+  return { streak, start: streakStartDay };
+}
+
+/**
+ * Length of the consecutive qualified-or-covered run ENDING exactly at
+ * `endDate` (0 when endDate itself doesn't qualify). Used for the
+ * prior-streak stamped on a break event — i.e. what an assist would restore.
+ */
+export async function streakEndingAt(
+  userId: string,
+  endDate: string,
+): Promise<number> {
+  const rows = await db.query<{ len: number; max_d: string }>(
+    `WITH days AS (
+       SELECT local_date FROM workouts
+       WHERE user_id = $1 AND local_date <= $2::date
+         AND deleted_at IS NULL AND exclusion_reason IS NULL
+       GROUP BY local_date HAVING SUM(distance) >= 0.95
+       UNION
+       SELECT local_date FROM streak_coverage
+       WHERE user_id = $1 AND local_date <= $2::date
+     ),
+     numbered AS (
+       SELECT local_date,
+              local_date - (ROW_NUMBER() OVER (ORDER BY local_date DESC))::int AS grp
+       FROM days
+     )
+     SELECT COUNT(*)::int AS len,
+            to_char(MAX(local_date), 'YYYY-MM-DD') AS max_d
+     FROM numbered
+     WHERE grp = (SELECT grp FROM numbered LIMIT 1)`,
+    [userId, endDate],
+  );
+  const row = rows[0];
+  if (!row || !row.max_d) return 0;
+  return row.max_d === endDate ? Number(row.len) : 0;
+}

--- a/backend/src/services/streakFeatureService.ts
+++ b/backend/src/services/streakFeatureService.ts
@@ -1,0 +1,713 @@
+import { PostgresService } from "./DbService.js";
+import {
+  streakFeaturesGloballyEnabled,
+  getStreakFeatureRow,
+  dateStrMinus,
+  streakEndingAt,
+  StreakFeatureUserRow,
+} from "./streakFeatureCore.js";
+import { getUserLocalToday, getMilesOnLocalDate } from "./workoutService.js";
+import { refreshCurrentStreak } from "./leaderboardService.js";
+import { sendPush } from "./pushNotificationService.js";
+
+const db = PostgresService.getInstance();
+
+/**
+ * The three streak tokens, all earned through activity meters and all writing
+ * the same substrate (streak_coverage) when spent:
+ *
+ *   🔥 Double Down    — meter: 14 mile-completing days (run OR walk). Held at
+ *                       14. Spend: miss yesterday, run 2× your goal today →
+ *                       yesterday is covered. Detected on the upload path.
+ *   ❄️ Streak Save    — meter: 7 mile-completing RUN days (walks and short
+ *                       jogs don't tick it). Held at 7. Spent automatically by
+ *                       the sweep when a miss can't be (or wasn't) Double
+ *                       Downed.
+ *   🤝 Streak Assist  — meter: 20 miles run/walked BEYOND the daily goal.
+ *                       Held at 20. Spent manually on a friend whose streak
+ *                       broke yesterday.
+ *
+ * Meters are DERIVED — counted from workouts since the token's last-used date
+ * — never stored, so retries/edits/deletes can't drift a counter. The window
+ * opens at GREATEST(last use, enrollment − 30d lookback, today − 90d), which
+ * both grants retroactive credit at enrollment and bounds the query.
+ *
+ * Everything here no-ops unless STREAK_FEATURES_ENABLED=true AND the user has
+ * the (new-build-only) enrollment stamp.
+ */
+
+// Meter targets (product-locked; see docs). The Assist threshold is the dial
+// most likely to need tuning after launch.
+export const DOUBLE_DOWN_TARGET_DAYS = 14;
+export const STREAK_SAVE_TARGET_RUN_DAYS = 7;
+export const STREAK_ASSIST_TARGET_MILES = 20;
+// Double Down completion threshold mirrors the 0.95 display tolerance.
+const DOUBLE_DOWN_GOAL_MULTIPLIER = 2;
+const DOUBLE_DOWN_TOLERANCE = 0.05;
+// Meter windows: retroactive credit at enrollment + a hard query bound.
+const ENROLL_LOOKBACK_DAYS = 30;
+const METER_WINDOW_DAYS = 90;
+// Assist-opportunity pushes only fire for streaks worth mourning.
+const MIN_NOTIFY_PRIOR_STREAK = 3;
+// A break stays rescuable for this many days after the missed day.
+const ASSIST_RESCUE_WINDOW_DAYS = 2;
+
+export interface MeterState {
+  progress: number;
+  target: number;
+  held: boolean;
+  last_used: string | null;
+}
+
+export interface StreakFeatureMeters {
+  double_down: MeterState;
+  streak_save: MeterState;
+  streak_assist: MeterState;
+  goalMiles: number;
+}
+
+/** Window floor for one meter: last use vs enrollment lookback vs hard bound. */
+function meterFloor(
+  lastUsed: string | null,
+  enrolledAt: string,
+  userToday: string,
+): string {
+  const enrollFloor = dateStrMinus(
+    enrolledAt.slice(0, 10),
+    ENROLL_LOOKBACK_DAYS,
+  );
+  const hardFloor = dateStrMinus(userToday, METER_WINDOW_DAYS);
+  let floor = enrollFloor > hardFloor ? enrollFloor : hardFloor;
+  if (lastUsed && lastUsed > floor) floor = lastUsed;
+  return floor;
+}
+
+/**
+ * Derive all three meters in one query. "Day counts" uses the same flat
+ * 0.95-mile rule as the streak walks; the Save meter additionally requires the
+ * RUNNING workouts alone to complete the mile (the "7 days of running a mile"
+ * rule — a short jog alongside a long walk does not tick it).
+ */
+export async function getMeters(
+  userId: string,
+  row: StreakFeatureUserRow,
+  userToday: string,
+): Promise<StreakFeatureMeters> {
+  const enrolledAt = row.streak_features_at ?? userToday;
+  const ddFloor = meterFloor(row.double_down_last_used, enrolledAt, userToday);
+  const saveFloor = meterFloor(
+    row.streak_save_last_used,
+    enrolledAt,
+    userToday,
+  );
+  const assistFloor = meterFloor(
+    row.streak_assist_last_used,
+    enrolledAt,
+    userToday,
+  );
+  const goalMiles = Number(row.goal_miles) || 1.0;
+
+  const rows = await db.query<{
+    dd_days: string | number;
+    save_days: string | number;
+    assist_miles: string | number;
+  }>(
+    `SELECT
+      (SELECT COUNT(*) FROM (
+        SELECT local_date FROM workouts
+        WHERE user_id = $1 AND deleted_at IS NULL AND exclusion_reason IS NULL
+          AND local_date > $2::date AND local_date <= $5::date
+        GROUP BY local_date HAVING SUM(distance) >= 0.95
+      ) dd) AS dd_days,
+      (SELECT COUNT(*) FROM (
+        SELECT local_date FROM workouts
+        WHERE user_id = $1 AND deleted_at IS NULL AND exclusion_reason IS NULL
+          AND workout_type = 'running'
+          AND local_date > $3::date AND local_date <= $5::date
+        GROUP BY local_date HAVING SUM(distance) >= 0.95
+      ) sv) AS save_days,
+      COALESCE((SELECT SUM(GREATEST(day_total - $6::double precision, 0)) FROM (
+        SELECT SUM(distance) AS day_total FROM workouts
+        WHERE user_id = $1 AND deleted_at IS NULL AND exclusion_reason IS NULL
+          AND local_date > $4::date AND local_date <= $5::date
+        GROUP BY local_date
+      ) a), 0) AS assist_miles`,
+    [userId, ddFloor, saveFloor, assistFloor, userToday, goalMiles],
+  );
+
+  const ddDays = Number(rows[0]?.dd_days ?? 0);
+  const saveDays = Number(rows[0]?.save_days ?? 0);
+  const assistMiles = Number(rows[0]?.assist_miles ?? 0);
+
+  return {
+    double_down: {
+      progress: Math.min(ddDays, DOUBLE_DOWN_TARGET_DAYS),
+      target: DOUBLE_DOWN_TARGET_DAYS,
+      held: ddDays >= DOUBLE_DOWN_TARGET_DAYS,
+      last_used: row.double_down_last_used,
+    },
+    streak_save: {
+      progress: Math.min(saveDays, STREAK_SAVE_TARGET_RUN_DAYS),
+      target: STREAK_SAVE_TARGET_RUN_DAYS,
+      held: saveDays >= STREAK_SAVE_TARGET_RUN_DAYS,
+      last_used: row.streak_save_last_used,
+    },
+    streak_assist: {
+      progress: Math.min(
+        Math.round(assistMiles * 100) / 100,
+        STREAK_ASSIST_TARGET_MILES,
+      ),
+      target: STREAK_ASSIST_TARGET_MILES,
+      held: assistMiles >= STREAK_ASSIST_TARGET_MILES,
+      last_used: row.streak_assist_last_used,
+    },
+    goalMiles,
+  };
+}
+
+/** Qualifying + covered day lookups for a small recent window. */
+async function recentDayFacts(
+  userId: string,
+  fromDate: string,
+): Promise<{ qualified: Set<string>; covered: Set<string> }> {
+  const [qual, cov] = await Promise.all([
+    db.query<{ d: string }>(
+      `SELECT to_char(local_date, 'YYYY-MM-DD') AS d FROM workouts
+       WHERE user_id = $1 AND local_date >= $2::date
+         AND deleted_at IS NULL AND exclusion_reason IS NULL
+       GROUP BY local_date HAVING SUM(distance) >= 0.95`,
+      [userId, fromDate],
+    ),
+    db.query<{ d: string }>(
+      `SELECT to_char(local_date, 'YYYY-MM-DD') AS d FROM streak_coverage
+       WHERE user_id = $1 AND local_date >= $2::date`,
+      [userId, fromDate],
+    ),
+  ]);
+  return {
+    qualified: new Set(qual.map((r) => r.d)),
+    covered: new Set(cov.map((r) => r.d)),
+  };
+}
+
+/** Insert one coverage row; true when THIS call inserted it (race-safe). */
+async function insertCoverage(
+  userId: string,
+  localDate: string,
+  kind: string,
+  triggerDate: string,
+  sourceUser: string | null = null,
+): Promise<boolean> {
+  const rows = await db.query(
+    `INSERT INTO streak_coverage (user_id, local_date, kind, trigger_date, source_user)
+     VALUES ($1, $2::date, $3, $4::date, $5)
+     ON CONFLICT (user_id, local_date) DO NOTHING
+     RETURNING local_date`,
+    [userId, localDate, kind, triggerDate, sourceUser],
+  );
+  return rows.length > 0;
+}
+
+/**
+ * Upload-path hook: detect a completed Double Down. Called fire-and-forget
+ * after every workout upload; the first two checks make it a cheap no-op for
+ * everyone until the feature is live (env switch) and the user enrolled.
+ */
+export async function reconcileStreakFeaturesOnUpload(
+  userId: string,
+): Promise<void> {
+  if (!streakFeaturesGloballyEnabled()) return;
+  const row = await getStreakFeatureRow(userId);
+  if (!row?.streak_features_at) return;
+
+  const userToday = await getUserLocalToday(userId);
+  const missedDay = dateStrMinus(userToday, 1);
+  const dayBefore = dateStrMinus(userToday, 2);
+
+  const facts = await recentDayFacts(userId, dateStrMinus(userToday, 3));
+  const ok = (d: string) => facts.qualified.has(d) || facts.covered.has(d);
+
+  // Only the classic shape: yesterday missed, an older streak to reconnect.
+  if (ok(missedDay) || !ok(dayBefore)) return;
+
+  const meters = await getMeters(userId, row, userToday);
+  if (!meters.double_down.held) return;
+
+  const todayMiles = await getMilesOnLocalDate(userId, userToday);
+  const threshold =
+    meters.goalMiles * DOUBLE_DOWN_GOAL_MULTIPLIER - DOUBLE_DOWN_TOLERANCE;
+  if (todayMiles < threshold) return;
+
+  const inserted = await insertCoverage(
+    userId,
+    missedDay,
+    "double_down_recover",
+    userToday,
+  );
+  if (!inserted) return;
+
+  await db.query(
+    `UPDATE users SET double_down_last_used = $1::date WHERE user_id = $2`,
+    [userToday, userId],
+  );
+  const streak = await refreshCurrentStreak(userId);
+  sendPush(userId, {
+    title: "\u{1F525} Double Down complete!",
+    body: `You ran it back — yesterday counts and your ${streak}-day streak lives on.`,
+    type: "streak_double_down",
+    data: { local_date: missedDay },
+  }).catch((e: any) =>
+    console.error("[StreakFeatures] double-down push failed:", e?.message ?? e),
+  );
+}
+
+/**
+ * Hourly sweep, processing each enrolled user during their local morning
+ * (6–11). Every action is idempotent (coverage/event PKs), so re-processing
+ * the same user across those hours is harmless.
+ *
+ * Per user it settles YESTERDAY (and the day before, for a Double Down window
+ * that expired unused): wait if the Double Down window is open and the token
+ * is held; otherwise auto-consume a held Streak Save; otherwise stamp the
+ * break and offer the rescue to assist-holding friends.
+ */
+export async function runStreakFeaturesSweep(): Promise<{
+  processed: number;
+  saved: number;
+  breaks: number;
+}> {
+  if (!streakFeaturesGloballyEnabled())
+    return { processed: 0, saved: 0, breaks: 0 };
+
+  const candidates = await db.query<{ user_id: string; user_today: string }>(
+    `SELECT u.user_id, to_char(t.local_now::date, 'YYYY-MM-DD') AS user_today
+     FROM users u
+     CROSS JOIN LATERAL (
+       SELECT NOW() + (COALESCE(
+         (SELECT timezone_offset FROM workouts w
+          WHERE w.user_id = u.user_id ORDER BY device_end_date DESC LIMIT 1),
+         0
+       ) || ' minutes')::interval AS local_now
+     ) t
+     WHERE u.streak_features_at IS NOT NULL
+       AND EXTRACT(HOUR FROM t.local_now) BETWEEN 6 AND 11`,
+  );
+
+  let saved = 0;
+  let breaks = 0;
+  for (const { user_id, user_today } of candidates) {
+    try {
+      const result = await sweepOneUser(user_id, user_today);
+      if (result === "saved") saved++;
+      if (result === "break") breaks++;
+    } catch (err: any) {
+      // Isolate per-user failures so one bad row doesn't abort the sweep.
+      console.error(
+        `[StreakFeatures] sweep failed for ${user_id}:`,
+        err?.message ?? err,
+      );
+    }
+  }
+  return { processed: candidates.length, saved, breaks };
+}
+
+async function sweepOneUser(
+  userId: string,
+  userToday: string,
+): Promise<"none" | "waiting" | "saved" | "break"> {
+  const row = await getStreakFeatureRow(userId);
+  if (!row?.streak_features_at) return "none";
+
+  const d1 = dateStrMinus(userToday, 1);
+  const d2 = dateStrMinus(userToday, 2);
+  const d3 = dateStrMinus(userToday, 3);
+  const facts = await recentDayFacts(userId, dateStrMinus(userToday, 4));
+  const ok = (d: string) => facts.qualified.has(d) || facts.covered.has(d);
+
+  // Which missed day are we settling?
+  //  - d1 missed with d2 intact  → fresh miss; Double Down window is OPEN today.
+  //  - d1 intact, d2 missed, d3 intact → the hole a DD window left behind
+  //    (user ran a normal mile yesterday instead of 2×) → window CLOSED.
+  //  - d1 AND d2 missed → 2-day gap: tokens never partially bridge; the streak
+  //    (if d3 was intact) broke at d2.
+  let missedDay: string | null = null;
+  let ddWindowOpen = false;
+  if (!ok(d1) && ok(d2)) {
+    missedDay = d1;
+    ddWindowOpen = true;
+  } else if (ok(d1) && !ok(d2) && ok(d3)) {
+    missedDay = d2;
+  } else if (!ok(d1) && !ok(d2)) {
+    // Unsalvageable gap — stamp the break at its first missed day if the
+    // streak actually ended here (d3 intact); older breaks were stamped on
+    // previous sweeps.
+    if (ok(d3)) return recordBreak(userId, d2);
+    return "none";
+  } else {
+    return "none";
+  }
+
+  const meters = await getMeters(userId, row, userToday);
+
+  // Effort first: while the Double Down window is open and the token is held,
+  // give the runner their shot at earning it back before burning a Save.
+  if (ddWindowOpen && meters.double_down.held) return "waiting";
+
+  if (meters.streak_save.held) {
+    const inserted = await insertCoverage(
+      userId,
+      missedDay,
+      "streak_save",
+      userToday,
+    );
+    if (!inserted) return "none"; // raced with another writer — already covered
+    await db.query(
+      `UPDATE users SET streak_save_last_used = $1::date WHERE user_id = $2`,
+      [userToday, userId],
+    );
+    const streak = await refreshCurrentStreak(userId);
+    sendPush(userId, {
+      title: "❄️ Streak Save used",
+      body: `Life happened — we covered the miss and your ${streak}-day streak lives on.`,
+      type: "streak_saved",
+      data: { local_date: missedDay },
+    }).catch((e: any) =>
+      console.error("[StreakFeatures] save push failed:", e?.message ?? e),
+    );
+    return "saved";
+  }
+
+  // No token could (or should) cover it → the streak broke at missedDay.
+  return recordBreak(userId, missedDay);
+}
+
+/** Stamp a break event once, and offer the rescue to assist-holding friends. */
+async function recordBreak(
+  userId: string,
+  missedDay: string,
+): Promise<"none" | "break"> {
+  const prior = await streakEndingAt(userId, dateStrMinus(missedDay, 1));
+  if (prior < 1) return "none";
+
+  const rows = await db.query(
+    `INSERT INTO streak_events (user_id, local_date, kind, prior_streak)
+     VALUES ($1, $2::date, 'break', $3)
+     ON CONFLICT (user_id, local_date, kind) DO NOTHING
+     RETURNING local_date`,
+    [userId, missedDay, prior],
+  );
+  if (rows.length === 0) return "none"; // already stamped by an earlier run
+
+  if (prior >= MIN_NOTIFY_PRIOR_STREAK) {
+    notifyAssistHolders(userId, missedDay, prior).catch((e: any) =>
+      console.error(
+        "[StreakFeatures] assist-opportunity notify failed:",
+        e?.message ?? e,
+      ),
+    );
+  }
+  return "break";
+}
+
+/** Push "you can save them" to enrolled friends currently holding an Assist. */
+async function notifyAssistHolders(
+  brokenUserId: string,
+  missedDay: string,
+  priorStreak: number,
+): Promise<void> {
+  const nameRows = await db.query<{
+    username: string | null;
+    first_name: string | null;
+  }>(`SELECT username, first_name FROM users WHERE user_id = $1`, [
+    brokenUserId,
+  ]);
+  const display =
+    nameRows[0]?.username || nameRows[0]?.first_name || "A friend";
+
+  const friends = await db.query<{ friend_id: string }>(
+    `SELECT f.friend_id
+     FROM friendships f
+     JOIN users fu ON fu.user_id = f.friend_id
+     WHERE f.user_id = $1 AND f.status = 'accepted'
+       AND fu.streak_features_at IS NOT NULL
+       AND NOT EXISTS (
+         SELECT 1 FROM user_blocks b
+         WHERE (b.blocker_id = $1 AND b.blocked_id = f.friend_id)
+            OR (b.blocker_id = f.friend_id AND b.blocked_id = $1)
+       )`,
+    [brokenUserId],
+  );
+
+  for (const { friend_id } of friends) {
+    try {
+      const row = await getStreakFeatureRow(friend_id);
+      if (!row?.streak_features_at) continue;
+      const friendToday = await getUserLocalToday(friend_id);
+      const meters = await getMeters(friend_id, row, friendToday);
+      if (!meters.streak_assist.held) continue;
+      await sendPush(friend_id, {
+        title: `\u{1F525} ${display}'s ${priorStreak}-day streak just broke`,
+        body: "You're holding a Streak Assist — you can save it from their profile today.",
+        type: "streak_assist_opportunity",
+        data: {
+          user_id: brokenUserId,
+          local_date: missedDay,
+          prior_streak: String(priorStreak),
+        },
+      });
+    } catch (err: any) {
+      console.error(
+        `[StreakFeatures] opportunity push to ${friend_id} failed:`,
+        err?.message ?? err,
+      );
+    }
+  }
+}
+
+export type GiveAssistResult =
+  | { status: "ok"; restored_streak: number }
+  | {
+      status:
+        | "disabled"
+        | "not_enrolled"
+        | "friend_not_enrolled"
+        | "forbidden"
+        | "no_token"
+        | "no_recent_break"
+        | "window_passed"
+        | "gap_too_wide"
+        | "already_saved";
+    };
+
+/**
+ * Spend the giver's Streak Assist to restore a friend's just-broken streak.
+ * Guards mirror the story-reaction pattern: accepted friendship, no block in
+ * either direction — plus BOTH sides must be enrolled (covering an un-enrolled
+ * user's day would change streak math the legacy walk can't see).
+ */
+export async function giveStreakAssist(
+  giverId: string,
+  friendId: string,
+): Promise<GiveAssistResult> {
+  if (!streakFeaturesGloballyEnabled()) return { status: "disabled" };
+  if (giverId === friendId) return { status: "forbidden" };
+
+  const [giverRow, friendRow] = await Promise.all([
+    getStreakFeatureRow(giverId),
+    getStreakFeatureRow(friendId),
+  ]);
+  if (!giverRow?.streak_features_at) return { status: "not_enrolled" };
+  if (!friendRow?.streak_features_at) return { status: "friend_not_enrolled" };
+
+  const allowed = await db.query(
+    `SELECT 1 FROM friendships f
+     WHERE f.user_id = $1 AND f.friend_id = $2 AND f.status = 'accepted'
+       AND NOT EXISTS (
+         SELECT 1 FROM user_blocks b
+         WHERE (b.blocker_id = $1 AND b.blocked_id = $2)
+            OR (b.blocker_id = $2 AND b.blocked_id = $1)
+       )`,
+    [giverId, friendId],
+  );
+  if (allowed.length === 0) return { status: "forbidden" };
+
+  const giverToday = await getUserLocalToday(giverId);
+  const giverMeters = await getMeters(giverId, giverRow, giverToday);
+  if (!giverMeters.streak_assist.held) return { status: "no_token" };
+
+  const friendToday = await getUserLocalToday(friendId);
+  const events = await db.query<{ local_date: string; prior_streak: number }>(
+    `SELECT to_char(local_date, 'YYYY-MM-DD') AS local_date, prior_streak
+     FROM streak_events
+     WHERE user_id = $1 AND kind = 'break' AND local_date >= $2::date
+     ORDER BY local_date DESC LIMIT 1`,
+    [friendId, dateStrMinus(friendToday, ASSIST_RESCUE_WINDOW_DAYS + 1)],
+  );
+  if (events.length === 0) return { status: "no_recent_break" };
+  const missedDay = events[0].local_date;
+  if (missedDay < dateStrMinus(friendToday, ASSIST_RESCUE_WINDOW_DAYS)) {
+    return { status: "window_passed" };
+  }
+
+  // The bridge must reconnect: every day between the miss and the friend's
+  // today has to be intact, or covering one day still leaves a hole (tokens
+  // never partially bridge).
+  const facts = await recentDayFacts(friendId, missedDay);
+  let cursor = dateStrMinus(friendToday, 1);
+  while (cursor > missedDay) {
+    if (!facts.qualified.has(cursor) && !facts.covered.has(cursor)) {
+      return { status: "gap_too_wide" };
+    }
+    cursor = dateStrMinus(cursor, 1);
+  }
+
+  const inserted = await insertCoverage(
+    friendId,
+    missedDay,
+    "streak_assist",
+    giverToday,
+    giverId,
+  );
+  if (!inserted) return { status: "already_saved" };
+
+  await db.query(
+    `UPDATE users SET streak_assist_last_used = $1::date WHERE user_id = $2`,
+    [giverToday, giverId],
+  );
+  const restored = await refreshCurrentStreak(friendId);
+
+  const giverName = await db.query<{
+    username: string | null;
+    first_name: string | null;
+  }>(`SELECT username, first_name FROM users WHERE user_id = $1`, [giverId]);
+  const display =
+    giverName[0]?.username || giverName[0]?.first_name || "A friend";
+  sendPush(friendId, {
+    title: `\u{1F91D} ${display} saved your streak!`,
+    body: `Your ${restored}-day streak is back — go keep it alive.`,
+    type: "streak_assisted",
+    data: { user_id: giverId, local_date: missedDay },
+  }).catch((e: any) =>
+    console.error("[StreakFeatures] assisted push failed:", e?.message ?? e),
+  );
+
+  return { status: "ok", restored_streak: restored };
+}
+
+/** Idempotent enrollment stamp — the new build calls this once on launch. */
+export async function enrollStreakFeatures(
+  userId: string,
+): Promise<{ enrolled: boolean; enrolled_at: string | null }> {
+  const rows = await db.query<{ streak_features_at: string }>(
+    `UPDATE users
+     SET streak_features_at = COALESCE(streak_features_at, NOW())
+     WHERE user_id = $1
+     RETURNING streak_features_at`,
+    [userId],
+  );
+  return {
+    enrolled: rows.length > 0,
+    enrolled_at: rows[0]?.streak_features_at ?? null,
+  };
+}
+
+export interface StreakFeaturesPayload {
+  double_down: MeterState & { recover_miles: number };
+  streak_save: MeterState;
+  streak_assist: MeterState;
+  frozen_dates: { local_date: string; kind: string }[];
+  natural_streak: boolean;
+  streak_at_risk: boolean;
+}
+
+/**
+ * The gated per-user payload for getUserStats / the status endpoint. Returns
+ * null when the gate is off for this user — callers OMIT the field entirely,
+ * keeping un-enrolled responses byte-identical.
+ *
+ * `natural_streak` is strict on purpose: ANY coverage inside the current
+ * streak span (a Save, a Double Down recovery, or a received Assist) makes
+ * the streak non-natural. GIVING an assist writes coverage on the friend's
+ * row, so it never taints the giver.
+ */
+export async function getStreakFeaturesPayload(
+  userId: string,
+  streak: number,
+  streakStart: string | undefined,
+): Promise<StreakFeaturesPayload | null> {
+  if (!streakFeaturesGloballyEnabled()) return null;
+  const row = await getStreakFeatureRow(userId);
+  if (!row?.streak_features_at) return null;
+
+  const userToday = await getUserLocalToday(userId);
+  const meters = await getMeters(userId, row, userToday);
+
+  const coverage = await db.query<{ local_date: string; kind: string }>(
+    `SELECT to_char(local_date, 'YYYY-MM-DD') AS local_date, kind
+     FROM streak_coverage
+     WHERE user_id = $1 AND local_date >= $2::date
+     ORDER BY local_date DESC`,
+    [userId, dateStrMinus(userToday, METER_WINDOW_DAYS)],
+  );
+
+  const natural =
+    streak === 0 ||
+    !streakStart ||
+    !coverage.some((c) => c.local_date >= streakStart);
+
+  // At risk = yesterday missed, older streak intact, and a held Double Down
+  // could still bring it back with a 2× run today.
+  let atRisk = false;
+  if (meters.double_down.held) {
+    const facts = await recentDayFacts(userId, dateStrMinus(userToday, 3));
+    const okDay = (d: string) => facts.qualified.has(d) || facts.covered.has(d);
+    const d1 = dateStrMinus(userToday, 1);
+    const d2 = dateStrMinus(userToday, 2);
+    atRisk = !okDay(d1) && okDay(d2);
+  }
+
+  return {
+    double_down: {
+      ...meters.double_down,
+      recover_miles:
+        Math.round(
+          (meters.goalMiles * DOUBLE_DOWN_GOAL_MULTIPLIER -
+            DOUBLE_DOWN_TOLERANCE) *
+            100,
+        ) / 100,
+    },
+    streak_save: meters.streak_save,
+    streak_assist: meters.streak_assist,
+    frozen_dates: coverage,
+    natural_streak: natural,
+    streak_at_risk: atRisk,
+  };
+}
+
+export interface AssistableFriend {
+  user_id: string;
+  username: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  profile_image_url: string | null;
+  broke_date: string;
+  prior_streak: number;
+}
+
+/**
+ * Friends with a fresh, still-uncovered break the caller could rescue.
+ * Approximate window here (the give call re-validates strictly against each
+ * friend's own local today).
+ */
+export async function getAssistableFriends(
+  userId: string,
+): Promise<AssistableFriend[]> {
+  return db.query<AssistableFriend>(
+    `SELECT e.user_id, u.username, u.first_name, u.last_name,
+            u.profile_image_url,
+            to_char(e.local_date, 'YYYY-MM-DD') AS broke_date,
+            e.prior_streak
+     FROM streak_events e
+     JOIN users u ON u.user_id = e.user_id
+     WHERE e.kind = 'break'
+       AND e.local_date >= (CURRENT_DATE - ${ASSIST_RESCUE_WINDOW_DAYS + 1})
+       AND e.prior_streak >= 1
+       AND u.streak_features_at IS NOT NULL
+       AND e.user_id IN (
+         SELECT friend_id FROM friendships
+         WHERE user_id = $1 AND status = 'accepted'
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM streak_coverage sc
+         WHERE sc.user_id = e.user_id AND sc.local_date = e.local_date
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM user_blocks b
+         WHERE (b.blocker_id = $1 AND b.blocked_id = e.user_id)
+            OR (b.blocker_id = e.user_id AND b.blocked_id = $1)
+       )
+     ORDER BY e.created_at DESC
+     LIMIT 20`,
+    [userId],
+  );
+}

--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -1,6 +1,10 @@
 import { Workout } from "../types/workouts.js";
 import { PostgresService } from "./DbService.js";
 import { VIEWER_MAY_SEE_WORKOUT_CONTENT_SQL } from "./visibilityService.js";
+import {
+  coverageActiveFor,
+  computeCoveredStreak,
+} from "./streakFeatureCore.js";
 
 const db = PostgresService.getInstance();
 
@@ -242,6 +246,15 @@ export async function getUserLocalToday(userId: string): Promise<string> {
 
 export async function getActiveStreak(userId: string) {
   const userToday = await getUserLocalToday(userId);
+
+  // Streak-features gate: enrolled users (new build + env switch on) walk the
+  // coverage-aware path so token-covered days count. Everyone else falls
+  // through to the UNTOUCHED legacy walk below — their output is byte-
+  // identical to before this feature existed.
+  if (await coverageActiveFor(userId)) {
+    return computeCoveredStreak(userId, userToday);
+  }
+
   const yesterday = dateStringMinus(userToday, 1);
 
   const qualifyingDaysQuery = `


### PR DESCRIPTION
## What & why

The full backend for streak saving — **deployed dark**. Nothing changes for anyone until two locks open:

1. **`STREAK_FEATURES_ENABLED=true`** (env; fail-closed, currently unset everywhere), **and**
2. a **per-user enrollment stamp** (`users.streak_features_at`) that only the future app build writes via `POST /users/streak-features/enable`.

Until both: every streak read/write runs the **untouched legacy loop** (the gate branches are pure insertions above the old code — see the diff), all new API fields are **omitted** (un-enrolled `getUserStats` JSON is byte-identical), no token side-effect runs, and no token push can fire. With the env unset, the gate short-circuits **before any query** — zero added load on live traffic.

## The three tokens (product-locked)

| Token | Meter (derived, never stored) | Held at | Spend |
|---|---|---|---|
| 🔥 **Double Down** | 14 mile-completing days (run **or** walk) | 14 | Miss yesterday → run `2×goal − 0.05` today → yesterday covered (upload-path detection) |
| ❄️ **Streak Save** | 7 mile-completing **run** days (running workouts alone ≥ 0.95 that day — walks/short jogs don't tick) | 7 | Auto-consumed by the sweep when a miss wasn't Double Downed |
| 🤝 **Streak Assist** | 20 miles **beyond** the daily goal | 20 | Manual: rescue a friend whose streak broke yesterday (`POST /users/streak-features/assist/:friendId`) |

Meters are **derived** from workouts since each token's `*_last_used` anchor (floor = enrollment −30d retroactive credit, bounded at 90d) — no stored counters to drift under retries, edits, or deletes. Priority on a miss: **Double Down window first, then Save, then break → friends offered the rescue.**

## Architecture
- **`streak_coverage` is the single substrate**: every token writes one "this day still counts" row (composite PK → idempotent + race-safe). The walks honor covered days and never branch per token.
- **`streakFeatureCore`** holds the gate + the coverage-aware walk. `getActiveStreak` **and** `refreshCurrentStreak` — the *only* writer of `current_streak`, also called by the **6-hourly `reconcileStaleStreaks` cron** and recalibrate — branch through it for enrolled users only. (That cron was the biggest hazard: unrouted, it would erase every token-saved streak within hours.)
- **Hourly sweep** (`streakFeaturesCron`, :10) processes enrolled users in their local morning (6–11), idempotently: waits out an open Double Down window, else consumes a held Save (+ "❄️ Streak Save used" push), else stamps a `streak_events` break row (insert doubles as push de-dupe) and notifies assist-holding friends ("🔥 {name}'s N-day streak just broke — you can save it"). Rescued friends get "🤝 {giver} saved your streak!". All four new push types are non-high-priority → **quiet hours apply automatically**.
- **`getUserStats`** gains a gated `streak_features` object: meters, `frozen_dates` (for the client walks), `streak_at_risk`, and **`natural_streak`** — strict: any coverage inside the current streak span (including a *received* Assist) breaks it; **giving** one never does. Field omitted entirely when gated off.
- **`checkStreaksBroken`** now skips users whose miss a token covered — no false "streak broken" push for a saved streak.
- **Migration `0021`** (additive only): gate/anchor columns on `users` + `streak_coverage` + `streak_events`. `drizzle-kit check` passes; boot-applied.

## Issues caught while building
- `main` had moved under the plan (streak PR #233 merged) — all anchors re-derived from live code before editing.
- Migration index is **0021** (spec said 0019; 0019/0020 landed since).
- `"double_down"` daily-challenge key collision → coverage kind is **`double_down_recover`**.
- `NotificationType` is a closed union → four new members added (additive).
- Assist requires **both** sides enrolled — covering an un-enrolled user's day would change streak math their legacy walk can't see.
- Known one-day cosmetic dip: while a Double Down window is open, the *written* `current_streak` stays conservative (no optimistic writes) — the leaderboard can dip for that day and repair on completion/save. Deliberate: optimistic writes that later collapse are exactly the flap the iOS quarantine gate exists to prevent.

## Rollout (per the staged plan)
1. Merge → deploys dark (env unset). Migration applies at boot.
2. Verify parity on prod: spot-check `getUserStats` streaks unchanged.
3. iOS PR (meters UI, enroll-on-launch, client walk coverage store, friends-page assist, natural-streak profile badge) → App Store.
4. Set `STREAK_FEATURES_ENABLED=true` in Coolify once the build is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY)_