### PR TITLE
What's New popup + streak-token dev testing tools

### DIFF
--- a/app/Mile A Day/Core/State/StreakTokensState.swift
+++ b/app/Mile A Day/Core/State/StreakTokensState.swift
@@ -14,6 +14,9 @@ final class StreakTokensState: ObservableObject {
     @Published var payload: StreakFeaturesPayload?
     /// Friends the user can rescue right now (from the status endpoint).
     @Published var assistableFriends: [AssistableFriend] = []
+    /// DEBUG preview: while true, refreshStatus() is a no-op so server state
+    /// can't clobber the injected sample data. Never persisted.
+    @Published var isPreviewingSampleData = false
 
     var isActive: Bool { payload != nil }
 
@@ -22,6 +25,7 @@ final class StreakTokensState: ObservableObject {
     /// friends page assist banner).
     @MainActor
     func refreshStatus() async {
+        guard !isPreviewingSampleData else { return }
         do {
             let status = try await StreakFeatureService.fetchStatus()
             guard status.active,
@@ -50,4 +54,48 @@ final class StreakTokensState: ObservableObject {
             print("[StreakTokens] status refresh failed: \(error.localizedDescription)")
         }
     }
+
+    #if DEBUG
+    /// Inject rich sample data so every token surface (StreakCard row, the
+    /// explainer sheet, the friends-page rescue banner, the Pure Flame badge)
+    /// is visible WITHOUT any backend — pure UI/UX review mode. Session-only.
+    @MainActor
+    func enableSamplePreview() {
+        isPreviewingSampleData = true
+        payload = StreakFeaturesPayload(
+            double_down: .init(
+                progress: 9, target: 14, held: false, last_used: nil,
+                recover_miles: 1.95
+            ),
+            streak_save: StreakTokenMeter(
+                progress: 7, target: 7, held: true, last_used: nil
+            ),
+            streak_assist: StreakTokenMeter(
+                progress: 12.5, target: 20, held: true, last_used: nil
+            ),
+            frozen_dates: [],
+            natural_streak: true,
+            streak_at_risk: true
+        )
+        assistableFriends = [
+            AssistableFriend(
+                user_id: "preview-friend",
+                username: "davey",
+                first_name: "Dave",
+                last_name: nil,
+                profile_image_url: nil,
+                broke_date: "2026-07-20",
+                prior_streak: 42
+            )
+        ]
+    }
+
+    @MainActor
+    func disableSamplePreview() {
+        isPreviewingSampleData = false
+        payload = nil
+        assistableFriends = []
+        Task { await refreshStatus() }
+    }
+    #endif
 }

--- a/app/Mile A Day/Services/StreakFeatureService.swift
+++ b/app/Mile A Day/Services/StreakFeatureService.swift
@@ -95,7 +95,9 @@ enum StreakFeatureService {
     /// local flag only skips redundant calls: the endpoint itself is COALESCE-
     /// idempotent, so a lost flag (reinstall) is harmless.
     static func enrollIfNeeded() {
-        guard UserDefaults.standard.string(forKey: "authToken") != nil else { return }
+        // Keychain-backed token check (the UserDefaults mirror can be missing
+        // on installs that authed before the mirror existed).
+        guard TokenStore.accessToken != nil else { return }
         guard !UserDefaults.standard.bool(forKey: enrolledFlagKey) else { return }
         Task {
             struct EnrollResponse: Decodable { let enrolled: Bool }
@@ -107,6 +109,9 @@ enum StreakFeatureService {
                 )
                 if resp.enrolled {
                     UserDefaults.standard.set(true, forKey: enrolledFlagKey)
+                    // Light the token surfaces up on THIS launch instead of
+                    // waiting for the next stats fetch.
+                    await StreakTokensState.shared.refreshStatus()
                 }
             } catch {
                 // Non-fatal: next launch retries.

--- a/app/Mile A Day/Views/Components/WhatsNewView.swift
+++ b/app/Mile A Day/Views/Components/WhatsNewView.swift
@@ -1,0 +1,221 @@
+import SwiftUI
+
+// MARK: - Catalog
+
+/// One feature bullet on a What's New page.
+struct WhatsNewFeature: Identifiable {
+    let emoji: String
+    let title: String
+    let blurb: String
+    let tint: Color
+    var id: String { title }
+}
+
+/// One release's worth of announcements. `id` is monotonically increasing —
+/// bump it (and add a new entry at the top of `releases`) each update; users
+/// auto-see a release exactly once and can reopen it from Settings anytime.
+struct WhatsNewRelease: Identifiable {
+    let id: Int
+    let versionLabel: String
+    let headline: String
+    let features: [WhatsNewFeature]
+}
+
+enum WhatsNewCatalog {
+    /// Newest first. Edit copy freely — keep it user-facing (no internal
+    /// names, no "beta"), one short line per feature.
+    static let releases: [WhatsNewRelease] = [
+        WhatsNewRelease(
+            id: 1,
+            versionLabel: "July 2026 Update",
+            headline: "Your streak just got backup",
+            features: [
+                WhatsNewFeature(
+                    emoji: "\u{1F525}",
+                    title: "Streak Tokens",
+                    blurb: "Earn Double Down, Streak Save, and Streak Assist by running — and use them to protect your streak when life happens.",
+                    tint: .orange
+                ),
+                WhatsNewFeature(
+                    emoji: "\u{1F91D}",
+                    title: "Save a friend's streak",
+                    blurb: "Go 20 miles past your goal to earn an Assist, then rescue a friend the day after their streak breaks.",
+                    tint: MADTheme.Colors.madRed
+                ),
+                WhatsNewFeature(
+                    emoji: "\u{1F3C5}",
+                    title: "The Pure Flame",
+                    blurb: "A gold flame on your profile when every day of your streak was earned on the day.",
+                    tint: .yellow
+                ),
+                WhatsNewFeature(
+                    emoji: "\u{1F4AC}",
+                    title: "Comments & collabs",
+                    blurb: "Comment on friends' posts and share a run together as a collab.",
+                    tint: MADTheme.Colors.walkBlue
+                ),
+                WhatsNewFeature(
+                    emoji: "\u{1F5D3}",
+                    title: "Your workouts, organized",
+                    blurb: "A calendar of every run, swipe between workouts, and photos that load instantly.",
+                    tint: .green
+                ),
+                WhatsNewFeature(
+                    emoji: "\u{1F44F}",
+                    title: "Unlimited hypes",
+                    blurb: "Cheer your friends as much as you want — no daily cap.",
+                    tint: .purple
+                ),
+            ]
+        ),
+    ]
+
+    static var latest: WhatsNewRelease { releases[0] }
+}
+
+// MARK: - Seen tracking
+
+enum WhatsNewManager {
+    private static let seenKey = "whatsNewSeenReleaseId"
+
+    /// Auto-present once per release — but never on a brand-new install
+    /// (the welcome tour owns that moment; we just mark the release seen).
+    static var shouldAutoPresent: Bool {
+        let seen = UserDefaults.standard.integer(forKey: seenKey)
+        guard WhatsNewCatalog.latest.id > seen else { return false }
+        if !UserDefaults.standard.bool(forKey: "hasSeenWelcomeTour") {
+            markSeen()
+            return false
+        }
+        return true
+    }
+
+    static func markSeen() {
+        UserDefaults.standard.set(WhatsNewCatalog.latest.id, forKey: seenKey)
+    }
+
+    /// Dev helper: forget the seen marker so the popup auto-fires again.
+    static func resetForTesting() {
+        UserDefaults.standard.removeObject(forKey: seenKey)
+    }
+}
+
+// MARK: - Sheet
+
+/// The What's New page: auto-appears once per release after an update, and
+/// reopens anytime from Settings → What's New.
+struct WhatsNewView: View {
+    var release: WhatsNewRelease = WhatsNewCatalog.latest
+    @Environment(\.dismiss) private var dismiss
+    @State private var revealed = false
+
+    var body: some View {
+        ZStack {
+            MADTheme.Colors.appBackgroundGradient.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(spacing: MADTheme.Spacing.lg) {
+                        header
+                        VStack(spacing: MADTheme.Spacing.sm) {
+                            ForEach(Array(release.features.enumerated()), id: \.element.id) { index, feature in
+                                featureRow(feature)
+                                    .opacity(revealed ? 1 : 0)
+                                    .offset(y: revealed ? 0 : 14)
+                                    .animation(
+                                        .spring(response: 0.5, dampingFraction: 0.8)
+                                            .delay(0.15 + Double(index) * 0.07),
+                                        value: revealed
+                                    )
+                            }
+                        }
+                    }
+                    .padding(MADTheme.Spacing.md)
+                    .padding(.top, MADTheme.Spacing.lg)
+                }
+
+                // Pinned dismiss CTA
+                Button {
+                    WhatsNewManager.markSeen()
+                    dismiss()
+                } label: {
+                    Text("Keep Running")
+                        .font(.system(size: 17, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(
+                            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                .fill(MADTheme.Colors.redGradient)
+                        )
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, MADTheme.Spacing.md)
+                .padding(.bottom, MADTheme.Spacing.md)
+            }
+        }
+        .onAppear {
+            revealed = true
+            // Opening the sheet counts as seeing the release, however it closes
+            // (swipe-down included) — never nag someone twice.
+            WhatsNewManager.markSeen()
+        }
+    }
+
+    private var header: some View {
+        VStack(spacing: MADTheme.Spacing.sm) {
+            ZStack {
+                Circle()
+                    .fill(MADTheme.Colors.redGradient)
+                    .frame(width: 64, height: 64)
+                    .shadow(color: MADTheme.Colors.madRed.opacity(0.5), radius: 12)
+                Image(systemName: "sparkles")
+                    .font(.system(size: 28, weight: .bold))
+                    .foregroundColor(.white)
+            }
+
+            Text("What's New")
+                .font(.system(size: 30, weight: .heavy, design: .rounded))
+                .foregroundColor(.primary)
+
+            Text(release.headline)
+                .font(.system(size: 15, weight: .semibold, design: .rounded))
+                .foregroundColor(.secondary)
+
+            Text(release.versionLabel)
+                .font(.system(size: 11, weight: .heavy, design: .rounded))
+                .tracking(1.1)
+                .textCase(.uppercase)
+                .foregroundColor(MADTheme.Colors.madRed)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background(Capsule().fill(MADTheme.Colors.madRed.opacity(0.14)))
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func featureRow(_ feature: WhatsNewFeature) -> some View {
+        HStack(alignment: .top, spacing: MADTheme.Spacing.md) {
+            ZStack {
+                Circle()
+                    .fill(feature.tint.opacity(0.16))
+                    .frame(width: 44, height: 44)
+                Text(feature.emoji)
+                    .font(.system(size: 21))
+            }
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(feature.title)
+                    .font(.system(size: 15, weight: .heavy, design: .rounded))
+                    .foregroundColor(.primary)
+                Text(feature.blurb)
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(MADTheme.Spacing.md)
+        .madLiquidGlass()
+    }
+}

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -31,6 +31,9 @@ struct DashboardView: View {
     /// the destination is registered on the stack's root — a
     /// navigationDestination declared inside the scroll content can miss.
     @State private var showWorkouts = false
+    /// What's New popup — auto-presents once per release, reopenable from
+    /// Settings → What's New.
+    @State private var showWhatsNew = false
     @State private var newGoalMiles: Double = 1.0
     @State private var isRefreshing = false
     @State private var showWorkoutUploadAlert = false
@@ -526,6 +529,25 @@ struct DashboardView: View {
                         }
                     }
                 }
+
+                // Streak-tokens enrollment stamp — idempotent; covers cold
+                // launches (the foreground observer only fires on background→
+                // foreground, and completeAuthentication only on fresh sign-in).
+                StreakFeatureService.enrollIfNeeded()
+
+                // What's New: auto-present once per release. Same stand-down
+                // rules as the tour — never stack on a celebration, the
+                // tracker, or the first-run tour itself.
+                if WhatsNewManager.shouldAutoPresent {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.9) {
+                        if WhatsNewManager.shouldAutoPresent,
+                           !celebrationManager.isShowingCelebration,
+                           !showWorkoutView,
+                           !showWelcomeTour {
+                            showWhatsNew = true
+                        }
+                    }
+                }
             }
             // Self-cleaning replacements for the old NotificationCenter.addObserver
             // calls in onAppear — those registered a fresh observer on every
@@ -537,6 +559,9 @@ struct DashboardView: View {
             }
             .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("MAD_OpenWorkoutFromLiveActivity"))) { _ in
                 showWorkoutView = true
+            }
+            .sheet(isPresented: $showWhatsNew) {
+                WhatsNewView()
             }
             .sheet(isPresented: $showGoalSheet) {
                 GoalSettingSheet(

--- a/app/Mile A Day/Views/Profile/ProfileSettingsView.swift
+++ b/app/Mile A Day/Views/Profile/ProfileSettingsView.swift
@@ -14,6 +14,10 @@ struct ProfileSettingsView: View {
     let isRecalibratingStreak: Bool
     let onPrivacySettings: () -> Void
 
+    /// What's New sheet — reopenable here anytime (auto-presents once per
+    /// release from the Dashboard).
+    @State private var showWhatsNew = false
+
     var body: some View {
         ScrollView {
             VStack(spacing: MADTheme.Spacing.lg) {
@@ -109,6 +113,23 @@ struct ProfileSettingsView: View {
                 )
             }
             .buttonStyle(.plain)
+
+            settingsDivider
+
+            Button {
+                showWhatsNew = true
+            } label: {
+                MADSettingsRow(
+                    icon: "sparkles",
+                    title: "What's New",
+                    subtitle: "Latest features and updates",
+                    iconColor: Color.yellow
+                )
+            }
+            .buttonStyle(.plain)
+            .sheet(isPresented: $showWhatsNew) {
+                WhatsNewView()
+            }
 
             settingsDivider
 

--- a/app/Mile A Day/Views/Settings/DeveloperSettingsView.swift
+++ b/app/Mile A Day/Views/Settings/DeveloperSettingsView.swift
@@ -33,6 +33,10 @@ struct DeveloperSettingsView: View {
     @State private var testNotificationMessage = ""
     @State private var isSendingNotification = false
     @State private var notificationResult: String?
+    // Streak-token testing
+    @ObservedObject private var tokensState = StreakTokensState.shared
+    @State private var tokenStatusResult: String?
+    @State private var customBaseURL = ""
 
     var body: some View {
         List {
@@ -85,6 +89,103 @@ struct DeveloperSettingsView: View {
                 }
                 .disabled(workoutService.isLoading)
             }
+
+            // Streak Tokens Section
+            #if DEBUG
+            Section(
+                header: Text("Streak Tokens"),
+                footer: Text("Preview shows every token surface (StreakCard meters, explainer sheet, friends-page rescue banner, Pure Flame badge) with sample data — no backend needed. The API target override needs an app relaunch and only exists in DEBUG builds.")
+            ) {
+                Toggle(isOn: Binding(
+                    get: { tokensState.isPreviewingSampleData },
+                    set: { on in
+                        if on { tokensState.enableSamplePreview() }
+                        else { tokensState.disableSamplePreview() }
+                    }
+                )) {
+                    HStack {
+                        Image(systemName: "eye.fill").foregroundColor(.orange)
+                        Text("Preview token UI (sample data)")
+                    }
+                }
+
+                Button(action: {
+                    tokenStatusResult = nil
+                    Task {
+                        StreakFeatureService.enrollIfNeeded()
+                        await tokensState.refreshStatus()
+                        await MainActor.run {
+                            tokenStatusResult = tokensState.isActive
+                                ? "ACTIVE — meters loaded from \(AppConfig.baseURL)"
+                                : "inactive — server gate is off for this user on \(AppConfig.baseURL)"
+                        }
+                    }
+                }) {
+                    HStack {
+                        Image(systemName: "bolt.horizontal.circle.fill")
+                            .foregroundColor(.green)
+                        Text("Enroll + refresh status")
+                    }
+                }
+
+                if let result = tokenStatusResult {
+                    Text(result)
+                        .font(.caption)
+                        .foregroundColor(result.hasPrefix("ACTIVE") ? .green : .secondary)
+                }
+
+                HStack {
+                    Image(systemName: "server.rack").foregroundColor(.blue)
+                    Text("API")
+                    Spacer()
+                    Text(AppConfig.baseURL)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+
+                TextField("http://localhost:3000", text: $customBaseURL)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .keyboardType(.URL)
+
+                Button(action: {
+                    let url = customBaseURL.isEmpty ? "http://localhost:3000" : customBaseURL
+                    UserDefaults.standard.set(url, forKey: "devBaseURLOverride")
+                    // Fresh enroll against the new target after relaunch.
+                    UserDefaults.standard.removeObject(forKey: "streakFeaturesEnrollPosted")
+                    tokenStatusResult = "Override saved: \(url) — relaunch the app to apply."
+                }) {
+                    HStack {
+                        Image(systemName: "arrow.right.circle.fill").foregroundColor(.blue)
+                        Text("Point at dev backend")
+                    }
+                }
+
+                Button(action: {
+                    UserDefaults.standard.removeObject(forKey: "devBaseURLOverride")
+                    UserDefaults.standard.removeObject(forKey: "streakFeaturesEnrollPosted")
+                    tokenStatusResult = "Override cleared — relaunch to return to production."
+                }) {
+                    HStack {
+                        Image(systemName: "arrow.uturn.backward.circle.fill")
+                            .foregroundColor(.orange)
+                        Text("Reset API to production")
+                    }
+                }
+
+                Button(action: {
+                    WhatsNewManager.resetForTesting()
+                    tokenStatusResult = "What's New reset — it auto-opens on the next Dashboard visit."
+                }) {
+                    HStack {
+                        Image(systemName: "sparkles").foregroundColor(.yellow)
+                        Text("Reset What's New popup")
+                    }
+                }
+            }
+            #endif
 
             // Review Prompt Section
             Section(


### PR DESCRIPTION
## 1. What's New ✨

A reusable release-announcement system:

- **`WhatsNewView`** — MAD-themed sheet: sparkles header, version chip, feature rows with tinted emoji chips and a staggered entrance, pinned "Keep Running" CTA.
- **Auto-presents once per release** from the Dashboard — stands down for celebrations, the workout tracker, and the first-run tour (brand-new installs skip it entirely; the welcome tour owns that moment). Opening it marks the release seen no matter how it's closed.
- **Reopenable anytime**: Settings → **What's New** (sparkles row, all builds).
- **Trivial to update each release**: add an entry to `WhatsNewCatalog.releases` with a bumped `id` — copy is plain data. Seeded with this release: streak tokens, friend assists, Pure Flame, comments & collabs, the workouts hub, unlimited hypes.

## 2. Why you weren't seeing tokens on dev — found and fixed

Three compounding causes:
1. **The enrollment stamp never fired on a cold launch** — it only ran on fresh sign-in (`completeAuthentication`) or background→foreground. An already-authed install that launches straight to the Dashboard never enrolled. It now also fires on Dashboard appear, and on success immediately refreshes token status so the meters light up the *same* launch.
2. Its guard read the UserDefaults token mirror, which older installs may not have — now guards on the Keychain (`TokenStore.accessToken`).
3. Pointing a build at a dev backend required a debugger incantation.

**New DEBUG-only "Streak Tokens" section in Developer Settings:**
- **Preview token UI (sample data)** — one toggle renders *every* surface with rich sample data (meters at 9/14 · 7/7 ready · 12.5/20, at-risk nudge on, Pure Flame on, a fake "davey, 42-day streak broke" rescue banner) — **zero backend needed**. This is the fastest way to review the UI/UX right now.
- **Enroll + refresh status** — one tap; prints `ACTIVE`/`inactive` and which API it hit.
- **Point at dev backend / Reset to production** — UI for the `devBaseURLOverride`, clearing the enroll flag so the new target gets stamped after relaunch.
- **Reset What's New popup** — re-trigger the auto-present for testing.

All compiled out of Release; nothing here ships to users.

## Testing (after pulling this)
1. **Instant UI review**: Settings → Developer Settings → toggle *Preview token UI* → check the Dashboard streak card, tap the meters for the explainer, visit Friends for the rescue banner, Profile for the gold flame.
2. **Real data**: *Point at dev backend* (dev gate is auto-on since #236) → relaunch → *Enroll + refresh status* should print ACTIVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY)_