### PR TITLE
Self-healing token activation + a real diagnostic

### DIFF
--- a/app/Mile A Day/Services/StreakFeatureService.swift
+++ b/app/Mile A Day/Services/StreakFeatureService.swift
@@ -87,18 +87,22 @@ struct StreakFeaturesStatus: Codable {
 /// the backend turns the feature on, status returns {active:false}, stats omit
 /// the payload, and this build shows nothing.
 enum StreakFeatureService {
-    private static let enrolledFlagKey = "streakFeaturesEnrollPosted"
+    /// Once-per-process latch. Deliberately NOT persisted: a stored "already
+    /// enrolled" flag is per-install while enrollment is per-BACKEND, so an
+    /// enroll against a dev backend would permanently skip enrolling against
+    /// production. The endpoint is COALESCE-idempotent — one tiny request per
+    /// launch is the correct price for self-healing.
+    private static var enrolledThisLaunch = false
 
     /// Idempotent enrollment stamp — fire-and-forget on launch (mirrors device
-    /// token registration). Marks this install as a streak-features-capable
-    /// build; the server still shows nothing until its env switch flips. The
-    /// local flag only skips redundant calls: the endpoint itself is COALESCE-
-    /// idempotent, so a lost flag (reinstall) is harmless.
+    /// token registration). Marks this account as token-UI-capable; the server
+    /// decides everything else.
     static func enrollIfNeeded() {
         // Keychain-backed token check (the UserDefaults mirror can be missing
         // on installs that authed before the mirror existed).
         guard TokenStore.accessToken != nil else { return }
-        guard !UserDefaults.standard.bool(forKey: enrolledFlagKey) else { return }
+        guard !enrolledThisLaunch else { return }
+        enrolledThisLaunch = true
         Task {
             struct EnrollResponse: Decodable { let enrolled: Bool }
             do {
@@ -108,16 +112,53 @@ enum StreakFeatureService {
                     responseType: EnrollResponse.self
                 )
                 if resp.enrolled {
-                    UserDefaults.standard.set(true, forKey: enrolledFlagKey)
                     // Light the token surfaces up on THIS launch instead of
                     // waiting for the next stats fetch.
                     await StreakTokensState.shared.refreshStatus()
                 }
             } catch {
-                // Non-fatal: next launch retries.
+                // Non-fatal, but retry next call — the latch shouldn't stick
+                // on a failed request.
+                enrolledThisLaunch = false
                 print("[StreakFeatures] enroll failed: \(error.localizedDescription)")
             }
         }
+    }
+
+    /// Step-by-step diagnostic for Developer Settings — pinpoints WHERE the
+    /// chain breaks (wrong API target, backend missing the endpoints because a
+    /// deploy didn't land, kill switch on, or not enrolled) instead of the
+    /// surfaces just silently showing nothing.
+    static func diagnose() async -> String {
+        var lines = ["API: \(AppConfig.baseURL)"]
+        guard TokenStore.accessToken != nil else {
+            return lines.joined(separator: "\n") + "\nNo auth token — sign in first."
+        }
+        struct EnrollResponse: Decodable { let enrolled: Bool }
+        do {
+            _ = try await APIClient.fancyFetch(
+                endpoint: "/users/streak-features/enable",
+                method: .POST,
+                responseType: EnrollResponse.self
+            )
+            lines.append("Enroll: OK (stamp written)")
+        } catch {
+            lines.append("Enroll FAILED: \(error.localizedDescription)")
+            lines.append("→ If this is a 404, this backend doesn't have the streak endpoints — the deploy didn't land.")
+            return lines.joined(separator: "\n")
+        }
+        do {
+            let status = try await fetchStatus()
+            if status.active {
+                lines.append("Status: ACTIVE — meters loaded. UI should be visible everywhere.")
+                await StreakTokensState.shared.refreshStatus()
+            } else {
+                lines.append("Status: inactive — enrolled, but the server gate is off (STREAK_FEATURES_DISABLED is set, or this backend predates the gate inversion).")
+            }
+        } catch {
+            lines.append("Status FAILED: \(error.localizedDescription)")
+        }
+        return lines.joined(separator: "\n")
     }
 
     /// Meters + rescuable friends for the token surfaces.

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -542,6 +542,13 @@ struct DashboardView: View {
                 // launches (the foreground observer only fires on background→
                 // foreground, and completeAuthentication only on fresh sign-in).
                 StreakFeatureService.enrollIfNeeded()
+                // Belt-and-braces activation: if the tokens aren't lit yet,
+                // ask the status endpoint directly — independent of the
+                // getUserStats decode path, so one broken link can't keep the
+                // whole feature invisible.
+                if StreakTokensState.shared.payload == nil {
+                    Task { await StreakTokensState.shared.refreshStatus() }
+                }
 
                 // What's New: auto-present once per release. Same stand-down
                 // rules as the tour — never stack on a celebration, the

--- a/app/Mile A Day/Views/Settings/DeveloperSettingsView.swift
+++ b/app/Mile A Day/Views/Settings/DeveloperSettingsView.swift
@@ -110,28 +110,24 @@ struct DeveloperSettingsView: View {
                 }
 
                 Button(action: {
-                    tokenStatusResult = nil
+                    tokenStatusResult = "Running diagnostics…"
                     Task {
-                        StreakFeatureService.enrollIfNeeded()
-                        await tokensState.refreshStatus()
-                        await MainActor.run {
-                            tokenStatusResult = tokensState.isActive
-                                ? "ACTIVE — meters loaded from \(AppConfig.baseURL)"
-                                : "inactive — server gate is off for this user on \(AppConfig.baseURL)"
-                        }
+                        let report = await StreakFeatureService.diagnose()
+                        await MainActor.run { tokenStatusResult = report }
                     }
                 }) {
                     HStack {
-                        Image(systemName: "bolt.horizontal.circle.fill")
+                        Image(systemName: "stethoscope")
                             .foregroundColor(.green)
-                        Text("Enroll + refresh status")
+                        Text("Diagnose streak tokens")
                     }
                 }
 
                 if let result = tokenStatusResult {
                     Text(result)
                         .font(.caption)
-                        .foregroundColor(result.hasPrefix("ACTIVE") ? .green : .secondary)
+                        .foregroundColor(result.contains("ACTIVE") ? .green : .secondary)
+                        .textSelection(.enabled)
                 }
 
                 HStack {
@@ -153,8 +149,6 @@ struct DeveloperSettingsView: View {
                 Button(action: {
                     let url = customBaseURL.isEmpty ? "http://localhost:3000" : customBaseURL
                     UserDefaults.standard.set(url, forKey: "devBaseURLOverride")
-                    // Fresh enroll against the new target after relaunch.
-                    UserDefaults.standard.removeObject(forKey: "streakFeaturesEnrollPosted")
                     tokenStatusResult = "Override saved: \(url) — relaunch the app to apply."
                 }) {
                     HStack {
@@ -165,7 +159,6 @@ struct DeveloperSettingsView: View {
 
                 Button(action: {
                     UserDefaults.standard.removeObject(forKey: "devBaseURLOverride")
-                    UserDefaults.standard.removeObject(forKey: "streakFeaturesEnrollPosted")
                     tokenStatusResult = "Override cleared — relaunch to return to production."
                 }) {
                     HStack {


### PR DESCRIPTION
## The bug I found

The enroll flag was **persisted per-install, but enrollment is per-backend**. If your phone ever successfully enrolled against a dev/localhost backend, the flag said "done" forever — so the app **never enrolled against production**, and every token surface stayed empty no matter what we fixed elsewhere. Exactly matches "still not seeing it."

## Fixes

1. **Per-launch latch instead of a persisted flag** — the enable endpoint is COALESCE-idempotent, so one tiny request per launch is the correct price for never getting stuck. The latch also releases on request failure so a flaky call retries.
2. **Activation no longer depends on one code path** — Dashboard appear now also queries the status endpoint directly whenever tokens aren't lit, independent of the `getUserStats` decode.
3. **Developer Settings → "Diagnose streak tokens"** — a step-by-step report that tells you exactly where the chain breaks:
   - which API the app is actually talking to (catches a stale `devBaseURLOverride` still pointing at localhost),
   - enroll result (**a 404 here means the backend deploy never landed** — check Coolify),
   - gate state (kill switch set / backend predates the inversion),
   - or `ACTIVE — meters loaded`.

## After merging
Pull, rebuild, launch → tokens should just appear (enroll + status both fire on Dashboard appear). If they still don't: Developer Settings → **Diagnose streak tokens** and read the report — it names the failing link instead of leaving us guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY)_