### PR TITLE
Keep the Fun flame's face and center the Modern flame as it shrinks

### DIFF
--- a/app/Mile A Day/Views/Components/FlameBuddyFigure.swift
+++ b/app/Mile A Day/Views/Components/FlameBuddyFigure.swift
@@ -60,6 +60,10 @@ struct FlameBuddyFigure: View {
     /// day — always vivid, never washed out. When nil the figure keeps its
     /// legacy stage-based look (widgets, Live Activity, previews).
     var vigor: CGFloat? = nil
+    /// Grounded flames (the Fun buddy) sit on the ground: they shrink toward
+    /// their base and cast a ground shadow. A non-grounded flame (the Modern
+    /// ring) shrinks toward its center so it stays framed in the circle.
+    var grounded: Bool = true
 
     var body: some View {
         ZStack {
@@ -81,13 +85,13 @@ struct FlameBuddyFigure: View {
                     .offset(y: size * 0.13)
                     .opacity(health == .dead ? 0 : innerOpacity)
 
-                if showsFace && faceIsVisible {
+                if showsFace {
                     face
                         .offset(y: size * 0.18)
                 }
             }
             .frame(width: size * 0.82, height: size)
-            .scaleEffect(effectiveBodyScale, anchor: .bottom)
+            .scaleEffect(effectiveBodyScale, anchor: grounded ? .bottom : .center)
             .offset(y: health == .dead ? size * 0.16 : 0)
         }
         .frame(width: size, height: size)
@@ -104,12 +108,6 @@ struct FlameBuddyFigure: View {
     private var effectiveBodyScale: CGFloat {
         if let v = vigorValue { return StreakFlameClock.flameScale(vigor: Double(v)) }
         return health.bodyScale
-    }
-
-    /// The face stays readable down to about a third of full size, then hides
-    /// so a guttering flame is a wisp rather than a smudged expression.
-    private var faceIsVisible: Bool {
-        vigorValue == nil || effectiveBodyScale >= 0.34
     }
 
     private var effectiveGlowOpacity: Double {
@@ -202,29 +200,39 @@ struct FlameBuddyFigure: View {
         vigorValue == nil ? 1 : 0.45 + effectiveBodyScale * 0.55
     }
 
+    /// How far the glow sinks toward the base as the flame shrinks. A grounded
+    /// flame's light pool follows it down to the ground; a centered flame (the
+    /// Modern ring) keeps its glow centered on the flame instead.
+    private var glowSink: CGFloat {
+        grounded ? (1 - lightSpread) : 0
+    }
+
     private var glowLayer: some View {
         ZStack {
             Circle()
                 .fill(glowColor.opacity(effectiveGlowOpacity * 0.45))
                 .blur(radius: size * 0.18 * lightSpread)
                 .frame(width: size * 1.1 * lightSpread, height: size * 0.92 * lightSpread)
-                .offset(y: size * 0.46 * (1 - lightSpread))
+                .offset(y: size * 0.46 * glowSink)
             Circle()
                 .fill(Color.yellow.opacity(health == .dead ? 0 : 0.16 * Double(lightSpread)))
                 .blur(radius: size * 0.09)
                 .frame(width: size * 0.62 * lightSpread, height: size * 0.62 * lightSpread)
-                .offset(y: size * 0.12 + size * 0.30 * (1 - lightSpread))
+                .offset(y: size * (grounded ? 0.12 : 0) + size * 0.30 * glowSink)
         }
     }
 
+    @ViewBuilder
     private var groundLayer: some View {
-        VStack {
-            Spacer()
-            Ellipse()
-                .fill(Color.black.opacity(0.24))
-                .frame(width: size * 0.78 * lightSpread, height: size * 0.16 * lightSpread)
-                .blur(radius: 3)
-                .offset(y: size * 0.02)
+        if grounded {
+            VStack {
+                Spacer()
+                Ellipse()
+                    .fill(Color.black.opacity(0.24))
+                    .frame(width: size * 0.78 * lightSpread, height: size * 0.16 * lightSpread)
+                    .blur(radius: 3)
+                    .offset(y: size * 0.02)
+            }
         }
     }
 

--- a/app/Mile A Day/Views/Components/FlameBuddyView.swift
+++ b/app/Mile A Day/Views/Components/FlameBuddyView.swift
@@ -21,6 +21,10 @@ struct FlameBuddyView: View {
     var dayEnd: Date? = nil
     /// Today's partial mile progress (0-1) — pre-warms the coal's ember cracks.
     var coalWarmth: Double = 0
+    /// Grounded (Fun buddy) sits on the ground and shrinks toward its base with
+    /// an ember bed; non-grounded (Modern ring) shrinks toward center to stay
+    /// framed in the circle.
+    var grounded: Bool = true
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var ignitionDate: Date?
@@ -109,7 +113,7 @@ struct FlameBuddyView: View {
             let bodyScale = vigorNow.map { StreakFlameClock.flameScale(vigor: $0) } ?? 1
 
             ZStack {
-                if let vigorNow, vigorNow < 0.45 {
+                if grounded, let vigorNow, vigorNow < 0.45 {
                     EmberBaseGlow(size: size, intensity: min(1, (0.45 - vigorNow) / 0.45))
                 }
 
@@ -126,7 +130,7 @@ struct FlameBuddyView: View {
     private var staticFlame: some View {
         let vigorNow = currentVigor(at: Date())
         return ZStack {
-            if let vigorNow, vigorNow < 0.45 {
+            if grounded, let vigorNow, vigorNow < 0.45 {
                 EmberBaseGlow(size: size, intensity: min(1, (0.45 - vigorNow) / 0.45))
             }
             figure(vigor: vigorNow, flicker: 0, blink: false)
@@ -140,7 +144,8 @@ struct FlameBuddyView: View {
             blink: blink,
             size: size,
             showsFace: showsFace,
-            vigor: vigor.map { CGFloat($0) }
+            vigor: vigor.map { CGFloat($0) },
+            grounded: grounded
         )
     }
 

--- a/app/Mile A Day/Views/Components/ProfessionalFlameView.swift
+++ b/app/Mile A Day/Views/Components/ProfessionalFlameView.swift
@@ -28,7 +28,8 @@ struct ProfessionalFlameView: View {
                 showsFace: false,
                 phase: phase,
                 dayEnd: dayEnd,
-                coalWarmth: coalWarmth
+                coalWarmth: coalWarmth,
+                grounded: false
             )
             .offset(y: -size * 0.035)
         }


### PR DESCRIPTION
## What & why

Two visual follow-ups to the flame burn-down (from screenshots at ~5h52m left, where the flame is ~34% size):

**1. Fun buddy lost its face.** A readability guard hid the face once the flame shrank past ~a third of full size — which lands right at mid-evening. Users expect the buddy to keep its face, so the flame now always renders its face while burning (it scales down with the flame). Modern passes `showsFace: false` regardless, so this only affects the Fun buddy.

**2. Modern flame sank to the bottom of the ring.** The flame was bottom-anchored, so as it shrank it slid to the bottom of the countdown ring and left the circle looking empty. Introduced a `grounded` flag on the flame views:

- **Fun buddy — grounded (default):** shrinks toward its base, keeps its ground shadow and the low-flame ember bed. Unchanged.
- **Modern ring — non-grounded:** shrinks toward its center and keeps its glow centered, so it stays framed inside the circle. Ground shadow and ember bed are suppressed (they'd be detached from a centered flame).

## Scope

- `FlameBuddyFigure` / `FlameBuddyView`: added `grounded: Bool = true`; anchor, glow-sink, ground shadow, and ember bed all key off it.
- `ProfessionalFlameView` (Modern): passes `grounded: false`.
- The `grounded` default is `true`, so every other caller — Fun dashboard, style-chooser preview, Live Activity, widgets, reignition animation — is byte-for-byte unchanged. No change to the burn-down curve, palette, ring, ignition, or coal transition.

## Testing

iOS-only SwiftUI change; verified by inspection (parameter threading, `UnitPoint` anchor, `@ViewBuilder` ground layer, all arithmetic stays `CGFloat`). Visual QA best done in the running app — check the Fun buddy keeps its face and the Modern flame stays centered in the ring across the afternoon/evening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsjUZtGkdF8Fd5LVaTsbzU)_