### PR TITLE
Fix composer optional-destination build error; make streak tokens testable on dev

### DIFF
--- a/app/Mile A Day/Core/AppEnvironment.swift
+++ b/app/Mile A Day/Core/AppEnvironment.swift
@@ -3,9 +3,23 @@ import Foundation
 /// App-wide configuration constants. Centralized so things like the backend
 /// URL don't drift across service files.
 enum AppConfig {
-    /// Production REST API base URL. All services should build URLs against
-    /// this rather than hardcoding the host.
-    static let baseURL = "https://mad.mindgoblin.tech"
+    /// REST API base URL. All services should build URLs against this rather
+    /// than hardcoding the host.
+    ///
+    /// DEBUG builds only: set the "devBaseURLOverride" UserDefaults string
+    /// (e.g. from a debugger pause or a dev menu) to point the app at a local
+    /// `npm run dev` backend — where streak features are always enabled — and
+    /// delete it to return to production. The override is compiled OUT of
+    /// Release builds: TestFlight/App Store always talk to production.
+    static let baseURL: String = {
+        #if DEBUG
+        if let override = UserDefaults.standard.string(forKey: "devBaseURLOverride"),
+           !override.isEmpty {
+            return override
+        }
+        #endif
+        return "https://mad.mindgoblin.tech"
+    }()
 }
 
 /// Identifies which environment the app is running in.

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -482,8 +482,10 @@ struct PostComposerView: View {
                             overlayEditor
                             if vm.hasRoute { routeToggle }
                             captionField
-                            // Collabs are a feed concept — hidden for story-only.
-                            if vm.destination.toFeed { coauthorRow }
+                            // Collabs are a feed concept — shown once the user
+                            // picks a destination that includes the feed
+                            // (destination starts nil until they choose).
+                            if vm.destination?.toFeed == true { coauthorRow }
                             destinationToggles
                         }
                         if let error = vm.errorMessage {

--- a/backend/src/services/streakFeatureCore.ts
+++ b/backend/src/services/streakFeatureCore.ts
@@ -18,6 +18,11 @@ const db = PostgresService.getInstance();
  */
 
 export function streakFeaturesGloballyEnabled(): boolean {
+  // Always ON in local dev (`npm run dev` sets NODE_ENV=development, same
+  // fail-closed pattern as /dev/* — a prod deploy can never have it) so the
+  // feature is testable without env plumbing. Prod stays dark until
+  // STREAK_FEATURES_ENABLED=true is set deliberately.
+  if (process.env.NODE_ENV === "development") return true;
   return process.env.STREAK_FEATURES_ENABLED === "true";
 }
 


### PR DESCRIPTION
## What & why

Two things: unblock the Xcode build, and make the streak tokens testable before the prod env flip.

## 1. The build error (`PostComposerView.swift:486`)
`vm.destination` is **deliberately optional** in the new collab/comments work — it starts `nil` until the user picks story/feed/both (so Share can't fire at an unchosen destination). The collab row check accessed `.toFeed` on the optional directly. Fixed to:

```swift
if vm.destination?.toFeed == true { coauthorRow }
```

…which also gets the semantics right: the collab row appears only once a feed-including destination is actually chosen. The other `.toFeed` uses (lines 221/227) sit inside a `guard let destination` and were already fine.

## 2. Streak tokens on dev
- **Backend**: `streakFeaturesGloballyEnabled()` now returns `true` when `NODE_ENV=development` — the same fail-closed pattern as `/dev/*` (`npm run dev` sets it; a prod deploy never has it). A local dev backend serves the tokens with zero env plumbing; **production stays dark** until `STREAK_FEATURES_ENABLED=true` is set deliberately. Backend `tsc` clean.
- **iOS**: `AppConfig.baseURL` gains a **DEBUG-only** `devBaseURLOverride` (UserDefaults) so a debug build can point at that dev backend. Compiled out of Release — TestFlight/App Store always talk to production.

## How to test (fastest paths)
- **Option A — local dev backend**: `cd backend && npm run dev` (boot applies migration 0021 to your dev DB, gate auto-on). In a paused debug session: `UserDefaults.standard.set("http://localhost:3000", forKey: "devBaseURLOverride")` and relaunch. Note: an `http://` LAN URL from a physical device may need an ATS local-networking exception — simulator + localhost is the low-friction path, or use an https tunnel.
- **Option B — prod, safely**: because only *new builds* write the enrollment stamp, setting `STREAK_FEATURES_ENABLED=true` on prod today lights the feature up **only for your and Dave's dev builds** — no shipped App Store build ever enrolls, so live users see nothing. This is the zero-setup way to test the full loop (sweep, pushes, assist) with real data. Just remember it also means the feature goes live for everyone the moment the new App Store build ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY)_