### PR TITLE
Make the dashboard flame shrink evenly with time left

### DIFF
--- a/app/Mile A Day/Views/Components/StreakFlameState.swift
+++ b/app/Mile A Day/Views/Components/StreakFlameState.swift
@@ -41,14 +41,18 @@ enum StreakFlameClock {
         return min(max(end.timeIntervalSince(date) / dayLength, 0), 1)
     }
 
-    /// Perceptual size of a burning flame. Eases so the flame barely shrinks
-    /// through the morning, visibly dwindles through the evening, and gutters
-    /// to almost nothing before midnight. A 5% wisp survives until the final
-    /// second so the flame never looks broken while the day is still alive.
+    /// Perceptual size of a burning flame — tracks the time left in the day as
+    /// directly as possible. A near-linear descent (gentle 0.9 ease for a touch
+    /// more body up top) so the flame shrinks a little every hour: full at the
+    /// day's start, roughly half by midday, a thin wisp as the next midnight
+    /// nears. It never hugs full size and then drops late — that read as a jump
+    /// from normal to small. The flame keeps a small floor while burning so it
+    /// never looks broken; the phase transition to coal renders the true "out"
+    /// state at midnight.
     static func flameScale(vigor: Double) -> CGFloat {
         let v = min(max(vigor, 0), 1)
-        guard v > 0 else { return 0 }
-        return CGFloat(max(1 - pow(1 - v, 1.7), 0.05))
+        let minScale = 0.08
+        return CGFloat(minScale + (1 - minScale) * pow(v, 0.9))
     }
 }
 


### PR DESCRIPTION
## What & why

Follow-up to the flame lifecycle (#252, merged). The burning flame was shrinking on a **back-loaded** curve — it hugged near-full size all morning and midday, then fell steeply in the evening. On screen that read as a jump from "normal" to "small" instead of a steady, all-day burn-down.

## The fix

One-line change to the size curve in `StreakFlameClock.flameScale(vigor:)`:

| | curve | 6am | noon | 6pm | 9pm | 11pm |
|---|---|---|---|---|---|---|
| Before | `1 - pow(1 - v, 1.7)` | 0.90 | 0.69 | 0.39 | 0.20 | 0.07 |
| After | `0.08 + 0.92 · v^0.9` | 0.79 | 0.57 | 0.34 | 0.22 | 0.13 |

`vigor` is the fraction of the day still left (linear in time), so the new near-linear map makes the flame's **size track time-left directly** — it shrinks a little every hour rather than holding big and dropping late. A gentle `^0.9` ease keeps a touch more body up top; a small floor keeps it a readable wisp while burning.

## Scope

- Both dashboard heroes (Modern `ProfessionalFlameView` + Fun `FlameBuddyView`) read this one function, so both get the smooth shrink.
- Nothing else changes: the countdown ring, palette burn-down, ignition burst, and the coal transition at midnight (the true "out" state) are untouched. Legacy phase-less callers (chooser preview, Live Activity, widgets) never hit `flameScale`.

## Testing

iOS-only SwiftUI change; size verified analytically across the day (table above). Visual QA best done in the running app — the shrink is intentionally slow (24h), so it's imperceptible per-glance but clearly proportional across the day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsjUZtGkdF8Fd5LVaTsbzU)_