### PR TITLE
Fix CI: keep pending collab invites out of the Tagged tab

### DIFF
--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -1203,10 +1203,12 @@ export async function getUserPosts(
 
 /**
  * Posts a user is TAGGED in, for the Instagram-style profile "Tagged" tab:
- * feed posts by OTHER people that either carry them as a collab coauthor
- * (pending is visible only to the author/invitee; accepted is visible to
- * anyone who may view the tagged profile) or @mention their username in the
- * caption. Mention matching
+ * feed posts by OTHER people that either carry them as an ACCEPTED collab
+ * coauthor or @mention their username in the caption. A pending collab invite
+ * is NOT a tag yet — it stays out of the tab entirely until accepted, for
+ * every viewer including the author (COAUTHOR_VISIBLE gates the coauthor
+ * LABEL on a displayed post, never tab ENTRY — don't reuse it here). Mention
+ * matching
  * mirrors mentionService.extractMentionUsernames (token charset
  * [A-Za-z0-9._-], trailing dots stripped, case-insensitive) in SQL so the
  * tab agrees with who mention pushes went to.
@@ -1257,11 +1259,7 @@ export async function getUserTaggedPosts(
 			AND p.share_to_feed
 			AND p.user_id <> $2
 			AND (
-				(p.coauthor_user_id = $2 AND (
-					p.coauthor_status = 'accepted'
-					OR p.user_id = $1
-					OR p.coauthor_user_id = $1
-				))
+				(p.coauthor_user_id = $2 AND p.coauthor_status = 'accepted')
 				OR ($5::text IS NOT NULL AND p.caption IS NOT NULL AND p.caption ~* $5)
 			)
 			-- Profile gate: may the viewer see the tagged user's content at all?


### PR DESCRIPTION
## What was failing

The **backend CI job** (build + migrations + smoke) has failed on **every commit since `bc1f2df`** ("Refactor iOS app architecture and introduce dashboard style preferences"). That commit was pushed **directly to `main`**, bypassing the PR/CI merge gate, so its red CI never blocked it — and every branch cut afterward (PRs #251, #252, #253) inherited the failure.

The failure is a single assertion in `backend/scripts/ci-smoke.mjs:207`:

```
AssertionError: pending collab invite stays out of the tagged tab
  actual: false, expected: true
```

(The `relation "post_terms_acceptance" does not exist` line in the Postgres logs is a red herring — that seed insert is wrapped in `.catch(() => {})` and is intentionally optional.)

## Root cause

Bundled into that otherwise iOS-only commit, `getUserTaggedPosts`' collab clause was widened to reuse the `COAUTHOR_VISIBLE` condition:

```sql
-- before (proven green)
(p.coauthor_user_id = $2 AND p.coauthor_status = 'accepted')
-- after bc1f2df (broke CI)
(p.coauthor_user_id = $2 AND (
    p.coauthor_status = 'accepted'
    OR p.user_id = $1
    OR p.coauthor_user_id = $1
))
```

This conflates two different concerns. `COAUTHOR_VISIBLE` gates whether the **coauthor label** shows on an *already-visible* post — it is not a tab-**entry** filter. Reusing it here let a **pending** collab invite leak into the Tagged tab (visible to the post's author, and to the invitee on their own tab), violating the Instagram-parity contract that a tag only counts once **accepted**.

## Fix

- Revert the Tagged-tab entry filter to `accepted`-only (its exact pre-`bc1f2df`, previously-green state).
- Document the `COAUTHOR_VISIBLE`-vs-tab-entry distinction in the function docstring so it isn't reintroduced.
- Unrelated `bc1f2df` changes to `postService.ts` (cross-workout `comment_count`, new `visibleWorkoutAuthor` helper) are **left intact** — they aren't part of the regression.

One file changed: `backend/src/services/postService.ts` (+7 / −9).

## Verification

Reproduced the CI backend job locally against a fresh Postgres 16:

- `tsc` build — passes
- `drizzle-kit check` — passes
- `node dist/db/migrateCli.js` (apply, then re-apply for idempotence) — both exit 0
- `node scripts/ci-smoke.mjs` — **`ci-smoke: all assertions passed`**

The website CI job was already green and is untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTkhFEvCw1UUeCyhXUPjKh)_