### PR TITLE
UX polish round: sequenced surfaces, calm share cards, haptic vocabulary, token widget + watch + recap

### DIFF
--- a/.claude/rules/ios.md
+++ b/.claude/rules/ios.md
@@ -45,7 +45,7 @@ globs: app/**
 ## Do NOT
 - Modify the Xcode project file (`project.pbxproj`) - it's excluded via .claudeignore.
 - Change the API base URL without coordinating both client and server.
-- Worry about pbxproj when CREATING .swift files — the project uses synchronized folders; files added on disk are picked up automatically (verified via git history).
+- Worry about pbxproj when CREATING .swift files in the MAIN app (incl. `Widgets/`, `Shared/`) — synchronized folders pick up files on disk automatically. EXCEPTION: the Watch target ("Mile A Day Watch Watch App/") is NOT synchronized (its files were pbxproj-registered) — modify existing watch files only, never create new ones from CLI.
 
 ## App Store Review Compliance
 Every change must pass App Review. Check BEFORE proposing and AFTER implementing. Flag any borderline item explicitly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Gamified fitness app: run a mile every day, build streaks, compete with friends.
 ### Website (`cd website`)
 - Dev: `npm run dev`
 - Build: `npm run build` (also type-checks — this is the pre-merge gate)
-- The `lint` script is broken: eslint is not a dependency and there is no config. Don't run it; don't add it to CI.
+- No lint script — `npm run build` (next build) is the only check.
 
 ### iOS (`app/`)
 - Build via Xcode only. Do not attempt `xcodebuild` from CLI.
@@ -57,7 +57,7 @@ This app ships through Apple's App Store. Every change — UI, backend, copy, as
 ## Code Style
 
 - No linter/formatter configured for backend. Follow existing patterns.
-- Website has NO working ESLint (the `lint` script references an uninstalled eslint). `next build` is the check.
+- Website has no ESLint; `next build` is the check.
 - iOS: follow existing SwiftUI patterns, no SwiftLint.
 
 ## Claude Skills & Agents

--- a/app/Mile A Day Watch Watch App/ContentView.swift
+++ b/app/Mile A Day Watch Watch App/ContentView.swift
@@ -329,6 +329,18 @@ struct ContentView: View {
             Text(currentStreak == 1 ? "day streak" : "day streak")
                 .font(.system(size: 11, weight: .medium, design: .rounded))
                 .foregroundColor(WatchTheme.textSecondary)
+
+            // Held streak tokens, mirrored from the iPhone — a tiny gold
+            // shield count. Hidden at 0 (feature off or none earned).
+            if healthManager.heldStreakTokens > 0 {
+                HStack(spacing: 3) {
+                    Image(systemName: "shield.lefthalf.filled")
+                        .font(.system(size: 10, weight: .bold))
+                    Text("\(healthManager.heldStreakTokens)")
+                        .font(.system(size: 12, weight: .heavy, design: .rounded))
+                }
+                .foregroundColor(Color(red: 1.0, green: 0.84, blue: 0.35))
+            }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 5)

--- a/app/Mile A Day/Core/State/StreakTokensState.swift
+++ b/app/Mile A Day/Core/State/StreakTokensState.swift
@@ -21,10 +21,58 @@ final class StreakTokensState: ObservableObject {
     /// "streak_save", "streak_assist") — drives the unlock celebration.
     /// Cleared by the overlay's dismiss.
     @Published var newlyEarned: [String] = []
+    /// Transient "+1 run day" chips per raw kind — set when a fresh payload
+    /// moves a meter forward within a session, auto-cleared a few seconds
+    /// later. Purely celebratory; nothing reads it for logic.
+    @Published var meterGains: [String: String] = [:]
+    private var gainsClearTask: Task<Void, Never>?
 
     var isActive: Bool { payload != nil }
 
     private static let heldFlagsKey = "streakTokenHeldFlags"
+
+    /// Single entry point for a fresh (or absent) payload: diffs meters for
+    /// the gain chips, publishes the payload, and diffs held flags for the
+    /// unlock celebration. Callers go through
+    /// `StreakFeatureService.applyStatsPayload`, which also syncs the
+    /// coverage store.
+    @MainActor
+    func apply(_ new: StreakFeaturesPayload?) {
+        if let new, let old = payload {
+            noteMeterGains(old: old, new: new)
+        }
+        payload = new
+        if let new {
+            registerHeldStates(from: new)
+        }
+    }
+
+    /// Meter deltas → short gain chips ("+1 day", "+0.8 mi"). Held meters are
+    /// skipped — the unlock overlay owns that bigger moment.
+    @MainActor
+    private func noteMeterGains(old: StreakFeaturesPayload, new: StreakFeaturesPayload) {
+        var gains: [String: String] = [:]
+        if !new.double_down.held {
+            let d = Int(new.double_down.progress) - Int(old.double_down.progress)
+            if d > 0 { gains["double_down"] = "+\(d) day\(d == 1 ? "" : "s")" }
+        }
+        if !new.streak_save.held {
+            let d = Int(new.streak_save.progress) - Int(old.streak_save.progress)
+            if d > 0 { gains["streak_save"] = "+\(d) run day\(d == 1 ? "" : "s")" }
+        }
+        if !new.streak_assist.held {
+            let d = new.streak_assist.progress - old.streak_assist.progress
+            if d >= 0.05 { gains["streak_assist"] = String(format: "+%.1f mi", d) }
+        }
+        guard !gains.isEmpty else { return }
+        meterGains = gains
+        gainsClearTask?.cancel()
+        gainsClearTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 4_000_000_000)
+            guard !Task.isCancelled else { return }
+            self?.meterGains = [:]
+        }
+    }
 
     /// Diff the held flags against the last seen set (persisted, so the
     /// celebration fires exactly once per earn — including the very first
@@ -61,7 +109,6 @@ final class StreakTokensState: ObservableObject {
                   let save = status.streak_save,
                   let assist = status.streak_assist
             else {
-                payload = nil
                 assistableFriends = []
                 StreakFeatureService.applyStatsPayload(nil)
                 return
@@ -74,9 +121,10 @@ final class StreakTokensState: ObservableObject {
                 natural_streak: status.natural_streak ?? true,
                 streak_at_risk: status.streak_at_risk ?? false
             )
-            payload = fresh
             assistableFriends = status.assistable_friends ?? []
-            registerHeldStates(from: fresh)
+            // Route through applyStatsPayload → apply() so the payload is
+            // published, held flags are diffed, gain chips fire, and the
+            // coverage store stays in sync — one path for every payload.
             StreakFeatureService.applyStatsPayload(fresh)
         } catch {
             // Keep last known state on transient failures.

--- a/app/Mile A Day/Core/State/StreakTokensState.swift
+++ b/app/Mile A Day/Core/State/StreakTokensState.swift
@@ -17,8 +17,36 @@ final class StreakTokensState: ObservableObject {
     /// DEBUG preview: while true, refreshStatus() is a no-op so server state
     /// can't clobber the injected sample data. Never persisted.
     @Published var isPreviewingSampleData = false
+    /// Tokens that just flipped to EARNED (raw kinds: "double_down",
+    /// "streak_save", "streak_assist") — drives the unlock celebration.
+    /// Cleared by the overlay's dismiss.
+    @Published var newlyEarned: [String] = []
 
     var isActive: Bool { payload != nil }
+
+    private static let heldFlagsKey = "streakTokenHeldFlags"
+
+    /// Diff the held flags against the last seen set (persisted, so the
+    /// celebration fires exactly once per earn — including the very first
+    /// payload after enrollment backfill, the "you start fully loaded" moment).
+    @MainActor
+    func registerHeldStates(from payload: StreakFeaturesPayload) {
+        let previous =
+            UserDefaults.standard.dictionary(forKey: Self.heldFlagsKey) as? [String: Bool] ?? [:]
+        let current: [String: Bool] = [
+            "double_down": payload.double_down.held,
+            "streak_save": payload.streak_save.held,
+            "streak_assist": payload.streak_assist.held,
+        ]
+        let earned = current
+            .filter { $0.value && previous[$0.key] != true }
+            .map { $0.key }
+            .sorted()
+        UserDefaults.standard.set(current, forKey: Self.heldFlagsKey)
+        if !earned.isEmpty {
+            newlyEarned = earned
+        }
+    }
 
     /// Refresh meters + rescuable friends from the status endpoint (used by
     /// surfaces that need fresher data than the last stats fetch, e.g. the
@@ -48,6 +76,7 @@ final class StreakTokensState: ObservableObject {
             )
             payload = fresh
             assistableFriends = status.assistable_friends ?? []
+            registerHeldStates(from: fresh)
             StreakFeatureService.applyStatsPayload(fresh)
         } catch {
             // Keep last known state on transient failures.

--- a/app/Mile A Day/Core/State/StreakTokensState.swift
+++ b/app/Mile A Day/Core/State/StreakTokensState.swift
@@ -45,6 +45,15 @@ final class StreakTokensState: ObservableObject {
         if let new {
             registerHeldStates(from: new)
         }
+        // Mirror the held count to the streak widget and the watch. Both
+        // sinks dedupe (no-op write skip / stable-hash), so calling on every
+        // payload is free.
+        let ready = new.map {
+            [$0.double_down.held, $0.streak_save.held, $0.streak_assist.held]
+                .filter { $0 }.count
+        } ?? 0
+        WidgetDataStore.save(tokensReady: ready)
+        MADWatchBridge.shared.pushSnapshotIfReady()
     }
 
     /// Meter deltas → short gain chips ("+1 day", "+0.8 mi"). Held meters are

--- a/app/Mile A Day/Core/Theme/MADHaptics.swift
+++ b/app/Mile A Day/Core/Theme/MADHaptics.swift
@@ -1,0 +1,38 @@
+import UIKit
+
+/// The app's haptic vocabulary — one meaning per pattern so interactions feel
+/// consistent everywhere:
+/// - `tap`      → light impact: navigation, toggles, pickers, expanding rows
+/// - `action`   → medium impact: doing something meaningful (hype, share, snap)
+/// - `emphasis` → heavy impact: big rhythm beats (countdowns, landings)
+/// - `success`  → something completed or was confirmed
+/// - `warning`  → blocked, rate-limited, or needs attention
+///
+/// Rhythm-critical sequences that pre-`prepare()` their generators (splash,
+/// the goal celebration) keep their own instances; everything else goes
+/// through here.
+enum MADHaptics {
+    static func tap() {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+
+    static func action() {
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+    }
+
+    static func emphasis() {
+        UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
+    }
+
+    static func success() {
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+    }
+
+    static func warning() {
+        UINotificationFeedbackGenerator().notificationOccurred(.warning)
+    }
+
+    static func error() {
+        UINotificationFeedbackGenerator().notificationOccurred(.error)
+    }
+}

--- a/app/Mile A Day/Models/HealthKitManager.swift
+++ b/app/Mile A Day/Models/HealthKitManager.swift
@@ -338,6 +338,10 @@ class HealthKitManager: ObservableObject {
     @Published var todaysSteps: Int = 0
     @Published var dailyStepsData: [Date: Int] = [:]
     @Published var dailyMileGoals: [Date: Bool] = [:]
+    /// Streak tokens currently held (0–3), mirrored from the iPhone via
+    /// WatchConnectivity. Display-only on the watch — the phone owns all
+    /// token logic; 0 (feature off) hides the watch's token pill.
+    @Published var heldStreakTokens: Int = 0
     
     // Caching properties.
     // Only the ones actually read from views remain @Published — internal-cache
@@ -1619,10 +1623,19 @@ final class MADWatchBridge: NSObject {
         if let authToken { payload["authToken"] = authToken }
         if let backendUserId { payload["backendUserId"] = backendUserId }
 
+        // Held streak tokens ride along so the watch can show the shield
+        // count next to the streak. Reads the last-applied payload only —
+        // no fetch; 0 (feature off) simply hides the watch pill.
+        let tokensReady = StreakTokensState.shared.payload.map {
+            [$0.double_down.held, $0.streak_save.held, $0.streak_assist.held]
+                .filter { $0 }.count
+        } ?? 0
+        payload["tokensReady"] = tokensReady
+
         // Hash on the value-bearing fields only (not the timestamp) so we don't
         // re-send identical state. Token + id are included so a token change
         // forces a re-push.
-        let stableHash = "\(payload["streak"] ?? 0)|\(payload["todayMiles"] ?? 0)|\(payload["goalMiles"] ?? 0)|\(payload["firstName"] ?? "")|\(payload["name"] ?? "")|\(authToken ?? "")|\(backendUserId ?? "")".hashValue
+        let stableHash = "\(payload["streak"] ?? 0)|\(payload["todayMiles"] ?? 0)|\(payload["goalMiles"] ?? 0)|\(payload["firstName"] ?? "")|\(payload["name"] ?? "")|\(authToken ?? "")|\(backendUserId ?? "")|\(tokensReady)".hashValue
         if stableHash == lastPushedHash { return }
         lastPushedHash = stableHash
 
@@ -1677,6 +1690,9 @@ final class MADWatchBridge: NSObject {
             }
             if let backendUserId = context["backendUserId"] as? String, !backendUserId.isEmpty {
                 UserDefaults.standard.set(backendUserId, forKey: "backendUserId")
+            }
+            if let tokens = context["tokensReady"] as? Int {
+                hk.heldStreakTokens = tokens
             }
             userManager.saveUserData()
         }

--- a/app/Mile A Day/Services/FriendService.swift
+++ b/app/Mile A Day/Services/FriendService.swift
@@ -922,6 +922,10 @@ struct FriendStats: Codable {
     let recentWorkouts: [FriendWorkout]?
     let todayMiles: Double?
     let goalMiles: Double?
+    /// True when this user's current streak is 100% natural. Read from the
+    /// gated `streak_features` payload — absent for un-enrolled users, so it
+    /// safely defaults to false and the Pure Flame badge simply doesn't show.
+    let naturalStreak: Bool
 
     enum CodingKeys: String, CodingKey {
         case streak
@@ -932,6 +936,18 @@ struct FriendStats: Codable {
         case recentWorkouts = "recent_workouts"
         case todayMiles = "today_miles"
         case goalMiles = "goal_miles"
+    }
+
+    /// Separate key enum for the gated payload so `streak_features` stays out
+    /// of CodingKeys — `naturalStreak` has no server-side twin field, and an
+    /// unmatched CodingKeys case would break the synthesized encode.
+    private enum GatedKeys: String, CodingKey {
+        case streakFeatures = "streak_features"
+    }
+
+    /// Only the one field friend surfaces need from the gated payload.
+    private struct GatedStreakFeatures: Decodable {
+        let natural_streak: Bool?
     }
     
     init(from decoder: Decoder) throws {
@@ -955,6 +971,12 @@ struct FriendStats: Codable {
         recentWorkouts = try? container.decode([FriendWorkout].self, forKey: .recentWorkouts)
         todayMiles = try? container.decode(Double.self, forKey: .todayMiles)
         goalMiles = try? container.decode(Double.self, forKey: .goalMiles)
+        if let gated = try? decoder.container(keyedBy: GatedKeys.self),
+           let features = try? gated.decode(GatedStreakFeatures.self, forKey: .streakFeatures) {
+            naturalStreak = features.natural_streak ?? false
+        } else {
+            naturalStreak = false
+        }
     }
 }
 

--- a/app/Mile A Day/Services/StreakFeatureService.swift
+++ b/app/Mile A Day/Services/StreakFeatureService.swift
@@ -197,6 +197,9 @@ enum StreakFeatureService {
         }
         Task { @MainActor in
             StreakTokensState.shared.payload = payload
+            if let payload {
+                StreakTokensState.shared.registerHeldStates(from: payload)
+            }
         }
     }
 }

--- a/app/Mile A Day/Services/StreakFeatureService.swift
+++ b/app/Mile A Day/Services/StreakFeatureService.swift
@@ -196,10 +196,7 @@ enum StreakFeatureService {
             StreakCoverageStore.deactivate()
         }
         Task { @MainActor in
-            StreakTokensState.shared.payload = payload
-            if let payload {
-                StreakTokensState.shared.registerHeldStates(from: payload)
-            }
+            StreakTokensState.shared.apply(payload)
         }
     }
 }

--- a/app/Mile A Day/Shared/WidgetDataStore.swift
+++ b/app/Mile A Day/Shared/WidgetDataStore.swift
@@ -110,6 +110,29 @@ struct WidgetDataStore {
         return defaults.integer(forKey: streakKey)
     }
 
+    // MARK: - Streak tokens (streak widget accessory)
+
+    private static let tokensReadyKey = "tokens_ready"
+
+    /// Count of streak tokens currently HELD (0–3), mirrored from the gated
+    /// token payload. Not day-stamped — held tokens persist until spent.
+    /// Absent/zero simply hides the widget's token pill, so installs without
+    /// the feature render exactly as before.
+    static func save(tokensReady: Int) {
+        guard let defaults = UserDefaults(suiteName: suiteName) else { return }
+        // Skip no-op writes — see save(todayMiles:goal:).
+        if defaults.integer(forKey: tokensReadyKey) == tokensReady { return }
+        defaults.set(tokensReady, forKey: tokensReadyKey)
+        DispatchQueue.main.async {
+            WidgetCenter.shared.reloadTimelines(ofKind: "StreakCountWidget")
+        }
+    }
+
+    static func loadTokensReady() -> Int {
+        guard let defaults = UserDefaults(suiteName: suiteName) else { return 0 }
+        return defaults.integer(forKey: tokensReadyKey)
+    }
+
     // MARK: - Week completions (medium streak widget)
 
     private static let weekCompletionsKey = "week_completions"

--- a/app/Mile A Day/Views/BadgesView.swift
+++ b/app/Mile A Day/Views/BadgesView.swift
@@ -275,7 +275,7 @@ struct BadgesView: View {
         ) {
             ForEach(filteredBadges, id: \.id) { badge in
                 Button {
-                    UIImpactFeedbackGenerator(style: badge.isLocked ? .light : .medium).impactOccurred()
+                    badge.isLocked ? MADHaptics.tap() : MADHaptics.action()
                     selectedBadge = badge
                     isShowingDetail = true
                 } label: {

--- a/app/Mile A Day/Views/Celebrations/BadgeSummaryCelebrationView.swift
+++ b/app/Mile A Day/Views/Celebrations/BadgeSummaryCelebrationView.swift
@@ -106,7 +106,7 @@ struct BadgeSummaryCelebrationView: View {
         withAnimation(.easeOut(duration: 0.3)) { showOverlay = true }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
             withAnimation(.spring(response: 0.6, dampingFraction: 0.6)) { showStack = true }
-            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            MADHaptics.success()
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) { showContent = true }

--- a/app/Mile A Day/Views/Celebrations/BadgeUnlockCelebrationView.swift
+++ b/app/Mile A Day/Views/Celebrations/BadgeUnlockCelebrationView.swift
@@ -452,8 +452,7 @@ struct BadgeUnlockCelebrationView: View {
     }
     
     private func triggerHaptic() {
-        let impact = UIImpactFeedbackGenerator(style: .medium)
-        impact.impactOccurred()
+        MADHaptics.action()
     }
 }
 

--- a/app/Mile A Day/Views/Celebrations/ChallengeCompletedCelebrationView.swift
+++ b/app/Mile A Day/Views/Celebrations/ChallengeCompletedCelebrationView.swift
@@ -194,7 +194,7 @@ struct ChallengeCompletedCelebrationView: View {
         withAnimation(.easeInOut(duration: 0.8).delay(0.2)) { ringTrim = 1 }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.55) {
             withAnimation(.spring(response: 0.4, dampingFraction: 0.5)) { checkScale = 1 }
-            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            MADHaptics.success()
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { showBurst = true }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) { showStars = true }

--- a/app/Mile A Day/Views/Celebrations/GoalCompletedCelebrationView.swift
+++ b/app/Mile A Day/Views/Celebrations/GoalCompletedCelebrationView.swift
@@ -47,6 +47,12 @@ struct GoalCompletedCelebrationView: View {
     // Share - use Identifiable wrapper so .sheet(item:) works on first tap
     @State private var shareItem: ShareableImage? = nil
 
+    // Streak tokens — the recap strip's data. Gains are captured once on
+    // appear: the dashboard's live chips auto-clear after a few seconds, and
+    // the recap must not vanish mid-celebration.
+    @ObservedObject private var tokensState = StreakTokensState.shared
+    @State private var recapGains: [String: String] = [:]
+
     private var isMajorMilestone: Bool {
         stats.streakMilestone?.isMajor == true
     }
@@ -129,6 +135,14 @@ struct GoalCompletedCelebrationView: View {
                                     .transition(.opacity.combined(with: .offset(y: 20)))
                             }
 
+                            // The token payoff, in the same screen as the
+                            // streak payoff — where each meter stands after
+                            // today's mile, with any progress just earned.
+                            if showMotivation, tokensState.payload != nil {
+                                tokenRecapSection
+                                    .transition(.opacity.combined(with: .offset(y: 20)))
+                            }
+
                             if showButtons, let pending = pendingService.mileCompletedPending {
                                 notifyFriendsCard(pending)
                                     .transition(.scale(scale: 0.9).combined(with: .opacity))
@@ -152,6 +166,11 @@ struct GoalCompletedCelebrationView: View {
             .ignoresSafeArea()
             .opacity(overlayOpacity)
             .onAppear {
+                // Snapshot any live meter-gain chips before their auto-clear
+                // fires — the recap strip shows them for the whole celebration.
+                if recapGains.isEmpty {
+                    recapGains = tokensState.meterGains
+                }
                 startAnimationIfActive()
             }
             .onChange(of: scenePhase) { _, newPhase in
@@ -562,6 +581,90 @@ struct GoalCompletedCelebrationView: View {
 
     private var nextMajorMilestone: StreakMilestone? {
         StreakMilestone.allCases.first { $0.days > stats.currentStreak && $0.isMajor }
+    }
+
+    // MARK: - Token Recap Section
+
+    /// Compact strip showing all three token meters right in the payoff
+    /// moment. A gold "+1 run day" tag marks any meter today's mile just
+    /// moved. Renders only while the token feature is active.
+    private var tokenRecapSection: some View {
+        VStack(spacing: 10) {
+            HStack(spacing: 6) {
+                Text("STREAK TOKENS")
+                    .font(.system(size: 10, weight: .heavy, design: .rounded))
+                    .tracking(1.2)
+                    .foregroundColor(.white.opacity(0.6))
+                Spacer()
+                if let payload = tokensState.payload {
+                    let ready = [
+                        payload.double_down.held,
+                        payload.streak_save.held,
+                        payload.streak_assist.held,
+                    ].filter { $0 }.count
+                    if ready > 0 {
+                        Text("\(ready) ready")
+                            .font(.system(size: 11, weight: .heavy, design: .rounded))
+                            .foregroundColor(.green)
+                    }
+                }
+            }
+
+            if let payload = tokensState.payload {
+                HStack(spacing: 0) {
+                    recapCell(
+                        kind: .doubleDown,
+                        held: payload.double_down.held,
+                        progress: payload.double_down.fraction,
+                        caption: payload.double_down.held
+                            ? "Ready"
+                            : "\(Int(payload.double_down.progress))/\(Int(payload.double_down.target))"
+                    )
+                    recapCell(
+                        kind: .save,
+                        held: payload.streak_save.held,
+                        progress: payload.streak_save.fraction,
+                        caption: payload.streak_save.held
+                            ? "Ready"
+                            : "\(Int(payload.streak_save.progress))/\(Int(payload.streak_save.target))"
+                    )
+                    recapCell(
+                        kind: .assist,
+                        held: payload.streak_assist.held,
+                        progress: payload.streak_assist.fraction,
+                        caption: payload.streak_assist.held
+                            ? "Ready"
+                            : String(format: "%.1f/%.0f mi", payload.streak_assist.progress, payload.streak_assist.target)
+                    )
+                }
+            }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.white.opacity(0.06))
+        )
+    }
+
+    private func recapCell(
+        kind: StreakTokenKind, held: Bool, progress: Double, caption: String
+    ) -> some View {
+        VStack(spacing: 5) {
+            TokenMedallion(kind: kind, held: held, progress: progress, size: 34)
+            if let gain = recapGains[kind.raw] {
+                Text(gain)
+                    .font(.system(size: 9, weight: .heavy, design: .rounded))
+                    .foregroundColor(Color(red: 1.0, green: 0.84, blue: 0.35))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            } else {
+                Text(caption)
+                    .font(.system(size: 9, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundColor(held ? .green : .white.opacity(0.5))
+            }
+        }
+        .frame(maxWidth: .infinity)
     }
 
     // MARK: - Notify Friends (ask-mode embed)

--- a/app/Mile A Day/Views/Celebrations/LeaderboardMoveUpView.swift
+++ b/app/Mile A Day/Views/Celebrations/LeaderboardMoveUpView.swift
@@ -296,10 +296,10 @@ struct LeaderboardMoveUpView: View {
             withAnimation(.easeOut(duration: 0.3)) { showBoard = true }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
                 withAnimation(.spring(response: 0.6, dampingFraction: 0.7)) { animateMe = true }
-                UINotificationFeedbackGenerator().notificationOccurred(.success)
+                MADHaptics.success()
                 // Extra thump when you land the top spot.
                 if myRank == 1 {
-                    UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
+                    MADHaptics.emphasis()
                 }
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.1) {

--- a/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
+++ b/app/Mile A Day/Views/Celebrations/PostRunPhotoPromptView.swift
@@ -295,7 +295,7 @@ struct PostRunPhotoPromptView: View {
 
     private func snapCard(index: Int, entry: MidRunPhotoStash.Entry) -> some View {
         Button {
-            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+            MADHaptics.action()
             composerLaunch = ComposerLaunch(image: entry.image)
         } label: {
             Image(uiImage: entry.image)
@@ -332,7 +332,7 @@ struct PostRunPhotoPromptView: View {
         // taps can never double-fire the use-photo action.
         .overlay(alignment: .topTrailing) {
             Button {
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                MADHaptics.tap()
                 galleryStartIndex = index
                 showGallery = true
             } label: {

--- a/app/Mile A Day/Views/Celebrations/YearlyMilestoneCelebrationView.swift
+++ b/app/Mile A Day/Views/Celebrations/YearlyMilestoneCelebrationView.swift
@@ -770,7 +770,7 @@ struct YearlyMilestoneSharePreviewSheet: View {
                     HStack(spacing: 12) {
                         Button {
                             UIPasteboard.general.image = image
-                            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                            MADHaptics.action()
                             showingCopiedFeedback = true
                         } label: {
                             HStack(spacing: 8) {
@@ -793,7 +793,7 @@ struct YearlyMilestoneSharePreviewSheet: View {
                         }
 
                         Button {
-                            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                            MADHaptics.action()
                             shareSheetItem = ShareableImage(image: image)
                         } label: {
                             HStack(spacing: 8) {

--- a/app/Mile A Day/Views/Competitions/CompetitionDetailView+Active.swift
+++ b/app/Mile A Day/Views/Competitions/CompetitionDetailView+Active.swift
@@ -435,7 +435,7 @@ extension CompetitionDetailView {
                 await MainActor.run {
                     isSendingAction = false
                     FlexNudgeTracker.markFlexSent(targetUserId: user.user_id)
-                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                    MADHaptics.success()
                     showActionFeedback(ActionFeedback(icon: "hand.raised.fill", message: "Flexed on \(user.displayName)!", isError: false))
                     completion?(true)
                 }

--- a/app/Mile A Day/Views/Competitions/CompetitionDetailView+MainTabs.swift
+++ b/app/Mile A Day/Views/Competitions/CompetitionDetailView+MainTabs.swift
@@ -224,7 +224,7 @@ extension CompetitionDetailView {
                     withAnimation(.easeInOut(duration: 0.18)) {
                         selectedMainTab = tab
                     }
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    MADHaptics.tap()
                 } label: {
                     HStack(spacing: 5) {
                         Image(systemName: tab.icon)

--- a/app/Mile A Day/Views/Competitions/CompetitionMyDailyRings.swift
+++ b/app/Mile A Day/Views/Competitions/CompetitionMyDailyRings.swift
@@ -117,7 +117,7 @@ struct CompetitionMyDailyRings: View {
                     ForEach(ds, id: \.self) { date in
                         Button {
                             selectedDate = date
-                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                            MADHaptics.tap()
                         } label: {
                             dayCell(for: date)
                                 .frame(maxWidth: .infinity)

--- a/app/Mile A Day/Views/Competitions/StreakActiveView.swift
+++ b/app/Mile A Day/Views/Competitions/StreakActiveView.swift
@@ -543,7 +543,7 @@ struct StreakActiveView: View {
                 isSendingAction = false
                 if successes > 0 {
                     FlexNudgeTracker.markFlexSent(competitionId: competition.competition_id)
-                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                    MADHaptics.success()
                     let msg = successes == 1 ? "Flex sent!" : "Flex sent to \(successes)!"
                     showFeedback(ActionFeedback(icon: "hand.raised.fill", message: msg, isError: false))
                 } else {

--- a/app/Mile A Day/Views/Components/MADCameraView.swift
+++ b/app/Mile A Day/Views/Components/MADCameraView.swift
@@ -175,7 +175,7 @@ struct MADCameraView: View {
         rotation: Double = 0, action: @escaping () -> Void
     ) -> some View {
         Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            MADHaptics.tap()
             action()
         } label: {
             Image(systemName: icon)
@@ -193,7 +193,7 @@ struct MADCameraView: View {
         icon: String, label: String, active: Bool, action: @escaping () -> Void
     ) -> some View {
         Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            MADHaptics.tap()
             action()
         } label: {
             HStack(spacing: 5) {
@@ -242,7 +242,7 @@ struct MADCameraView: View {
             ForEach(camera.zoomOptions, id: \.self) { factor in
                 let selected = isSelectedZoom(factor)
                 Button {
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    MADHaptics.tap()
                     pinchBaseline = nil
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                         camera.setDisplayZoom(factor)
@@ -365,7 +365,7 @@ struct MADCameraView: View {
             return
         }
 
-        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        MADHaptics.action()
         guard camera.timerSeconds > 0 else {
             capture()
             return
@@ -377,7 +377,7 @@ struct MADCameraView: View {
                 withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
                     countdown = remaining
                 }
-                UIImpactFeedbackGenerator(style: remaining <= 3 ? .medium : .light).impactOccurred()
+                remaining <= 3 ? MADHaptics.action() : MADHaptics.tap()
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
                 guard !Task.isCancelled else { return }
             }

--- a/app/Mile A Day/Views/Components/SnapGalleryView.swift
+++ b/app/Mile A Day/Views/Components/SnapGalleryView.swift
@@ -132,7 +132,7 @@ struct SnapGalleryView: View {
                 guard let current, !saved else { return }
                 PhotoRollSaver.save(current.image, ledgerKey: current.id) { ok in
                     guard ok else { return }
-                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                    MADHaptics.success()
                     withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
                         showSavedToast = true
                     }
@@ -146,7 +146,7 @@ struct SnapGalleryView: View {
             if let onUse {
                 Button {
                     guard let current else { return }
-                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                    MADHaptics.action()
                     dismiss()
                     onUse(current)
                 } label: {

--- a/app/Mile A Day/Views/Components/TokenUnlockOverlay.swift
+++ b/app/Mile A Day/Views/Components/TokenUnlockOverlay.swift
@@ -1,0 +1,157 @@
+import SwiftUI
+
+/// Full-screen "Token Earned!" moment. Fires when a meter completes (or when
+/// enrollment backfill hands a long streaker their starting set): dimmed
+/// backdrop, slow-spinning gold rays, the medallion(s) spring in oversized
+/// with a glow, then title + names + a single CTA. Deliberately self-contained
+/// — no coupling to the goal-celebration state machine.
+struct TokenUnlockOverlay: View {
+    let kinds: [StreakTokenKind]
+    let onDismiss: () -> Void
+
+    @State private var appeared = false
+    @State private var raysAngle: Angle = .degrees(0)
+
+    private var title: String {
+        kinds.count == 1 ? "Token Earned!" : "\(kinds.count) Tokens Earned!"
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.82).ignoresSafeArea()
+                .onTapGesture { dismiss() }
+
+            // Gold rays radiating behind the medallions — the "reward" light.
+            RaysShape(count: 12)
+                .fill(
+                    LinearGradient(
+                        colors: [Color(red: 1.0, green: 0.84, blue: 0.35).opacity(0.35), .clear],
+                        startPoint: .center,
+                        endPoint: .top
+                    )
+                )
+                .frame(width: 420, height: 420)
+                .rotationEffect(raysAngle)
+                .opacity(appeared ? 1 : 0)
+                .allowsHitTesting(false)
+
+            VStack(spacing: MADTheme.Spacing.lg) {
+                HStack(spacing: kinds.count > 1 ? 18 : 0) {
+                    ForEach(Array(kinds.enumerated()), id: \.element.title) { index, kind in
+                        TokenMedallion(
+                            kind: kind,
+                            held: true,
+                            size: kinds.count == 1 ? 132 : 84
+                        )
+                        .scaleEffect(appeared ? 1 : 0.2)
+                        .opacity(appeared ? 1 : 0)
+                        .animation(
+                            .spring(response: 0.5, dampingFraction: 0.62)
+                                .delay(0.12 + Double(index) * 0.14),
+                            value: appeared
+                        )
+                    }
+                }
+
+                VStack(spacing: 6) {
+                    Text(title)
+                        .font(.system(size: 30, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+
+                    Text(kinds.map { $0.title }.joined(separator: " · "))
+                        .font(.system(size: 15, weight: .bold, design: .rounded))
+                        .foregroundColor(Color(red: 1.0, green: 0.84, blue: 0.35))
+
+                    Text(subtitle)
+                        .font(.system(size: 13, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.7))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, MADTheme.Spacing.xl)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .opacity(appeared ? 1 : 0)
+                .offset(y: appeared ? 0 : 12)
+                .animation(.easeOut(duration: 0.4).delay(0.35), value: appeared)
+
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Let's Go")
+                        .font(.system(size: 16, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 44)
+                        .padding(.vertical, 14)
+                        .background(Capsule().fill(MADTheme.Colors.redGradient))
+                        .shadow(color: MADTheme.Colors.madRed.opacity(0.5), radius: 10)
+                }
+                .buttonStyle(ScaleButtonStyle())
+                .opacity(appeared ? 1 : 0)
+                .animation(.easeOut(duration: 0.4).delay(0.5), value: appeared)
+            }
+            .padding(MADTheme.Spacing.lg)
+        }
+        .onAppear {
+            appeared = true
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            withAnimation(.linear(duration: 24).repeatForever(autoreverses: false)) {
+                raysAngle = .degrees(360)
+            }
+        }
+    }
+
+    private var subtitle: String {
+        if kinds.count > 1 {
+            return "Your streak history earned these. They're on your dashboard — tap them anytime to see what they do."
+        }
+        switch kinds[0] {
+        case .doubleDown:
+            return "Miss a day? Run 2× your goal the next day and it still counts."
+        case .save:
+            return "If you ever miss a day, this covers it automatically."
+        case .assist:
+            return "A friend's streak breaks? You can now save it from their row on the Friends tab."
+        }
+    }
+
+    private func dismiss() {
+        withAnimation(.easeOut(duration: 0.25)) { onDismiss() }
+    }
+}
+
+/// Simple radial burst of tapered rays.
+private struct RaysShape: Shape {
+    let count: Int
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let radius = min(rect.width, rect.height) / 2
+        let halfWidth = CGFloat.pi / CGFloat(count) * 0.35
+        for i in 0..<count {
+            let angle = CGFloat(i) / CGFloat(count) * 2 * .pi
+            path.move(to: center)
+            path.addLine(to: CGPoint(
+                x: center.x + radius * cos(angle - halfWidth),
+                y: center.y + radius * sin(angle - halfWidth)
+            ))
+            path.addLine(to: CGPoint(
+                x: center.x + radius * cos(angle + halfWidth),
+                y: center.y + radius * sin(angle + halfWidth)
+            ))
+            path.closeSubpath()
+        }
+        return path
+    }
+}
+
+/// Maps the state's raw earned kinds to medallion kinds.
+extension StreakTokenKind {
+    static func from(raw: String) -> StreakTokenKind? {
+        switch raw {
+        case "double_down": return .doubleDown
+        case "streak_save": return .save
+        case "streak_assist": return .assist
+        default: return nil
+        }
+    }
+}

--- a/app/Mile A Day/Views/Components/TokenUnlockOverlay.swift
+++ b/app/Mile A Day/Views/Components/TokenUnlockOverlay.swift
@@ -9,6 +9,7 @@ struct TokenUnlockOverlay: View {
     let kinds: [StreakTokenKind]
     let onDismiss: () -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var appeared = false
     @State private var raysAngle: Angle = .degrees(0)
 
@@ -92,9 +93,12 @@ struct TokenUnlockOverlay: View {
         }
         .onAppear {
             appeared = true
-            UINotificationFeedbackGenerator().notificationOccurred(.success)
-            withAnimation(.linear(duration: 24).repeatForever(autoreverses: false)) {
-                raysAngle = .degrees(360)
+            MADHaptics.success()
+            // Reduce Motion: rays stay as a static glow instead of spinning.
+            if !reduceMotion {
+                withAnimation(.linear(duration: 24).repeatForever(autoreverses: false)) {
+                    raysAngle = .degrees(360)
+                }
             }
         }
     }

--- a/app/Mile A Day/Views/Dashboard/DashboardCards.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardCards.swift
@@ -76,36 +76,18 @@ struct StreakCard: View {
                             .foregroundColor(.white.opacity(0.8))
                     }
 
-                    // Status message - make completion status super obvious with consistent colors
-                    VStack(alignment: .leading, spacing: 6) {
-                        if isGoalCompleted {
-                            HStack(spacing: 4) {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .font(.subheadline)
-                                    .foregroundColor(statusColor)
-                                Text("Goal completed today!")
-                                    .font(.subheadline)
-                                    .foregroundColor(statusColor)
-                                    .fontWeight(.bold)
-                            }
-                        } else {
-                            HStack(spacing: 4) {
-                                Image(systemName: isAtRisk ? "exclamationmark.triangle.fill" : "exclamationmark.circle.fill")
-                                    .font(.subheadline)
-                                    .foregroundColor(statusColor)
-                                Text(isAtRisk ? "Streak at risk!" : "Goal not completed")
-                                    .font(.subheadline)
-                                    .foregroundColor(statusColor)
-                                    .fontWeight(.bold)
-                            }
-
-                            if !isAtRisk {
-                                Text("\(String(format: "%.2f", user.goalMiles - currentDistance)) mi to go")
-                                    .font(.caption)
-                                    .foregroundColor(.white.opacity(0.8))
-                            }
-                        }
+                    // One status line — completion, distance-to-go, and
+                    // time-left merged into a single caption instead of
+                    // three stacked fragments (calm-pass density cut).
+                    HStack(spacing: 5) {
+                        Image(systemName: statusIconName)
+                            .font(.system(size: 12, weight: .bold))
+                        Text(statusLineText)
+                            .font(.system(size: 13, weight: .semibold, design: .rounded))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
                     }
+                    .foregroundColor(statusColor)
                 }
 
                 Spacer()
@@ -113,26 +95,9 @@ struct StreakCard: View {
                 // Right side: Flame icon - consistent colors based on status
                 ZStack {
                     if isGoalCompleted {
-                        // Outer glow - green/orange when completed
-                        Circle()
-                            .fill(
-                                RadialGradient(
-                                    colors: [
-                                        statusColor.opacity(0.5),
-                                        statusColor.opacity(0.2),
-                                        Color.clear
-                                    ],
-                                    center: .center,
-                                    startRadius: 20,
-                                    endRadius: 45
-                                )
-                            )
-                            .frame(width: 90, height: 90)
-                            .scaleEffect(animateFire ? 1.15 : 0.95)
-                            .opacity(animateFire ? 0.9 : 0.5)
-                            .animation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true), value: animateFire)
-
-                        // Inner circle background - green/orange when completed
+                        // Flat completed state: one tinted disc + a gently
+                        // breathing flame. The old animated radial glow ring
+                        // was pure ornament — cut in the calm pass.
                         Circle()
                             .fill(
                                 LinearGradient(
@@ -146,7 +111,6 @@ struct StreakCard: View {
                             )
                             .frame(width: 70, height: 70)
 
-                        // Flame icon with animation - green/orange and pulsing when completed
                         Image(systemName: "flame.fill")
                             .font(.system(size: 36))
                             .foregroundStyle(
@@ -156,54 +120,42 @@ struct StreakCard: View {
                                     endPoint: .bottom
                                 )
                             )
-                            .scaleEffect(animateFire ? 1.15 : 1.0)
-                            .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: animateFire)
-                            .shadow(color: statusColor.opacity(0.7), radius: animateFire ? 15 : 8)
+                            .scaleEffect(animateFire ? 1.08 : 1.0)
+                            .animation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true), value: animateFire)
+                            .shadow(color: statusColor.opacity(0.5), radius: animateFire ? 9 : 6)
                     } else if isAtRisk {
-                        // At-risk state: countdown ring around flame with time label below
                         let countdownProgress: Double = {
                             guard let remaining = user.timeUntilStreakReset else { return 0 }
                             // 6 hours = 21600 seconds (from 6pm to midnight)
                             return min(remaining / 21600, 1.0)
                         }()
 
-                        VStack(spacing: 6) {
-                            ZStack {
-                                Circle()
-                                    .fill(Color.red.opacity(0.1))
-                                    .frame(width: 70, height: 70)
+                        // At-risk: countdown ring around the flame. The time
+                        // itself lives in the status line on the left now —
+                        // no duplicate label under the ring.
+                        ZStack {
+                            Circle()
+                                .fill(Color.red.opacity(0.1))
+                                .frame(width: 70, height: 70)
 
-                                // Countdown ring
-                                Circle()
-                                    .trim(from: 0, to: countdownProgress)
-                                    .stroke(
-                                        LinearGradient(
-                                            colors: [.red, .orange],
-                                            startPoint: .topLeading,
-                                            endPoint: .bottomTrailing
-                                        ),
-                                        style: StrokeStyle(lineWidth: 3, lineCap: .round)
-                                    )
-                                    .frame(width: 74, height: 74)
-                                    .rotationEffect(.degrees(-90))
+                            Circle()
+                                .trim(from: 0, to: countdownProgress)
+                                .stroke(
+                                    LinearGradient(
+                                        colors: [.red, .orange],
+                                        startPoint: .topLeading,
+                                        endPoint: .bottomTrailing
+                                    ),
+                                    style: StrokeStyle(lineWidth: 3, lineCap: .round)
+                                )
+                                .frame(width: 74, height: 74)
+                                .rotationEffect(.degrees(-90))
 
-                                Image(systemName: "flame.fill")
-                                    .font(.system(size: 36))
-                                    .foregroundColor(.red.opacity(0.8))
-                                    .scaleEffect(animateUrgency ? 1.05 : 0.95)
-                                    .animation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true), value: animateUrgency)
-                            }
-
-                            if !timeRemainingText.isEmpty {
-                                HStack(spacing: 4) {
-                                    Image(systemName: "exclamationmark.triangle.fill")
-                                        .font(.system(size: 10, weight: .bold))
-                                    Text(formattedTimeOnly)
-                                        .font(.system(size: 13, weight: .bold, design: .rounded))
-                                }
-                                .foregroundColor(.red)
-                                .opacity(animateUrgency ? 1.0 : 0.6)
-                            }
+                            Image(systemName: "flame.fill")
+                                .font(.system(size: 36))
+                                .foregroundColor(.red.opacity(0.8))
+                                .scaleEffect(animateUrgency ? 1.05 : 0.95)
+                                .animation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true), value: animateUrgency)
                         }
                     } else {
                         // Default: not completed, not at risk
@@ -218,31 +170,16 @@ struct StreakCard: View {
                 }
             }
 
-            // Milestone progress
+            // Milestone — one slim row (bar + tiny caption) instead of the
+            // old two-line header + thick bar block.
             if let milestone = nextMilestone {
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack {
-                        Text("Next Milestone: \(milestone.value) Days")
-                            .font(.subheadline)
-                            .fontWeight(.semibold)
-                            .foregroundColor(.white.opacity(0.9))
-
-                        Spacer()
-
-                        Text("\(milestone.daysToGo) days to go")
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                            .foregroundColor(statusColor)
-                    }
-
-                    // Progress bar
+                HStack(spacing: 10) {
                     GeometryReader { geometry in
                         ZStack(alignment: .leading) {
-                            RoundedRectangle(cornerRadius: 8)
-                                .fill(Color.white.opacity(0.15))
-                                .frame(height: 8)
+                            Capsule()
+                                .fill(Color.white.opacity(0.12))
 
-                            RoundedRectangle(cornerRadius: 8)
+                            Capsule()
                                 .fill(
                                     LinearGradient(
                                         colors: [.yellow, .orange, .red],
@@ -250,27 +187,21 @@ struct StreakCard: View {
                                         endPoint: .trailing
                                     )
                                 )
-                                .frame(width: milestone.progress * geometry.size.width, height: 8)
+                                .frame(width: max(5, milestone.progress * geometry.size.width))
                                 .animation(.easeOut(duration: 0.8), value: milestone.progress)
                         }
                     }
-                    .frame(height: 8)
+                    .frame(height: 5)
+
+                    Text("Day \(milestone.value) in \(milestone.daysToGo)")
+                        .font(.system(size: 11, weight: .semibold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.55))
+                        .layoutPriority(1)
                 }
             }
 
             // Compact week-at-a-glance row
             compactWeekRow
-
-            // Share hint
-            HStack(spacing: 6) {
-                Image(systemName: "square.and.arrow.up")
-                    .font(.system(size: 10))
-                Text("Tap to share your streak")
-                    .font(.system(size: 11, weight: .medium))
-            }
-            .foregroundColor(.white.opacity(0.45))
-            .frame(maxWidth: .infinity)
-            .padding(.top, 4)
         }
         .padding(.horizontal, 24)
         .padding(.vertical, 24)
@@ -307,27 +238,14 @@ struct StreakCard: View {
             }
         )
         .overlay(alignment: .topTrailing) {
-            // Time/check positioned at absolute top right edge.
-            // At-risk state renders its time label under the flame ring instead.
-            if isGoalCompleted {
-                Image(systemName: "checkmark.circle.fill")
-                    .font(.caption)
-                    .foregroundColor(.green)
-                    .padding(.top, 24)
-                    .padding(.trailing, 24)
-            } else if !isAtRisk && !timeRemainingText.isEmpty {
-                HStack(spacing: 4) {
-                    Image(systemName: "clock.fill")
-                        .font(.caption2)
-                        .foregroundColor(statusColor)
-                    Text(formattedTimeOnly)
-                        .font(.caption2)
-                        .foregroundColor(statusColor)
-                        .fontWeight(.medium)
-                }
-                .padding(.top, 24)
-                .padding(.trailing, 24)
-            }
+            // Quiet share affordance — replaces the old check/clock cluster
+            // (both merged into the status line) and the full-width
+            // "Tap to share" hint row.
+            Image(systemName: "square.and.arrow.up")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(.white.opacity(0.35))
+                .padding(.top, 20)
+                .padding(.trailing, 20)
         }
         .shadow(color: .black.opacity(0.1), radius: 8, x: 0, y: 4)
         .onAppear {
@@ -492,6 +410,30 @@ struct StreakCard: View {
             return .orange  // Orange when not completed but not at risk
         }
     }
+
+    private var statusIconName: String {
+        if isGoalCompleted { return "checkmark.circle.fill" }
+        if isAtRisk { return "exclamationmark.triangle.fill" }
+        return "clock.fill"
+    }
+
+    /// The merged single-line status: completion / distance-to-go / time-left.
+    /// Reads `timeRemainingText` (the timer-refreshed @State) — nothing else
+    /// in body does anymore, and without that dependency SwiftUI would never
+    /// re-render on the minute tick and the countdown would freeze.
+    private var statusLineText: String {
+        if isGoalCompleted { return "Done for today" }
+        let toGo = String(format: "%.2f", max(user.goalMiles - currentDistance, 0))
+        let time = timeRemainingText.isEmpty ? "" : formattedTimeOnly
+        if isAtRisk {
+            return time.isEmpty
+                ? "At risk — \(toGo) mi to go"
+                : "At risk — \(toGo) mi to go · \(time) left"
+        }
+        return time.isEmpty
+            ? "\(toGo) mi to go"
+            : "\(toGo) mi to go · \(time) left"
+    }
 }
 
 struct TodayProgressCard: View {
@@ -518,21 +460,20 @@ struct TodayProgressCard: View {
 
     var body: some View {
         VStack(spacing: 16) {
-            // Header
-            HStack {
-                Image(systemName: "figure.run")
-                    .foregroundColor(.white)
-                    .font(.title3)
-                Text("Today's Progress")
-                    .font(.headline)
+            // Eyebrow header — same quiet grammar as the streak card's
+            // "CURRENT STREAK" label; the big number below is the headline.
+            HStack(spacing: 6) {
+                Text("TODAY")
+                    .font(.caption)
                     .fontWeight(.semibold)
-                    .foregroundColor(.white)
-                Spacer()
+                    .tracking(1.2)
+                    .foregroundColor(didComplete ? .green : .white.opacity(0.7))
                 if didComplete {
                     Image(systemName: "checkmark.circle.fill")
+                        .font(.caption)
                         .foregroundColor(.green)
-                        .font(.title3)
                 }
+                Spacer()
             }
 
             // Large progress display

--- a/app/Mile A Day/Views/Dashboard/DashboardCards.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardCards.swift
@@ -18,6 +18,7 @@ struct StreakCard: View {
     @ObservedObject var healthManager: HealthKitManager
     @ObservedObject var userManager: UserManager
     @Environment(\.colorScheme) var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var animateStreak = false
     @State private var animateFire = false
     @State private var animateUrgency = false
@@ -251,8 +252,9 @@ struct StreakCard: View {
         .onAppear {
             updateTimeRemaining()
             startTimer()
-            // Start fire animation only if goal is completed
-            if isGoalCompleted {
+            // Start fire animation only if goal is completed (and the user
+            // hasn't asked the system for reduced motion).
+            if isGoalCompleted && !reduceMotion {
                 animateFire = true
             } else {
                 animateFire = false
@@ -262,7 +264,7 @@ struct StreakCard: View {
             // `timeRemainingText` above has rendered first — otherwise the
             // `.animation(_:value:)` on the flame Image catches the position
             // change and oscillates the flame diagonally forever.
-            if isAtRisk && !isGoalCompleted {
+            if isAtRisk && !isGoalCompleted && !reduceMotion {
                 DispatchQueue.main.async {
                     animateUrgency = true
                 }
@@ -270,7 +272,7 @@ struct StreakCard: View {
         }
         .onChange(of: isGoalCompleted) { oldValue, newValue in
             updateTimeRemaining()
-            if newValue && !oldValue {
+            if newValue && !oldValue && !reduceMotion {
                 // Start fire animation when goal completed
                 animateFire = true
             } else if !newValue {
@@ -287,8 +289,7 @@ struct StreakCard: View {
         }
         .contentShape(Rectangle())
         .onTapGesture {
-            let impact = UIImpactFeedbackGenerator(style: .medium)
-            impact.impactOccurred()
+            MADHaptics.action()
             showingShareSheet = true
         }
         .sheet(isPresented: $showingShareSheet) {

--- a/app/Mile A Day/Views/Dashboard/DashboardShareViews.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardShareViews.swift
@@ -3,210 +3,6 @@ import UIKit
 
 // MARK: - Share Views
 
-struct StreakShareView: View {
-    let streak: Int
-    let isGoalCompleted: Bool
-    let isAtRisk: Bool
-
-    // Dynamic colors for share view
-    var streakColor: Color {
-        if isGoalCompleted {
-            return .green
-        } else if isAtRisk {
-            return .red
-        } else {
-            return .orange
-        }
-    }
-
-    var gradientColors: [Color] {
-        if isGoalCompleted {
-            return [.green.opacity(0.3), .green.opacity(0.1)]
-        } else if isAtRisk {
-            return [.red.opacity(0.3), .red.opacity(0.1)]
-        } else {
-            return [.orange.opacity(0.3), .orange.opacity(0.1)]
-        }
-    }
-
-    var body: some View {
-        VStack(spacing: 20) {
-            // App branding
-            MADLogoMark(size: 46, shadow: false)
-
-            // Streak display
-            VStack(spacing: 16) {
-                Text("Current Streak")
-                    .font(.headline)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.primary)
-
-                ZStack {
-                    // Background circle
-                    Circle()
-                        .fill(
-                            LinearGradient(
-                                gradient: Gradient(colors: gradientColors),
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
-                            )
-                        )
-                        .frame(width: 140, height: 140)
-
-                    // Progress ring
-                    Circle()
-                        .stroke(Color.gray.opacity(0.2), lineWidth: 6)
-                        .frame(width: 150, height: 150)
-
-                    Circle()
-                        .trim(from: 0, to: isGoalCompleted ? 1.0 : (isAtRisk ? 0.2 : 0.8))
-                        .stroke(streakColor, style: StrokeStyle(lineWidth: 6, lineCap: .round))
-                        .frame(width: 150, height: 150)
-                        .rotationEffect(.degrees(-90))
-
-                    // Center content
-                    VStack(spacing: 4) {
-                        Text("\(streak)")
-                            .font(.system(size: 48, weight: .bold, design: .rounded))
-                            .foregroundColor(streakColor)
-
-                        Text(streak == 1 ? "day" : "days")
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                            .foregroundColor(streakColor.opacity(0.8))
-                    }
-                }
-
-                // Status message
-                if isGoalCompleted {
-                    Text("Goal Completed Today! 🎉")
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                        .foregroundColor(.green)
-                } else if isAtRisk {
-                    Text("Streak at risk! ⚠️")
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                        .foregroundColor(.red)
-                } else {
-                    Text("Keep the streak alive!")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                }
-            }
-
-            // Footer
-            Text("Track your daily mile progress with Mile A Day")
-                .font(.caption)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-        }
-        .padding(40)
-        .background(
-            LinearGradient(
-                gradient: Gradient(colors: [Color(.systemBackground), Color(.systemGray6)]),
-                startPoint: .top,
-                endPoint: .bottom
-            )
-        )
-        .frame(width: 400, height: 600)
-    }
-}
-
-struct TodayProgressShareView: View {
-    let currentDistance: Double
-    let goalDistance: Double
-    let progress: Double
-    let didComplete: Bool
-    let totalMiles: Double
-
-    var body: some View {
-        VStack(spacing: 20) {
-            // App branding
-            MADLogoMark(size: 46, shadow: false)
-
-            // Progress display
-            VStack(spacing: 16) {
-                Text("Today's Progress")
-                    .font(.headline)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.primary)
-
-                // Progress Bar
-                GeometryReader { geometry in
-                    ZStack(alignment: .leading) {
-                        RoundedRectangle(cornerRadius: 12)
-                            .fill(Color.gray.opacity(0.2))
-                            .frame(height: 24)
-
-                        RoundedRectangle(cornerRadius: 12)
-                            .fill(didComplete ? Color.green : Color.orange)
-                            .frame(width: progress * geometry.size.width, height: 24)
-                    }
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
-                }
-                .frame(height: 24)
-
-                // Distance Display
-                HStack(spacing: 8) {
-                    Text(String(format: "%.2f", currentDistance))
-                        .font(.title)
-                        .fontWeight(.bold)
-                        .foregroundColor(.primary)
-
-                    Text("of")
-                        .font(.title3)
-                        .foregroundColor(.secondary)
-
-                    Text(String(format: "%.1f mi", goalDistance))
-                        .font(.title)
-                        .fontWeight(.bold)
-                        .foregroundColor(.primary)
-                }
-
-                if didComplete {
-                    Label("Goal Complete!", systemImage: "star.fill")
-                        .foregroundColor(.green)
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                } else {
-                    let remaining = max(goalDistance - currentDistance, 0.0)
-                    Text(String(format: "%.2f mi to go", remaining))
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                }
-
-                // Total miles display
-                HStack {
-                    Image(systemName: "trophy.fill")
-                        .foregroundColor(.orange)
-                        .font(.subheadline)
-                    Text(String(format: "Total Miles: %.1f", totalMiles))
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                        .foregroundColor(.primary)
-                }
-                .padding(.top, 8)
-            }
-
-            // Footer
-            Text("Track your daily mile progress with Mile A Day")
-                .font(.caption)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-        }
-        .padding(40)
-        .background(
-            LinearGradient(
-                gradient: Gradient(colors: [Color(.systemBackground), Color(.systemGray6)]),
-                startPoint: .top,
-                endPoint: .bottom
-            )
-        )
-        .frame(width: 400, height: 600)
-    }
-}
-
 // MARK: - Dashboard Card Share Views
 
 struct StreakCardShareView: View {
@@ -251,10 +47,13 @@ struct StreakCardShareView: View {
             .padding(.bottom, 12)
 
             VStack(spacing: 10) {
-                // Title
-                Text("Current Streak")
-                    .font(.headline)
+                // Eyebrow title — same quiet grammar as the in-app card, so
+                // the shared image matches what the app looks like.
+                Text("CURRENT STREAK")
+                    .font(.caption)
                     .fontWeight(.semibold)
+                    .tracking(1.2)
+                    .foregroundColor(streakColor)
 
                 // Streak circle
                 ZStack {
@@ -290,24 +89,18 @@ struct StreakCardShareView: View {
                     }
                 }
 
-                // Status message
-                VStack(spacing: 2) {
-                    if isGoalCompleted {
-                        Label("Goal completed!", systemImage: "checkmark.circle.fill")
-                            .foregroundColor(.green)
-                            .font(.caption)
-                            .fontWeight(.medium)
-                    } else if isAtRisk {
-                        Label("Streak at risk!", systemImage: "exclamationmark.triangle.fill")
-                            .foregroundColor(.red)
-                            .font(.caption)
-                            .fontWeight(.medium)
-                    } else {
-                        Text("Keep it going!")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
+                // One status line — mirrors the in-app card's merged caption.
+                HStack(spacing: 4) {
+                    Image(systemName: isGoalCompleted
+                          ? "checkmark.circle.fill"
+                          : (isAtRisk ? "exclamationmark.triangle.fill" : "flame.fill"))
+                        .font(.system(size: 11, weight: .bold))
+                    Text(isGoalCompleted
+                         ? "Done for today"
+                         : (isAtRisk ? "Streak at risk" : "Keep it going"))
+                        .font(.system(size: 12, weight: .semibold, design: .rounded))
                 }
+                .foregroundColor(streakColor)
             }
             .padding(16)
         }
@@ -340,7 +133,7 @@ struct StreakCardShareView: View {
                     )
             }
         )
-        .shadow(color: .black.opacity(0.15), radius: 15, x: 0, y: 8)
+        .shadow(color: .black.opacity(0.12), radius: 8, x: 0, y: 4)
         .frame(width: 300, height: 380)
     }
 }
@@ -365,34 +158,33 @@ struct TodayProgressCardShareView: View {
             .padding(.bottom, 12)
 
             VStack(spacing: 12) {
-                // Header
-                HStack {
-                    Image(systemName: "figure.run")
-                        .foregroundColor(.primary)
-                    Text("Today's Progress")
-                        .font(.headline)
+                // Eyebrow header — same quiet grammar as the in-app card.
+                HStack(spacing: 6) {
+                    Text("TODAY")
+                        .font(.caption)
                         .fontWeight(.semibold)
-                    Spacer()
+                        .tracking(1.2)
+                        .foregroundColor(didComplete ? .green : .secondary)
                     if didComplete {
                         Image(systemName: "checkmark.circle.fill")
+                            .font(.caption)
                             .foregroundColor(.green)
                     }
+                    Spacer()
                 }
 
-                // Progress Bar
+                // Progress bar — slim capsule, matching the app.
                 GeometryReader { geometry in
                     ZStack(alignment: .leading) {
-                        RoundedRectangle(cornerRadius: 8)
+                        Capsule()
                             .fill(Color.gray.opacity(0.2))
-                            .frame(height: 14)
 
-                        RoundedRectangle(cornerRadius: 8)
+                        Capsule()
                             .fill(didComplete ? Color.green : Color(red: 217/255, green: 64/255, blue: 63/255))
-                            .frame(width: progress * geometry.size.width, height: 14)
+                            .frame(width: max(10, progress * geometry.size.width))
                     }
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
                 }
-                .frame(height: 14)
+                .frame(height: 10)
 
                 // Distance Display
                 HStack {
@@ -462,7 +254,7 @@ struct TodayProgressCardShareView: View {
                     )
             }
         )
-        .shadow(color: .black.opacity(0.15), radius: 15, x: 0, y: 8)
+        .shadow(color: .black.opacity(0.12), radius: 8, x: 0, y: 4)
         .frame(width: 300, height: 350)
     }
 }
@@ -576,8 +368,7 @@ struct SharePreviewView: View {
                         if let imageToCopy = selectedImage {
                             UIPasteboard.general.image = imageToCopy
                             // Haptic feedback for copy
-                            let impact = UIImpactFeedbackGenerator(style: .medium)
-                            impact.impactOccurred()
+                            MADHaptics.action()
 
                             // Show "Copied!" feedback
                             copyButtonText = "Copied!"

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -554,13 +554,15 @@ struct DashboardView: View {
 
                 // What's New: auto-present once per release. Same stand-down
                 // rules as the tour — never stack on a celebration, the
-                // tracker, or the first-run tour itself.
+                // tracker, the first-run tour, or the pending-notifications
+                // sheet (two sheets presented together = one silently drops).
                 if WhatsNewManager.shouldAutoPresent {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.9) {
                         if WhatsNewManager.shouldAutoPresent,
                            !celebrationManager.isShowingCelebration,
                            !showWorkoutView,
-                           !showWelcomeTour {
+                           !showWelcomeTour,
+                           !showPendingSheet {
                             showWhatsNew = true
                         }
                     }
@@ -800,6 +802,9 @@ struct DashboardView: View {
         guard !pendingService.pending.isEmpty else { return }
         guard !celebrationManager.isShowingCelebration else { return }
         guard !showPendingSheet else { return }
+        // Mutual stand-down with the What's New sheet — whichever presented
+        // first wins; the other retries on its next trigger.
+        guard !showWhatsNew else { return }
 
         let onlyMile = pendingService.pending.allSatisfy {
             $0.eventType == AudienceEventType.mileCompleted.rawValue

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -34,6 +34,8 @@ struct DashboardView: View {
     /// What's New popup — auto-presents once per release, reopenable from
     /// Settings → What's New.
     @State private var showWhatsNew = false
+    /// Streak tokens — drives the tokens card + the unlock celebration.
+    @ObservedObject private var tokensState = StreakTokensState.shared
     @State private var newGoalMiles: Double = 1.0
     @State private var isRefreshing = false
     @State private var showWorkoutUploadAlert = false
@@ -577,6 +579,21 @@ struct DashboardView: View {
             }
             .sheet(isPresented: $showWhatsNew) {
                 WhatsNewView()
+            }
+            // Token unlock celebration — a meter just completed (or enrollment
+            // backfill handed over the starting set). Self-contained overlay;
+            // stands down while a goal celebration is playing (newlyEarned
+            // persists until dismissed, so the moment isn't lost).
+            .overlay {
+                if !tokensState.newlyEarned.isEmpty,
+                   !celebrationManager.isShowingCelebration {
+                    TokenUnlockOverlay(
+                        kinds: tokensState.newlyEarned.compactMap { StreakTokenKind.from(raw: $0) },
+                        onDismiss: { tokensState.newlyEarned = [] }
+                    )
+                    .transition(.opacity)
+                    .zIndex(50)
+                }
             }
             .sheet(isPresented: $showGoalSheet) {
                 GoalSettingSheet(

--- a/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
+++ b/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
@@ -181,6 +181,8 @@ struct PureFlameBadge: View {
 struct StreakTokensCard: View {
     @ObservedObject var tokensState = StreakTokensState.shared
     @State private var showDetail = false
+    /// Drives the slow breathing pulse on earned medallions.
+    @State private var pulse = false
 
     var body: some View {
         if let payload = tokensState.payload {
@@ -266,6 +268,15 @@ struct StreakTokensCard: View {
     ) -> some View {
         VStack(spacing: 6) {
             TokenMedallion(kind: kind, held: held, progress: progress, size: 46)
+                // Earned tokens breathe gently — alive, not static.
+                .scaleEffect(held && pulse ? 1.05 : 1.0)
+                .animation(
+                    held
+                        ? .easeInOut(duration: 1.5).repeatForever(autoreverses: true)
+                        : .default,
+                    value: pulse
+                )
+                .onAppear { pulse = true }
             Text(kind.title)
                 .font(.system(size: 10, weight: .bold, design: .rounded))
                 .foregroundColor(.white.opacity(held ? 0.95 : 0.6))
@@ -406,31 +417,7 @@ struct StreakTokensDetailView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            // Meter bar + count
-            VStack(alignment: .leading, spacing: 4) {
-                GeometryReader { geo in
-                    ZStack(alignment: .leading) {
-                        Capsule().fill(Color.white.opacity(0.08))
-                        Capsule()
-                            .fill(
-                                LinearGradient(
-                                    colors: kind.gradient,
-                                    startPoint: .leading,
-                                    endPoint: .trailing
-                                )
-                            )
-                            .frame(width: max(6, geo.size.width * (meter.held ? 1 : meter.fraction)))
-                    }
-                }
-                .frame(height: 8)
-
-                Text(meter.held
-                     ? "Earned — you're holding 1 (max 1). Using it restarts the meter."
-                     : "\(trimmed(meter.progress)) / \(trimmed(meter.target)) \(unit)")
-                    .font(.system(size: 11, weight: .bold, design: .rounded))
-                    .monospacedDigit()
-                    .foregroundColor(meter.held ? .green : .secondary)
-            }
+            TokenMeterBar(kind: kind, meter: meter, unit: unit)
         }
         .padding(MADTheme.Spacing.md)
         .madLiquidGlass()
@@ -467,5 +454,90 @@ struct StreakTokensDetailView: View {
         value.truncatingRemainder(dividingBy: 1) == 0
             ? String(Int(value))
             : String(format: "%.1f", value)
+    }
+}
+
+// MARK: - Animated meter bar
+
+/// The earn meter, made satisfying: the fill springs from zero on appear, a
+/// light shimmer sweeps the filled portion, and the copy counts DOWN ("3 to
+/// go") so progress reads as approach, not bookkeeping.
+private struct TokenMeterBar: View {
+    let kind: StreakTokenKind
+    let meter: StreakTokenMeter
+    let unit: String
+
+    @State private var grown = false
+    @State private var shimmer = false
+
+    private var fraction: Double { meter.held ? 1 : meter.fraction }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            GeometryReader { geo in
+                let fillWidth = max(6, geo.size.width * fraction * (grown ? 1 : 0))
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Color.white.opacity(0.08))
+                    Capsule()
+                        .fill(
+                            LinearGradient(
+                                colors: kind.gradient,
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                        )
+                        .frame(width: fillWidth)
+                        .overlay(
+                            // Shimmer sweep across the filled portion.
+                            Capsule()
+                                .fill(
+                                    LinearGradient(
+                                        colors: [.clear, .white.opacity(0.45), .clear],
+                                        startPoint: .leading,
+                                        endPoint: .trailing
+                                    )
+                                )
+                                .frame(width: 46)
+                                .offset(x: shimmer ? fillWidth : -46)
+                                .animation(
+                                    .linear(duration: 1.8)
+                                        .repeatForever(autoreverses: false)
+                                        .delay(0.8),
+                                    value: shimmer
+                                )
+                                .mask(Capsule().frame(width: fillWidth))
+                        , alignment: .leading)
+                }
+            }
+            .frame(height: 8)
+
+            Text(statusLine)
+                .font(.system(size: 11, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .foregroundColor(meter.held ? .green : .secondary)
+        }
+        .onAppear {
+            withAnimation(.spring(response: 0.7, dampingFraction: 0.85).delay(0.15)) {
+                grown = true
+            }
+            if fraction > 0.1 { shimmer = true }
+        }
+    }
+
+    private var statusLine: String {
+        if meter.held {
+            return "Earned — you're holding 1 (max 1). Using it restarts the meter."
+        }
+        let remaining = max(meter.target - meter.progress, 0)
+        let togo = remaining.truncatingRemainder(dividingBy: 1) == 0
+            ? String(Int(remaining))
+            : String(format: "%.1f", remaining)
+        let progressText = meter.progress.truncatingRemainder(dividingBy: 1) == 0
+            ? String(Int(meter.progress))
+            : String(format: "%.1f", meter.progress)
+        let targetText = meter.target.truncatingRemainder(dividingBy: 1) == 0
+            ? String(Int(meter.target))
+            : String(format: "%.1f", meter.target)
+        return "\(progressText) / \(targetText) \(unit) · \(togo) to go"
     }
 }

--- a/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
+++ b/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
@@ -5,6 +5,16 @@ import SwiftUI
 enum StreakTokenKind {
     case doubleDown, save, assist
 
+    /// Backend raw kind — the key used by meter-gain chips and the unlock
+    /// event list (inverse of `from(raw:)`).
+    var raw: String {
+        switch self {
+        case .doubleDown: return "double_down"
+        case .save: return "streak_save"
+        case .assist: return "streak_assist"
+        }
+    }
+
     var title: String {
         switch self {
         case .doubleDown: return "Double Down"
@@ -190,14 +200,15 @@ struct StreakTokensCard: View {
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 showDetail = true
             } label: {
-                VStack(spacing: 14) {
-                    HStack(spacing: MADTheme.Spacing.sm) {
-                        Image(systemName: "shield.lefthalf.filled")
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundStyle(MADTheme.Colors.redGradient)
-                        Text("Streak Tokens")
-                            .font(.system(size: 16, weight: .heavy, design: .rounded))
-                            .foregroundColor(.white)
+                VStack(spacing: 12) {
+                    // Eyebrow header — matches the streak/today cards' quiet
+                    // caption grammar; the medallions are the headline here.
+                    HStack(spacing: 6) {
+                        Text("STREAK TOKENS")
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                            .tracking(1.2)
+                            .foregroundColor(.white.opacity(0.7))
                         Spacer()
                         let ready = [
                             payload.double_down.held,
@@ -277,6 +288,27 @@ struct StreakTokensCard: View {
                     value: pulse
                 )
                 .onAppear { pulse = true }
+                // Transient "+1 run day" chip when a fresh payload moved
+                // this meter forward — the bar visibly ticks, not just sits.
+                .overlay(alignment: .top) {
+                    if let gain = tokensState.meterGains[kind.raw] {
+                        Text(gain)
+                            .font(.system(size: 9, weight: .heavy, design: .rounded))
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 3)
+                            .background(Capsule().fill(kind.tint))
+                            .fixedSize()
+                            .offset(y: -15)
+                            .transition(
+                                .scale(scale: 0.5).combined(with: .opacity)
+                            )
+                    }
+                }
+                .animation(
+                    .spring(response: 0.4, dampingFraction: 0.7),
+                    value: tokensState.meterGains
+                )
             Text(kind.title)
                 .font(.system(size: 10, weight: .bold, design: .rounded))
                 .foregroundColor(.white.opacity(held ? 0.95 : 0.6))
@@ -298,6 +330,7 @@ struct StreakTokensCard: View {
 struct StreakTokensDetailView: View {
     @ObservedObject var tokensState = StreakTokensState.shared
     @Environment(\.dismiss) private var dismiss
+    @State private var showPureFlameInfo = false
 
     var body: some View {
         NavigationStack {
@@ -423,32 +456,76 @@ struct StreakTokensDetailView: View {
         .madLiquidGlass()
     }
 
+    /// Pure Flame explainer — deliberately an INFO PANEL, not another card in
+    /// the earnable-token language above it (no medallion, no meter, flat
+    /// fill, gold accent stripe): it's a status you keep, not a token you
+    /// spend. Tapping opens the full badge explainer.
     private func naturalCard(_ natural: Bool) -> some View {
-        HStack(spacing: 12) {
-            if natural {
-                PureFlameBadge(size: 30)
-            } else {
-                Image(systemName: "flame")
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundColor(.secondary)
-                    .frame(width: 30, height: 30)
+        Button {
+            showPureFlameInfo = true
+        } label: {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "info.circle.fill")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundColor(pureFlameGold)
+                    .padding(.top, 1)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        Text("ABOUT THE PURE FLAME")
+                            .font(.system(size: 10, weight: .heavy, design: .rounded))
+                            .tracking(1.1)
+                            .foregroundColor(pureFlameGold)
+                        if natural {
+                            PureFlameBadge(size: 15)
+                        }
+                    }
+                    Text(natural
+                         ? "Your streak is 100% natural — every day earned on the day. The gold flame shows beside your name."
+                         : "A token kept this streak alive, so the badge is resting. It returns with your next untouched streak.")
+                        .font(.system(size: 12, weight: .medium, design: .rounded))
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text("A status, not a token — nothing to spend. Tap to learn more.")
+                        .font(.system(size: 11, weight: .medium, design: .rounded))
+                        .foregroundColor(.secondary.opacity(0.7))
+                        .multilineTextAlignment(.leading)
+                }
+
+                Spacer(minLength: 0)
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundColor(.secondary.opacity(0.5))
+                    .padding(.top, 2)
             }
-            VStack(alignment: .leading, spacing: 2) {
-                Text(natural ? "Pure Flame — natural streak" : "Streak rescued along the way")
-                    .font(.system(size: 14, weight: .heavy, design: .rounded))
-                    .foregroundColor(.primary)
-                Text(natural
-                     ? "Every day of this streak was earned on the day. The gold flame shows on your profile."
-                     : "A token kept this streak alive — the Pure Flame returns with your next untouched streak. (Helping a friend never affects yours.)")
-                    .font(.system(size: 12, weight: .medium, design: .rounded))
-                    .foregroundColor(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+            .padding(MADTheme.Spacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(Color.white.opacity(0.04))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 14)
+                            .strokeBorder(pureFlameGold.opacity(0.25), lineWidth: 1)
+                    )
+            )
+            .overlay(alignment: .leading) {
+                // Gold accent stripe — the info-box signature.
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(pureFlameGold.opacity(0.8))
+                    .frame(width: 3)
+                    .padding(.vertical, 12)
+                    .padding(.leading, 1)
             }
-            Spacer(minLength: 0)
+            .contentShape(Rectangle())
         }
-        .padding(MADTheme.Spacing.md)
-        .madLiquidGlass()
+        .buttonStyle(.plain)
+        .sheet(isPresented: $showPureFlameInfo) {
+            PureFlameInfoSheet()
+        }
     }
+
+    private var pureFlameGold: Color { Color(red: 1.0, green: 0.84, blue: 0.35) }
 
     private func trimmed(_ value: Double) -> String {
         value.truncatingRemainder(dividingBy: 1) == 0
@@ -539,5 +616,91 @@ private struct TokenMeterBar: View {
             ? String(Int(meter.target))
             : String(format: "%.1f", meter.target)
         return "\(progressText) / \(targetText) \(unit) · \(togo) to go"
+    }
+}
+
+// MARK: - Pure Flame info sheet
+
+/// "What's the gold flame?" — presented when anyone taps a Pure Flame badge
+/// next to a name (own profile, friend profiles, the explainer's info panel).
+/// One badge, one sentence, three quick rules. Medium detent.
+struct PureFlameInfoSheet: View {
+    private var gold: Color { Color(red: 1.0, green: 0.84, blue: 0.35) }
+
+    var body: some View {
+        ZStack {
+            MADTheme.Colors.appBackgroundGradient.ignoresSafeArea()
+
+            VStack(spacing: MADTheme.Spacing.md) {
+                PureFlameBadge(size: 68)
+                    .padding(.top, MADTheme.Spacing.xl)
+
+                VStack(spacing: 6) {
+                    Text("Pure Flame")
+                        .font(.system(size: 26, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+
+                    Text("A 100% natural streak — every single day earned the day it happened. No saves, no rescues.")
+                        .font(.system(size: 14, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.75))
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.horizontal, MADTheme.Spacing.lg)
+                }
+
+                VStack(spacing: 10) {
+                    ruleRow(
+                        icon: "figure.run",
+                        tint: .green,
+                        text: "Keep completing your mile every day and the gold flame stays lit."
+                    )
+                    ruleRow(
+                        icon: "snowflake",
+                        tint: MADTheme.Colors.walkBlue,
+                        text: "Using a token to cover a missed day rests the badge until your next untouched streak."
+                    )
+                    ruleRow(
+                        icon: "lifepreserver",
+                        tint: MADTheme.Colors.madRed,
+                        text: "Saving a friend's streak never dims your own flame."
+                    )
+                }
+                .padding(.horizontal, MADTheme.Spacing.lg)
+                .padding(.top, MADTheme.Spacing.xs)
+
+                Text("It's a status, not a token — nothing to spend, everything to defend.")
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                    .foregroundColor(gold.opacity(0.9))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, MADTheme.Spacing.lg)
+
+                Spacer(minLength: 0)
+            }
+        }
+        .presentationDetents([.medium])
+        .presentationDragIndicator(.visible)
+    }
+
+    private func ruleRow(icon: String, tint: Color, text: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 15, weight: .bold))
+                .foregroundColor(tint)
+                .frame(width: 26, height: 26)
+                .background(Circle().fill(tint.opacity(0.15)))
+
+            Text(text)
+                .font(.system(size: 13, weight: .medium, design: .rounded))
+                .foregroundColor(.white.opacity(0.85))
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.white.opacity(0.05))
+        )
     }
 }

--- a/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
+++ b/app/Mile A Day/Views/Dashboard/StreakTokensDetailView.swift
@@ -190,6 +190,7 @@ struct PureFlameBadge: View {
 /// off. Tapping opens the explainer.
 struct StreakTokensCard: View {
     @ObservedObject var tokensState = StreakTokensState.shared
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var showDetail = false
     /// Drives the slow breathing pulse on earned medallions.
     @State private var pulse = false
@@ -197,7 +198,7 @@ struct StreakTokensCard: View {
     var body: some View {
         if let payload = tokensState.payload {
             Button {
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                MADHaptics.tap()
                 showDetail = true
             } label: {
                 VStack(spacing: 12) {
@@ -287,7 +288,7 @@ struct StreakTokensCard: View {
                         : .default,
                     value: pulse
                 )
-                .onAppear { pulse = true }
+                .onAppear { if !reduceMotion { pulse = true } }
                 // Transient "+1 run day" chip when a fresh payload moved
                 // this meter forward — the bar visibly ticks, not just sits.
                 .overlay(alignment: .top) {
@@ -544,6 +545,7 @@ private struct TokenMeterBar: View {
     let meter: StreakTokenMeter
     let unit: String
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var grown = false
     @State private var shimmer = false
 
@@ -594,6 +596,11 @@ private struct TokenMeterBar: View {
                 .foregroundColor(meter.held ? .green : .secondary)
         }
         .onAppear {
+            // Reduce Motion: show the final fill immediately, no shimmer loop.
+            if reduceMotion {
+                grown = true
+                return
+            }
             withAnimation(.spring(response: 0.7, dampingFraction: 0.85).delay(0.15)) {
                 grown = true
             }

--- a/app/Mile A Day/Views/Dashboard/WorkoutRecapView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutRecapView.swift
@@ -78,7 +78,7 @@ struct WorkoutRecapView: View {
             doneButton
         }
         .onAppear {
-            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            MADHaptics.success()
             withAnimation(.spring(response: 0.55, dampingFraction: 0.7)) { showHero = true }
             withAnimation(.easeOut(duration: 0.35).delay(0.2)) { showDistance = true }
             withAnimation(.easeOut(duration: 0.35).delay(0.35)) { showStats = true }

--- a/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
@@ -346,7 +346,7 @@ struct WorkoutTrackingView: View {
     /// for the end-of-run prompt.
     private var midRunTrayButton: some View {
         Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            MADHaptics.tap()
             showSnapTray = true
         } label: {
             Group {
@@ -415,7 +415,7 @@ struct WorkoutTrackingView: View {
 
     private var midRunLibraryButton: some View {
         Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            MADHaptics.tap()
             showLibraryImport = true
         } label: {
             midRunCircleIcon("photo.badge.plus")
@@ -473,7 +473,7 @@ struct WorkoutTrackingView: View {
     }
 
     private func showImportToast(_ text: String, ok: Bool) {
-        if ok { UINotificationFeedbackGenerator().notificationOccurred(.success) }
+        if ok { MADHaptics.success() }
         withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
             importToast = ImportToast(text: text, ok: ok)
         }
@@ -484,7 +484,7 @@ struct WorkoutTrackingView: View {
 
     private var midRunCameraButton: some View {
         Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            MADHaptics.tap()
             showMidRunCamera = true
         } label: {
             midRunCircleIcon("camera.fill")
@@ -517,7 +517,7 @@ struct WorkoutTrackingView: View {
                     guard entry != nil else { return }
                     midRunSnapCount = count
                     lastSnapThumb = thumb
-                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                    MADHaptics.success()
                     withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
                         showSnapSavedToast = true
                     }
@@ -880,8 +880,7 @@ struct WorkoutTrackingView: View {
                 }
 
                 // Haptic feedback
-                let notification = UINotificationFeedbackGenerator()
-                notification.notificationOccurred(.success)
+                MADHaptics.success()
 
                 // Hide notification after 2 seconds
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
@@ -905,8 +904,7 @@ struct WorkoutTrackingView: View {
                 }
 
                 // Haptic feedback
-                let notification = UINotificationFeedbackGenerator()
-                notification.notificationOccurred(.success)
+                MADHaptics.success()
 
                 // Hide completion after 3 seconds
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
@@ -1016,8 +1014,7 @@ struct WorkoutTrackingView: View {
         selectedActivityType = activityType
 
         // Haptic feedback
-        let impact = UIImpactFeedbackGenerator(style: .medium)
-        impact.impactOccurred()
+        MADHaptics.action()
 
         // Hide activity selection and show location type selection
         withAnimation {
@@ -1030,8 +1027,7 @@ struct WorkoutTrackingView: View {
         selectedLocationType = locationType
 
         // Haptic feedback
-        let impact = UIImpactFeedbackGenerator(style: .medium)
-        impact.impactOccurred()
+        MADHaptics.action()
 
         // Hide location type selection and show countdown
         withAnimation {

--- a/app/Mile A Day/Views/Feed/ActivityCardView.swift
+++ b/app/Mile A Day/Views/Feed/ActivityCardView.swift
@@ -85,7 +85,7 @@ struct ActivityCardView: View {
     /// the same clap burst the double-tap does.
     private func celebrateAndHype() {
         hypeBurst += 1
-        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        MADHaptics.action()
         if !entry.is_hyped {
             onHype()
         }

--- a/app/Mile A Day/Views/Feed/PostCardView.swift
+++ b/app/Mile A Day/Views/Feed/PostCardView.swift
@@ -212,7 +212,7 @@ struct PostCardView: View {
     /// feels identical to double-tapping the photo.
     private func celebrateAndHype() {
         hypeBurst += 1
-        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        MADHaptics.action()
         if !post.is_hyped {
             onHype()
         }

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -733,7 +733,7 @@ struct PostComposerView: View {
                         Button {
                             guard let flat = vm.flatten() else { return }
                             PhotoRollSaver.save(flat)
-                            UINotificationFeedbackGenerator().notificationOccurred(.success)
+                            MADHaptics.success()
                             withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
                                 showSavedToPhotos = true
                             }
@@ -1139,7 +1139,7 @@ struct PostComposerView: View {
 
     private func destinationCard(_ dest: PostDestination, selected: Bool) -> some View {
         Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            MADHaptics.tap()
             withAnimation(.easeInOut(duration: 0.15)) { vm.destination = dest }
         } label: {
             VStack(spacing: 4) {

--- a/app/Mile A Day/Views/Feed/ProfilePostsGridView.swift
+++ b/app/Mile A Day/Views/Feed/ProfilePostsGridView.swift
@@ -496,7 +496,7 @@ struct ProfilePostsFeedSheet: View {
                 )
             )
             await MainActor.run {
-                UINotificationFeedbackGenerator().notificationOccurred(.success)
+                MADHaptics.success()
             }
         } catch APIError.conflict {
             // Already hyped server-side — keep the optimistic state.

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -950,7 +950,7 @@ struct SocialFeedView: View {
             await MainActor.run {
                 hypesRemaining = response.hypes_remaining
                 hypesUnlimited = response.unlimited ?? hypesUnlimited
-                UINotificationFeedbackGenerator().notificationOccurred(.success)
+                MADHaptics.success()
             }
         } catch APIError.rateLimited {
             // Out of hypes for today — walk the optimistic state back and say
@@ -958,7 +958,7 @@ struct SocialFeedView: View {
             await MainActor.run {
                 revert()
                 hypesRemaining = 0
-                UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                MADHaptics.warning()
                 withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
                     showHypeLimitBanner = true
                 }

--- a/app/Mile A Day/Views/Feed/StoryViewerView.swift
+++ b/app/Mile A Day/Views/Feed/StoryViewerView.swift
@@ -512,7 +512,7 @@ struct StoryViewerView: View {
         // Optimistic — the server keeps one reaction per story and swapping is
         // idempotent, so a failed call just means no push went out.
         myReactions[post.post_id] = emoji
-        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        MADHaptics.action()
         Task {
             try? await PostService.reactToStory(postId: post.post_id, emoji: emoji)
             // Reconcile the bubble row with the server (adds/updates my bubble).
@@ -542,7 +542,7 @@ struct StoryViewerView: View {
             await MainActor.run {
                 promotedIds.insert(post.post_id)
                 changed = true
-                UINotificationFeedbackGenerator().notificationOccurred(.success)
+                MADHaptics.success()
             }
         } catch APIError.conflict {
             await MainActor.run {

--- a/app/Mile A Day/Views/FriendActivitySettingsView.swift
+++ b/app/Mile A Day/Views/FriendActivitySettingsView.swift
@@ -317,7 +317,7 @@ struct FriendActivitySettingsView: View {
 	// MARK: - Mutation
 
 	private func set(eventType: AudienceEventType, activity: AudienceActivity, audience aud: Audience?) {
-		UIImpactFeedbackGenerator(style: .light).impactOccurred()
+		MADHaptics.tap()
 		Task {
 			do {
 				try await audience.set(direction: direction, eventType: eventType, activity: activity, audience: aud)

--- a/app/Mile A Day/Views/Friends/CloseFriendsListView.swift
+++ b/app/Mile A Day/Views/Friends/CloseFriendsListView.swift
@@ -196,13 +196,13 @@ struct CloseFriendsListView: View {
 	private func toggle(_ friend: BackendUser) {
 		guard !busyIds.contains(friend.user_id) else { return }
 		busyIds.insert(friend.user_id)
-		UIImpactFeedbackGenerator(style: .light).impactOccurred()
+		MADHaptics.tap()
 		Task {
 			do {
 				try await closeFriends.toggle(friend)
 			} catch {
 				print("[CloseFriendsList] toggle failed: \(error)")
-				UINotificationFeedbackGenerator().notificationOccurred(.error)
+				MADHaptics.error()
 			}
 			await MainActor.run { _ = busyIds.remove(friend.user_id) }
 		}

--- a/app/Mile A Day/Views/Friends/FriendsListView.swift
+++ b/app/Mile A Day/Views/Friends/FriendsListView.swift
@@ -251,7 +251,7 @@ struct FriendsListView: View {
                     withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
                         savedFriendIds.insert(rescue.user_id)
                     }
-                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                    MADHaptics.success()
                     print("[Assist] restored streak: \(result.restored_streak ?? -1)")
                 }
                 // Refresh meters/rescues + row statuses so the friend's flame
@@ -263,7 +263,7 @@ struct FriendsListView: View {
                     assistingFriendId = nil
                     // Someone else may have saved them first, or the window
                     // closed — refresh so the slot reflects reality.
-                    UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                    MADHaptics.warning()
                 }
                 await tokensState.refreshStatus()
             }
@@ -446,7 +446,7 @@ struct FriendsListView: View {
 
                 // Tapping the body expands the row to reveal workout details.
                 Button {
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    MADHaptics.tap()
                     withAnimation(.spring(response: 0.34, dampingFraction: 0.82)) {
                         if expanded { expandedWorkoutIds.remove(item.workout_id) }
                         else { expandedWorkoutIds.insert(item.workout_id) }
@@ -503,7 +503,7 @@ struct FriendsListView: View {
                             // button and the gesture feel identical (and match
                             // the feed cards' behavior).
                             rowHypeBursts[item.workout_id, default: 0] += 1
-                            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                            MADHaptics.action()
                             Task { await sendHype(for: item) }
                         }
                     }
@@ -672,7 +672,7 @@ struct FriendsListView: View {
         lastDoubleTapAt = now
 
         rowHypeBursts[item.workout_id, default: 0] += 1
-        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        MADHaptics.action()
         if !item.is_hyped {
             Task { await sendHype(for: item) }
         }
@@ -693,7 +693,7 @@ struct FriendsListView: View {
             let response = try await HypeService.sendHype(targetUserId: item.user_id, context: context)
             hypesRemaining = response.hypes_remaining
             hypesUnlimited = response.unlimited ?? hypesUnlimited
-            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            MADHaptics.success()
         } catch let error as APIError {
             switch error {
             case .conflict:
@@ -704,7 +704,7 @@ struct FriendsListView: View {
             case .rateLimited:
                 setHyped(item.workout_id, hyped: false, countDelta: -1)
                 hypesRemaining = 0
-                UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                MADHaptics.warning()
             default:
                 setHyped(item.workout_id, hyped: false, countDelta: -1)
                 print("[FriendsListView] hype failed: \(error)")
@@ -753,7 +753,7 @@ struct FriendsListView: View {
         let streakInDanger = streak > 0 && !isComplete && hour >= 21
 
         return Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            MADHaptics.tap()
             withAnimation(.spring(response: 0.32, dampingFraction: 0.85)) {
                 topMode = .leaderboard
             }
@@ -1410,7 +1410,7 @@ struct FriendsListView: View {
                         has_nudged_today: true,
                         unlimited_nudges: existing?.unlimited_nudges
                     )
-                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                    MADHaptics.success()
                     showNudgeFeedback(NudgeFeedback(
                         icon: "bell.badge.fill",
                         message: "Nudge sent to \(friend.displayName)!",

--- a/app/Mile A Day/Views/Friends/LeaderboardSection.swift
+++ b/app/Mile A Day/Views/Friends/LeaderboardSection.swift
@@ -344,7 +344,7 @@ struct LeaderboardSection: View {
 
             if let onAddFriends = onAddFriends {
                 Button {
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    MADHaptics.tap()
                     onAddFriends()
                 } label: {
                     HStack(spacing: 6) {
@@ -466,7 +466,7 @@ struct LeaderboardSection: View {
                 VStack(spacing: 4) {
                     ForEach(rest) { entry in
                         Button {
-                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                            MADHaptics.tap()
                             selectedUser = makeBackendUser(entry)
                         } label: {
                             listRow(entry: entry)
@@ -532,7 +532,7 @@ struct LeaderboardSection: View {
 
     private func podiumSlot(entry: LeaderboardEntry, height: CGFloat, avatarSize: CGFloat, accent: Color, isFirst: Bool = false) -> some View {
         Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            MADHaptics.tap()
             selectedUser = makeBackendUser(entry)
         } label: {
             podiumSlotContent(entry: entry, height: height, avatarSize: avatarSize, accent: accent, isFirst: isFirst)

--- a/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
+++ b/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
@@ -21,6 +21,10 @@ struct UserProfileDetailView: View {
     @State private var closeFriendActionInProgress = false
 
     @State private var userStats: UserStats?
+    /// Pure Flame — true when this user's streak is 100% natural (from the
+    /// gated streak_features payload; false for un-enrolled users).
+    @State private var hasPureFlame = false
+    @State private var showPureFlameInfo = false
     @State private var userBadges: [Badge] = []
     @State private var catalogBadges: [Badge] = []
     @State private var hasLoadedBadges = false
@@ -336,9 +340,23 @@ struct UserProfileDetailView: View {
 
                     // User Info
                     VStack(spacing: MADTheme.Spacing.sm) {
-                        Text(user.username ?? "Unknown")
-                            .font(MADTheme.Typography.title1)
-                            .foregroundColor(MADTheme.Colors.primaryText)
+                        HStack(spacing: 6) {
+                            Text(user.username ?? "Unknown")
+                                .font(MADTheme.Typography.title1)
+                                .foregroundColor(MADTheme.Colors.primaryText)
+                            if hasPureFlame {
+                                // Natural-streak seal — tap explains it.
+                                Button {
+                                    showPureFlameInfo = true
+                                } label: {
+                                    PureFlameBadge(size: 20)
+                                }
+                                .buttonStyle(.plain)
+                                .sheet(isPresented: $showPureFlameInfo) {
+                                    PureFlameInfoSheet()
+                                }
+                            }
+                        }
 
                         if user.displayName != user.username {
                             Text(user.displayName)
@@ -983,6 +1001,7 @@ struct UserProfileDetailView: View {
                         hasCompletedGoalToday: hasCompletedGoalToday,
                         goalMiles: goalMiles
                     )
+                    hasPureFlame = stats.naturalStreak && stats.streak > 0
 
                     friendWorkouts = workouts
                     hasLoadedInitial = true

--- a/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
+++ b/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
@@ -233,13 +233,13 @@ struct UserProfileDetailView: View {
         guard !closeFriendActionInProgress else { return }
         closeFriendActionInProgress = true
         hasSeenCloseFriendHint = true
-        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        MADHaptics.tap()
         Task {
             do {
                 try await closeFriends.toggle(user)
             } catch {
                 print("[UserProfile] close-friend toggle failed: \(error)")
-                UINotificationFeedbackGenerator().notificationOccurred(.error)
+                MADHaptics.error()
             }
             await MainActor.run { closeFriendActionInProgress = false }
         }
@@ -537,7 +537,7 @@ struct UserProfileDetailView: View {
         // attention. Smaller text + tighter padding keeps it discoverable
         // without overwhelming the profile header.
         Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            MADHaptics.tap()
             showCompeteSheet = true
         } label: {
             HStack(spacing: 5) {
@@ -820,7 +820,7 @@ struct UserProfileDetailView: View {
                         has_nudged_today: true,
                         unlimited_nudges: nudgeStatus?.unlimited_nudges
                     )
-                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                    MADHaptics.success()
                     showProfileNudgeFeedback(NudgeFeedback(
                         icon: "bell.badge.fill",
                         message: "Nudge sent to \(user.displayName)!",
@@ -830,7 +830,7 @@ struct UserProfileDetailView: View {
             } catch {
                 await MainActor.run {
                     isNudging = false
-                    UINotificationFeedbackGenerator().notificationOccurred(.error)
+                    MADHaptics.error()
                     showProfileNudgeFeedback(NudgeFeedback(
                         icon: "xmark.circle.fill",
                         message: "Couldn't send nudge",
@@ -1638,7 +1638,7 @@ struct Last7DaysChart: View {
             : (didHit ? .green : .orange)
 
         return Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            MADHaptics.tap()
             // Second tap on the same bar closes the detail panel.
             if isSelected {
                 selectedDay = nil

--- a/app/Mile A Day/Views/NotificationSettingsView.swift
+++ b/app/Mile A Day/Views/NotificationSettingsView.swift
@@ -295,7 +295,7 @@ struct NotificationSettingsView: View {
                         withAnimation(.easeInOut(duration: 0.2)) {
                             prefs = .default
                         }
-                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                        MADHaptics.action()
                     } label: {
                         HStack(spacing: MADTheme.Spacing.sm) {
                             Image(systemName: "arrow.counterclockwise")
@@ -427,7 +427,7 @@ struct NotificationSettingsView: View {
         let tint = visibilityTint(option)
         return Button {
             guard !selected else { return }
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            MADHaptics.tap()
             withAnimation(.easeInOut(duration: 0.15)) {
                 prefs.workoutVisibility = option
             }
@@ -483,7 +483,7 @@ struct NotificationSettingsView: View {
     // MARK: - Actions
 
     private func saveAndApply() {
-        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        MADHaptics.action()
         prefs.save()
         // Daily reminder is now backend-driven (server cron + APNs push). Clear
         // any legacy local-notification still pending from older app versions —

--- a/app/Mile A Day/Views/PendingNotificationsSheet.swift
+++ b/app/Mile A Day/Views/PendingNotificationsSheet.swift
@@ -190,14 +190,14 @@ struct PendingNotificationsSheet: View {
 	private func notify(_ item: PendingFriendNotification) {
 		guard !busyIds.contains(item.id) else { return }
 		busyIds.insert(item.id)
-		UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+		MADHaptics.action()
 		Task {
 			do {
 				try await service.send(item)
-				UINotificationFeedbackGenerator().notificationOccurred(.success)
+				MADHaptics.success()
 			} catch {
 				print("[PendingSheet] notify failed: \(error)")
-				UINotificationFeedbackGenerator().notificationOccurred(.error)
+				MADHaptics.error()
 			}
 			await MainActor.run { _ = busyIds.remove(item.id) }
 		}

--- a/app/Mile A Day/Views/Profile/DailyChallengeSettingsView.swift
+++ b/app/Mile A Day/Views/Profile/DailyChallengeSettingsView.swift
@@ -120,7 +120,7 @@ struct DailyChallengeSettingsView: View {
 
     private func savePreference(_ newValue: Bool, revertTo oldValue: Bool) {
         saveError = nil
-        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        MADHaptics.tap()
         Task {
             do {
                 _ = try await friendService.updateNotificationSettings([

--- a/app/Mile A Day/Views/Profile/ProfileView.swift
+++ b/app/Mile A Day/Views/Profile/ProfileView.swift
@@ -4,8 +4,10 @@ struct ProfileView: View {
     @Environment(\.appStateManager) var appStateManager
     @ObservedObject var userManager: UserManager
     @ObservedObject var healthManager: HealthKitManager
-    /// Streak-token state — drives the Pure Flame (natural streak) seal.
+    /// Streak-token state — drives the Pure Flame (natural streak) seal and
+    /// the profile token shelf.
     @ObservedObject private var tokensState = StreakTokensState.shared
+    @State private var showTokenSheet = false
 
     @State private var activeSheet: ProfileSheetType?
     @State private var showingEditProfile = false
@@ -510,6 +512,40 @@ struct ProfileView: View {
                             Text(displayName)
                                 .font(MADTheme.Typography.body)
                                 .foregroundColor(MADTheme.Colors.secondaryText)
+                        }
+
+                        // Token shelf — your minted set, right on the profile.
+                        // Hidden until streak features are active.
+                        if let tokens = tokensState.payload {
+                            Button {
+                                showTokenSheet = true
+                            } label: {
+                                HStack(spacing: 14) {
+                                    TokenMedallion(
+                                        kind: .doubleDown,
+                                        held: tokens.double_down.held,
+                                        progress: tokens.double_down.fraction,
+                                        size: 34
+                                    )
+                                    TokenMedallion(
+                                        kind: .save,
+                                        held: tokens.streak_save.held,
+                                        progress: tokens.streak_save.fraction,
+                                        size: 34
+                                    )
+                                    TokenMedallion(
+                                        kind: .assist,
+                                        held: tokens.streak_assist.held,
+                                        progress: tokens.streak_assist.fraction,
+                                        size: 34
+                                    )
+                                }
+                                .padding(.top, MADTheme.Spacing.xs)
+                            }
+                            .buttonStyle(ScaleButtonStyle())
+                            .sheet(isPresented: $showTokenSheet) {
+                                StreakTokensDetailView()
+                            }
                         }
 
                         // Bio with quote-style accent

--- a/app/Mile A Day/Views/Profile/ProfileView.swift
+++ b/app/Mile A Day/Views/Profile/ProfileView.swift
@@ -8,6 +8,7 @@ struct ProfileView: View {
     /// the profile token shelf.
     @ObservedObject private var tokensState = StreakTokensState.shared
     @State private var showTokenSheet = false
+    @State private var showPureFlameInfo = false
 
     @State private var activeSheet: ProfileSheetType?
     @State private var showingEditProfile = false
@@ -501,7 +502,16 @@ struct ProfileView: View {
                                     .foregroundColor(MADTheme.Colors.primaryText)
                                 if tokensState.payload?.natural_streak == true,
                                    userManager.currentUser.streak > 0 {
-                                    PureFlameBadge(size: 22)
+                                    // Tappable — the badge explains itself.
+                                    Button {
+                                        showPureFlameInfo = true
+                                    } label: {
+                                        PureFlameBadge(size: 22)
+                                    }
+                                    .buttonStyle(.plain)
+                                    .sheet(isPresented: $showPureFlameInfo) {
+                                        PureFlameInfoSheet()
+                                    }
                                 }
                             }
                         }

--- a/app/Mile A Day/Views/ReviewPromptView.swift
+++ b/app/Mile A Day/Views/ReviewPromptView.swift
@@ -54,7 +54,7 @@ struct ReviewPromptView: View {
 
                 VStack(spacing: MADTheme.Spacing.sm) {
                     Button {
-                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                        MADHaptics.action()
                         manager.userTappedRate()
                     } label: {
                         HStack(spacing: 8) {

--- a/app/Mile A Day/Views/ShareCards/ShareCardsView.swift
+++ b/app/Mile A Day/Views/ShareCards/ShareCardsView.swift
@@ -277,8 +277,7 @@ struct EnhancedShareView: View {
                                 if let image = generatedImage {
                                     UIPasteboard.general.image = image
                                     showingCopiedFeedback = true
-                                    let impact = UIImpactFeedbackGenerator(style: .medium)
-                                    impact.impactOccurred()
+                                    MADHaptics.action()
                                 }
                             } label: {
                                 HStack {

--- a/app/Mile A Day/Views/StepsView.swift
+++ b/app/Mile A Day/Views/StepsView.swift
@@ -310,7 +310,7 @@ struct CalendarDayView: View {
 
     var body: some View {
         Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            MADHaptics.tap()
             onTap()
         } label: {
             VStack(spacing: 2) {
@@ -483,7 +483,7 @@ struct DateDetailView: View {
                             // Date navigation
                             HStack {
                                 Button {
-                                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                                    MADHaptics.tap()
                                     navigateToPreviousDay()
                                 } label: {
                                     Image(systemName: "chevron.left")
@@ -505,7 +505,7 @@ struct DateDetailView: View {
                                 Spacer()
 
                                 Button {
-                                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                                    MADHaptics.tap()
                                     navigateToNextDay()
                                 } label: {
                                     Image(systemName: "chevron.right")

--- a/app/Mile A Day/Widgets/StreakCountWidget.swift
+++ b/app/Mile A Day/Widgets/StreakCountWidget.swift
@@ -12,6 +12,8 @@ struct StreakCountEntry: TimelineEntry {
     var weekCompletions: [Bool] = []
     /// Total miles this week, for the medium widget's status line (0 = unknown).
     var weekMiles: Double = 0
+    /// Streak tokens currently held (0 = none or feature off → indicator hidden).
+    var tokensReady: Int = 0
 }
 
 struct StreakCountProvider: TimelineProvider {
@@ -42,12 +44,13 @@ struct StreakCountProvider: TimelineProvider {
         let timeUntilReset = calculateTimeUntilReset(isCompleted: isGoalCompleted)
                 
         completion(StreakCountEntry(
-            date: Date(), 
-            streak: streak, 
-            liveProgress: progress, 
+            date: Date(),
+            streak: streak,
+            liveProgress: progress,
             isGoalCompleted: isGoalCompleted,
             isAtRisk: isAtRisk,
-            timeUntilReset: timeUntilReset
+            timeUntilReset: timeUntilReset,
+            tokensReady: WidgetDataStore.loadTokensReady()
         ))
     }
 
@@ -74,7 +77,8 @@ struct StreakCountProvider: TimelineProvider {
             isAtRisk: isAtRisk,
             timeUntilReset: timeUntilReset,
             weekCompletions: WidgetDataStore.loadWeekCompletions(),
-            weekMiles: WidgetDataStore.loadWeekMiles()
+            weekMiles: WidgetDataStore.loadWeekMiles(),
+            tokensReady: WidgetDataStore.loadTokensReady()
         )
 
         // Refresh more frequently if streak is at risk
@@ -180,6 +184,18 @@ struct MediumStreakView: View {
                     .font(.system(size: 7.5, weight: .semibold, design: .rounded))
                     .tracking(1.0)
                     .foregroundColor(MADWidgetStyle.secondaryText)
+
+                // Held streak tokens — tiny gold shield count; hidden at 0
+                // so pre-token installs render exactly as before.
+                if entry.tokensReady > 0 {
+                    HStack(spacing: 2) {
+                        Image(systemName: "shield.lefthalf.filled")
+                            .font(.system(size: 8, weight: .bold))
+                        Text("\(entry.tokensReady)")
+                            .font(.system(size: 10, weight: .heavy, design: .rounded))
+                    }
+                    .foregroundColor(Color(red: 1.0, green: 0.84, blue: 0.35))
+                }
             }
 
             // Right column: section label, the week dots (focal element),
@@ -474,6 +490,19 @@ struct HomeScreenStreakView: View {
             Spacer(minLength: 0)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // Held streak tokens — a quiet gold shield count in the corner.
+        // Hidden at 0 so pre-token installs render exactly as before.
+        .overlay(alignment: .topTrailing) {
+            if entry.tokensReady > 0 {
+                HStack(spacing: 2) {
+                    Image(systemName: "shield.lefthalf.filled")
+                        .font(.system(size: 8, weight: .bold))
+                    Text("\(entry.tokensReady)")
+                        .font(.system(size: 10, weight: .heavy, design: .rounded))
+                }
+                .foregroundColor(Color(red: 1.0, green: 0.84, blue: 0.35))
+            }
+        }
     }
 
     @ViewBuilder

--- a/backend/src/services/streakFeatureService.ts
+++ b/backend/src/services/streakFeatureService.ts
@@ -46,8 +46,12 @@ export const STREAK_ASSIST_TARGET_MILES = 20;
 const DOUBLE_DOWN_GOAL_MULTIPLIER = 2;
 const DOUBLE_DOWN_TOLERANCE = 0.05;
 // Meter windows: retroactive credit at enrollment + a hard query bound.
-const ENROLL_LOOKBACK_DAYS = 30;
-const METER_WINDOW_DAYS = 90;
+// A FULL YEAR on purpose — a 400-day streaker must enroll fully loaded
+// (all three tokens held), not start from scratch like a new runner. The
+// original 30/90 made long streaks count the same as one month. Post-launch
+// the window is naturally bounded by each token's last-used date anyway.
+const ENROLL_LOOKBACK_DAYS = 365;
+const METER_WINDOW_DAYS = 365;
 // Assist-opportunity pushes only fire for streaks worth mourning.
 const MIN_NOTIFY_PRIOR_STREAK = 3;
 // A break stays rescuable for this many days after the missed day.

--- a/website/package.json
+++ b/website/package.json
@@ -5,8 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
-    "lint": "eslint ."
+    "start": "next start"
   },
   "dependencies": {
     "@vercel/analytics": "1.6.1",


### PR DESCRIPTION
> ⚠️ **Stacked on #245** (which stacks on #244). Merge order: **#244 → #245 → this**. Until then this diff includes their commits.

The full green-light batch: all four quick wins, all three bigger bets, plus the accessibility work that came out of the motion audit.

## Quick wins

- **Surfaces can't stack anymore.** What's New and the pending-notifications sheet now mutually stand down (two sheets presenting together silently dropped one — a real bug). The tour → What's New ordering was already enforced by `WhatsNewManager`; this closes the last gap.
- **Share cards match the app.** The streak/progress share cards get the calm grammar — `CURRENT STREAK` / `TODAY` eyebrows, one merged status line, slim capsule bars, softer shadows — so what people post looks like the app they'll download. Also deleted two 400×600 share views that nothing has instantiated in months. (The badge/PR achievement cards already match — untouched.)
- **One haptic vocabulary.** New `MADHaptics` (tap = navigate, action = do something, emphasis = big beat, success/warning/error) and a sweep of ~45 inline generator calls across 35 files. Rhythm-critical prepared generators (splash landing, celebration sequences, workout countdown) deliberately keep their instances.
- **Website `lint` script deleted** — it referenced an eslint that was never installed. Docs updated so it stops being a documented landmine.

## Reduce Motion (new, from the motion audit)

Every `repeatForever` loop now respects the system Reduce Motion setting: medallion breathing, meter shimmer, streak-flame pulse, unlock-overlay ray spin. Meters still fill (instantly), rays still glow (statically) — nothing loses information, it just stops moving.

## Bigger bets

- **Streak widget** — a gold shield + held-token count sits quietly in the corner of the small widget and under the ring on the medium one. New `tokens_ready` key in `WidgetDataStore` follows all the house rules: no-op writes skipped, single-kind reload, hidden at 0 so pre-token installs render pixel-identical. Not day-stamped on purpose — held tokens persist.
- **Watch** — the streak pill on the watch home screen shows the same gold shield count. It rides the existing WatchConnectivity snapshot (new `tokensReady` key, included in the dedupe hash, pushed whenever the token payload changes). Display-only; the phone owns all token logic. No new watch files (the watch target isn't a synchronized folder — now recorded in `ios.md`).
- **Post-run recap in one screen** — the goal celebration now ends with a **Streak Tokens strip**: all three medallions with live meter state, and any progress today's mile just earned tagged in gold (`+1 run day`). The gains are snapshotted on appear so they don't vanish mid-celebration when the dashboard chips auto-clear. Zero celebration state-machine changes — it's a section inside the existing goal-completed view, hidden entirely when the feature is off.

## Compatibility

Pure iOS UI + one JSON script removal on the website. New widget/watch fields default to 0/absent → all surfaces hide, old installs unchanged. No API or backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY

---
_Generated by [Claude Code](https://claude.ai/code/session_018yCS8WkRxyCncZ9jJguBeY)_