### PR TITLE
Give streak tokens their own always-visible Dashboard card

### DIFF
--- a/app/Mile A Day/Views/Dashboard/DashboardCards.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardCards.swift
@@ -261,11 +261,6 @@ struct StreakCard: View {
             // Compact week-at-a-glance row
             compactWeekRow
 
-            // Streak tokens (Double Down / Save / Assist) — renders ONLY when
-            // the server has the feature on for this user; its own Button
-            // swallows taps so it never triggers the card's share gesture.
-            StreakTokensRow()
-
             // Share hint
             HStack(spacing: 6) {
                 Image(systemName: "square.and.arrow.up")

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -409,6 +409,14 @@ struct DashboardView: View {
                         .padding(.top, 8)
                         .padding(.bottom, 8)
 
+                    // Streak Tokens — its own card, ALWAYS on the dashboard
+                    // when the feature is active (it must never depend on
+                    // which week-view tab is selected). Renders nothing when
+                    // the server gate is off.
+                    StreakTokensCard()
+                        .padding(.horizontal, 16)
+                        .padding(.bottom, 8)
+
                     dashboardContent
                         .frame(maxWidth: .infinity)
                 }

--- a/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
+++ b/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
@@ -30,12 +30,13 @@ struct PureFlameBadge: View {
     }
 }
 
-// MARK: - Compact meters row (lives inside StreakCard)
+// MARK: - Dashboard card
 
-/// One-glance strip of the three token meters. Rendered only when the server
-/// says streak features are active for this user; tapping opens the full
-/// explainer. Has its OWN tap target so it never triggers the card's share.
-struct StreakTokensRow: View {
+/// The tokens' one home on the Dashboard: a standalone card, always present
+/// while the feature is active (never dependent on which week-view tab is
+/// selected — the old in-StreakCard row vanished on the chart/trends tabs).
+/// Renders nothing when the server gate is off. Tapping opens the explainer.
+struct StreakTokensCard: View {
     @ObservedObject var tokensState = StreakTokensState.shared
     @State private var showDetail = false
 
@@ -45,10 +46,27 @@ struct StreakTokensRow: View {
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 showDetail = true
             } label: {
-                VStack(spacing: 8) {
-                    Rectangle()
-                        .fill(Color.white.opacity(0.1))
-                        .frame(height: 1)
+                VStack(spacing: 12) {
+                    HStack(spacing: MADTheme.Spacing.sm) {
+                        Image(systemName: "shield.lefthalf.filled")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(MADTheme.Colors.redGradient)
+                        Text("Streak Tokens")
+                            .font(.system(size: 16, weight: .heavy, design: .rounded))
+                            .foregroundColor(.white)
+                        Spacer()
+                        let ready = [
+                            payload.double_down.held,
+                            payload.streak_save.held,
+                            payload.streak_assist.held,
+                        ].filter { $0 }.count
+                        Text(ready > 0 ? "\(ready) ready" : "How they work")
+                            .font(.system(size: 12, weight: .bold, design: .rounded))
+                            .foregroundColor(ready > 0 ? .green : .white.opacity(0.55))
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 11, weight: .bold))
+                            .foregroundColor(.white.opacity(0.4))
+                    }
 
                     HStack(spacing: 0) {
                         meterCell(
@@ -87,6 +105,8 @@ struct StreakTokensRow: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
+                .padding(MADTheme.Spacing.md)
+                .madLiquidGlass()
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)


### PR DESCRIPTION
## The bug you hit

The token meters were embedded **inside `StreakCard`** — which only renders on the **"Streak" tab** of the dashboard's week-view picker. On the **"This Week" (chart)** or **"Trends"** tabs, the token UI simply didn't exist on the dashboard. So with the feature (or preview) on, the dashboard could legitimately show *nothing*. My placement mistake.

## The fix

- **`StreakTokensCard`** — a standalone card directly under the week-view section, present on **every** tab whenever the feature is active: "Streak Tokens" header with a live **"N ready"** count, the three meter rings (🔥 ❄️ 🤝) with READY checkmarks, the at-risk "run 2× today" nudge, and tap-anywhere → the explainer sheet. Renders nothing when the server gate is off (unchanged safety).
- Removed the old in-StreakCard row — one home, no tab-dependent visibility, no double-render.

## To see everything with REAL data, on by default (no toggles)

The client is already fully automatic — it enrolls on launch and lights up if the server says so. The one switch left is server-side: set **`STREAK_FEATURES_ENABLED=true`** in Coolify (backend env) and restart. This is **safe for live users**: only builds with the token UI ever write the enrollment stamp, and no shipped App Store build does — so flipping it today lights up exactly you and Dave, with meters derived from your real last-30-days of workouts. (Dev backends via `npm run dev` are already auto-on.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY)_