### PR TITLE
Invert the streak-token gate: on by default, env becomes a kill switch

### DIFF
--- a/backend/src/cron/streakFeaturesCron.ts
+++ b/backend/src/cron/streakFeaturesCron.ts
@@ -9,7 +9,8 @@ import { streakFeaturesGloballyEnabled } from "../services/streakFeatureCore.js"
  * the rescue to assist-holding friends. Runs at :10 so it never lands on the
  * same tick as the :00 daily-reminder batch.
  *
- * Instant no-op while STREAK_FEATURES_ENABLED is unset — safe to deploy dark.
+ * Only enrolled users are processed (none exist until a token-UI build runs),
+ * and STREAK_FEATURES_DISABLED=true freezes the sweep entirely.
  */
 export function startStreakFeaturesCron(): void {
   cron.schedule("10 * * * *", async () => {

--- a/backend/src/services/pushNotificationService.ts
+++ b/backend/src/services/pushNotificationService.ts
@@ -135,8 +135,8 @@ export type NotificationType =
   | "coauthor_accepted"
   | "daily_reminder"
   | "weekly_recap"
-  // Streak tokens (gated behind STREAK_FEATURES_ENABLED + per-user enrollment;
-  // none are high-priority, so quiet hours apply automatically).
+  // Streak tokens (gated by per-user enrollment + the STREAK_FEATURES_DISABLED
+  // kill switch; none are high-priority, so quiet hours apply automatically).
   | "streak_double_down"
   | "streak_saved"
   | "streak_assist_opportunity"

--- a/backend/src/services/streakFeatureCore.ts
+++ b/backend/src/services/streakFeatureCore.ts
@@ -9,21 +9,23 @@ const db = PostgresService.getInstance();
  * streakFeatureService, which imports those services in turn).
  *
  * The safety contract of the whole feature lives here:
- *   - streak features are DOUBLE-gated: the STREAK_FEATURES_ENABLED env switch
- *     (fail-closed master kill switch) AND a per-user enrollment stamp that
- *     only the new app build writes. Un-enrolled users' streak math runs the
- *     EXACT legacy code path — the callers branch before any of this runs.
+ *   - the per-user gate is the ENROLLMENT STAMP, which only app builds that
+ *     ship the token UI write — so the feature reaches a user exactly when
+ *     their app can display it. Un-enrolled users' streak math runs the EXACT
+ *     legacy code path — the callers branch before any of this runs.
+ *   - STREAK_FEATURES_DISABLED=true is the emergency kill switch: it freezes
+ *     every token behavior (walks fall back to legacy, no earning/consuming,
+ *     no pushes) for everyone without needing an app release. Normally unset.
  *   - a covered day (one streak_coverage row) counts as "not a miss" in the
  *     walk, no matter WHICH token wrote it. The walks never branch per token.
  */
 
 export function streakFeaturesGloballyEnabled(): boolean {
-  // Always ON in local dev (`npm run dev` sets NODE_ENV=development, same
-  // fail-closed pattern as /dev/* — a prod deploy can never have it) so the
-  // feature is testable without env plumbing. Prod stays dark until
-  // STREAK_FEATURES_ENABLED=true is set deliberately.
-  if (process.env.NODE_ENV === "development") return true;
-  return process.env.STREAK_FEATURES_ENABLED === "true";
+  // ON by default everywhere — enrollment does the targeting. The env var is
+  // only the emergency brake, deliberately inverted (fail-open) now that the
+  // feature is code-complete: nothing to remember at launch, one line of
+  // config to freeze it in an incident.
+  return process.env.STREAK_FEATURES_DISABLED !== "true";
 }
 
 /** One users-row read of everything the token logic needs. */

--- a/backend/src/services/streakFeatureService.ts
+++ b/backend/src/services/streakFeatureService.ts
@@ -32,8 +32,9 @@ const db = PostgresService.getInstance();
  * opens at GREATEST(last use, enrollment − 30d lookback, today − 90d), which
  * both grants retroactive credit at enrollment and bounds the query.
  *
- * Everything here no-ops unless STREAK_FEATURES_ENABLED=true AND the user has
- * the (new-build-only) enrollment stamp.
+ * Everything here no-ops unless the user has the (new-build-only) enrollment
+ * stamp — and freezes entirely if the STREAK_FEATURES_DISABLED kill switch is
+ * set (normally unset).
  */
 
 // Meter targets (product-locked; see docs). The Assist threshold is the dial


### PR DESCRIPTION
## Why

Rob's point was correct: the env flag never targeted anyone — **the enrollment stamp does all per-user gating** (only builds that ship the token UI ever enroll). So requiring `STREAK_FEATURES_ENABLED=true` at launch bought nothing except a step to remember. Inverted per product decision.

## Change

- `streakFeaturesGloballyEnabled()` is now **true unless `STREAK_FEATURES_DISABLED=true`**. The env var's only remaining job is the **emergency brake**: set it in Coolify during an incident and every token behavior freezes for everyone — walks fall back to the byte-identical legacy loop, no earning/consuming, no pushes — with zero app release. Normally it stays unset.
- Dropped the `NODE_ENV=development` special case (on-by-default covers dev).
- Comments updated everywhere the old semantics were referenced (core, service, cron, push types).

## Impact when this deploys

- **Live App Store users: nothing changes.** They cannot enroll, so their streak math still runs the untouched legacy path and their API responses are byte-identical.
- **Your and Dave's dev builds: tokens light up immediately** — no Coolify step, no toggles — with meters derived from your real last-30-days of workouts. (If your build already enrolled you, it's live on your next stats fetch after deploy.)
- **The next App Store build: feature is live for everyone as they update.** That's the accepted trade of removing the staged flip.

Backend `tsc` clean; no schema or endpoint changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY)_