### PR TITLE
Design pass: calm dashboard, Pure Flame info box + tappable badge, living meters

### DIFF
--- a/app/Mile A Day/Core/State/StreakTokensState.swift
+++ b/app/Mile A Day/Core/State/StreakTokensState.swift
@@ -21,10 +21,58 @@ final class StreakTokensState: ObservableObject {
     /// "streak_save", "streak_assist") — drives the unlock celebration.
     /// Cleared by the overlay's dismiss.
     @Published var newlyEarned: [String] = []
+    /// Transient "+1 run day" chips per raw kind — set when a fresh payload
+    /// moves a meter forward within a session, auto-cleared a few seconds
+    /// later. Purely celebratory; nothing reads it for logic.
+    @Published var meterGains: [String: String] = [:]
+    private var gainsClearTask: Task<Void, Never>?
 
     var isActive: Bool { payload != nil }
 
     private static let heldFlagsKey = "streakTokenHeldFlags"
+
+    /// Single entry point for a fresh (or absent) payload: diffs meters for
+    /// the gain chips, publishes the payload, and diffs held flags for the
+    /// unlock celebration. Callers go through
+    /// `StreakFeatureService.applyStatsPayload`, which also syncs the
+    /// coverage store.
+    @MainActor
+    func apply(_ new: StreakFeaturesPayload?) {
+        if let new, let old = payload {
+            noteMeterGains(old: old, new: new)
+        }
+        payload = new
+        if let new {
+            registerHeldStates(from: new)
+        }
+    }
+
+    /// Meter deltas → short gain chips ("+1 day", "+0.8 mi"). Held meters are
+    /// skipped — the unlock overlay owns that bigger moment.
+    @MainActor
+    private func noteMeterGains(old: StreakFeaturesPayload, new: StreakFeaturesPayload) {
+        var gains: [String: String] = [:]
+        if !new.double_down.held {
+            let d = Int(new.double_down.progress) - Int(old.double_down.progress)
+            if d > 0 { gains["double_down"] = "+\(d) day\(d == 1 ? "" : "s")" }
+        }
+        if !new.streak_save.held {
+            let d = Int(new.streak_save.progress) - Int(old.streak_save.progress)
+            if d > 0 { gains["streak_save"] = "+\(d) run day\(d == 1 ? "" : "s")" }
+        }
+        if !new.streak_assist.held {
+            let d = new.streak_assist.progress - old.streak_assist.progress
+            if d >= 0.05 { gains["streak_assist"] = String(format: "+%.1f mi", d) }
+        }
+        guard !gains.isEmpty else { return }
+        meterGains = gains
+        gainsClearTask?.cancel()
+        gainsClearTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 4_000_000_000)
+            guard !Task.isCancelled else { return }
+            self?.meterGains = [:]
+        }
+    }
 
     /// Diff the held flags against the last seen set (persisted, so the
     /// celebration fires exactly once per earn — including the very first
@@ -61,7 +109,6 @@ final class StreakTokensState: ObservableObject {
                   let save = status.streak_save,
                   let assist = status.streak_assist
             else {
-                payload = nil
                 assistableFriends = []
                 StreakFeatureService.applyStatsPayload(nil)
                 return
@@ -74,9 +121,10 @@ final class StreakTokensState: ObservableObject {
                 natural_streak: status.natural_streak ?? true,
                 streak_at_risk: status.streak_at_risk ?? false
             )
-            payload = fresh
             assistableFriends = status.assistable_friends ?? []
-            registerHeldStates(from: fresh)
+            // Route through applyStatsPayload → apply() so the payload is
+            // published, held flags are diffed, gain chips fire, and the
+            // coverage store stays in sync — one path for every payload.
             StreakFeatureService.applyStatsPayload(fresh)
         } catch {
             // Keep last known state on transient failures.

--- a/app/Mile A Day/Core/State/StreakTokensState.swift
+++ b/app/Mile A Day/Core/State/StreakTokensState.swift
@@ -17,8 +17,36 @@ final class StreakTokensState: ObservableObject {
     /// DEBUG preview: while true, refreshStatus() is a no-op so server state
     /// can't clobber the injected sample data. Never persisted.
     @Published var isPreviewingSampleData = false
+    /// Tokens that just flipped to EARNED (raw kinds: "double_down",
+    /// "streak_save", "streak_assist") — drives the unlock celebration.
+    /// Cleared by the overlay's dismiss.
+    @Published var newlyEarned: [String] = []
 
     var isActive: Bool { payload != nil }
+
+    private static let heldFlagsKey = "streakTokenHeldFlags"
+
+    /// Diff the held flags against the last seen set (persisted, so the
+    /// celebration fires exactly once per earn — including the very first
+    /// payload after enrollment backfill, the "you start fully loaded" moment).
+    @MainActor
+    func registerHeldStates(from payload: StreakFeaturesPayload) {
+        let previous =
+            UserDefaults.standard.dictionary(forKey: Self.heldFlagsKey) as? [String: Bool] ?? [:]
+        let current: [String: Bool] = [
+            "double_down": payload.double_down.held,
+            "streak_save": payload.streak_save.held,
+            "streak_assist": payload.streak_assist.held,
+        ]
+        let earned = current
+            .filter { $0.value && previous[$0.key] != true }
+            .map { $0.key }
+            .sorted()
+        UserDefaults.standard.set(current, forKey: Self.heldFlagsKey)
+        if !earned.isEmpty {
+            newlyEarned = earned
+        }
+    }
 
     /// Refresh meters + rescuable friends from the status endpoint (used by
     /// surfaces that need fresher data than the last stats fetch, e.g. the
@@ -48,6 +76,7 @@ final class StreakTokensState: ObservableObject {
             )
             payload = fresh
             assistableFriends = status.assistable_friends ?? []
+            registerHeldStates(from: fresh)
             StreakFeatureService.applyStatsPayload(fresh)
         } catch {
             // Keep last known state on transient failures.

--- a/app/Mile A Day/Services/FriendService.swift
+++ b/app/Mile A Day/Services/FriendService.swift
@@ -922,6 +922,10 @@ struct FriendStats: Codable {
     let recentWorkouts: [FriendWorkout]?
     let todayMiles: Double?
     let goalMiles: Double?
+    /// True when this user's current streak is 100% natural. Read from the
+    /// gated `streak_features` payload — absent for un-enrolled users, so it
+    /// safely defaults to false and the Pure Flame badge simply doesn't show.
+    let naturalStreak: Bool
 
     enum CodingKeys: String, CodingKey {
         case streak
@@ -932,6 +936,18 @@ struct FriendStats: Codable {
         case recentWorkouts = "recent_workouts"
         case todayMiles = "today_miles"
         case goalMiles = "goal_miles"
+    }
+
+    /// Separate key enum for the gated payload so `streak_features` stays out
+    /// of CodingKeys — `naturalStreak` has no server-side twin field, and an
+    /// unmatched CodingKeys case would break the synthesized encode.
+    private enum GatedKeys: String, CodingKey {
+        case streakFeatures = "streak_features"
+    }
+
+    /// Only the one field friend surfaces need from the gated payload.
+    private struct GatedStreakFeatures: Decodable {
+        let natural_streak: Bool?
     }
     
     init(from decoder: Decoder) throws {
@@ -955,6 +971,12 @@ struct FriendStats: Codable {
         recentWorkouts = try? container.decode([FriendWorkout].self, forKey: .recentWorkouts)
         todayMiles = try? container.decode(Double.self, forKey: .todayMiles)
         goalMiles = try? container.decode(Double.self, forKey: .goalMiles)
+        if let gated = try? decoder.container(keyedBy: GatedKeys.self),
+           let features = try? gated.decode(GatedStreakFeatures.self, forKey: .streakFeatures) {
+            naturalStreak = features.natural_streak ?? false
+        } else {
+            naturalStreak = false
+        }
     }
 }
 

--- a/app/Mile A Day/Services/StreakFeatureService.swift
+++ b/app/Mile A Day/Services/StreakFeatureService.swift
@@ -197,6 +197,9 @@ enum StreakFeatureService {
         }
         Task { @MainActor in
             StreakTokensState.shared.payload = payload
+            if let payload {
+                StreakTokensState.shared.registerHeldStates(from: payload)
+            }
         }
     }
 }

--- a/app/Mile A Day/Services/StreakFeatureService.swift
+++ b/app/Mile A Day/Services/StreakFeatureService.swift
@@ -196,10 +196,7 @@ enum StreakFeatureService {
             StreakCoverageStore.deactivate()
         }
         Task { @MainActor in
-            StreakTokensState.shared.payload = payload
-            if let payload {
-                StreakTokensState.shared.registerHeldStates(from: payload)
-            }
+            StreakTokensState.shared.apply(payload)
         }
     }
 }

--- a/app/Mile A Day/Views/Components/TokenUnlockOverlay.swift
+++ b/app/Mile A Day/Views/Components/TokenUnlockOverlay.swift
@@ -1,0 +1,157 @@
+import SwiftUI
+
+/// Full-screen "Token Earned!" moment. Fires when a meter completes (or when
+/// enrollment backfill hands a long streaker their starting set): dimmed
+/// backdrop, slow-spinning gold rays, the medallion(s) spring in oversized
+/// with a glow, then title + names + a single CTA. Deliberately self-contained
+/// — no coupling to the goal-celebration state machine.
+struct TokenUnlockOverlay: View {
+    let kinds: [StreakTokenKind]
+    let onDismiss: () -> Void
+
+    @State private var appeared = false
+    @State private var raysAngle: Angle = .degrees(0)
+
+    private var title: String {
+        kinds.count == 1 ? "Token Earned!" : "\(kinds.count) Tokens Earned!"
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.82).ignoresSafeArea()
+                .onTapGesture { dismiss() }
+
+            // Gold rays radiating behind the medallions — the "reward" light.
+            RaysShape(count: 12)
+                .fill(
+                    LinearGradient(
+                        colors: [Color(red: 1.0, green: 0.84, blue: 0.35).opacity(0.35), .clear],
+                        startPoint: .center,
+                        endPoint: .top
+                    )
+                )
+                .frame(width: 420, height: 420)
+                .rotationEffect(raysAngle)
+                .opacity(appeared ? 1 : 0)
+                .allowsHitTesting(false)
+
+            VStack(spacing: MADTheme.Spacing.lg) {
+                HStack(spacing: kinds.count > 1 ? 18 : 0) {
+                    ForEach(Array(kinds.enumerated()), id: \.element.title) { index, kind in
+                        TokenMedallion(
+                            kind: kind,
+                            held: true,
+                            size: kinds.count == 1 ? 132 : 84
+                        )
+                        .scaleEffect(appeared ? 1 : 0.2)
+                        .opacity(appeared ? 1 : 0)
+                        .animation(
+                            .spring(response: 0.5, dampingFraction: 0.62)
+                                .delay(0.12 + Double(index) * 0.14),
+                            value: appeared
+                        )
+                    }
+                }
+
+                VStack(spacing: 6) {
+                    Text(title)
+                        .font(.system(size: 30, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+
+                    Text(kinds.map { $0.title }.joined(separator: " · "))
+                        .font(.system(size: 15, weight: .bold, design: .rounded))
+                        .foregroundColor(Color(red: 1.0, green: 0.84, blue: 0.35))
+
+                    Text(subtitle)
+                        .font(.system(size: 13, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.7))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, MADTheme.Spacing.xl)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .opacity(appeared ? 1 : 0)
+                .offset(y: appeared ? 0 : 12)
+                .animation(.easeOut(duration: 0.4).delay(0.35), value: appeared)
+
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Let's Go")
+                        .font(.system(size: 16, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 44)
+                        .padding(.vertical, 14)
+                        .background(Capsule().fill(MADTheme.Colors.redGradient))
+                        .shadow(color: MADTheme.Colors.madRed.opacity(0.5), radius: 10)
+                }
+                .buttonStyle(ScaleButtonStyle())
+                .opacity(appeared ? 1 : 0)
+                .animation(.easeOut(duration: 0.4).delay(0.5), value: appeared)
+            }
+            .padding(MADTheme.Spacing.lg)
+        }
+        .onAppear {
+            appeared = true
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            withAnimation(.linear(duration: 24).repeatForever(autoreverses: false)) {
+                raysAngle = .degrees(360)
+            }
+        }
+    }
+
+    private var subtitle: String {
+        if kinds.count > 1 {
+            return "Your streak history earned these. They're on your dashboard — tap them anytime to see what they do."
+        }
+        switch kinds[0] {
+        case .doubleDown:
+            return "Miss a day? Run 2× your goal the next day and it still counts."
+        case .save:
+            return "If you ever miss a day, this covers it automatically."
+        case .assist:
+            return "A friend's streak breaks? You can now save it from their row on the Friends tab."
+        }
+    }
+
+    private func dismiss() {
+        withAnimation(.easeOut(duration: 0.25)) { onDismiss() }
+    }
+}
+
+/// Simple radial burst of tapered rays.
+private struct RaysShape: Shape {
+    let count: Int
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let radius = min(rect.width, rect.height) / 2
+        let halfWidth = CGFloat.pi / CGFloat(count) * 0.35
+        for i in 0..<count {
+            let angle = CGFloat(i) / CGFloat(count) * 2 * .pi
+            path.move(to: center)
+            path.addLine(to: CGPoint(
+                x: center.x + radius * cos(angle - halfWidth),
+                y: center.y + radius * sin(angle - halfWidth)
+            ))
+            path.addLine(to: CGPoint(
+                x: center.x + radius * cos(angle + halfWidth),
+                y: center.y + radius * sin(angle + halfWidth)
+            ))
+            path.closeSubpath()
+        }
+        return path
+    }
+}
+
+/// Maps the state's raw earned kinds to medallion kinds.
+extension StreakTokenKind {
+    static func from(raw: String) -> StreakTokenKind? {
+        switch raw {
+        case "double_down": return .doubleDown
+        case "streak_save": return .save
+        case "streak_assist": return .assist
+        default: return nil
+        }
+    }
+}

--- a/app/Mile A Day/Views/Dashboard/DashboardCards.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardCards.swift
@@ -76,36 +76,18 @@ struct StreakCard: View {
                             .foregroundColor(.white.opacity(0.8))
                     }
 
-                    // Status message - make completion status super obvious with consistent colors
-                    VStack(alignment: .leading, spacing: 6) {
-                        if isGoalCompleted {
-                            HStack(spacing: 4) {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .font(.subheadline)
-                                    .foregroundColor(statusColor)
-                                Text("Goal completed today!")
-                                    .font(.subheadline)
-                                    .foregroundColor(statusColor)
-                                    .fontWeight(.bold)
-                            }
-                        } else {
-                            HStack(spacing: 4) {
-                                Image(systemName: isAtRisk ? "exclamationmark.triangle.fill" : "exclamationmark.circle.fill")
-                                    .font(.subheadline)
-                                    .foregroundColor(statusColor)
-                                Text(isAtRisk ? "Streak at risk!" : "Goal not completed")
-                                    .font(.subheadline)
-                                    .foregroundColor(statusColor)
-                                    .fontWeight(.bold)
-                            }
-
-                            if !isAtRisk {
-                                Text("\(String(format: "%.2f", user.goalMiles - currentDistance)) mi to go")
-                                    .font(.caption)
-                                    .foregroundColor(.white.opacity(0.8))
-                            }
-                        }
+                    // One status line — completion, distance-to-go, and
+                    // time-left merged into a single caption instead of
+                    // three stacked fragments (calm-pass density cut).
+                    HStack(spacing: 5) {
+                        Image(systemName: statusIconName)
+                            .font(.system(size: 12, weight: .bold))
+                        Text(statusLineText)
+                            .font(.system(size: 13, weight: .semibold, design: .rounded))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
                     }
+                    .foregroundColor(statusColor)
                 }
 
                 Spacer()
@@ -113,26 +95,9 @@ struct StreakCard: View {
                 // Right side: Flame icon - consistent colors based on status
                 ZStack {
                     if isGoalCompleted {
-                        // Outer glow - green/orange when completed
-                        Circle()
-                            .fill(
-                                RadialGradient(
-                                    colors: [
-                                        statusColor.opacity(0.5),
-                                        statusColor.opacity(0.2),
-                                        Color.clear
-                                    ],
-                                    center: .center,
-                                    startRadius: 20,
-                                    endRadius: 45
-                                )
-                            )
-                            .frame(width: 90, height: 90)
-                            .scaleEffect(animateFire ? 1.15 : 0.95)
-                            .opacity(animateFire ? 0.9 : 0.5)
-                            .animation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true), value: animateFire)
-
-                        // Inner circle background - green/orange when completed
+                        // Flat completed state: one tinted disc + a gently
+                        // breathing flame. The old animated radial glow ring
+                        // was pure ornament — cut in the calm pass.
                         Circle()
                             .fill(
                                 LinearGradient(
@@ -146,7 +111,6 @@ struct StreakCard: View {
                             )
                             .frame(width: 70, height: 70)
 
-                        // Flame icon with animation - green/orange and pulsing when completed
                         Image(systemName: "flame.fill")
                             .font(.system(size: 36))
                             .foregroundStyle(
@@ -156,54 +120,42 @@ struct StreakCard: View {
                                     endPoint: .bottom
                                 )
                             )
-                            .scaleEffect(animateFire ? 1.15 : 1.0)
-                            .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: animateFire)
-                            .shadow(color: statusColor.opacity(0.7), radius: animateFire ? 15 : 8)
+                            .scaleEffect(animateFire ? 1.08 : 1.0)
+                            .animation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true), value: animateFire)
+                            .shadow(color: statusColor.opacity(0.5), radius: animateFire ? 9 : 6)
                     } else if isAtRisk {
-                        // At-risk state: countdown ring around flame with time label below
                         let countdownProgress: Double = {
                             guard let remaining = user.timeUntilStreakReset else { return 0 }
                             // 6 hours = 21600 seconds (from 6pm to midnight)
                             return min(remaining / 21600, 1.0)
                         }()
 
-                        VStack(spacing: 6) {
-                            ZStack {
-                                Circle()
-                                    .fill(Color.red.opacity(0.1))
-                                    .frame(width: 70, height: 70)
+                        // At-risk: countdown ring around the flame. The time
+                        // itself lives in the status line on the left now —
+                        // no duplicate label under the ring.
+                        ZStack {
+                            Circle()
+                                .fill(Color.red.opacity(0.1))
+                                .frame(width: 70, height: 70)
 
-                                // Countdown ring
-                                Circle()
-                                    .trim(from: 0, to: countdownProgress)
-                                    .stroke(
-                                        LinearGradient(
-                                            colors: [.red, .orange],
-                                            startPoint: .topLeading,
-                                            endPoint: .bottomTrailing
-                                        ),
-                                        style: StrokeStyle(lineWidth: 3, lineCap: .round)
-                                    )
-                                    .frame(width: 74, height: 74)
-                                    .rotationEffect(.degrees(-90))
+                            Circle()
+                                .trim(from: 0, to: countdownProgress)
+                                .stroke(
+                                    LinearGradient(
+                                        colors: [.red, .orange],
+                                        startPoint: .topLeading,
+                                        endPoint: .bottomTrailing
+                                    ),
+                                    style: StrokeStyle(lineWidth: 3, lineCap: .round)
+                                )
+                                .frame(width: 74, height: 74)
+                                .rotationEffect(.degrees(-90))
 
-                                Image(systemName: "flame.fill")
-                                    .font(.system(size: 36))
-                                    .foregroundColor(.red.opacity(0.8))
-                                    .scaleEffect(animateUrgency ? 1.05 : 0.95)
-                                    .animation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true), value: animateUrgency)
-                            }
-
-                            if !timeRemainingText.isEmpty {
-                                HStack(spacing: 4) {
-                                    Image(systemName: "exclamationmark.triangle.fill")
-                                        .font(.system(size: 10, weight: .bold))
-                                    Text(formattedTimeOnly)
-                                        .font(.system(size: 13, weight: .bold, design: .rounded))
-                                }
-                                .foregroundColor(.red)
-                                .opacity(animateUrgency ? 1.0 : 0.6)
-                            }
+                            Image(systemName: "flame.fill")
+                                .font(.system(size: 36))
+                                .foregroundColor(.red.opacity(0.8))
+                                .scaleEffect(animateUrgency ? 1.05 : 0.95)
+                                .animation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true), value: animateUrgency)
                         }
                     } else {
                         // Default: not completed, not at risk
@@ -218,31 +170,16 @@ struct StreakCard: View {
                 }
             }
 
-            // Milestone progress
+            // Milestone — one slim row (bar + tiny caption) instead of the
+            // old two-line header + thick bar block.
             if let milestone = nextMilestone {
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack {
-                        Text("Next Milestone: \(milestone.value) Days")
-                            .font(.subheadline)
-                            .fontWeight(.semibold)
-                            .foregroundColor(.white.opacity(0.9))
-
-                        Spacer()
-
-                        Text("\(milestone.daysToGo) days to go")
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                            .foregroundColor(statusColor)
-                    }
-
-                    // Progress bar
+                HStack(spacing: 10) {
                     GeometryReader { geometry in
                         ZStack(alignment: .leading) {
-                            RoundedRectangle(cornerRadius: 8)
-                                .fill(Color.white.opacity(0.15))
-                                .frame(height: 8)
+                            Capsule()
+                                .fill(Color.white.opacity(0.12))
 
-                            RoundedRectangle(cornerRadius: 8)
+                            Capsule()
                                 .fill(
                                     LinearGradient(
                                         colors: [.yellow, .orange, .red],
@@ -250,27 +187,21 @@ struct StreakCard: View {
                                         endPoint: .trailing
                                     )
                                 )
-                                .frame(width: milestone.progress * geometry.size.width, height: 8)
+                                .frame(width: max(5, milestone.progress * geometry.size.width))
                                 .animation(.easeOut(duration: 0.8), value: milestone.progress)
                         }
                     }
-                    .frame(height: 8)
+                    .frame(height: 5)
+
+                    Text("Day \(milestone.value) in \(milestone.daysToGo)")
+                        .font(.system(size: 11, weight: .semibold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.55))
+                        .layoutPriority(1)
                 }
             }
 
             // Compact week-at-a-glance row
             compactWeekRow
-
-            // Share hint
-            HStack(spacing: 6) {
-                Image(systemName: "square.and.arrow.up")
-                    .font(.system(size: 10))
-                Text("Tap to share your streak")
-                    .font(.system(size: 11, weight: .medium))
-            }
-            .foregroundColor(.white.opacity(0.45))
-            .frame(maxWidth: .infinity)
-            .padding(.top, 4)
         }
         .padding(.horizontal, 24)
         .padding(.vertical, 24)
@@ -307,27 +238,14 @@ struct StreakCard: View {
             }
         )
         .overlay(alignment: .topTrailing) {
-            // Time/check positioned at absolute top right edge.
-            // At-risk state renders its time label under the flame ring instead.
-            if isGoalCompleted {
-                Image(systemName: "checkmark.circle.fill")
-                    .font(.caption)
-                    .foregroundColor(.green)
-                    .padding(.top, 24)
-                    .padding(.trailing, 24)
-            } else if !isAtRisk && !timeRemainingText.isEmpty {
-                HStack(spacing: 4) {
-                    Image(systemName: "clock.fill")
-                        .font(.caption2)
-                        .foregroundColor(statusColor)
-                    Text(formattedTimeOnly)
-                        .font(.caption2)
-                        .foregroundColor(statusColor)
-                        .fontWeight(.medium)
-                }
-                .padding(.top, 24)
-                .padding(.trailing, 24)
-            }
+            // Quiet share affordance — replaces the old check/clock cluster
+            // (both merged into the status line) and the full-width
+            // "Tap to share" hint row.
+            Image(systemName: "square.and.arrow.up")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(.white.opacity(0.35))
+                .padding(.top, 20)
+                .padding(.trailing, 20)
         }
         .shadow(color: .black.opacity(0.1), radius: 8, x: 0, y: 4)
         .onAppear {
@@ -492,6 +410,30 @@ struct StreakCard: View {
             return .orange  // Orange when not completed but not at risk
         }
     }
+
+    private var statusIconName: String {
+        if isGoalCompleted { return "checkmark.circle.fill" }
+        if isAtRisk { return "exclamationmark.triangle.fill" }
+        return "clock.fill"
+    }
+
+    /// The merged single-line status: completion / distance-to-go / time-left.
+    /// Reads `timeRemainingText` (the timer-refreshed @State) — nothing else
+    /// in body does anymore, and without that dependency SwiftUI would never
+    /// re-render on the minute tick and the countdown would freeze.
+    private var statusLineText: String {
+        if isGoalCompleted { return "Done for today" }
+        let toGo = String(format: "%.2f", max(user.goalMiles - currentDistance, 0))
+        let time = timeRemainingText.isEmpty ? "" : formattedTimeOnly
+        if isAtRisk {
+            return time.isEmpty
+                ? "At risk — \(toGo) mi to go"
+                : "At risk — \(toGo) mi to go · \(time) left"
+        }
+        return time.isEmpty
+            ? "\(toGo) mi to go"
+            : "\(toGo) mi to go · \(time) left"
+    }
 }
 
 struct TodayProgressCard: View {
@@ -518,21 +460,20 @@ struct TodayProgressCard: View {
 
     var body: some View {
         VStack(spacing: 16) {
-            // Header
-            HStack {
-                Image(systemName: "figure.run")
-                    .foregroundColor(.white)
-                    .font(.title3)
-                Text("Today's Progress")
-                    .font(.headline)
+            // Eyebrow header — same quiet grammar as the streak card's
+            // "CURRENT STREAK" label; the big number below is the headline.
+            HStack(spacing: 6) {
+                Text("TODAY")
+                    .font(.caption)
                     .fontWeight(.semibold)
-                    .foregroundColor(.white)
-                Spacer()
+                    .tracking(1.2)
+                    .foregroundColor(didComplete ? .green : .white.opacity(0.7))
                 if didComplete {
                     Image(systemName: "checkmark.circle.fill")
+                        .font(.caption)
                         .foregroundColor(.green)
-                        .font(.title3)
                 }
+                Spacer()
             }
 
             // Large progress display

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -34,6 +34,8 @@ struct DashboardView: View {
     /// What's New popup — auto-presents once per release, reopenable from
     /// Settings → What's New.
     @State private var showWhatsNew = false
+    /// Streak tokens — drives the tokens card + the unlock celebration.
+    @ObservedObject private var tokensState = StreakTokensState.shared
     @State private var newGoalMiles: Double = 1.0
     @State private var isRefreshing = false
     @State private var showWorkoutUploadAlert = false
@@ -577,6 +579,21 @@ struct DashboardView: View {
             }
             .sheet(isPresented: $showWhatsNew) {
                 WhatsNewView()
+            }
+            // Token unlock celebration — a meter just completed (or enrollment
+            // backfill handed over the starting set). Self-contained overlay;
+            // stands down while a goal celebration is playing (newlyEarned
+            // persists until dismissed, so the moment isn't lost).
+            .overlay {
+                if !tokensState.newlyEarned.isEmpty,
+                   !celebrationManager.isShowingCelebration {
+                    TokenUnlockOverlay(
+                        kinds: tokensState.newlyEarned.compactMap { StreakTokenKind.from(raw: $0) },
+                        onDismiss: { tokensState.newlyEarned = [] }
+                    )
+                    .transition(.opacity)
+                    .zIndex(50)
+                }
             }
             .sheet(isPresented: $showGoalSheet) {
                 GoalSettingSheet(

--- a/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
+++ b/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
@@ -181,6 +181,8 @@ struct PureFlameBadge: View {
 struct StreakTokensCard: View {
     @ObservedObject var tokensState = StreakTokensState.shared
     @State private var showDetail = false
+    /// Drives the slow breathing pulse on earned medallions.
+    @State private var pulse = false
 
     var body: some View {
         if let payload = tokensState.payload {
@@ -266,6 +268,15 @@ struct StreakTokensCard: View {
     ) -> some View {
         VStack(spacing: 6) {
             TokenMedallion(kind: kind, held: held, progress: progress, size: 46)
+                // Earned tokens breathe gently — alive, not static.
+                .scaleEffect(held && pulse ? 1.05 : 1.0)
+                .animation(
+                    held
+                        ? .easeInOut(duration: 1.5).repeatForever(autoreverses: true)
+                        : .default,
+                    value: pulse
+                )
+                .onAppear { pulse = true }
             Text(kind.title)
                 .font(.system(size: 10, weight: .bold, design: .rounded))
                 .foregroundColor(.white.opacity(held ? 0.95 : 0.6))
@@ -406,31 +417,7 @@ struct StreakTokensDetailView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            // Meter bar + count
-            VStack(alignment: .leading, spacing: 4) {
-                GeometryReader { geo in
-                    ZStack(alignment: .leading) {
-                        Capsule().fill(Color.white.opacity(0.08))
-                        Capsule()
-                            .fill(
-                                LinearGradient(
-                                    colors: kind.gradient,
-                                    startPoint: .leading,
-                                    endPoint: .trailing
-                                )
-                            )
-                            .frame(width: max(6, geo.size.width * (meter.held ? 1 : meter.fraction)))
-                    }
-                }
-                .frame(height: 8)
-
-                Text(meter.held
-                     ? "Earned — you're holding 1 (max 1). Using it restarts the meter."
-                     : "\(trimmed(meter.progress)) / \(trimmed(meter.target)) \(unit)")
-                    .font(.system(size: 11, weight: .bold, design: .rounded))
-                    .monospacedDigit()
-                    .foregroundColor(meter.held ? .green : .secondary)
-            }
+            TokenMeterBar(kind: kind, meter: meter, unit: unit)
         }
         .padding(MADTheme.Spacing.md)
         .madLiquidGlass()
@@ -467,5 +454,90 @@ struct StreakTokensDetailView: View {
         value.truncatingRemainder(dividingBy: 1) == 0
             ? String(Int(value))
             : String(format: "%.1f", value)
+    }
+}
+
+// MARK: - Animated meter bar
+
+/// The earn meter, made satisfying: the fill springs from zero on appear, a
+/// light shimmer sweeps the filled portion, and the copy counts DOWN ("3 to
+/// go") so progress reads as approach, not bookkeeping.
+private struct TokenMeterBar: View {
+    let kind: StreakTokenKind
+    let meter: StreakTokenMeter
+    let unit: String
+
+    @State private var grown = false
+    @State private var shimmer = false
+
+    private var fraction: Double { meter.held ? 1 : meter.fraction }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            GeometryReader { geo in
+                let fillWidth = max(6, geo.size.width * fraction * (grown ? 1 : 0))
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Color.white.opacity(0.08))
+                    Capsule()
+                        .fill(
+                            LinearGradient(
+                                colors: kind.gradient,
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                        )
+                        .frame(width: fillWidth)
+                        .overlay(
+                            // Shimmer sweep across the filled portion.
+                            Capsule()
+                                .fill(
+                                    LinearGradient(
+                                        colors: [.clear, .white.opacity(0.45), .clear],
+                                        startPoint: .leading,
+                                        endPoint: .trailing
+                                    )
+                                )
+                                .frame(width: 46)
+                                .offset(x: shimmer ? fillWidth : -46)
+                                .animation(
+                                    .linear(duration: 1.8)
+                                        .repeatForever(autoreverses: false)
+                                        .delay(0.8),
+                                    value: shimmer
+                                )
+                                .mask(Capsule().frame(width: fillWidth))
+                        , alignment: .leading)
+                }
+            }
+            .frame(height: 8)
+
+            Text(statusLine)
+                .font(.system(size: 11, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .foregroundColor(meter.held ? .green : .secondary)
+        }
+        .onAppear {
+            withAnimation(.spring(response: 0.7, dampingFraction: 0.85).delay(0.15)) {
+                grown = true
+            }
+            if fraction > 0.1 { shimmer = true }
+        }
+    }
+
+    private var statusLine: String {
+        if meter.held {
+            return "Earned — you're holding 1 (max 1). Using it restarts the meter."
+        }
+        let remaining = max(meter.target - meter.progress, 0)
+        let togo = remaining.truncatingRemainder(dividingBy: 1) == 0
+            ? String(Int(remaining))
+            : String(format: "%.1f", remaining)
+        let progressText = meter.progress.truncatingRemainder(dividingBy: 1) == 0
+            ? String(Int(meter.progress))
+            : String(format: "%.1f", meter.progress)
+        let targetText = meter.target.truncatingRemainder(dividingBy: 1) == 0
+            ? String(Int(meter.target))
+            : String(format: "%.1f", meter.target)
+        return "\(progressText) / \(targetText) \(unit) · \(togo) to go"
     }
 }

--- a/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
+++ b/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
@@ -5,6 +5,16 @@ import SwiftUI
 enum StreakTokenKind {
     case doubleDown, save, assist
 
+    /// Backend raw kind — the key used by meter-gain chips and the unlock
+    /// event list (inverse of `from(raw:)`).
+    var raw: String {
+        switch self {
+        case .doubleDown: return "double_down"
+        case .save: return "streak_save"
+        case .assist: return "streak_assist"
+        }
+    }
+
     var title: String {
         switch self {
         case .doubleDown: return "Double Down"
@@ -190,14 +200,15 @@ struct StreakTokensCard: View {
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 showDetail = true
             } label: {
-                VStack(spacing: 14) {
-                    HStack(spacing: MADTheme.Spacing.sm) {
-                        Image(systemName: "shield.lefthalf.filled")
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundStyle(MADTheme.Colors.redGradient)
-                        Text("Streak Tokens")
-                            .font(.system(size: 16, weight: .heavy, design: .rounded))
-                            .foregroundColor(.white)
+                VStack(spacing: 12) {
+                    // Eyebrow header — matches the streak/today cards' quiet
+                    // caption grammar; the medallions are the headline here.
+                    HStack(spacing: 6) {
+                        Text("STREAK TOKENS")
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                            .tracking(1.2)
+                            .foregroundColor(.white.opacity(0.7))
                         Spacer()
                         let ready = [
                             payload.double_down.held,
@@ -277,6 +288,27 @@ struct StreakTokensCard: View {
                     value: pulse
                 )
                 .onAppear { pulse = true }
+                // Transient "+1 run day" chip when a fresh payload moved
+                // this meter forward — the bar visibly ticks, not just sits.
+                .overlay(alignment: .top) {
+                    if let gain = tokensState.meterGains[kind.raw] {
+                        Text(gain)
+                            .font(.system(size: 9, weight: .heavy, design: .rounded))
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 3)
+                            .background(Capsule().fill(kind.tint))
+                            .fixedSize()
+                            .offset(y: -15)
+                            .transition(
+                                .scale(scale: 0.5).combined(with: .opacity)
+                            )
+                    }
+                }
+                .animation(
+                    .spring(response: 0.4, dampingFraction: 0.7),
+                    value: tokensState.meterGains
+                )
             Text(kind.title)
                 .font(.system(size: 10, weight: .bold, design: .rounded))
                 .foregroundColor(.white.opacity(held ? 0.95 : 0.6))
@@ -298,6 +330,7 @@ struct StreakTokensCard: View {
 struct StreakTokensDetailView: View {
     @ObservedObject var tokensState = StreakTokensState.shared
     @Environment(\.dismiss) private var dismiss
+    @State private var showPureFlameInfo = false
 
     var body: some View {
         NavigationStack {
@@ -423,32 +456,76 @@ struct StreakTokensDetailView: View {
         .madLiquidGlass()
     }
 
+    /// Pure Flame explainer — deliberately an INFO PANEL, not another card in
+    /// the earnable-token language above it (no medallion, no meter, flat
+    /// fill, gold accent stripe): it's a status you keep, not a token you
+    /// spend. Tapping opens the full badge explainer.
     private func naturalCard(_ natural: Bool) -> some View {
-        HStack(spacing: 12) {
-            if natural {
-                PureFlameBadge(size: 30)
-            } else {
-                Image(systemName: "flame")
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundColor(.secondary)
-                    .frame(width: 30, height: 30)
+        Button {
+            showPureFlameInfo = true
+        } label: {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "info.circle.fill")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundColor(pureFlameGold)
+                    .padding(.top, 1)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        Text("ABOUT THE PURE FLAME")
+                            .font(.system(size: 10, weight: .heavy, design: .rounded))
+                            .tracking(1.1)
+                            .foregroundColor(pureFlameGold)
+                        if natural {
+                            PureFlameBadge(size: 15)
+                        }
+                    }
+                    Text(natural
+                         ? "Your streak is 100% natural — every day earned on the day. The gold flame shows beside your name."
+                         : "A token kept this streak alive, so the badge is resting. It returns with your next untouched streak.")
+                        .font(.system(size: 12, weight: .medium, design: .rounded))
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text("A status, not a token — nothing to spend. Tap to learn more.")
+                        .font(.system(size: 11, weight: .medium, design: .rounded))
+                        .foregroundColor(.secondary.opacity(0.7))
+                        .multilineTextAlignment(.leading)
+                }
+
+                Spacer(minLength: 0)
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundColor(.secondary.opacity(0.5))
+                    .padding(.top, 2)
             }
-            VStack(alignment: .leading, spacing: 2) {
-                Text(natural ? "Pure Flame — natural streak" : "Streak rescued along the way")
-                    .font(.system(size: 14, weight: .heavy, design: .rounded))
-                    .foregroundColor(.primary)
-                Text(natural
-                     ? "Every day of this streak was earned on the day. The gold flame shows on your profile."
-                     : "A token kept this streak alive — the Pure Flame returns with your next untouched streak. (Helping a friend never affects yours.)")
-                    .font(.system(size: 12, weight: .medium, design: .rounded))
-                    .foregroundColor(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+            .padding(MADTheme.Spacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(Color.white.opacity(0.04))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 14)
+                            .strokeBorder(pureFlameGold.opacity(0.25), lineWidth: 1)
+                    )
+            )
+            .overlay(alignment: .leading) {
+                // Gold accent stripe — the info-box signature.
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(pureFlameGold.opacity(0.8))
+                    .frame(width: 3)
+                    .padding(.vertical, 12)
+                    .padding(.leading, 1)
             }
-            Spacer(minLength: 0)
+            .contentShape(Rectangle())
         }
-        .padding(MADTheme.Spacing.md)
-        .madLiquidGlass()
+        .buttonStyle(.plain)
+        .sheet(isPresented: $showPureFlameInfo) {
+            PureFlameInfoSheet()
+        }
     }
+
+    private var pureFlameGold: Color { Color(red: 1.0, green: 0.84, blue: 0.35) }
 
     private func trimmed(_ value: Double) -> String {
         value.truncatingRemainder(dividingBy: 1) == 0
@@ -539,5 +616,91 @@ private struct TokenMeterBar: View {
             ? String(Int(meter.target))
             : String(format: "%.1f", meter.target)
         return "\(progressText) / \(targetText) \(unit) · \(togo) to go"
+    }
+}
+
+// MARK: - Pure Flame info sheet
+
+/// "What's the gold flame?" — presented when anyone taps a Pure Flame badge
+/// next to a name (own profile, friend profiles, the explainer's info panel).
+/// One badge, one sentence, three quick rules. Medium detent.
+struct PureFlameInfoSheet: View {
+    private var gold: Color { Color(red: 1.0, green: 0.84, blue: 0.35) }
+
+    var body: some View {
+        ZStack {
+            MADTheme.Colors.appBackgroundGradient.ignoresSafeArea()
+
+            VStack(spacing: MADTheme.Spacing.md) {
+                PureFlameBadge(size: 68)
+                    .padding(.top, MADTheme.Spacing.xl)
+
+                VStack(spacing: 6) {
+                    Text("Pure Flame")
+                        .font(.system(size: 26, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+
+                    Text("A 100% natural streak — every single day earned the day it happened. No saves, no rescues.")
+                        .font(.system(size: 14, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.75))
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.horizontal, MADTheme.Spacing.lg)
+                }
+
+                VStack(spacing: 10) {
+                    ruleRow(
+                        icon: "figure.run",
+                        tint: .green,
+                        text: "Keep completing your mile every day and the gold flame stays lit."
+                    )
+                    ruleRow(
+                        icon: "snowflake",
+                        tint: MADTheme.Colors.walkBlue,
+                        text: "Using a token to cover a missed day rests the badge until your next untouched streak."
+                    )
+                    ruleRow(
+                        icon: "lifepreserver",
+                        tint: MADTheme.Colors.madRed,
+                        text: "Saving a friend's streak never dims your own flame."
+                    )
+                }
+                .padding(.horizontal, MADTheme.Spacing.lg)
+                .padding(.top, MADTheme.Spacing.xs)
+
+                Text("It's a status, not a token — nothing to spend, everything to defend.")
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                    .foregroundColor(gold.opacity(0.9))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, MADTheme.Spacing.lg)
+
+                Spacer(minLength: 0)
+            }
+        }
+        .presentationDetents([.medium])
+        .presentationDragIndicator(.visible)
+    }
+
+    private func ruleRow(icon: String, tint: Color, text: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 15, weight: .bold))
+                .foregroundColor(tint)
+                .frame(width: 26, height: 26)
+                .background(Circle().fill(tint.opacity(0.15)))
+
+            Text(text)
+                .font(.system(size: 13, weight: .medium, design: .rounded))
+                .foregroundColor(.white.opacity(0.85))
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.white.opacity(0.05))
+        )
     }
 }

--- a/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
+++ b/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
@@ -21,6 +21,10 @@ struct UserProfileDetailView: View {
     @State private var closeFriendActionInProgress = false
 
     @State private var userStats: UserStats?
+    /// Pure Flame — true when this user's streak is 100% natural (from the
+    /// gated streak_features payload; false for un-enrolled users).
+    @State private var hasPureFlame = false
+    @State private var showPureFlameInfo = false
     @State private var userBadges: [Badge] = []
     @State private var catalogBadges: [Badge] = []
     @State private var hasLoadedBadges = false
@@ -336,9 +340,23 @@ struct UserProfileDetailView: View {
 
                     // User Info
                     VStack(spacing: MADTheme.Spacing.sm) {
-                        Text(user.username ?? "Unknown")
-                            .font(MADTheme.Typography.title1)
-                            .foregroundColor(MADTheme.Colors.primaryText)
+                        HStack(spacing: 6) {
+                            Text(user.username ?? "Unknown")
+                                .font(MADTheme.Typography.title1)
+                                .foregroundColor(MADTheme.Colors.primaryText)
+                            if hasPureFlame {
+                                // Natural-streak seal — tap explains it.
+                                Button {
+                                    showPureFlameInfo = true
+                                } label: {
+                                    PureFlameBadge(size: 20)
+                                }
+                                .buttonStyle(.plain)
+                                .sheet(isPresented: $showPureFlameInfo) {
+                                    PureFlameInfoSheet()
+                                }
+                            }
+                        }
 
                         if user.displayName != user.username {
                             Text(user.displayName)
@@ -983,6 +1001,7 @@ struct UserProfileDetailView: View {
                         hasCompletedGoalToday: hasCompletedGoalToday,
                         goalMiles: goalMiles
                     )
+                    hasPureFlame = stats.naturalStreak && stats.streak > 0
 
                     friendWorkouts = workouts
                     hasLoadedInitial = true

--- a/app/Mile A Day/Views/Profile/ProfileView.swift
+++ b/app/Mile A Day/Views/Profile/ProfileView.swift
@@ -4,8 +4,10 @@ struct ProfileView: View {
     @Environment(\.appStateManager) var appStateManager
     @ObservedObject var userManager: UserManager
     @ObservedObject var healthManager: HealthKitManager
-    /// Streak-token state — drives the Pure Flame (natural streak) seal.
+    /// Streak-token state — drives the Pure Flame (natural streak) seal and
+    /// the profile token shelf.
     @ObservedObject private var tokensState = StreakTokensState.shared
+    @State private var showTokenSheet = false
 
     @State private var activeSheet: ProfileSheetType?
     @State private var showingEditProfile = false
@@ -510,6 +512,40 @@ struct ProfileView: View {
                             Text(displayName)
                                 .font(MADTheme.Typography.body)
                                 .foregroundColor(MADTheme.Colors.secondaryText)
+                        }
+
+                        // Token shelf — your minted set, right on the profile.
+                        // Hidden until streak features are active.
+                        if let tokens = tokensState.payload {
+                            Button {
+                                showTokenSheet = true
+                            } label: {
+                                HStack(spacing: 14) {
+                                    TokenMedallion(
+                                        kind: .doubleDown,
+                                        held: tokens.double_down.held,
+                                        progress: tokens.double_down.fraction,
+                                        size: 34
+                                    )
+                                    TokenMedallion(
+                                        kind: .save,
+                                        held: tokens.streak_save.held,
+                                        progress: tokens.streak_save.fraction,
+                                        size: 34
+                                    )
+                                    TokenMedallion(
+                                        kind: .assist,
+                                        held: tokens.streak_assist.held,
+                                        progress: tokens.streak_assist.fraction,
+                                        size: 34
+                                    )
+                                }
+                                .padding(.top, MADTheme.Spacing.xs)
+                            }
+                            .buttonStyle(ScaleButtonStyle())
+                            .sheet(isPresented: $showTokenSheet) {
+                                StreakTokensDetailView()
+                            }
                         }
 
                         // Bio with quote-style accent

--- a/app/Mile A Day/Views/Profile/ProfileView.swift
+++ b/app/Mile A Day/Views/Profile/ProfileView.swift
@@ -8,6 +8,7 @@ struct ProfileView: View {
     /// the profile token shelf.
     @ObservedObject private var tokensState = StreakTokensState.shared
     @State private var showTokenSheet = false
+    @State private var showPureFlameInfo = false
 
     @State private var activeSheet: ProfileSheetType?
     @State private var showingEditProfile = false
@@ -501,7 +502,16 @@ struct ProfileView: View {
                                     .foregroundColor(MADTheme.Colors.primaryText)
                                 if tokensState.payload?.natural_streak == true,
                                    userManager.currentUser.streak > 0 {
-                                    PureFlameBadge(size: 22)
+                                    // Tappable — the badge explains itself.
+                                    Button {
+                                        showPureFlameInfo = true
+                                    } label: {
+                                        PureFlameBadge(size: 22)
+                                    }
+                                    .buttonStyle(.plain)
+                                    .sheet(isPresented: $showPureFlameInfo) {
+                                        PureFlameInfoSheet()
+                                    }
                                 }
                             }
                         }

--- a/backend/src/services/streakFeatureService.ts
+++ b/backend/src/services/streakFeatureService.ts
@@ -46,8 +46,12 @@ export const STREAK_ASSIST_TARGET_MILES = 20;
 const DOUBLE_DOWN_GOAL_MULTIPLIER = 2;
 const DOUBLE_DOWN_TOLERANCE = 0.05;
 // Meter windows: retroactive credit at enrollment + a hard query bound.
-const ENROLL_LOOKBACK_DAYS = 30;
-const METER_WINDOW_DAYS = 90;
+// A FULL YEAR on purpose — a 400-day streaker must enroll fully loaded
+// (all three tokens held), not start from scratch like a new runner. The
+// original 30/90 made long streaks count the same as one month. Post-launch
+// the window is naturally bounded by each token's last-used date anyway.
+const ENROLL_LOOKBACK_DAYS = 365;
+const METER_WINDOW_DAYS = 365;
 // Assist-opportunity pushes only fire for streaks worth mourning.
 const MIN_NOTIFY_PRIOR_STREAK = 3;
 // A break stays rescuable for this many days after the missed day.


### PR DESCRIPTION
> ⚠️ **Stacked on #244** — merge that first; this branch includes its commit. Once #244 lands, this PR's diff shrinks to just the design pass.

Your buddy's feedback, acted on — plus the CDO call on flat vs. 3D.

## 1. Dashboard calm pass (the "7 elements vs Apple's 2" critique)

They were right — the streak card alone stacked a status line, a second "mi to go" line, a corner clock, a two-line milestone block, a share-hint row, and an animated glow ring around the flame. Now:

- **One status line** carries everything: `0.28 mi to go · 5h 12m left`, `At risk — … · 2h left`, or `Done for today`. The corner clock and checkmark are gone (merged in).
- **Milestone** is a slim 5pt bar with a tiny `Day 500 in 42` caption — one row instead of three.
- **Share hint row removed**; a quiet corner glyph is the affordance (whole card still taps to share).
- **Today's Progress** loses its icon-heavy header for a small `TODAY` eyebrow — the big number is the headline.
- **Tokens card** gets the same eyebrow grammar so the top of the dashboard reads as one calm system.

**The flat-vs-3D call:** flat *surfaces*, dimensional *rewards*. The chrome got flattened — the streak flame's animated outer glow ring is gone, shadows toned down, headers quieted. The token medallions deliberately stay minted and dimensional: they're game pieces you earn, and reward objects should feel like objects. That contrast is the design language now — calm cards, treasure on top of them.

## 2. Pure Flame is no longer a fake token

- In the explainer it's now an obvious **info box**: flat fill, gold accent stripe, `info.circle` icon, `ABOUT THE PURE FLAME` eyebrow, and the line "A status, not a token — nothing to spend." Visually nothing like the three earnable token cards above it.
- **The badge next to a name is now tappable** — on your profile *and* on friend profiles — opening a polished medium sheet: big badge, one-sentence definition, three quick rules (keep it lit / what rests it / assisting friends never dims yours).
- **Friend profiles now show the badge** — `FriendStats` additively decodes `natural_streak` from the gated payload, so an enrolled friend on a natural streak gets the gold seal beside their username. Un-enrolled users decode to `false` and nothing changes.

## 3. Meters that visibly tick (more engaging surfaces)

`StreakTokensState.apply()` now diffs each fresh payload against the last one in-session. When a meter moves, a transient chip pops over that medallion on the dashboard — **+1 run day**, **+0.8 mi** — springs in, holds ~4s, fades. Finish a run, come back to the dashboard, and the bars visibly credit you. Held tokens are skipped (the unlock overlay owns that bigger moment).

## Compatibility

Pure UI + additive decode. No API changes, no new data collection, nothing for un-enrolled/live users — every new surface hides when the gated payload is absent.

## Future surface ideas (not in this PR)
Medallion in the streak widget, a meter tick on the post-run recap screen, Watch complication. Say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY

---
_Generated by [Claude Code](https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY)_