### PR TITLE
iOS streak tokens: meters, coverage-aware walks, assist flow, Pure Flame badge

### DIFF
--- a/app/Mile A Day/Core/State/AppStateManager.swift
+++ b/app/Mile A Day/Core/State/AppStateManager.swift
@@ -85,6 +85,11 @@ class AppStateManager: ObservableObject {
             await MADNotificationService.shared.syncDailyReminderPrefsToBackend()
         }
 
+        // Stamp this install as a streak-tokens-capable build (idempotent,
+        // fire-and-forget). The server still shows nothing until its env
+        // switch flips — this only marks that the UI exists here.
+        StreakFeatureService.enrollIfNeeded()
+
         DispatchQueue.main.async {
             withAnimation(MADTheme.Animation.standard) {
                 if userManager.currentUser.hasUsername {

--- a/app/Mile A Day/Core/State/StreakCoverageStore.swift
+++ b/app/Mile A Day/Core/State/StreakCoverageStore.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Local mirror of the server's token-covered streak days ("frozen dates").
+///
+/// The streak rule lives in three client walks (WorkoutIndex, WorkoutProcessor,
+/// retroactive calculation) that only see HealthKit workouts — a day rescued by
+/// a Double Down / Streak Save / Streak Assist has NO workout, so without this
+/// store every local recompute would break at the covered day and fight the
+/// backend (tripping the vettedHealthKitStreak quarantine). Each walk unions
+/// these dates into its "day counts" set so all five walks (2 server, 3 client)
+/// agree.
+///
+/// Populated from the gated `streak_features.frozen_dates` on getUserStats;
+/// empty (and therefore a no-op in every walk) until the server enables the
+/// feature for this user.
+enum StreakCoverageStore {
+    private static let datesKey = "streakCoverageDates"
+    private static let activeKey = "streakFeaturesActive"
+
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.timeZone = TimeZone.current
+        return f
+    }()
+
+    /// Covered local-day strings ("yyyy-MM-dd"), matching WorkoutIndex's
+    /// dateKey format and the server's local_date values.
+    static var coveredDayKeys: Set<String> {
+        Set(UserDefaults.standard.stringArray(forKey: datesKey) ?? [])
+    }
+
+    /// Covered days as start-of-day Dates, for the walks keyed by Date.
+    static var coveredDays: Set<Date> {
+        let calendar = Calendar.current
+        return Set(coveredDayKeys.compactMap { key in
+            dayFormatter.date(from: key).map { calendar.startOfDay(for: $0) }
+        })
+    }
+
+    /// Whether the server has streak features ON for this user — the client
+    /// gate for every token surface. Off (default) = zero UI, zero behavior
+    /// change anywhere.
+    static var isActive: Bool {
+        UserDefaults.standard.bool(forKey: activeKey)
+    }
+
+    /// Replace the store from a fresh gated stats payload.
+    static func update(coveredDates: [String]) {
+        UserDefaults.standard.set(Array(Set(coveredDates)).sorted(), forKey: datesKey)
+        UserDefaults.standard.set(true, forKey: activeKey)
+    }
+
+    /// Server stopped sending the payload (feature off / un-enrolled): clear so
+    /// walks and UI return to stock behavior.
+    static func deactivate() {
+        UserDefaults.standard.removeObject(forKey: datesKey)
+        UserDefaults.standard.set(false, forKey: activeKey)
+    }
+}

--- a/app/Mile A Day/Core/State/StreakTokensState.swift
+++ b/app/Mile A Day/Core/State/StreakTokensState.swift
@@ -1,0 +1,53 @@
+import Foundation
+import SwiftUI
+
+/// Observable snapshot of the user's streak-token state (meters, natural
+/// streak, at-risk), refreshed whenever the user's OWN gated stats payload
+/// arrives. `payload == nil` means the feature is off server-side — every
+/// token surface hides, so older behavior is untouched.
+/// Plain ObservableObject (matching UserManager/CelebrationManager); all
+/// mutations happen on the main actor via the annotated method below.
+final class StreakTokensState: ObservableObject {
+    static let shared = StreakTokensState()
+    private init() {}
+
+    @Published var payload: StreakFeaturesPayload?
+    /// Friends the user can rescue right now (from the status endpoint).
+    @Published var assistableFriends: [AssistableFriend] = []
+
+    var isActive: Bool { payload != nil }
+
+    /// Refresh meters + rescuable friends from the status endpoint (used by
+    /// surfaces that need fresher data than the last stats fetch, e.g. the
+    /// friends page assist banner).
+    @MainActor
+    func refreshStatus() async {
+        do {
+            let status = try await StreakFeatureService.fetchStatus()
+            guard status.active,
+                  let dd = status.double_down,
+                  let save = status.streak_save,
+                  let assist = status.streak_assist
+            else {
+                payload = nil
+                assistableFriends = []
+                StreakFeatureService.applyStatsPayload(nil)
+                return
+            }
+            let fresh = StreakFeaturesPayload(
+                double_down: dd,
+                streak_save: save,
+                streak_assist: assist,
+                frozen_dates: status.frozen_dates ?? [],
+                natural_streak: status.natural_streak ?? true,
+                streak_at_risk: status.streak_at_risk ?? false
+            )
+            payload = fresh
+            assistableFriends = status.assistable_friends ?? []
+            StreakFeatureService.applyStatsPayload(fresh)
+        } catch {
+            // Keep last known state on transient failures.
+            print("[StreakTokens] status refresh failed: \(error.localizedDescription)")
+        }
+    }
+}

--- a/app/Mile A Day/Mile_A_DayApp.swift
+++ b/app/Mile A Day/Mile_A_DayApp.swift
@@ -42,6 +42,9 @@ struct Mile_A_DayApp: App {
                             MADNotificationService.shared.registerForRemoteNotifications()
                             await MADNotificationService.shared.syncDailyReminderPrefsToBackend()
                             await DailyStepsSyncService.shared.syncNow(force: true)
+                            // Streak-tokens enrollment stamp (idempotent; covers
+                            // users who authed on an older build).
+                            StreakFeatureService.enrollIfNeeded()
                         }
                     }
                 }

--- a/app/Mile A Day/Models/HealthKitManager+StreakCalculation.swift
+++ b/app/Mile A Day/Models/HealthKitManager+StreakCalculation.swift
@@ -64,7 +64,10 @@ extension HealthKitManager {
 
         // Calculate current streak. Set lookup keeps the walk-back O(1) per
         // day — Array.contains made a 365-day streak do 365 linear scans.
+        // Union in token-covered days (Streak Save / Double Down / Assist) so
+        // a rescued day doesn't break the walk; empty store = identical.
         let qualifyingDaySet = Set(daysWithQualifyingWorkouts)
+            .union(StreakCoverageStore.coveredDays)
         var currentStreak = 0
         var checkDate = today
 

--- a/app/Mile A Day/Models/WorkoutIndex.swift
+++ b/app/Mile A Day/Models/WorkoutIndex.swift
@@ -156,14 +156,24 @@ struct WorkoutIndex: Codable {
     /// streak from this method — which reads `qualifyingDays` relative to `now` —
     /// instead of trusting `currentStreak`.
     func activeStreak(asOf now: Date = Date()) -> Int {
+        // Token-covered days (Streak Save / Double Down / Assist) count as
+        // "not a miss", matching the server's coverage-aware walk — otherwise
+        // a local recompute would break at a rescued day and fight the backend.
+        // Empty store (feature off) = byte-identical legacy behavior.
+        let covered = StreakCoverageStore.coveredDayKeys
         guard !qualifyingDays.isEmpty else { return 0 }
 
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: now)
         var streak = 0
 
+        func dayCounts(_ date: Date) -> Bool {
+            let key = dateKey(from: date)
+            return qualifyingDays.contains(key) || covered.contains(key)
+        }
+
         // Today counts if it qualifies, but isn't required (grace window).
-        if hasQualifyingWorkout(on: today) {
+        if dayCounts(today) {
             streak += 1
         }
 
@@ -171,7 +181,7 @@ struct WorkoutIndex: Codable {
         guard var checkDate = calendar.date(byAdding: .day, value: -1, to: today) else {
             return streak
         }
-        while hasQualifyingWorkout(on: checkDate) {
+        while dayCounts(checkDate) {
             streak += 1
             guard let previous = calendar.date(byAdding: .day, value: -1, to: checkDate) else { break }
             checkDate = previous

--- a/app/Mile A Day/Models/WorkoutProcessor.swift
+++ b/app/Mile A Day/Models/WorkoutProcessor.swift
@@ -115,9 +115,14 @@ class WorkoutProcessor {
             milesByDate[date, default: 0] += record.distance
         }
         
-        // Find days with qualifying workouts (>= 0.95 miles)
+        // Find days with qualifying workouts (>= 0.95 miles), plus any
+        // token-covered days from the server (Streak Save / Double Down /
+        // Assist) — a rescued day has no workout, so without the union this
+        // walk would break there and diverge from the backend. Empty store
+        // (feature off) leaves behavior identical.
         let qualifyingDays = Set(milesByDate.filter { $0.value >= 0.95 }.keys)
-        
+            .union(StreakCoverageStore.coveredDays)
+
         guard !qualifyingDays.isEmpty else {
             print("[WorkoutProcessor] No qualifying workout days found")
             return 0

--- a/app/Mile A Day/Services/StreakFeatureService.swift
+++ b/app/Mile A Day/Services/StreakFeatureService.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+// MARK: - Models (mirror the backend's gated streak_features payload)
+
+/// One token's earn meter. Meters are server-derived; the client only renders.
+struct StreakTokenMeter: Codable {
+    let progress: Double
+    let target: Double
+    let held: Bool
+    let last_used: String?
+
+    /// 0…1 for progress rings.
+    var fraction: Double {
+        guard target > 0 else { return 0 }
+        return min(max(progress / target, 0), 1)
+    }
+}
+
+/// A day the server says still counts (token-covered), with which token did it.
+struct CoveredDate: Codable {
+    let local_date: String
+    let kind: String
+}
+
+/// The gated `streak_features` object on getUserStats. Absent entirely until
+/// the backend enables the feature for this user.
+struct StreakFeaturesPayload: Codable {
+    struct DoubleDownMeter: Codable {
+        let progress: Double
+        let target: Double
+        let held: Bool
+        let last_used: String?
+        /// Today's total needed to complete a Double Down (2× goal − 0.05).
+        let recover_miles: Double?
+
+        var fraction: Double {
+            guard target > 0 else { return 0 }
+            return min(max(progress / target, 0), 1)
+        }
+    }
+
+    let double_down: DoubleDownMeter
+    let streak_save: StreakTokenMeter
+    let streak_assist: StreakTokenMeter
+    let frozen_dates: [CoveredDate]
+    let natural_streak: Bool
+    let streak_at_risk: Bool
+}
+
+/// A friend whose just-broken streak the user can rescue right now.
+struct AssistableFriend: Codable, Identifiable {
+    let user_id: String
+    let username: String?
+    let first_name: String?
+    let last_name: String?
+    let profile_image_url: String?
+    let broke_date: String
+    let prior_streak: Int
+
+    var id: String { user_id }
+
+    var displayName: String {
+        if let username, !username.isEmpty { return username }
+        if let first_name, !first_name.isEmpty { return first_name }
+        return "A friend"
+    }
+}
+
+/// GET /users/streak-features/status. `active` false = feature off server-side
+/// (env switch off or not enrolled) → hide every token surface.
+struct StreakFeaturesStatus: Codable {
+    let active: Bool
+    let streak: Int?
+    let double_down: StreakFeaturesPayload.DoubleDownMeter?
+    let streak_save: StreakTokenMeter?
+    let streak_assist: StreakTokenMeter?
+    let frozen_dates: [CoveredDate]?
+    let natural_streak: Bool?
+    let streak_at_risk: Bool?
+    let assistable_friends: [AssistableFriend]?
+}
+
+// MARK: - Service
+
+/// Streak tokens API: enrollment, status (meters + rescuable friends), and
+/// spending a Streak Assist on a friend. Everything is server-gated — until
+/// the backend turns the feature on, status returns {active:false}, stats omit
+/// the payload, and this build shows nothing.
+enum StreakFeatureService {
+    private static let enrolledFlagKey = "streakFeaturesEnrollPosted"
+
+    /// Idempotent enrollment stamp — fire-and-forget on launch (mirrors device
+    /// token registration). Marks this install as a streak-features-capable
+    /// build; the server still shows nothing until its env switch flips. The
+    /// local flag only skips redundant calls: the endpoint itself is COALESCE-
+    /// idempotent, so a lost flag (reinstall) is harmless.
+    static func enrollIfNeeded() {
+        guard UserDefaults.standard.string(forKey: "authToken") != nil else { return }
+        guard !UserDefaults.standard.bool(forKey: enrolledFlagKey) else { return }
+        Task {
+            struct EnrollResponse: Decodable { let enrolled: Bool }
+            do {
+                let resp: EnrollResponse = try await APIClient.fancyFetch(
+                    endpoint: "/users/streak-features/enable",
+                    method: .POST,
+                    responseType: EnrollResponse.self
+                )
+                if resp.enrolled {
+                    UserDefaults.standard.set(true, forKey: enrolledFlagKey)
+                }
+            } catch {
+                // Non-fatal: next launch retries.
+                print("[StreakFeatures] enroll failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Meters + rescuable friends for the token surfaces.
+    static func fetchStatus() async throws -> StreakFeaturesStatus {
+        try await APIClient.fancyFetch(
+            endpoint: "/users/streak-features/status",
+            responseType: StreakFeaturesStatus.self
+        )
+    }
+
+    struct AssistResponse: Decodable {
+        let ok: Bool?
+        let restored_streak: Int?
+    }
+
+    /// Spend a held Streak Assist to restore a friend's just-broken streak.
+    static func assist(friendId: String) async throws -> AssistResponse {
+        try await APIClient.fancyFetch(
+            endpoint: "/users/streak-features/assist/\(friendId)",
+            method: .POST,
+            responseType: AssistResponse.self
+        )
+    }
+
+    /// Apply the CURRENT USER's fresh gated stats payload: sync the coverage
+    /// store the three client streak walks union in, and the observable UI
+    /// state. Pass nil when the response had no payload (feature off) so stale
+    /// coverage can't linger. NEVER call this with a FRIEND's stats response.
+    static func applyStatsPayload(_ payload: StreakFeaturesPayload?) {
+        if let payload {
+            StreakCoverageStore.update(
+                coveredDates: payload.frozen_dates.map { $0.local_date }
+            )
+        } else if StreakCoverageStore.isActive {
+            StreakCoverageStore.deactivate()
+        }
+        Task { @MainActor in
+            StreakTokensState.shared.payload = payload
+        }
+    }
+}

--- a/app/Mile A Day/Services/WorkoutService.swift
+++ b/app/Mile A Day/Services/WorkoutService.swift
@@ -530,6 +530,10 @@ struct UserStatsAPIResponse: Decodable {
     let recentWorkouts: [RecentWorkout]
     let todayMiles: Double?
     let goalMiles: Double?
+    /// Gated streak-tokens payload — absent (nil) until the server enables the
+    /// feature for this user. Only apply it to local state for the CURRENT
+    /// user's own stats; this response type is also used for friends.
+    let streakFeatures: StreakFeaturesPayload?
 
     enum CodingKeys: String, CodingKey {
         case streak
@@ -540,6 +544,7 @@ struct UserStatsAPIResponse: Decodable {
         case recentWorkouts = "recent_workouts"
         case todayMiles = "today_miles"
         case goalMiles = "goal_miles"
+        case streakFeatures = "streak_features"
     }
 
     init(from decoder: Decoder) throws {
@@ -571,6 +576,8 @@ struct UserStatsAPIResponse: Decodable {
             (try? container.decode([RecentWorkout].self, forKey: .recentWorkouts)) ?? []
         self.todayMiles = try? container.decode(Double.self, forKey: .todayMiles)
         self.goalMiles = try? container.decode(Double.self, forKey: .goalMiles)
+        self.streakFeatures = try? container.decode(
+            StreakFeaturesPayload.self, forKey: .streakFeatures)
     }
 
     /// Calculates if the user has completed their goal today

--- a/app/Mile A Day/Views/Dashboard/DashboardCards.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardCards.swift
@@ -261,6 +261,11 @@ struct StreakCard: View {
             // Compact week-at-a-glance row
             compactWeekRow
 
+            // Streak tokens (Double Down / Save / Assist) — renders ONLY when
+            // the server has the feature on for this user; its own Button
+            // swallows taps so it never triggers the card's share gesture.
+            StreakTokensRow()
+
             // Share hint
             HStack(spacing: 6) {
                 Image(systemName: "square.and.arrow.up")

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -766,6 +766,9 @@ struct DashboardView: View {
                     // updateStreakFromBackend only raises the value, so it can't clobber a
                     // higher HealthKit-computed streak from a later refresh.
                     userManager.updateStreakFromBackend(stats.streak)
+                    // Sync the streak-token state (meters + covered days) from the
+                    // gated payload — this is OUR stats call, never a friend's.
+                    StreakFeatureService.applyStatsPayload(stats.streakFeatures)
                     repairWorkoutIndexIfStale(backendStreak: stats.streak)
                     if let bestSplitSeconds = stats.bestSplitTimeSeconds, bestSplitSeconds > 0 {
                         let paceMinutesPerMile = bestSplitSeconds / 60.0
@@ -810,6 +813,7 @@ struct DashboardView: View {
             let stats = try await workoutService.getUserStats(userId: userId)
             print("[Dashboard] 🔄 Fresh streak for celebration = \(stats.streak)")
             userManager.updateStreakFromBackend(stats.streak)
+            StreakFeatureService.applyStatsPayload(stats.streakFeatures)
         } catch {
             print("[Dashboard] ⚠️ Fresh streak fetch for celebration failed: \(error)")
         }

--- a/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
+++ b/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
@@ -1,0 +1,330 @@
+import SwiftUI
+
+// MARK: - Pure Flame badge (natural streak)
+
+/// The "never needed a rescue" seal — shown beside the username when the
+/// current streak is 100% natural (no Save, Double Down, or received Assist
+/// inside it). Mile A Day's answer to a verified check: a gold-ringed flame.
+struct PureFlameBadge: View {
+    var size: CGFloat = 22
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(
+                    LinearGradient(
+                        colors: [Color(red: 1.0, green: 0.84, blue: 0.3),
+                                 Color(red: 0.95, green: 0.55, blue: 0.1)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+            Image(systemName: "flame.fill")
+                .font(.system(size: size * 0.5, weight: .bold))
+                .foregroundColor(.white)
+        }
+        .frame(width: size, height: size)
+        .overlay(Circle().strokeBorder(Color.white.opacity(0.85), lineWidth: 1.2))
+        .shadow(color: Color.orange.opacity(0.45), radius: 3)
+        .accessibilityLabel("Natural streak — every day earned")
+    }
+}
+
+// MARK: - Compact meters row (lives inside StreakCard)
+
+/// One-glance strip of the three token meters. Rendered only when the server
+/// says streak features are active for this user; tapping opens the full
+/// explainer. Has its OWN tap target so it never triggers the card's share.
+struct StreakTokensRow: View {
+    @ObservedObject var tokensState = StreakTokensState.shared
+    @State private var showDetail = false
+
+    var body: some View {
+        if let payload = tokensState.payload {
+            Button {
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                showDetail = true
+            } label: {
+                VStack(spacing: 8) {
+                    Rectangle()
+                        .fill(Color.white.opacity(0.1))
+                        .frame(height: 1)
+
+                    HStack(spacing: 0) {
+                        meterCell(
+                            emoji: "\u{1F525}",
+                            label: "Double Down",
+                            fraction: payload.double_down.fraction,
+                            held: payload.double_down.held,
+                            tint: .orange
+                        )
+                        meterCell(
+                            emoji: "\u{2744}\u{FE0F}",
+                            label: "Streak Save",
+                            fraction: payload.streak_save.fraction,
+                            held: payload.streak_save.held,
+                            tint: MADTheme.Colors.walkBlue
+                        )
+                        meterCell(
+                            emoji: "\u{1F91D}",
+                            label: "Assist",
+                            fraction: payload.streak_assist.fraction,
+                            held: payload.streak_assist.held,
+                            tint: MADTheme.Colors.madRed
+                        )
+                    }
+
+                    if payload.streak_at_risk {
+                        HStack(spacing: 6) {
+                            Image(systemName: "bolt.fill")
+                                .font(.system(size: 10, weight: .bold))
+                            Text("Missed yesterday — run 2× today to save your streak!")
+                                .font(.system(size: 11, weight: .heavy, design: .rounded))
+                                .lineLimit(2)
+                                .multilineTextAlignment(.leading)
+                        }
+                        .foregroundColor(.orange)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .sheet(isPresented: $showDetail) {
+                StreakTokensDetailView()
+            }
+        }
+    }
+
+    private func meterCell(
+        emoji: String, label: String, fraction: Double, held: Bool, tint: Color
+    ) -> some View {
+        VStack(spacing: 4) {
+            ZStack {
+                Circle()
+                    .stroke(Color.white.opacity(0.12), lineWidth: 3)
+                Circle()
+                    .trim(from: 0, to: held ? 1 : fraction)
+                    .stroke(tint, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                Text(emoji)
+                    .font(.system(size: 13))
+                    .opacity(held ? 1 : 0.55)
+            }
+            .frame(width: 32, height: 32)
+            .overlay(alignment: .topTrailing) {
+                if held {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundColor(.green)
+                        .background(Circle().fill(.black.opacity(0.6)))
+                        .offset(x: 4, y: -3)
+                }
+            }
+
+            Text(label)
+                .font(.system(size: 9, weight: .bold, design: .rounded))
+                .foregroundColor(.white.opacity(held ? 0.9 : 0.55))
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - Full explainer sheet
+
+/// What each token does, how it's earned, and where its meter stands — the
+/// "easily known how to unlock and what they do" surface.
+struct StreakTokensDetailView: View {
+    @ObservedObject var tokensState = StreakTokensState.shared
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                MADTheme.Colors.appBackgroundGradient.ignoresSafeArea()
+                ScrollView {
+                    VStack(spacing: MADTheme.Spacing.md) {
+                        if let payload = tokensState.payload {
+                            if payload.streak_at_risk {
+                                atRiskBanner(payload)
+                            }
+
+                            tokenCard(
+                                emoji: "\u{1F525}",
+                                title: "Double Down",
+                                tint: .orange,
+                                what: "Miss a day? Run 2× your goal the next day and yesterday still counts.",
+                                how: "Earn it by completing your mile 14 days (runs or walks count).",
+                                meter: .init(
+                                    progress: payload.double_down.progress,
+                                    target: payload.double_down.target,
+                                    held: payload.double_down.held,
+                                    last_used: payload.double_down.last_used
+                                ),
+                                unit: "days"
+                            )
+
+                            tokenCard(
+                                emoji: "\u{2744}\u{FE0F}",
+                                title: "Streak Save",
+                                tint: MADTheme.Colors.walkBlue,
+                                what: "Life happens — if you miss a day and can't Double Down, this covers it automatically.",
+                                how: "Earn it with 7 days of running your mile (walks don't count toward this one).",
+                                meter: payload.streak_save,
+                                unit: "run days"
+                            )
+
+                            tokenCard(
+                                emoji: "\u{1F91D}",
+                                title: "Streak Assist",
+                                tint: MADTheme.Colors.madRed,
+                                what: "Save a FRIEND's streak the day after it breaks — be their hero.",
+                                how: "Earn it by going 20 miles beyond your daily goal, over any number of days.",
+                                meter: payload.streak_assist,
+                                unit: "mi over goal"
+                            )
+
+                            naturalCard(payload.natural_streak)
+                        } else {
+                            ProgressView().tint(.white)
+                                .padding(.top, MADTheme.Spacing.xl)
+                        }
+                    }
+                    .padding(MADTheme.Spacing.md)
+                }
+            }
+            .navigationTitle("Streak Tokens")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundColor(MADTheme.Colors.madRed)
+                        .fontWeight(.semibold)
+                }
+            }
+            .task { await tokensState.refreshStatus() }
+        }
+    }
+
+    private func atRiskBanner(_ payload: StreakFeaturesPayload) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "bolt.fill")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundColor(.orange)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Your streak is on the line")
+                    .font(.system(size: 14, weight: .heavy, design: .rounded))
+                    .foregroundColor(.primary)
+                Text("You missed yesterday. Run \(String(format: "%.1f", payload.double_down.recover_miles ?? 2.0)) mi today to Double Down and save it.")
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(Color.orange.opacity(0.13))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .strokeBorder(Color.orange.opacity(0.35), lineWidth: 1)
+                )
+        )
+    }
+
+    private func tokenCard(
+        emoji: String,
+        title: String,
+        tint: Color,
+        what: String,
+        how: String,
+        meter: StreakTokenMeter,
+        unit: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+            HStack(spacing: 10) {
+                Text(emoji).font(.system(size: 22))
+                Text(title)
+                    .font(.system(size: 17, weight: .heavy, design: .rounded))
+                    .foregroundColor(.primary)
+                Spacer()
+                if meter.held {
+                    Text("READY")
+                        .font(.system(size: 11, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 4)
+                        .background(Capsule().fill(Color.green.opacity(0.85)))
+                }
+            }
+
+            Text(what)
+                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                .foregroundColor(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(how)
+                .font(.system(size: 12, weight: .medium, design: .rounded))
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            // Meter bar + count
+            VStack(alignment: .leading, spacing: 4) {
+                GeometryReader { geo in
+                    ZStack(alignment: .leading) {
+                        Capsule().fill(Color.white.opacity(0.08))
+                        Capsule()
+                            .fill(tint)
+                            .frame(width: max(6, geo.size.width * (meter.held ? 1 : meter.fraction)))
+                    }
+                }
+                .frame(height: 8)
+
+                Text(meter.held
+                     ? "Earned — 1 held (max 1). Using it restarts the meter."
+                     : "\(trimmed(meter.progress)) / \(trimmed(meter.target)) \(unit)")
+                    .font(.system(size: 11, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundColor(meter.held ? .green : .secondary)
+            }
+        }
+        .padding(MADTheme.Spacing.md)
+        .madLiquidGlass()
+    }
+
+    private func naturalCard(_ natural: Bool) -> some View {
+        HStack(spacing: 12) {
+            if natural {
+                PureFlameBadge(size: 30)
+            } else {
+                Image(systemName: "flame")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundColor(.secondary)
+                    .frame(width: 30, height: 30)
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                Text(natural ? "Pure Flame — natural streak" : "Streak rescued along the way")
+                    .font(.system(size: 14, weight: .heavy, design: .rounded))
+                    .foregroundColor(.primary)
+                Text(natural
+                     ? "Every day of this streak was earned on the day. The gold flame shows on your profile."
+                     : "A token kept this streak alive — the Pure Flame returns with your next untouched streak. (Helping a friend never affects yours.)")
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(MADTheme.Spacing.md)
+        .madLiquidGlass()
+    }
+
+    private func trimmed(_ value: Double) -> String {
+        value.truncatingRemainder(dividingBy: 1) == 0
+            ? String(Int(value))
+            : String(format: "%.1f", value)
+    }
+}

--- a/app/Mile A Day/Views/Friends/FriendsListView.swift
+++ b/app/Mile A Day/Views/Friends/FriendsListView.swift
@@ -64,6 +64,12 @@ struct FriendsListView: View {
     // "Cheer Them On" and "Done Today" when their status flips.
     @Namespace private var friendRowNamespace
 
+    // Streak Assist: rescuable friends + send state (server-gated; empty
+    // until streak features are live for this user).
+    @ObservedObject private var tokensState = StreakTokensState.shared
+    @State private var isSendingAssist = false
+    @State private var assistSavedName: String?
+
     var body: some View {
         ZStack(alignment: .top) {
             VStack(spacing: 0) {
@@ -90,6 +96,17 @@ struct FriendsListView: View {
                     .padding(.top, 6)
                     .transition(.move(edge: .top).combined(with: .opacity))
                     .zIndex(100)
+            }
+
+            // Streak Assist hero moment: a friend's streak broke and the user
+            // holds an Assist — offer the rescue. Server-gated (the list is
+            // empty unless streak features are on), one friend at a time.
+            if nudgeFeedback == nil, let rescue = tokensState.assistableFriends.first {
+                assistBanner(rescue)
+                    .padding(.horizontal, MADTheme.Spacing.md)
+                    .padding(.top, 6)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                    .zIndex(99)
             }
         }
         .background(MADTheme.Colors.appBackgroundGradient)
@@ -145,6 +162,9 @@ struct FriendsListView: View {
             await loadNudgeStatuses()
             await loadMyRank()
             await loadFeed()
+            // Rescuable friends + meters (no-op {active:false} until the
+            // server enables streak features for this user).
+            await tokensState.refreshStatus()
         }
         .onReceive(DeepLinkRouter.shared.$pendingProfileUsername) { username in
             guard let username else { return }
@@ -171,6 +191,97 @@ struct FriendsListView: View {
             }
         } message: {
             Text("You will no longer be friends with this person.")
+        }
+    }
+
+    // MARK: - Streak Assist banner
+
+    /// "You can save them" — shown while the user holds a Streak Assist and a
+    /// friend's streak broke yesterday. One tap spends the token, restores the
+    /// friend's streak, and the friend gets a push that they were saved.
+    private func assistBanner(_ friend: AssistableFriend) -> some View {
+        HStack(spacing: 10) {
+            AvatarView(name: friend.displayName, imageURL: friend.profile_image_url, size: 36)
+            VStack(alignment: .leading, spacing: 2) {
+                if let saved = assistSavedName {
+                    Text("You saved \(saved)'s streak! \u{1F91D}")
+                        .font(.system(size: 13, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+                } else {
+                    Text("\(friend.displayName)'s \(friend.prior_streak)-day streak broke")
+                        .font(.system(size: 13, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+                    Text("You're holding a Streak Assist — save it before the day ends.")
+                        .font(.system(size: 11, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.75))
+                        .lineLimit(2)
+                }
+            }
+            Spacer(minLength: 6)
+            if assistSavedName == nil {
+                Button {
+                    sendAssist(to: friend)
+                } label: {
+                    HStack(spacing: 5) {
+                        if isSendingAssist {
+                            ProgressView().tint(.white).scaleEffect(0.7)
+                        } else {
+                            Image(systemName: "hands.clap.fill")
+                                .font(.system(size: 11, weight: .bold))
+                        }
+                        Text("Save it")
+                            .font(.system(size: 13, weight: .heavy, design: .rounded))
+                    }
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 13)
+                    .padding(.vertical, 8)
+                    .background(Capsule().fill(MADTheme.Colors.redGradient))
+                }
+                .buttonStyle(.plain)
+                .disabled(isSendingAssist)
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.black.opacity(0.75))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .strokeBorder(MADTheme.Colors.madRed.opacity(0.5), lineWidth: 1)
+                )
+        )
+    }
+
+    private func sendAssist(to friend: AssistableFriend) {
+        guard !isSendingAssist else { return }
+        isSendingAssist = true
+        Task {
+            do {
+                let result = try await StreakFeatureService.assist(friendId: friend.user_id)
+                await MainActor.run {
+                    isSendingAssist = false
+                    assistSavedName = friend.displayName
+                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                    print("[Assist] restored streak: \(result.restored_streak ?? -1)")
+                }
+                // Let the hero moment breathe, then clear the banner + refresh.
+                try? await Task.sleep(for: .seconds(2.5))
+                await MainActor.run {
+                    withAnimation(.easeOut(duration: 0.3)) {
+                        assistSavedName = nil
+                        tokensState.assistableFriends.removeAll { $0.user_id == friend.user_id }
+                    }
+                }
+                await tokensState.refreshStatus()
+            } catch {
+                await MainActor.run {
+                    isSendingAssist = false
+                    // Someone else may have saved them first, or the window
+                    // closed — refresh so the banner reflects reality.
+                    UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                }
+                await tokensState.refreshStatus()
+            }
         }
     }
 

--- a/app/Mile A Day/Views/Profile/ProfileView.swift
+++ b/app/Mile A Day/Views/Profile/ProfileView.swift
@@ -4,6 +4,8 @@ struct ProfileView: View {
     @Environment(\.appStateManager) var appStateManager
     @ObservedObject var userManager: UserManager
     @ObservedObject var healthManager: HealthKitManager
+    /// Streak-token state — drives the Pure Flame (natural streak) seal.
+    @ObservedObject private var tokensState = StreakTokensState.shared
 
     @State private var activeSheet: ProfileSheetType?
     @State private var showingEditProfile = false
@@ -486,11 +488,20 @@ struct ProfileView: View {
 
                     // User Info
                     VStack(spacing: MADTheme.Spacing.sm) {
-                        // Username (primary, large)
+                        // Username (primary, large) — with the Pure Flame seal
+                        // when the current streak is 100% natural (no token
+                        // rescues). Server-gated: hidden until streak features
+                        // are live for this user.
                         if let username = userManager.currentUser.username {
-                            Text("@\(username)")
-                                .font(MADTheme.Typography.title1)
-                                .foregroundColor(MADTheme.Colors.primaryText)
+                            HStack(spacing: 6) {
+                                Text("@\(username)")
+                                    .font(MADTheme.Typography.title1)
+                                    .foregroundColor(MADTheme.Colors.primaryText)
+                                if tokensState.payload?.natural_streak == true,
+                                   userManager.currentUser.streak > 0 {
+                                    PureFlameBadge(size: 22)
+                                }
+                            }
                         }
 
                         // Display name


### PR DESCRIPTION
## What & why

The client half of streak saving (backend shipped dark in #234). Everything here is **server-gated**: until `STREAK_FEATURES_ENABLED` flips *and* this build's enrollment stamp exists, stats omit the payload, status returns `{active:false}`, and every new surface renders **nothing** — the app looks and behaves exactly as today. Ship it to the App Store safely; the feature lights up only when we flip the env switch afterward.

## What's in it

**Plumbing**
- `StreakFeatureService` + `StreakCoverageStore` + `StreakTokensState`: gated models (three meters, `frozen_dates`, `natural_streak`, `streak_at_risk`), the enable/status/assist calls, and a UserDefaults store of token-covered days.
- **Enrollment stamp** fires idempotently on auth completion + app foreground (same pattern as device-token registration). It only marks "this build has the UI" — the server still shows nothing until its env switch flips.
- `UserStatsAPIResponse` decodes `streak_features` via `try?` — old servers / gated-off responses decode identically.

**The lockstep piece (most important)**
- Token-covered days are **unioned into all three client streak walks** (`WorkoutIndex.activeStreak`, `WorkoutProcessor.calculateStreak`, `calculateRetroactiveStreak`), so a rescued day doesn't break local recomputes and fight the backend through the quarantine gate. An empty store leaves each walk **byte-identical** to today.
- The store syncs **only** from the user's own stats fetches — a **friend's** stats response (same type, used on friend profiles) never touches it.

**UI**
- **StreakCard tokens row**: three compact progress rings (🔥 Double Down ❄️ Streak Save 🤝 Assist) with READY checkmarks and an at-risk nudge ("Missed yesterday — run 2× today to save your streak!"). Own tap target, so it never triggers the card's share gesture; opens…
- **Streak Tokens explainer sheet**: per-token card with *what it does*, *how to earn it*, live meter bar, and the natural-streak status — the "easily known how to unlock and what they do" surface.
- **Friends page rescue banner**: when a friend's streak broke yesterday and you hold an Assist — avatar, "{name}'s N-day streak broke", one-tap **Save it** → restores them (they get the "saved your streak" push), success moment, state refresh. Races handled (someone saved them first → warning haptic + refresh).
- **Pure Flame badge**: gold-ringed flame seal beside `@username` on the profile when the current streak is 100% natural (no Save/Double Down/received Assist — giving one never counts against you).

## Not in this PR (follow-ups)
- Friend-profile Pure Flame badge (needs friend-stats plumbing on that view).
- An in-app "Streak Saved" celebration animation (the push covers the moment for now).
- Push-type handling/deep links for the four new notification types.

## Verify in Xcode
iOS can't compile in CI. The specific things worth a device pass: the tokens row hit-testing inside StreakCard's tap-to-share, banner layering vs the nudge toast on the friends page, and the explainer sheet with the gate off (should be unreachable) and on (via a dev backend with `STREAK_FEATURES_ENABLED=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY)_