### PR TITLE
Fix 500 on streak-features status: timestamptz arrives as a JS Date

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -5,7 +5,7 @@ globs: backend/**
 # Backend Conventions
 
 - Daily-mile completion checks must use `DAILY_GOAL_TOLERANCE` (0.95) from workoutService, never a raw `>= 1.0` — streaks/challenges count 0.95 days, and today_miles is displayed 2-decimal-rounded ("1.00" can be 0.996). iOS mirror: `ProgressCalculator.dailyGoalTolerance`.
-- Streak tokens (streak_coverage): any code that recomputes a streak MUST branch through `coverageActiveFor`/`computeCoveredStreak` (streakFeatureCore) like getActiveStreak + refreshCurrentStreak do — the 6h `reconcileStaleStreaks` cron rewrites `current_streak` via refreshCurrentStreak, so an unrouted walk silently erases token-saved streaks. Un-enrolled/env-off users must keep the byte-identical legacy loop. Meters are DERIVED from workouts since `*_last_used` (never stored counters).
+- Streak tokens (streak_coverage): any code that recomputes a streak MUST branch through `coverageActiveFor`/`computeCoveredStreak` (streakFeatureCore) like getActiveStreak + refreshCurrentStreak do — the 6h `reconcileStaleStreaks` cron rewrites `current_streak` via refreshCurrentStreak, so an unrouted walk silently erases token-saved streaks. Un-enrolled/env-off users must keep the byte-identical legacy loop. Meters are DERIVED from workouts since `*_last_used` (never stored counters). Raw-SQL `timestamptz` columns come back as JS Date objects (only `date` cols are strings) — `to_char(...)` in SQL or coerce before any string op; a `.slice()` on `streak_features_at` 500'd the status endpoint in prod.
 
 ## Architecture: Routes -> Controllers -> Services
 - `routes/` - Express Router definitions. Thin: just wire HTTP verbs to controller functions + middleware.

--- a/backend/src/services/streakFeatureCore.ts
+++ b/backend/src/services/streakFeatureCore.ts
@@ -30,7 +30,9 @@ export function streakFeaturesGloballyEnabled(): boolean {
 
 /** One users-row read of everything the token logic needs. */
 export interface StreakFeatureUserRow {
-  streak_features_at: string | null;
+  // timestamptz: node-pg parses this to a JS Date (unlike `date` columns,
+  // which arrive as strings) — never call string methods on it directly.
+  streak_features_at: string | Date | null;
   double_down_last_used: string | null;
   streak_save_last_used: string | null;
   streak_assist_last_used: string | null;

--- a/backend/src/services/streakFeatureService.ts
+++ b/backend/src/services/streakFeatureService.ts
@@ -67,6 +67,13 @@ export interface StreakFeatureMeters {
   goalMiles: number;
 }
 
+/** "YYYY-MM-DD" from either pg shape: `date` → string, timestamptz → Date. */
+function dateOnly(value: string | Date | null): string | null {
+  if (!value) return null;
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  return String(value).slice(0, 10);
+}
+
 /** Window floor for one meter: last use vs enrollment lookback vs hard bound. */
 function meterFloor(
   lastUsed: string | null,
@@ -94,7 +101,11 @@ export async function getMeters(
   row: StreakFeatureUserRow,
   userToday: string,
 ): Promise<StreakFeatureMeters> {
-  const enrolledAt = row.streak_features_at ?? userToday;
+  // streak_features_at is a timestamptz → node-pg hands back a JS Date (not a
+  // string like `date` columns). Calling .slice() on it was a TypeError that
+  // 500'd the status endpoint (and silently killed Double Down detection and
+  // the sweep) for every enrolled user.
+  const enrolledAt = dateOnly(row.streak_features_at) ?? userToday;
   const ddFloor = meterFloor(row.double_down_last_used, enrolledAt, userToday);
   const saveFloor = meterFloor(
     row.streak_save_last_used,


### PR DESCRIPTION
## Root cause (confirmed by the on-device diagnostic + client log)

The diagnose report showed: API = prod ✓, **Enroll: OK** ✓, **Status FAILED: "Error getting streak features"** — the status endpoint's 500.

`streak_features_at` is a **timestamptz**, and node-pg parses those to **JS `Date` objects** — unlike `date` columns, which arrive as strings (the only case the repo's gotchas covered). `getMeters` called `.slice(0,10)` on it to derive the enrollment lookback floor → `TypeError: enrolledAt.slice is not a function` → 500 for **every enrolled user**, and the same crash silently killed Double Down detection on upload and the hourly sweep (both are caught/fire-and-forget, so nothing surfaced).

## Fix
- `dateOnly()` coerces both pg shapes (`Date` or string) to `"YYYY-MM-DD"`.
- `StreakFeatureUserRow.streak_features_at` is now typed `string | Date | null` so tsc keeps this honest.
- Audited the rest of the token code: every other date/timestamp it reads is already `to_char`'d in SQL.

## After merge
Auto-deploys; no iOS change needed. Next app launch: enroll fires, status returns ACTIVE, and the Dashboard card + explainer + rescue banner + Pure Flame light up with real meters. The Developer Settings **Diagnose** button should print `Status: ACTIVE — meters loaded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY)_