### PR TITLE
Redesign Streak Flame widget: dashboard-synced burn-down + header stats

### DIFF
--- a/app/Mile A Day/Shared/WidgetDataStore.swift
+++ b/app/Mile A Day/Shared/WidgetDataStore.swift
@@ -190,7 +190,6 @@ struct WidgetDataStore {
         defaults.set(stamp, forKey: weekStampKey)
         DispatchQueue.main.async {
             WidgetCenter.shared.reloadTimelines(ofKind: "StreakCountWidget")
-            WidgetCenter.shared.reloadTimelines(ofKind: "StreakFlameWidget")
         }
     }
 

--- a/app/MileADayWidgets/FlameBuddyFigure.swift
+++ b/app/MileADayWidgets/FlameBuddyFigure.swift
@@ -1,5 +1,11 @@
 import SwiftUI
 
+// Widget-target copy of the flame figure. KEEP IN SYNC with
+// app/Mile A Day/Views/Components/FlameBuddyFigure.swift — the Streak Flame
+// widget drives it with `vigor` so the flame burns down in lock-step with the
+// dashboard. Widgets render statically, so callers pass flickerPhase 0 / no
+// blink; the size + palette still track time left via `vigor`.
+
 enum FlameHealth: String, CaseIterable {
     case blazing
     case healthy
@@ -56,6 +62,14 @@ struct FlameBuddyFigure: View {
     var size: CGFloat = 170
     /// The Modern flame renders faceless; the Fun buddy keeps its face.
     var showsFace: Bool = true
+    /// Continuous time-left driver (1 = full day ahead, 0 = midnight). When set,
+    /// the flame's size, palette and glow burn down with the day — matching the
+    /// dashboard. When nil the figure keeps its stage-based look.
+    var vigor: CGFloat? = nil
+    /// Grounded flames (the Fun buddy) shrink toward their base and cast a
+    /// ground shadow; a non-grounded flame (the Modern ring) shrinks toward its
+    /// center so it stays framed in the circle.
+    var grounded: Bool = true
 
     var body: some View {
         ZStack {
@@ -65,7 +79,7 @@ struct FlameBuddyFigure: View {
             ZStack {
                 FlameBuddyOuterShape(wobble: wobble)
                     .fill(outerFill)
-                    .shadow(color: glowColor.opacity(health.glowOpacity), radius: size * 0.16)
+                    .shadow(color: glowColor.opacity(effectiveGlowOpacity), radius: size * 0.16)
                     .overlay(
                         FlameBuddyOuterShape(wobble: wobble)
                             .stroke(Color.white.opacity(health == .dead ? 0.10 : 0.28), lineWidth: max(1.5, size * 0.012))
@@ -83,12 +97,28 @@ struct FlameBuddyFigure: View {
                 }
             }
             .frame(width: size * 0.82, height: size)
-            .scaleEffect(health.bodyScale, anchor: .bottom)
+            .scaleEffect(effectiveBodyScale, anchor: grounded ? .bottom : .center)
             .offset(y: health == .dead ? size * 0.16 : 0)
         }
         .frame(width: size, height: size)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityText)
+    }
+
+    /// Clamped vigor, only honored for states that represent a live flame.
+    private var vigorValue: CGFloat? {
+        guard let vigor, health != .dead, health != .blazing else { return nil }
+        return min(max(vigor, 0), 1)
+    }
+
+    private var effectiveBodyScale: CGFloat {
+        if let v = vigorValue { return StreakFlameClock.flameScale(vigor: Double(v)) }
+        return health.bodyScale
+    }
+
+    private var effectiveGlowOpacity: Double {
+        if let v = vigorValue, health != .critical { return 0.16 + Double(v) * 0.36 }
+        return health.glowOpacity
     }
 
     private var wobble: CGFloat {
@@ -105,6 +135,9 @@ struct FlameBuddyFigure: View {
     }
 
     private var outerColors: [Color] {
+        if let v = vigorValue, health != .critical {
+            return FlamePalette.outer(vigor: v)
+        }
         switch health {
         case .blazing:
             return [.white, Color(red: 1, green: 0.88, blue: 0.28), .orange, Color(red: 1, green: 0.20, blue: 0.10)]
@@ -122,6 +155,9 @@ struct FlameBuddyFigure: View {
     }
 
     private var innerColors: [Color] {
+        if let v = vigorValue, health != .critical {
+            return FlamePalette.inner(vigor: v)
+        }
         switch health {
         case .blazing:
             return [.white, Color(red: 1, green: 0.92, blue: 0.30), Color(red: 1, green: 0.50, blue: 0.08)]
@@ -137,6 +173,9 @@ struct FlameBuddyFigure: View {
     }
 
     private var innerOpacity: Double {
+        if let v = vigorValue, health != .critical {
+            return 0.36 + Double(v) * 0.52
+        }
         switch health {
         case .blazing: return 0.95
         case .healthy: return 0.82
@@ -156,28 +195,44 @@ struct FlameBuddyFigure: View {
         }
     }
 
+    /// Light and shadow follow the flame's real size so a guttering wisp casts
+    /// a small pool of light, not a full-size halo.
+    private var lightSpread: CGFloat {
+        vigorValue == nil ? 1 : 0.45 + effectiveBodyScale * 0.55
+    }
+
+    /// How far the glow sinks toward the base as the flame shrinks. A grounded
+    /// flame's light pool follows it down; a centered flame keeps it centered.
+    private var glowSink: CGFloat {
+        grounded ? (1 - lightSpread) : 0
+    }
+
     private var glowLayer: some View {
         ZStack {
             Circle()
-                .fill(glowColor.opacity(health.glowOpacity * 0.45))
-                .blur(radius: size * 0.18)
-                .frame(width: size * 1.1, height: size * 0.92)
+                .fill(glowColor.opacity(effectiveGlowOpacity * 0.45))
+                .blur(radius: size * 0.18 * lightSpread)
+                .frame(width: size * 1.1 * lightSpread, height: size * 0.92 * lightSpread)
+                .offset(y: size * 0.46 * glowSink)
             Circle()
-                .fill(Color.yellow.opacity(health == .dead ? 0 : 0.16))
+                .fill(Color.yellow.opacity(health == .dead ? 0 : 0.16 * Double(lightSpread)))
                 .blur(radius: size * 0.09)
-                .frame(width: size * 0.62, height: size * 0.62)
-                .offset(y: size * 0.12)
+                .frame(width: size * 0.62 * lightSpread, height: size * 0.62 * lightSpread)
+                .offset(y: size * (grounded ? 0.12 : 0) + size * 0.30 * glowSink)
         }
     }
 
+    @ViewBuilder
     private var groundLayer: some View {
-        VStack {
-            Spacer()
-            Ellipse()
-                .fill(Color.black.opacity(0.24))
-                .frame(width: size * 0.78, height: size * 0.16)
-                .blur(radius: 3)
-                .offset(y: size * 0.02)
+        if grounded {
+            VStack {
+                Spacer()
+                Ellipse()
+                    .fill(Color.black.opacity(0.24))
+                    .frame(width: size * 0.78 * lightSpread, height: size * 0.16 * lightSpread)
+                    .blur(radius: 3)
+                    .offset(y: size * 0.02)
+            }
         }
     }
 

--- a/app/MileADayWidgets/StreakFlameState.swift
+++ b/app/MileADayWidgets/StreakFlameState.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+// Widget-target copy of the dashboard's flame burn-down math, so the widget
+// flame shrinks and recolors in lock-step with the in-app hero.
+// KEEP IN SYNC with app/Mile A Day/Views/Components/StreakFlameState.swift.
+
+enum StreakFlameClock {
+    static let dayLength: TimeInterval = 24 * 60 * 60
+
+    /// Perceptual size of a burning flame — a near-linear descent that tracks
+    /// the fraction of the day remaining. Mirrors the dashboard exactly.
+    static func flameScale(vigor: Double) -> CGFloat {
+        let v = min(max(vigor, 0), 1)
+        let minScale = 0.08
+        return CGFloat(minScale + (1 - minScale) * pow(v, 0.9))
+    }
+}
+
+/// Continuous flame coloring: rich golden-orange with a full day ahead,
+/// deepening toward starving ember-red as midnight nears. Always fully
+/// saturated and opaque — a live flame only shrinks, never washes out.
+enum FlamePalette {
+    static func lerp(_ a: (Double, Double, Double), _ b: (Double, Double, Double), _ t: Double) -> Color {
+        let clamped = min(max(t, 0), 1)
+        return Color(
+            red: a.0 + (b.0 - a.0) * clamped,
+            green: a.1 + (b.1 - a.1) * clamped,
+            blue: a.2 + (b.2 - a.2) * clamped
+        )
+    }
+
+    static func outer(vigor: CGFloat) -> [Color] {
+        let t = 1 - Double(min(max(vigor, 0), 1))
+        return [
+            lerp((1.00, 0.95, 0.32), (1.00, 0.66, 0.16), t),
+            lerp((1.00, 0.58, 0.00), (0.97, 0.34, 0.10), t),
+            lerp((1.00, 0.22, 0.10), (0.55, 0.08, 0.10), t)
+        ]
+    }
+
+    static func inner(vigor: CGFloat) -> [Color] {
+        let t = 1 - Double(min(max(vigor, 0), 1))
+        return [
+            lerp((1.00, 0.98, 0.44), (1.00, 0.78, 0.26), t),
+            lerp((1.00, 0.65, 0.12), (0.92, 0.32, 0.10), t)
+        ]
+    }
+}

--- a/app/MileADayWidgets/StreakFlameWidget.swift
+++ b/app/MileADayWidgets/StreakFlameWidget.swift
@@ -4,13 +4,13 @@ import SwiftUI
 // MARK: - Streak Flame Widget
 //
 // The dashboard's flame, on the home screen. It mirrors the user's chosen
-// dashboard style from the App Group: the Fun buddy (with its face and
-// expressions) or the Modern flame framed in the progress ring. Informative —
-// streak, today's mile, time left — and alive: the flame's color and mood walk
-// through the day via pre-baked hourly timeline entries, so it animates its
-// story without spending WidgetKit's reload budget. The app still force-reloads
-// on every real data write, and the timeline rebuilds at midnight for the fresh
-// day.
+// dashboard style from the App Group: the Fun buddy (face + expressions) or the
+// Modern flame framed in the progress ring. The flame burns DOWN with the day
+// exactly like the in-app hero — same size curve, same golden→ember palette —
+// driven by a per-entry `vigor` value; WidgetKit advances the pre-baked hourly
+// entries with no reload cost. Numbers use the dashboard header's stat-line
+// styling. The app still force-reloads on every real data write; the timeline
+// rebuilds at midnight.
 
 struct StreakFlameEntry: TimelineEntry {
     let date: Date
@@ -20,8 +20,11 @@ struct StreakFlameEntry: TimelineEntry {
     let goal: Double
     let isGoalCompleted: Bool
     let health: FlameHealth
-    let timeLeftText: String?
-    let weekCompletions: [Bool]
+    /// Fraction of the day left (1→0). Drives the flame's burn-down; nil when
+    /// blazing (done) or coal (no streak), which render at their own size.
+    let vigor: Double?
+    /// Hours/minutes left, e.g. "5h 12m" (nil when the mile is done).
+    let timeLeftValue: String?
     let tokensReady: Int
     let isFun: Bool
 
@@ -29,15 +32,12 @@ struct StreakFlameEntry: TimelineEntry {
 }
 
 struct StreakFlameProvider: TimelineProvider {
-    /// Immutable per-refresh snapshot read once from the App Group, then shared
-    /// across every baked entry (the only per-entry differences are time-driven).
     private struct Snapshot {
         let streak: Int
         let progress: Double
         let miles: Double
         let goal: Double
         let completed: Bool
-        let weekCompletions: [Bool]
         let tokensReady: Int
         let isFun: Bool
     }
@@ -51,8 +51,8 @@ struct StreakFlameProvider: TimelineProvider {
             goal: 1,
             isGoalCompleted: false,
             health: .healthy,
-            timeLeftText: "5h 51m left",
-            weekCompletions: [true, true, true, true, false, false, false],
+            vigor: 0.62,
+            timeLeftValue: "5h 51m",
             tokensReady: 3,
             isFun: true
         )
@@ -78,9 +78,6 @@ struct StreakFlameProvider: TimelineProvider {
         if entries.isEmpty {
             entries.append(makeEntry(date: now, snapshot: snapshot))
         }
-
-        // Rebuild at midnight so the completed/at-risk state resets for the new
-        // day even if the app is never opened.
         completion(Timeline(entries: entries, policy: .after(midnight)))
     }
 
@@ -92,7 +89,6 @@ struct StreakFlameProvider: TimelineProvider {
             miles: data.miles,
             goal: data.goal,
             completed: data.streakCompleted,
-            weekCompletions: WidgetDataStore.loadWeekCompletions(),
             tokensReady: WidgetDataStore.loadTokensReady(),
             isFun: WidgetDataStore.loadDashboardStyle() == "fun"
         )
@@ -110,6 +106,7 @@ struct StreakFlameProvider: TimelineProvider {
             secondsToReset: snapshot.completed ? nil : secondsToReset,
             streak: snapshot.streak
         )
+        let burning = !snapshot.completed && snapshot.streak > 0
         return StreakFlameEntry(
             date: date,
             streak: snapshot.streak,
@@ -118,21 +115,21 @@ struct StreakFlameProvider: TimelineProvider {
             goal: snapshot.goal,
             isGoalCompleted: snapshot.completed,
             health: health,
-            timeLeftText: snapshot.completed ? nil : Self.timeLeftText(secondsToReset),
-            weekCompletions: snapshot.weekCompletions,
+            vigor: burning ? min(max(secondsToReset / StreakFlameClock.dayLength, 0), 1) : nil,
+            timeLeftValue: snapshot.completed ? nil : Self.timeLeftValue(secondsToReset),
             tokensReady: snapshot.tokensReady,
             isFun: snapshot.isFun
         )
     }
 
-    private static func timeLeftText(_ seconds: TimeInterval) -> String {
+    private static func timeLeftValue(_ seconds: TimeInterval) -> String {
         let hours = Int(seconds) / 3600
         let minutes = Int(seconds) % 3600 / 60
-        return hours > 0 ? "\(hours)h \(minutes)m left" : "\(minutes)m left"
+        return hours > 0 ? "\(hours)h \(minutes)m" : "\(minutes)m"
     }
 }
 
-// MARK: - Shared helpers
+// MARK: - Shared pieces
 
 private func flameStatusColor(_ entry: StreakFlameEntry) -> Color {
     if entry.isGoalCompleted { return MADWidgetStyle.green }
@@ -140,85 +137,103 @@ private func flameStatusColor(_ entry: StreakFlameEntry) -> Color {
     return MADWidgetStyle.orange
 }
 
-/// Unfinished mile → tap drops straight into the tracker; done → open the app.
 private func flameDeepLink(_ entry: StreakFlameEntry) -> URL? {
     entry.isGoalCompleted ? nil : URL(string: "mileaday://workout/start")
 }
 
-/// The flame art itself — the Fun buddy, or the Modern flame set in the brand
-/// progress ring. Kept in one place so both widget sizes stay in sync.
-private struct FlameHero: View {
+/// The flame art itself — Fun buddy or Modern flame in the progress ring, both
+/// driven by `vigor` so they shrink exactly like the dashboard hero.
+private struct FlameArt: View {
     let entry: StreakFlameEntry
-    /// Footprint of the hero. For Fun this is the buddy size; for Modern it is
-    /// the ring diameter.
+    /// Fun: buddy footprint. Modern: ring diameter.
     let size: CGFloat
-    /// Modern only: overlay the streak number inside the ring (small widget,
-    /// which has no room for a separate stat column).
-    var streakInRing: Bool = false
+
+    private var vigor: CGFloat? { entry.vigor.map { CGFloat($0) } }
 
     var body: some View {
         if entry.isFun {
-            FlameBuddyFigure(health: entry.health, size: size)
+            FlameBuddyFigure(health: entry.health, size: size, showsFace: true, vigor: vigor, grounded: true)
         } else {
             MADWidgetRing(
                 progress: entry.progress,
                 size: size,
-                lineWidth: max(5, size * 0.075),
+                lineWidth: max(5, size * 0.07),
                 isComplete: entry.isGoalCompleted
             ) {
-                ZStack {
-                    FlameBuddyFigure(health: entry.health, size: size * 0.60, showsFace: false)
-                        .offset(y: -size * 0.05)
-
-                    if streakInRing {
-                        VStack(spacing: -2) {
-                            Spacer(minLength: 0)
-                            Text("\(entry.streak)")
-                                .font(.system(size: size * 0.26, weight: .bold, design: .rounded))
-                                .foregroundColor(.white)
-                                .shadow(color: .black.opacity(0.7), radius: 3, x: 0, y: 1)
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.5)
-                            Text("DAYS")
-                                .font(.system(size: size * 0.075, weight: .black, design: .rounded))
-                                .tracking(1.0)
-                                .foregroundColor(.white.opacity(0.85))
-                                .shadow(color: .black.opacity(0.7), radius: 2, x: 0, y: 1)
-                        }
-                        .padding(.bottom, size * 0.16)
-                    }
-                }
+                FlameBuddyFigure(health: entry.health, size: size * 0.70, showsFace: false, vigor: vigor, grounded: false)
             }
         }
     }
 }
 
-/// Tinted status pill: green when the mile is banked, red countdown when at
-/// risk, otherwise the time left in the day.
-private struct FlameStatusChip: View {
-    let entry: StreakFlameEntry
+/// Dashboard-header stat row: tinted icon chip, big value + unit, small-caps
+/// label. Mirrors `ModernHeroStatLine`.
+private struct FlameStat: View {
+    let icon: String
+    let value: String
+    let unit: String
+    let label: String
+    let tint: Color
 
     var body: some View {
-        let color = flameStatusColor(entry)
-        return HStack(spacing: 4) {
-            Image(systemName: entry.isGoalCompleted
-                  ? "checkmark.seal.fill"
-                  : entry.isAtRisk ? "exclamationmark.triangle.fill" : "clock.fill")
-                .font(.system(size: 9, weight: .semibold))
-            Text(entry.isGoalCompleted ? "Streak safe" : (entry.timeLeftText ?? "Keep it alive"))
-                .font(.system(size: 11, weight: .semibold, design: .rounded))
-                .lineLimit(1)
-                .minimumScaleFactor(0.75)
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.system(size: 12, weight: .bold))
+                .foregroundColor(tint)
+                .frame(width: 26, height: 26)
+                .background(Circle().fill(tint.opacity(0.14)))
+
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .firstTextBaseline, spacing: 3) {
+                    Text(value)
+                        .font(.system(size: 17, weight: .black, design: .rounded))
+                        .monospacedDigit()
+                        .foregroundColor(.white)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.6)
+                    Text(unit)
+                        .font(.system(size: 9, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white.opacity(0.6))
+                        .lineLimit(1)
+                }
+                Text(label)
+                    .font(.system(size: 8.5, weight: .black, design: .rounded))
+                    .textCase(.uppercase)
+                    .foregroundColor(.white.opacity(0.42))
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 0)
         }
-        .foregroundColor(color)
-        .padding(.horizontal, 9)
-        .padding(.vertical, 4)
-        .background(Capsule().fill(color.opacity(0.16)))
     }
 }
 
-/// Held streak tokens — a quiet gold shield count. Hidden at 0 so token-free
-/// installs render exactly as before.
+/// Big streak number set off by a divider, like the Fun dashboard headline.
+private struct FlameStreakHeadline: View {
+    let streak: Int
+    let color: Color
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 8) {
+            Text("\(streak)")
+                .font(.system(size: 40, weight: .black, design: .rounded))
+                .monospacedDigit()
+                .foregroundColor(.white)
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+            Rectangle()
+                .fill(color.opacity(0.5))
+                .frame(width: 1, height: 26)
+            Text("DAY\nSTREAK")
+                .font(.system(size: 9, weight: .black, design: .rounded))
+                .tracking(1.0)
+                .foregroundColor(color)
+                .lineLimit(2)
+                .fixedSize()
+        }
+    }
+}
+
 private struct FlameTokenPill: View {
     let count: Int
 
@@ -241,34 +256,48 @@ private struct SmallFlameView: View {
     let entry: StreakFlameEntry
 
     var body: some View {
-        VStack(spacing: 4) {
-            if entry.isFun {
-                FlameHero(entry: entry, size: 74)
-                    .frame(maxHeight: .infinity)
-                VStack(spacing: -2) {
-                    Text("\(entry.streak)")
-                        .font(.system(size: 24, weight: .bold, design: .rounded))
-                        .foregroundColor(.white)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.5)
-                    Text("DAY STREAK")
-                        .font(.system(size: 7.5, weight: .black, design: .rounded))
-                        .tracking(1.0)
-                        .foregroundColor(MADWidgetStyle.secondaryText)
-                }
-            } else {
-                FlameHero(entry: entry, size: 96, streakInRing: true)
-                    .frame(maxHeight: .infinity)
+        VStack(spacing: 3) {
+            FlameArt(entry: entry, size: entry.isFun ? 88 : 98)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            HStack(alignment: .firstTextBaseline, spacing: 5) {
+                Text("\(entry.streak)")
+                    .font(.system(size: 28, weight: .black, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundColor(.white)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.5)
+                Text("DAY STREAK")
+                    .font(.system(size: 8, weight: .black, design: .rounded))
+                    .tracking(0.8)
+                    .foregroundColor(MADWidgetStyle.secondaryText)
             }
 
-            FlameStatusChip(entry: entry)
+            statusPill
         }
         .padding(.vertical, 6)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .overlay(alignment: .topTrailing) {
-            FlameTokenPill(count: entry.tokensReady)
-        }
+        .overlay(alignment: .topTrailing) { FlameTokenPill(count: entry.tokensReady) }
         .widgetURL(flameDeepLink(entry))
+    }
+
+    @ViewBuilder
+    private var statusPill: some View {
+        let color = flameStatusColor(entry)
+        HStack(spacing: 4) {
+            Image(systemName: entry.isGoalCompleted
+                  ? "checkmark.seal.fill"
+                  : entry.isAtRisk ? "exclamationmark.triangle.fill" : "clock.fill")
+                .font(.system(size: 8.5, weight: .semibold))
+            Text(entry.isGoalCompleted ? "Streak safe" : (entry.timeLeftValue.map { "\($0) left" } ?? "Keep it alive"))
+                .font(.system(size: 10.5, weight: .semibold, design: .rounded))
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+        }
+        .foregroundColor(color)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3.5)
+        .background(Capsule().fill(color.opacity(0.16)))
     }
 }
 
@@ -277,83 +306,46 @@ private struct SmallFlameView: View {
 private struct MediumFlameView: View {
     let entry: StreakFlameEntry
 
-    private static let dayLetters = ["S", "M", "T", "W", "T", "F", "S"]
-
-    private var todayIndex: Int {
-        Calendar.current.component(.weekday, from: entry.date) - 1
-    }
-
     var body: some View {
-        HStack(spacing: 14) {
-            FlameHero(entry: entry, size: entry.isFun ? 128 : 112)
-                .frame(width: 124, height: 150)
+        HStack(spacing: 12) {
+            FlameArt(entry: entry, size: entry.isFun ? 146 : 122)
+                .frame(width: 140, height: 150)
 
-            VStack(alignment: .leading, spacing: 5) {
-                HStack(spacing: 6) {
-                    MADWidgetLabel(icon: "flame.fill", text: "DAY STREAK", color: flameStatusColor(entry))
-                    Spacer(minLength: 4)
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .top, spacing: 6) {
+                    FlameStreakHeadline(streak: entry.streak, color: flameStatusColor(entry))
+                    Spacer(minLength: 0)
                     FlameTokenPill(count: entry.tokensReady)
                 }
 
-                Text("\(entry.streak)")
-                    .font(.system(size: 42, weight: .bold, design: .rounded))
-                    .foregroundColor(.white)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.5)
+                Rectangle()
+                    .fill(Color.white.opacity(0.08))
+                    .frame(height: 1)
 
-                HStack(alignment: .firstTextBaseline, spacing: 4) {
-                    Image(systemName: "figure.run")
-                        .font(.system(size: 11, weight: .bold))
-                        .foregroundColor(MADWidgetStyle.red)
-                    Text(String(format: "%.2f", entry.miles))
-                        .font(.system(size: 16, weight: .heavy, design: .rounded))
-                        .monospacedDigit()
-                        .foregroundColor(.white)
-                    Text(String(format: "/ %.1f mi", entry.goal))
-                        .font(.system(size: 11, weight: .medium, design: .rounded))
-                        .foregroundColor(MADWidgetStyle.secondaryText)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.7)
+                FlameStat(
+                    icon: "figure.run",
+                    value: String(format: "%.2f", entry.miles),
+                    unit: "mi",
+                    label: "Mileage",
+                    tint: MADWidgetStyle.red
+                )
+
+                if entry.isGoalCompleted {
+                    FlameStat(icon: "checkmark.seal.fill", value: "Done", unit: "", label: "Streak safe", tint: MADWidgetStyle.green)
+                } else {
+                    FlameStat(
+                        icon: "clock.fill",
+                        value: entry.timeLeftValue ?? "--",
+                        unit: "left",
+                        label: "Left today",
+                        tint: flameStatusColor(entry)
+                    )
                 }
-
-                Spacer(minLength: 2)
-
-                weekStrip
-
-                Spacer(minLength: 2)
-
-                FlameStatusChip(entry: entry)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .frame(maxHeight: .infinity)
         .widgetURL(flameDeepLink(entry))
-    }
-
-    private var weekStrip: some View {
-        HStack(spacing: 5) {
-            ForEach(0..<7, id: \.self) { index in
-                let completed = index < entry.weekCompletions.count ? entry.weekCompletions[index] : false
-                let isToday = index == todayIndex
-                Circle()
-                    .fill(completed
-                          ? AnyShapeStyle(MADWidgetStyle.green)
-                          : AnyShapeStyle(Color.white.opacity(index > todayIndex ? 0.06 : 0.14)))
-                    .frame(width: 12, height: 12)
-                    .overlay {
-                        if isToday {
-                            Circle().strokeBorder(flameStatusColor(entry), lineWidth: 1.5)
-                        }
-                    }
-                    .overlay {
-                        if completed {
-                            Image(systemName: "checkmark")
-                                .font(.system(size: 6, weight: .black))
-                                .foregroundColor(.white)
-                        }
-                    }
-            }
-        }
     }
 }
 
@@ -390,14 +382,14 @@ struct StreakFlameWidget: Widget {
 #Preview(as: .systemSmall) {
     StreakFlameWidget()
 } timeline: {
-    StreakFlameEntry(date: .now, streak: 436, progress: 0.0, miles: 0, goal: 1, isGoalCompleted: false, health: .healthy, timeLeftText: "5h 51m left", weekCompletions: [true, true, true, true, false, false, false], tokensReady: 3, isFun: true)
-    StreakFlameEntry(date: .now, streak: 436, progress: 0.4, miles: 0.4, goal: 1, isGoalCompleted: false, health: .critical, timeLeftText: "1h 12m left", weekCompletions: [true, true, true, true, false, false, false], tokensReady: 0, isFun: false)
-    StreakFlameEntry(date: .now, streak: 437, progress: 1.0, miles: 1.0, goal: 1, isGoalCompleted: true, health: .blazing, timeLeftText: nil, weekCompletions: [true, true, true, true, true, false, false], tokensReady: 2, isFun: true)
+    StreakFlameEntry(date: .now, streak: 436, progress: 0.0, miles: 0, goal: 1, isGoalCompleted: false, health: .healthy, vigor: 0.62, timeLeftValue: "5h 51m", tokensReady: 3, isFun: true)
+    StreakFlameEntry(date: .now, streak: 436, progress: 0.4, miles: 0.4, goal: 1, isGoalCompleted: false, health: .critical, vigor: 0.2, timeLeftValue: "1h 12m", tokensReady: 0, isFun: false)
+    StreakFlameEntry(date: .now, streak: 437, progress: 1.0, miles: 1.0, goal: 1, isGoalCompleted: true, health: .blazing, vigor: nil, timeLeftValue: nil, tokensReady: 2, isFun: true)
 }
 
 #Preview(as: .systemMedium) {
     StreakFlameWidget()
 } timeline: {
-    StreakFlameEntry(date: .now, streak: 436, progress: 0.25, miles: 0.25, goal: 1, isGoalCompleted: false, health: .dimming, timeLeftText: "5h 51m left", weekCompletions: [true, true, true, true, false, false, false], tokensReady: 3, isFun: true)
-    StreakFlameEntry(date: .now, streak: 436, progress: 0.25, miles: 0.25, goal: 1, isGoalCompleted: false, health: .dimming, timeLeftText: "5h 51m left", weekCompletions: [true, true, true, true, false, false, false], tokensReady: 3, isFun: false)
+    StreakFlameEntry(date: .now, streak: 436, progress: 0.25, miles: 0.25, goal: 1, isGoalCompleted: false, health: .dimming, vigor: 0.45, timeLeftValue: "5h 12m", tokensReady: 3, isFun: true)
+    StreakFlameEntry(date: .now, streak: 436, progress: 0.25, miles: 0.25, goal: 1, isGoalCompleted: false, health: .critical, vigor: 0.2, timeLeftValue: "1h 30m", tokensReady: 3, isFun: false)
 }


### PR DESCRIPTION
## What

Addresses feedback on the Streak Flame widget (from a home-screen screenshot):

1. **Flame shrinks in sync with the dashboard.** The widget flame now burns down with the day *exactly* like the in-app hero — same size curve, same golden→ember palette. I ported the dashboard's burn-down math into the widget target (`StreakFlameState.swift`: `StreakFlameClock.flameScale` + `FlamePalette`) and brought the widget's `FlameBuddyFigure` to parity with the app copy (`vigor` + `grounded`). The provider bakes a per-hour `vigor` into each timeline entry, so the flame visibly shrinks through the day — with zero reload-budget cost.
2. **Numbers styled like the dashboard header.** A local `FlameStat` reproduces `ModernHeroStatLine` (tinted icon chip, big value + unit, small-caps label) for Mileage and Left Today, plus a streak headline with the divider treatment.
3. **Fill the empty space.** Larger flame on both sizes; the medium's right column is now a denser streak-headline + stat-lines stack.
4. **Dropped the past-7-days strip.**

## Notes

- The two `FlameBuddyFigure` copies (app + widget) are now in sync, per the project rule. Documented the sync requirement already lives in `.claude/rules/ios.md`.
- Stopped reloading the flame widget on week-only writes (it no longer shows week data), saving a bit of reload budget.
- The Fun buddy stays grounded (shrinks toward its base); the Modern flame is non-grounded (shrinks toward the ring's center) — same as the dashboards.

## Testing

iOS-only; verified by inspection (arg order, ViewBuilder, CGFloat/Double, and cross-target symbol availability — a dedicated compile review is running and I'll fold in anything it finds). Real QA needs Xcode/device: add both sizes in Fun and Modern styles and check the flame shrinks over the day and the stat lines read cleanly. The exact flame sizes / paddings are best-guess without a live render — easy to nudge from a screenshot. Backend + Website CI unaffected (iOS isn't built in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsjUZtGkdF8Fd5LVaTsbzU)_