### PR TITLE
Token design pass: minted medallions, in-row Save Streak, richer explainer

### DIFF
--- a/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
+++ b/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
@@ -1,5 +1,147 @@
 import SwiftUI
 
+// MARK: - Token identity (one source of truth for look & copy)
+
+enum StreakTokenKind {
+    case doubleDown, save, assist
+
+    var title: String {
+        switch self {
+        case .doubleDown: return "Double Down"
+        case .save: return "Streak Save"
+        case .assist: return "Streak Assist"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .doubleDown: return "flame.fill"
+        case .save: return "snowflake"
+        case .assist: return "lifepreserver"
+        }
+    }
+
+    /// Coin-face gradient. Kept saturated and MAD-branded: ember for effort,
+    /// ice for the freeze, brand red for the friend rescue.
+    var gradient: [Color] {
+        switch self {
+        case .doubleDown:
+            return [Color(red: 1.0, green: 0.62, blue: 0.20),
+                    Color(red: 0.86, green: 0.28, blue: 0.08)]
+        case .save:
+            return [Color(red: 0.45, green: 0.78, blue: 1.0),
+                    Color(red: 0.12, green: 0.42, blue: 0.85)]
+        case .assist:
+            return [Color(red: 0.95, green: 0.35, blue: 0.55),
+                    MADTheme.Colors.madRed]
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .doubleDown: return .orange
+        case .save: return MADTheme.Colors.walkBlue
+        case .assist: return MADTheme.Colors.madRed
+        }
+    }
+
+    var what: String {
+        switch self {
+        case .doubleDown:
+            return "Miss a day? Run 2× your goal the next day and yesterday still counts."
+        case .save:
+            return "Life happens — if you miss a day and can't Double Down, this covers it automatically."
+        case .assist:
+            return "Save a friend's streak the day after it breaks — be their hero."
+        }
+    }
+
+    var howToEarn: String {
+        switch self {
+        case .doubleDown:
+            return "Complete your mile on 14 days — runs or walks both count."
+        case .save:
+            return "Run your full mile on 7 days. Running only — walks don't tick this one."
+        case .assist:
+            return "Go a total of 20 miles beyond your daily goal, over any number of days."
+        }
+    }
+}
+
+// MARK: - Token medallion (the token itself — a minted coin, not an emoji)
+
+/// The canonical rendering of a token everywhere it appears: a coin with a
+/// gradient face, top-light sheen, inner ring, and an engraved SF Symbol.
+/// EARNED  → full color, gold rim, soft glow.
+/// EARNING → dimmed face with a progress arc filling the rim.
+struct TokenMedallion: View {
+    let kind: StreakTokenKind
+    var held: Bool = false
+    /// 0…1 earn progress; ignored when held.
+    var progress: Double = 0
+    var size: CGFloat = 44
+
+    private var gold: Color { Color(red: 1.0, green: 0.84, blue: 0.35) }
+
+    var body: some View {
+        ZStack {
+            // Coin face
+            Circle()
+                .fill(
+                    LinearGradient(
+                        colors: kind.gradient,
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+
+            // Top-light sheen — what makes it read as minted metal, not a dot.
+            Circle()
+                .fill(
+                    RadialGradient(
+                        colors: [Color.white.opacity(0.45), .clear],
+                        center: .init(x: 0.32, y: 0.25),
+                        startRadius: 0,
+                        endRadius: size * 0.75
+                    )
+                )
+
+            // Inner ring (the coin's lip)
+            Circle()
+                .strokeBorder(Color.white.opacity(0.35), lineWidth: max(1, size * 0.035))
+                .padding(size * 0.10)
+
+            // Engraved icon
+            Image(systemName: kind.icon)
+                .font(.system(size: size * 0.42, weight: .bold))
+                .foregroundColor(.white)
+                .shadow(color: .black.opacity(0.35), radius: 1, y: 1)
+        }
+        .frame(width: size, height: size)
+        .saturation(held ? 1 : 0.45)
+        .opacity(held ? 1 : 0.85)
+        .overlay(
+            // Rim: solid gold when earned; progress arc while earning.
+            Group {
+                if held {
+                    Circle().strokeBorder(gold, lineWidth: max(1.5, size * 0.05))
+                } else {
+                    Circle()
+                        .trim(from: 0, to: max(0.02, min(progress, 1)))
+                        .stroke(
+                            kind.tint,
+                            style: StrokeStyle(lineWidth: max(1.5, size * 0.05), lineCap: .round)
+                        )
+                        .rotationEffect(.degrees(-90))
+                        .padding(max(0.75, size * 0.025))
+                }
+            }
+        )
+        .shadow(color: held ? kind.tint.opacity(0.55) : .clear, radius: size * 0.18)
+        .accessibilityLabel("\(kind.title)\(held ? ", ready" : "")")
+    }
+}
+
 // MARK: - Pure Flame badge (natural streak)
 
 /// The "never needed a rescue" seal — shown beside the username when the
@@ -32,10 +174,10 @@ struct PureFlameBadge: View {
 
 // MARK: - Dashboard card
 
-/// The tokens' one home on the Dashboard: a standalone card, always present
-/// while the feature is active (never dependent on which week-view tab is
-/// selected — the old in-StreakCard row vanished on the chart/trends tabs).
-/// Renders nothing when the server gate is off. Tapping opens the explainer.
+/// The tokens' home on the Dashboard: three minted medallions with earn
+/// progress, always present while the feature is active (never dependent on
+/// which week-view tab is selected). Renders nothing when the server gate is
+/// off. Tapping opens the explainer.
 struct StreakTokensCard: View {
     @ObservedObject var tokensState = StreakTokensState.shared
     @State private var showDetail = false
@@ -46,7 +188,7 @@ struct StreakTokensCard: View {
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 showDetail = true
             } label: {
-                VStack(spacing: 12) {
+                VStack(spacing: 14) {
                     HStack(spacing: MADTheme.Spacing.sm) {
                         Image(systemName: "shield.lefthalf.filled")
                             .font(.system(size: 14, weight: .semibold))
@@ -69,26 +211,29 @@ struct StreakTokensCard: View {
                     }
 
                     HStack(spacing: 0) {
-                        meterCell(
-                            emoji: "\u{1F525}",
-                            label: "Double Down",
-                            fraction: payload.double_down.fraction,
+                        medallionCell(
+                            kind: .doubleDown,
                             held: payload.double_down.held,
-                            tint: .orange
+                            progress: payload.double_down.fraction,
+                            caption: payload.double_down.held
+                                ? "Ready"
+                                : "\(Int(payload.double_down.progress))/\(Int(payload.double_down.target))"
                         )
-                        meterCell(
-                            emoji: "\u{2744}\u{FE0F}",
-                            label: "Streak Save",
-                            fraction: payload.streak_save.fraction,
+                        medallionCell(
+                            kind: .save,
                             held: payload.streak_save.held,
-                            tint: MADTheme.Colors.walkBlue
+                            progress: payload.streak_save.fraction,
+                            caption: payload.streak_save.held
+                                ? "Ready"
+                                : "\(Int(payload.streak_save.progress))/\(Int(payload.streak_save.target))"
                         )
-                        meterCell(
-                            emoji: "\u{1F91D}",
-                            label: "Assist",
-                            fraction: payload.streak_assist.fraction,
+                        medallionCell(
+                            kind: .assist,
                             held: payload.streak_assist.held,
-                            tint: MADTheme.Colors.madRed
+                            progress: payload.streak_assist.fraction,
+                            caption: payload.streak_assist.held
+                                ? "Ready"
+                                : String(format: "%.1f/%.0f mi", payload.streak_assist.progress, payload.streak_assist.target)
                         )
                     }
 
@@ -116,36 +261,20 @@ struct StreakTokensCard: View {
         }
     }
 
-    private func meterCell(
-        emoji: String, label: String, fraction: Double, held: Bool, tint: Color
+    private func medallionCell(
+        kind: StreakTokenKind, held: Bool, progress: Double, caption: String
     ) -> some View {
-        VStack(spacing: 4) {
-            ZStack {
-                Circle()
-                    .stroke(Color.white.opacity(0.12), lineWidth: 3)
-                Circle()
-                    .trim(from: 0, to: held ? 1 : fraction)
-                    .stroke(tint, style: StrokeStyle(lineWidth: 3, lineCap: .round))
-                    .rotationEffect(.degrees(-90))
-                Text(emoji)
-                    .font(.system(size: 13))
-                    .opacity(held ? 1 : 0.55)
-            }
-            .frame(width: 32, height: 32)
-            .overlay(alignment: .topTrailing) {
-                if held {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 11, weight: .bold))
-                        .foregroundColor(.green)
-                        .background(Circle().fill(.black.opacity(0.6)))
-                        .offset(x: 4, y: -3)
-                }
-            }
-
-            Text(label)
-                .font(.system(size: 9, weight: .bold, design: .rounded))
-                .foregroundColor(.white.opacity(held ? 0.9 : 0.55))
+        VStack(spacing: 6) {
+            TokenMedallion(kind: kind, held: held, progress: progress, size: 46)
+            Text(kind.title)
+                .font(.system(size: 10, weight: .bold, design: .rounded))
+                .foregroundColor(.white.opacity(held ? 0.95 : 0.6))
                 .lineLimit(1)
+                .minimumScaleFactor(0.8)
+            Text(caption)
+                .font(.system(size: 10, weight: .heavy, design: .rounded))
+                .monospacedDigit()
+                .foregroundColor(held ? .green : .white.opacity(0.45))
         }
         .frame(maxWidth: .infinity)
     }
@@ -171,12 +300,8 @@ struct StreakTokensDetailView: View {
                             }
 
                             tokenCard(
-                                emoji: "\u{1F525}",
-                                title: "Double Down",
-                                tint: .orange,
-                                what: "Miss a day? Run 2× your goal the next day and yesterday still counts.",
-                                how: "Earn it by completing your mile 14 days (runs or walks count).",
-                                meter: .init(
+                                kind: .doubleDown,
+                                meter: StreakTokenMeter(
                                     progress: payload.double_down.progress,
                                     target: payload.double_down.target,
                                     held: payload.double_down.held,
@@ -184,26 +309,8 @@ struct StreakTokensDetailView: View {
                                 ),
                                 unit: "days"
                             )
-
-                            tokenCard(
-                                emoji: "\u{2744}\u{FE0F}",
-                                title: "Streak Save",
-                                tint: MADTheme.Colors.walkBlue,
-                                what: "Life happens — if you miss a day and can't Double Down, this covers it automatically.",
-                                how: "Earn it with 7 days of running your mile (walks don't count toward this one).",
-                                meter: payload.streak_save,
-                                unit: "run days"
-                            )
-
-                            tokenCard(
-                                emoji: "\u{1F91D}",
-                                title: "Streak Assist",
-                                tint: MADTheme.Colors.madRed,
-                                what: "Save a FRIEND's streak the day after it breaks — be their hero.",
-                                how: "Earn it by going 20 miles beyond your daily goal, over any number of days.",
-                                meter: payload.streak_assist,
-                                unit: "mi over goal"
-                            )
+                            tokenCard(kind: .save, meter: payload.streak_save, unit: "run days")
+                            tokenCard(kind: .assist, meter: payload.streak_assist, unit: "mi over goal")
 
                             naturalCard(payload.natural_streak)
                         } else {
@@ -256,21 +363,28 @@ struct StreakTokensDetailView: View {
     }
 
     private func tokenCard(
-        emoji: String,
-        title: String,
-        tint: Color,
-        what: String,
-        how: String,
+        kind: StreakTokenKind,
         meter: StreakTokenMeter,
         unit: String
     ) -> some View {
         VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
-            HStack(spacing: 10) {
-                Text(emoji).font(.system(size: 22))
-                Text(title)
-                    .font(.system(size: 17, weight: .heavy, design: .rounded))
-                    .foregroundColor(.primary)
-                Spacer()
+            HStack(spacing: 14) {
+                TokenMedallion(
+                    kind: kind,
+                    held: meter.held,
+                    progress: meter.fraction,
+                    size: 54
+                )
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(kind.title)
+                        .font(.system(size: 17, weight: .heavy, design: .rounded))
+                        .foregroundColor(.primary)
+                    Text(kind.what)
+                        .font(.system(size: 13, weight: .semibold, design: .rounded))
+                        .foregroundColor(.primary.opacity(0.85))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 0)
                 if meter.held {
                     Text("READY")
                         .font(.system(size: 11, weight: .heavy, design: .rounded))
@@ -281,15 +395,16 @@ struct StreakTokensDetailView: View {
                 }
             }
 
-            Text(what)
-                .font(.system(size: 13, weight: .semibold, design: .rounded))
-                .foregroundColor(.primary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            Text(how)
-                .font(.system(size: 12, weight: .medium, design: .rounded))
-                .foregroundColor(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("HOW TO EARN")
+                    .font(.system(size: 10, weight: .heavy, design: .rounded))
+                    .tracking(1.1)
+                    .foregroundColor(kind.tint)
+                Text(kind.howToEarn)
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
 
             // Meter bar + count
             VStack(alignment: .leading, spacing: 4) {
@@ -297,14 +412,20 @@ struct StreakTokensDetailView: View {
                     ZStack(alignment: .leading) {
                         Capsule().fill(Color.white.opacity(0.08))
                         Capsule()
-                            .fill(tint)
+                            .fill(
+                                LinearGradient(
+                                    colors: kind.gradient,
+                                    startPoint: .leading,
+                                    endPoint: .trailing
+                                )
+                            )
                             .frame(width: max(6, geo.size.width * (meter.held ? 1 : meter.fraction)))
                     }
                 }
                 .frame(height: 8)
 
                 Text(meter.held
-                     ? "Earned — 1 held (max 1). Using it restarts the meter."
+                     ? "Earned — you're holding 1 (max 1). Using it restarts the meter."
                      : "\(trimmed(meter.progress)) / \(trimmed(meter.target)) \(unit)")
                     .font(.system(size: 11, weight: .bold, design: .rounded))
                     .monospacedDigit()

--- a/app/Mile A Day/Views/Friends/FriendsListView.swift
+++ b/app/Mile A Day/Views/Friends/FriendsListView.swift
@@ -64,11 +64,12 @@ struct FriendsListView: View {
     // "Cheer Them On" and "Done Today" when their status flips.
     @Namespace private var friendRowNamespace
 
-    // Streak Assist: rescuable friends + send state (server-gated; empty
-    // until streak features are live for this user).
+    // Streak Assist: rescuable friends + per-row send state (server-gated;
+    // the rescuable list is empty until streak features are live). The CTA
+    // lives ON the friend's row, in the nudge/action slot.
     @ObservedObject private var tokensState = StreakTokensState.shared
-    @State private var isSendingAssist = false
-    @State private var assistSavedName: String?
+    @State private var assistingFriendId: String?
+    @State private var savedFriendIds: Set<String> = []
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -98,16 +99,6 @@ struct FriendsListView: View {
                     .zIndex(100)
             }
 
-            // Streak Assist hero moment: a friend's streak broke and the user
-            // holds an Assist — offer the rescue. Server-gated (the list is
-            // empty unless streak features are on), one friend at a time.
-            if nudgeFeedback == nil, let rescue = tokensState.assistableFriends.first {
-                assistBanner(rescue)
-                    .padding(.horizontal, MADTheme.Spacing.md)
-                    .padding(.top, 6)
-                    .transition(.move(edge: .top).combined(with: .opacity))
-                    .zIndex(99)
-            }
         }
         .background(MADTheme.Colors.appBackgroundGradient)
         .toolbar(.hidden, for: .navigationBar)
@@ -194,90 +185,84 @@ struct FriendsListView: View {
         }
     }
 
-    // MARK: - Streak Assist banner
+    // MARK: - Streak Assist (in-row rescue)
 
-    /// "You can save them" — shown while the user holds a Streak Assist and a
-    /// friend's streak broke yesterday. One tap spends the token, restores the
-    /// friend's streak, and the friend gets a push that they were saved.
-    private func assistBanner(_ friend: AssistableFriend) -> some View {
-        HStack(spacing: 10) {
-            AvatarView(name: friend.displayName, imageURL: friend.profile_image_url, size: 36)
-            VStack(alignment: .leading, spacing: 2) {
-                if let saved = assistSavedName {
-                    Text("You saved \(saved)'s streak! \u{1F91D}")
-                        .font(.system(size: 13, weight: .heavy, design: .rounded))
-                        .foregroundColor(.white)
-                } else {
-                    Text("\(friend.displayName)'s \(friend.prior_streak)-day streak broke")
-                        .font(.system(size: 13, weight: .heavy, design: .rounded))
-                        .foregroundColor(.white)
-                    Text("You're holding a Streak Assist — save it before the day ends.")
-                        .font(.system(size: 11, weight: .medium, design: .rounded))
-                        .foregroundColor(.white.opacity(0.75))
-                        .lineLimit(2)
-                }
-            }
-            Spacer(minLength: 6)
-            if assistSavedName == nil {
-                Button {
-                    sendAssist(to: friend)
-                } label: {
-                    HStack(spacing: 5) {
-                        if isSendingAssist {
-                            ProgressView().tint(.white).scaleEffect(0.7)
-                        } else {
-                            Image(systemName: "hands.clap.fill")
-                                .font(.system(size: 11, weight: .bold))
-                        }
-                        Text("Save it")
-                            .font(.system(size: 13, weight: .heavy, design: .rounded))
-                    }
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 13)
-                    .padding(.vertical, 8)
-                    .background(Capsule().fill(MADTheme.Colors.redGradient))
-                }
-                .buttonStyle(.plain)
-                .disabled(isSendingAssist)
-            }
-        }
-        .padding(12)
-        .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(Color.black.opacity(0.75))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        .strokeBorder(MADTheme.Colors.madRed.opacity(0.5), lineWidth: 1)
-                )
-        )
+    /// The rescue for this friend, if one is open: their streak broke within
+    /// the window, I'm holding an Assist, and I haven't just saved them.
+    private func assistRescue(for friend: BackendUser) -> AssistableFriend? {
+        guard tokensState.payload?.streak_assist.held == true else { return nil }
+        guard !savedFriendIds.contains(friend.user_id) else { return nil }
+        return tokensState.assistableFriends.first { $0.user_id == friend.user_id }
     }
 
-    private func sendAssist(to friend: AssistableFriend) {
-        guard !isSendingAssist else { return }
-        isSendingAssist = true
+    /// "Save Streak" — lives in the row's action slot (where Nudge sits), led
+    /// by the minted Assist medallion. One tap spends the token, restores the
+    /// friend's streak, and they get the "saved your streak" push.
+    private func saveStreakButton(friend: BackendUser, rescue: AssistableFriend) -> some View {
+        Button {
+            sendAssist(to: rescue)
+        } label: {
+            HStack(spacing: 6) {
+                if assistingFriendId == rescue.user_id {
+                    ProgressView().tint(.white).scaleEffect(0.6)
+                } else {
+                    TokenMedallion(kind: .assist, held: true, size: 18)
+                }
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("Save Streak")
+                        .font(.system(size: 11, weight: .heavy, design: .rounded))
+                    Text("\(rescue.prior_streak) days")
+                        .font(.system(size: 9, weight: .bold, design: .rounded))
+                        .opacity(0.8)
+                }
+            }
+            .foregroundColor(.white)
+            .padding(.horizontal, 11)
+            .padding(.vertical, 6)
+            .background(Capsule().fill(MADTheme.Colors.redGradient))
+            .shadow(color: MADTheme.Colors.madRed.opacity(0.45), radius: 5)
+        }
+        .buttonStyle(ScaleButtonStyle())
+        .disabled(assistingFriendId != nil)
+    }
+
+    /// Post-rescue confirmation chip in the same slot.
+    private var savedChip: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 11, weight: .bold))
+            Text("Saved!")
+                .font(.system(size: 11, weight: .heavy, design: .rounded))
+        }
+        .foregroundColor(.green)
+        .padding(.horizontal, 11)
+        .padding(.vertical, 6)
+        .background(Capsule().fill(Color.green.opacity(0.14)))
+    }
+
+    private func sendAssist(to rescue: AssistableFriend) {
+        guard assistingFriendId == nil else { return }
+        assistingFriendId = rescue.user_id
         Task {
             do {
-                let result = try await StreakFeatureService.assist(friendId: friend.user_id)
+                let result = try await StreakFeatureService.assist(friendId: rescue.user_id)
                 await MainActor.run {
-                    isSendingAssist = false
-                    assistSavedName = friend.displayName
+                    assistingFriendId = nil
+                    withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
+                        savedFriendIds.insert(rescue.user_id)
+                    }
                     UINotificationFeedbackGenerator().notificationOccurred(.success)
                     print("[Assist] restored streak: \(result.restored_streak ?? -1)")
                 }
-                // Let the hero moment breathe, then clear the banner + refresh.
-                try? await Task.sleep(for: .seconds(2.5))
-                await MainActor.run {
-                    withAnimation(.easeOut(duration: 0.3)) {
-                        assistSavedName = nil
-                        tokensState.assistableFriends.removeAll { $0.user_id == friend.user_id }
-                    }
-                }
+                // Refresh meters/rescues + row statuses so the friend's flame
+                // comes back at its restored length.
                 await tokensState.refreshStatus()
+                await loadNudgeStatuses()
             } catch {
                 await MainActor.run {
-                    isSendingAssist = false
+                    assistingFriendId = nil
                     // Someone else may have saved them first, or the window
-                    // closed — refresh so the banner reflects reality.
+                    // closed — refresh so the slot reflects reality.
                     UINotificationFeedbackGenerator().notificationOccurred(.warning)
                 }
                 await tokensState.refreshStatus()
@@ -1060,7 +1045,15 @@ struct FriendsListView: View {
             }
             .buttonStyle(.plain)
 
-            if !isCompleted {
+            // Action slot (where hype used to live): a rescuable broken streak
+            // outranks a nudge — restoring yesterday beats poking about today.
+            if let rescue = assistRescue(for: friend) {
+                saveStreakButton(friend: friend, rescue: rescue)
+                    .padding(.trailing, MADTheme.Spacing.md)
+            } else if savedFriendIds.contains(friend.user_id) {
+                savedChip
+                    .padding(.trailing, MADTheme.Spacing.md)
+            } else if !isCompleted {
                 nudgeButton(friend: friend, alreadyNudged: alreadyNudged, canRenudge: canRenudge)
                     .padding(.trailing, MADTheme.Spacing.md)
             }


### PR DESCRIPTION
## Tokens now look earned, not typed

**New `TokenMedallion`** — the one canonical rendering of a token everywhere it appears: a minted coin with a gradient face, top-light sheen, inner lip ring, and an engraved symbol (🔥→`flame.fill` ember coin, ❄️→`snowflake` ice coin, 🤝→`lifepreserver` brand-red coin).
- **Earned**: full color, **gold rim**, soft glow — reads as a reward.
- **Earning**: dimmed face with a tinted **progress arc filling the rim** — the unlock is literally visible on the token.
- `StreakTokenKind` centralizes each token's art *and* copy (what it does / how to earn), so every surface says the same thing.

## Where they live now

- **Dashboard card**: three medallions with clean per-token captions (`9/14`, `Ready`, `12.5/20 mi`) + the "N ready" header count + at-risk nudge. No emoji anywhere.
- **Explainer sheet**: each token card leads with the big medallion → what it does → a tinted **HOW TO EARN** label → a gradient meter bar with exact progress. Pure Flame card unchanged.
- **Friends list (the ask)**: the floating banner is gone. **"Save Streak" now sits on the friend's row in the action slot** — exactly where Nudge lives and hypes used to — as a brand-gradient pill led by the mini Assist medallion, showing the streak length it restores ("Save Streak / 42 days"). A rescuable break **outranks** the nudge (restoring yesterday beats poking about today); after the rescue the slot flips to a green **"Saved!"** chip and row statuses refresh so the friend's flame returns at its restored length.

## Verify on device
The medallion sheens/glows and the row pill sizing are the visual bits worth a real-screen look (CI can't compile iOS). All behavior unchanged from #241 — same endpoints, same gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY)_