### PR TITLE
Full-year retro credit, token unlock celebration, profile shelf, living meters

### DIFF
--- a/app/Mile A Day/Core/State/StreakTokensState.swift
+++ b/app/Mile A Day/Core/State/StreakTokensState.swift
@@ -17,8 +17,36 @@ final class StreakTokensState: ObservableObject {
     /// DEBUG preview: while true, refreshStatus() is a no-op so server state
     /// can't clobber the injected sample data. Never persisted.
     @Published var isPreviewingSampleData = false
+    /// Tokens that just flipped to EARNED (raw kinds: "double_down",
+    /// "streak_save", "streak_assist") — drives the unlock celebration.
+    /// Cleared by the overlay's dismiss.
+    @Published var newlyEarned: [String] = []
 
     var isActive: Bool { payload != nil }
+
+    private static let heldFlagsKey = "streakTokenHeldFlags"
+
+    /// Diff the held flags against the last seen set (persisted, so the
+    /// celebration fires exactly once per earn — including the very first
+    /// payload after enrollment backfill, the "you start fully loaded" moment).
+    @MainActor
+    func registerHeldStates(from payload: StreakFeaturesPayload) {
+        let previous =
+            UserDefaults.standard.dictionary(forKey: Self.heldFlagsKey) as? [String: Bool] ?? [:]
+        let current: [String: Bool] = [
+            "double_down": payload.double_down.held,
+            "streak_save": payload.streak_save.held,
+            "streak_assist": payload.streak_assist.held,
+        ]
+        let earned = current
+            .filter { $0.value && previous[$0.key] != true }
+            .map { $0.key }
+            .sorted()
+        UserDefaults.standard.set(current, forKey: Self.heldFlagsKey)
+        if !earned.isEmpty {
+            newlyEarned = earned
+        }
+    }
 
     /// Refresh meters + rescuable friends from the status endpoint (used by
     /// surfaces that need fresher data than the last stats fetch, e.g. the
@@ -48,6 +76,7 @@ final class StreakTokensState: ObservableObject {
             )
             payload = fresh
             assistableFriends = status.assistable_friends ?? []
+            registerHeldStates(from: fresh)
             StreakFeatureService.applyStatsPayload(fresh)
         } catch {
             // Keep last known state on transient failures.

--- a/app/Mile A Day/Services/StreakFeatureService.swift
+++ b/app/Mile A Day/Services/StreakFeatureService.swift
@@ -197,6 +197,9 @@ enum StreakFeatureService {
         }
         Task { @MainActor in
             StreakTokensState.shared.payload = payload
+            if let payload {
+                StreakTokensState.shared.registerHeldStates(from: payload)
+            }
         }
     }
 }

--- a/app/Mile A Day/Views/Components/TokenUnlockOverlay.swift
+++ b/app/Mile A Day/Views/Components/TokenUnlockOverlay.swift
@@ -1,0 +1,157 @@
+import SwiftUI
+
+/// Full-screen "Token Earned!" moment. Fires when a meter completes (or when
+/// enrollment backfill hands a long streaker their starting set): dimmed
+/// backdrop, slow-spinning gold rays, the medallion(s) spring in oversized
+/// with a glow, then title + names + a single CTA. Deliberately self-contained
+/// — no coupling to the goal-celebration state machine.
+struct TokenUnlockOverlay: View {
+    let kinds: [StreakTokenKind]
+    let onDismiss: () -> Void
+
+    @State private var appeared = false
+    @State private var raysAngle: Angle = .degrees(0)
+
+    private var title: String {
+        kinds.count == 1 ? "Token Earned!" : "\(kinds.count) Tokens Earned!"
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.82).ignoresSafeArea()
+                .onTapGesture { dismiss() }
+
+            // Gold rays radiating behind the medallions — the "reward" light.
+            RaysShape(count: 12)
+                .fill(
+                    LinearGradient(
+                        colors: [Color(red: 1.0, green: 0.84, blue: 0.35).opacity(0.35), .clear],
+                        startPoint: .center,
+                        endPoint: .top
+                    )
+                )
+                .frame(width: 420, height: 420)
+                .rotationEffect(raysAngle)
+                .opacity(appeared ? 1 : 0)
+                .allowsHitTesting(false)
+
+            VStack(spacing: MADTheme.Spacing.lg) {
+                HStack(spacing: kinds.count > 1 ? 18 : 0) {
+                    ForEach(Array(kinds.enumerated()), id: \.element.title) { index, kind in
+                        TokenMedallion(
+                            kind: kind,
+                            held: true,
+                            size: kinds.count == 1 ? 132 : 84
+                        )
+                        .scaleEffect(appeared ? 1 : 0.2)
+                        .opacity(appeared ? 1 : 0)
+                        .animation(
+                            .spring(response: 0.5, dampingFraction: 0.62)
+                                .delay(0.12 + Double(index) * 0.14),
+                            value: appeared
+                        )
+                    }
+                }
+
+                VStack(spacing: 6) {
+                    Text(title)
+                        .font(.system(size: 30, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+
+                    Text(kinds.map { $0.title }.joined(separator: " · "))
+                        .font(.system(size: 15, weight: .bold, design: .rounded))
+                        .foregroundColor(Color(red: 1.0, green: 0.84, blue: 0.35))
+
+                    Text(subtitle)
+                        .font(.system(size: 13, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.7))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, MADTheme.Spacing.xl)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .opacity(appeared ? 1 : 0)
+                .offset(y: appeared ? 0 : 12)
+                .animation(.easeOut(duration: 0.4).delay(0.35), value: appeared)
+
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Let's Go")
+                        .font(.system(size: 16, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 44)
+                        .padding(.vertical, 14)
+                        .background(Capsule().fill(MADTheme.Colors.redGradient))
+                        .shadow(color: MADTheme.Colors.madRed.opacity(0.5), radius: 10)
+                }
+                .buttonStyle(ScaleButtonStyle())
+                .opacity(appeared ? 1 : 0)
+                .animation(.easeOut(duration: 0.4).delay(0.5), value: appeared)
+            }
+            .padding(MADTheme.Spacing.lg)
+        }
+        .onAppear {
+            appeared = true
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            withAnimation(.linear(duration: 24).repeatForever(autoreverses: false)) {
+                raysAngle = .degrees(360)
+            }
+        }
+    }
+
+    private var subtitle: String {
+        if kinds.count > 1 {
+            return "Your streak history earned these. They're on your dashboard — tap them anytime to see what they do."
+        }
+        switch kinds[0] {
+        case .doubleDown:
+            return "Miss a day? Run 2× your goal the next day and it still counts."
+        case .save:
+            return "If you ever miss a day, this covers it automatically."
+        case .assist:
+            return "A friend's streak breaks? You can now save it from their row on the Friends tab."
+        }
+    }
+
+    private func dismiss() {
+        withAnimation(.easeOut(duration: 0.25)) { onDismiss() }
+    }
+}
+
+/// Simple radial burst of tapered rays.
+private struct RaysShape: Shape {
+    let count: Int
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let radius = min(rect.width, rect.height) / 2
+        let halfWidth = CGFloat.pi / CGFloat(count) * 0.35
+        for i in 0..<count {
+            let angle = CGFloat(i) / CGFloat(count) * 2 * .pi
+            path.move(to: center)
+            path.addLine(to: CGPoint(
+                x: center.x + radius * cos(angle - halfWidth),
+                y: center.y + radius * sin(angle - halfWidth)
+            ))
+            path.addLine(to: CGPoint(
+                x: center.x + radius * cos(angle + halfWidth),
+                y: center.y + radius * sin(angle + halfWidth)
+            ))
+            path.closeSubpath()
+        }
+        return path
+    }
+}
+
+/// Maps the state's raw earned kinds to medallion kinds.
+extension StreakTokenKind {
+    static func from(raw: String) -> StreakTokenKind? {
+        switch raw {
+        case "double_down": return .doubleDown
+        case "streak_save": return .save
+        case "streak_assist": return .assist
+        default: return nil
+        }
+    }
+}

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -34,6 +34,8 @@ struct DashboardView: View {
     /// What's New popup — auto-presents once per release, reopenable from
     /// Settings → What's New.
     @State private var showWhatsNew = false
+    /// Streak tokens — drives the tokens card + the unlock celebration.
+    @ObservedObject private var tokensState = StreakTokensState.shared
     @State private var newGoalMiles: Double = 1.0
     @State private var isRefreshing = false
     @State private var showWorkoutUploadAlert = false
@@ -577,6 +579,21 @@ struct DashboardView: View {
             }
             .sheet(isPresented: $showWhatsNew) {
                 WhatsNewView()
+            }
+            // Token unlock celebration — a meter just completed (or enrollment
+            // backfill handed over the starting set). Self-contained overlay;
+            // stands down while a goal celebration is playing (newlyEarned
+            // persists until dismissed, so the moment isn't lost).
+            .overlay {
+                if !tokensState.newlyEarned.isEmpty,
+                   !celebrationManager.isShowingCelebration {
+                    TokenUnlockOverlay(
+                        kinds: tokensState.newlyEarned.compactMap { StreakTokenKind.from(raw: $0) },
+                        onDismiss: { tokensState.newlyEarned = [] }
+                    )
+                    .transition(.opacity)
+                    .zIndex(50)
+                }
             }
             .sheet(isPresented: $showGoalSheet) {
                 GoalSettingSheet(

--- a/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
+++ b/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
@@ -181,6 +181,8 @@ struct PureFlameBadge: View {
 struct StreakTokensCard: View {
     @ObservedObject var tokensState = StreakTokensState.shared
     @State private var showDetail = false
+    /// Drives the slow breathing pulse on earned medallions.
+    @State private var pulse = false
 
     var body: some View {
         if let payload = tokensState.payload {
@@ -266,6 +268,15 @@ struct StreakTokensCard: View {
     ) -> some View {
         VStack(spacing: 6) {
             TokenMedallion(kind: kind, held: held, progress: progress, size: 46)
+                // Earned tokens breathe gently — alive, not static.
+                .scaleEffect(held && pulse ? 1.05 : 1.0)
+                .animation(
+                    held
+                        ? .easeInOut(duration: 1.5).repeatForever(autoreverses: true)
+                        : .default,
+                    value: pulse
+                )
+                .onAppear { pulse = true }
             Text(kind.title)
                 .font(.system(size: 10, weight: .bold, design: .rounded))
                 .foregroundColor(.white.opacity(held ? 0.95 : 0.6))
@@ -406,31 +417,7 @@ struct StreakTokensDetailView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            // Meter bar + count
-            VStack(alignment: .leading, spacing: 4) {
-                GeometryReader { geo in
-                    ZStack(alignment: .leading) {
-                        Capsule().fill(Color.white.opacity(0.08))
-                        Capsule()
-                            .fill(
-                                LinearGradient(
-                                    colors: kind.gradient,
-                                    startPoint: .leading,
-                                    endPoint: .trailing
-                                )
-                            )
-                            .frame(width: max(6, geo.size.width * (meter.held ? 1 : meter.fraction)))
-                    }
-                }
-                .frame(height: 8)
-
-                Text(meter.held
-                     ? "Earned — you're holding 1 (max 1). Using it restarts the meter."
-                     : "\(trimmed(meter.progress)) / \(trimmed(meter.target)) \(unit)")
-                    .font(.system(size: 11, weight: .bold, design: .rounded))
-                    .monospacedDigit()
-                    .foregroundColor(meter.held ? .green : .secondary)
-            }
+            TokenMeterBar(kind: kind, meter: meter, unit: unit)
         }
         .padding(MADTheme.Spacing.md)
         .madLiquidGlass()
@@ -467,5 +454,90 @@ struct StreakTokensDetailView: View {
         value.truncatingRemainder(dividingBy: 1) == 0
             ? String(Int(value))
             : String(format: "%.1f", value)
+    }
+}
+
+// MARK: - Animated meter bar
+
+/// The earn meter, made satisfying: the fill springs from zero on appear, a
+/// light shimmer sweeps the filled portion, and the copy counts DOWN ("3 to
+/// go") so progress reads as approach, not bookkeeping.
+private struct TokenMeterBar: View {
+    let kind: StreakTokenKind
+    let meter: StreakTokenMeter
+    let unit: String
+
+    @State private var grown = false
+    @State private var shimmer = false
+
+    private var fraction: Double { meter.held ? 1 : meter.fraction }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            GeometryReader { geo in
+                let fillWidth = max(6, geo.size.width * fraction * (grown ? 1 : 0))
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Color.white.opacity(0.08))
+                    Capsule()
+                        .fill(
+                            LinearGradient(
+                                colors: kind.gradient,
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                        )
+                        .frame(width: fillWidth)
+                        .overlay(
+                            // Shimmer sweep across the filled portion.
+                            Capsule()
+                                .fill(
+                                    LinearGradient(
+                                        colors: [.clear, .white.opacity(0.45), .clear],
+                                        startPoint: .leading,
+                                        endPoint: .trailing
+                                    )
+                                )
+                                .frame(width: 46)
+                                .offset(x: shimmer ? fillWidth : -46)
+                                .animation(
+                                    .linear(duration: 1.8)
+                                        .repeatForever(autoreverses: false)
+                                        .delay(0.8),
+                                    value: shimmer
+                                )
+                                .mask(Capsule().frame(width: fillWidth))
+                        , alignment: .leading)
+                }
+            }
+            .frame(height: 8)
+
+            Text(statusLine)
+                .font(.system(size: 11, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .foregroundColor(meter.held ? .green : .secondary)
+        }
+        .onAppear {
+            withAnimation(.spring(response: 0.7, dampingFraction: 0.85).delay(0.15)) {
+                grown = true
+            }
+            if fraction > 0.1 { shimmer = true }
+        }
+    }
+
+    private var statusLine: String {
+        if meter.held {
+            return "Earned — you're holding 1 (max 1). Using it restarts the meter."
+        }
+        let remaining = max(meter.target - meter.progress, 0)
+        let togo = remaining.truncatingRemainder(dividingBy: 1) == 0
+            ? String(Int(remaining))
+            : String(format: "%.1f", remaining)
+        let progressText = meter.progress.truncatingRemainder(dividingBy: 1) == 0
+            ? String(Int(meter.progress))
+            : String(format: "%.1f", meter.progress)
+        let targetText = meter.target.truncatingRemainder(dividingBy: 1) == 0
+            ? String(Int(meter.target))
+            : String(format: "%.1f", meter.target)
+        return "\(progressText) / \(targetText) \(unit) · \(togo) to go"
     }
 }

--- a/app/Mile A Day/Views/Profile/ProfileView.swift
+++ b/app/Mile A Day/Views/Profile/ProfileView.swift
@@ -4,8 +4,10 @@ struct ProfileView: View {
     @Environment(\.appStateManager) var appStateManager
     @ObservedObject var userManager: UserManager
     @ObservedObject var healthManager: HealthKitManager
-    /// Streak-token state — drives the Pure Flame (natural streak) seal.
+    /// Streak-token state — drives the Pure Flame (natural streak) seal and
+    /// the profile token shelf.
     @ObservedObject private var tokensState = StreakTokensState.shared
+    @State private var showTokenSheet = false
 
     @State private var activeSheet: ProfileSheetType?
     @State private var showingEditProfile = false
@@ -510,6 +512,40 @@ struct ProfileView: View {
                             Text(displayName)
                                 .font(MADTheme.Typography.body)
                                 .foregroundColor(MADTheme.Colors.secondaryText)
+                        }
+
+                        // Token shelf — your minted set, right on the profile.
+                        // Hidden until streak features are active.
+                        if let tokens = tokensState.payload {
+                            Button {
+                                showTokenSheet = true
+                            } label: {
+                                HStack(spacing: 14) {
+                                    TokenMedallion(
+                                        kind: .doubleDown,
+                                        held: tokens.double_down.held,
+                                        progress: tokens.double_down.fraction,
+                                        size: 34
+                                    )
+                                    TokenMedallion(
+                                        kind: .save,
+                                        held: tokens.streak_save.held,
+                                        progress: tokens.streak_save.fraction,
+                                        size: 34
+                                    )
+                                    TokenMedallion(
+                                        kind: .assist,
+                                        held: tokens.streak_assist.held,
+                                        progress: tokens.streak_assist.fraction,
+                                        size: 34
+                                    )
+                                }
+                                .padding(.top, MADTheme.Spacing.xs)
+                            }
+                            .buttonStyle(ScaleButtonStyle())
+                            .sheet(isPresented: $showTokenSheet) {
+                                StreakTokensDetailView()
+                            }
                         }
 
                         // Bio with quote-style accent

--- a/backend/src/services/streakFeatureService.ts
+++ b/backend/src/services/streakFeatureService.ts
@@ -46,8 +46,12 @@ export const STREAK_ASSIST_TARGET_MILES = 20;
 const DOUBLE_DOWN_GOAL_MULTIPLIER = 2;
 const DOUBLE_DOWN_TOLERANCE = 0.05;
 // Meter windows: retroactive credit at enrollment + a hard query bound.
-const ENROLL_LOOKBACK_DAYS = 30;
-const METER_WINDOW_DAYS = 90;
+// A FULL YEAR on purpose — a 400-day streaker must enroll fully loaded
+// (all three tokens held), not start from scratch like a new runner. The
+// original 30/90 made long streaks count the same as one month. Post-launch
+// the window is naturally bounded by each token's last-used date anyway.
+const ENROLL_LOOKBACK_DAYS = 365;
+const METER_WINDOW_DAYS = 365;
 // Assist-opportunity pushes only fire for streaks worth mourning.
 const MIN_NOTIFY_PRIOR_STREAK = 3;
 // A break stays rescuable for this many days after the missed day.


### PR DESCRIPTION
## 1. The retroactivity bug — real, and fixed

Enrollment lookback + meter window were **30/90 days**, so your 400-day streak counted the same as someone's first month — that's why you weren't fully loaded. Both windows are now **365 days**: enrolling counts a year of history, so a serious streak starts with **all three tokens held** (14 active days ✓, 7 run days ✓, 20 over-goal miles ✓ — easily, in a year). Post-launch the windows re-anchor to each token's last-used date, so this only widens the *starting* credit. Backend `tsc` clean.

## 2. The unlock moment 🎉

- `StreakTokensState` now diffs held flags against a persisted snapshot — any token flipping to EARNED publishes the event, **including the first payload after backfill** (so when this deploys, your app opens to the full ceremony).
- New **`TokenUnlockOverlay`**: dimmed backdrop, slow-turning gold rays, the medallion(s) springing in oversized with glow, "3 Tokens Earned!", success haptic, one CTA. Fires once per earn (persisted), waits out goal celebrations, and holds the moment until dismissed.

## 3. More homes + meters that feel alive

- **Profile token shelf** — your three medallions right under your name; tap → the explainer sheet.
- **Explainer meter bars** — the fill springs from zero when the sheet opens, a light shimmer sweeps the filled portion, and the copy counts **down** ("5 / 7 run days · **2 to go**") so it reads as approach, not bookkeeping.
- **Dashboard card** — earned medallions breathe with a slow 1.05× pulse; in-progress ones stay still with their rim arc.

## After merge
Backend deploys → relaunch the app → the year-window meters land → the unlock overlay fires with your starting set → dashboard, profile shelf, and explainer all show gold-rimmed, glowing, gently breathing tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY)_