### PR TITLE
Fix "Couldn't prepare that photo" on posts with HDR/wide-gamut images

### DIFF
--- a/app/Mile A Day/Services/PostService.swift
+++ b/app/Mile A Day/Services/PostService.swift
@@ -360,13 +360,37 @@ enum PostService {
         return "&before=\(encoded)"
     }
 
+    /// JPEG-encode a post image for upload, normalizing away formats that
+    /// `UIImage.jpegData` silently rejects. Composer flattens (SwiftUI
+    /// `ImageRenderer`) and modern iPhone camera captures are frequently
+    /// wide-gamut / extended-range (Display P3, 16-bit float) bitmaps — and
+    /// ImageIO's JPEG encoder can't write those, so `jpegData` returns nil and
+    /// a perfectly valid photo dies with "Couldn't prepare that photo". Only
+    /// HDR/wide-gamut source photos trip it, which is why it hit some users and
+    /// not others. Redrawing into an opaque, standard-range sRGB bitmap first
+    /// guarantees an encodable image without touching the happy path.
+    private static func jpegDataForUpload(_ image: UIImage, quality: CGFloat = 0.85) -> Data? {
+        if let data = image.jpegData(compressionQuality: quality) { return data }
+
+        let format = UIGraphicsImageRendererFormat.preferred()
+        format.opaque = true
+        format.scale = image.scale > 0 ? image.scale : 1
+        // Force an 8-bit sRGB context; the source's P3/extended-range colors are
+        // converted down as it draws, yielding a bitmap JPEG always accepts.
+        format.preferredRange = .standard
+        let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
+        return renderer.jpegData(withCompressionQuality: quality) { _ in
+            image.draw(in: CGRect(origin: .zero, size: image.size))
+        }
+    }
+
     /// Upload a flattened post photo (overlay already composited). Returns the
     /// server `media_url` to reference when creating the post.
     static func uploadMedia(_ image: UIImage) async throws -> String {
         guard let url = URL(string: "\(AppConfig.baseURL)/posts/media") else {
             throw PostError.invalidURL
         }
-        guard let imageData = image.jpegData(compressionQuality: 0.85) else {
+        guard let imageData = jpegDataForUpload(image) else {
             throw PostError.compressionFailed
         }
         guard let accessToken = TokenStore.accessToken else {


### PR DESCRIPTION
## Summary

Some users hit **"Couldn't prepare that photo"** when publishing a feed/story post — even after accepting the community guidelines (the guidelines gate is unrelated to this error).

That string is `PostError.compressionFailed`, thrown in `PostService.uploadMedia` when `UIImage.jpegData(compressionQuality:)` returns `nil`.

## Root cause

The composer's `flatten()` rasterizes the photo + stats sticker through SwiftUI `ImageRenderer`, and modern iPhone camera captures (`photo.fileDataRepresentation()` → `UIImage(data:)`) and their composites are frequently **Display P3, extended-range (16-bit float) bitmaps**. ImageIO's JPEG encoder can't write those pixel formats, so `jpegData()` returns `nil` on a perfectly valid, correctly-sized (1080×1350) image.

Only HDR / wide-gamut *source* photos trip it, which is exactly why it affected some buddies and not most users — it's photo-specific, not account-specific.

## Fix

Added `jpegDataForUpload(_:quality:)` and routed `uploadMedia` through it:

- **Happy path unchanged** — tries `image.jpegData(...)` directly first, so the ~99% of posts that already worked are byte-identical.
- **Fallback** — when that returns `nil`, redraw the image into an **opaque, standard-range (`preferredRange = .standard`) sRGB** `UIGraphicsImageRenderer` context and encode from there. Drawing converts P3/extended-range colors down to 8-bit sRGB, which the JPEG encoder always accepts.

`uploadMedia` is the single shared upload chokepoint, so this also covers the auto-post route/stats-card path (`RunPostService.autoPostMile`).

## Compatibility & compliance

- Output is still JPEG at quality 0.85 → **no backend or API change** (`/posts/media` accepts JPEG regardless of color space).
- Uses only public UIKit APIs (`UIGraphicsImageRenderer`, `UIGraphicsImageRendererFormat.preferred()`, `.preferredRange`). No new entitlements, permissions, or private APIs — App Review clean.

## Testing notes

iOS is Xcode-build-only per project rules, so this hasn't been compiled from CLI. To verify manually: post a photo shot on a recent iPhone with HDR enabled (or an HDR photo from the library) — it should now upload instead of erroring.

## Related (not changed here)

`ProfileImageService` and `MidRunPhotoStash` share the same fragile `jpegData`-returns-nil pattern. Left out to keep this scoped to the reported feed-post bug; worth the same treatment in a follow-up.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjcscVCMLENQYiiRQv1RG2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjcscVCMLENQYiiRQv1RG2)_