### PR TITLE
Fix: mile-complete celebration + photo prompt fire reliably every time

### DIFF
--- a/app/Mile A Day/Views/Celebrations/FunGoalCompletedCelebrationView.swift
+++ b/app/Mile A Day/Views/Celebrations/FunGoalCompletedCelebrationView.swift
@@ -351,31 +351,43 @@ struct FunGoalCompletedCelebrationView: View {
             overlayOpacity = 1
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.32) {
-            MADHaptics.emphasis()
-            withAnimation(.timingCurve(0.16, 0.90, 0.18, 1.0, duration: 1.18)) {
+        // Reignite in readable beats instead of one front-loaded rush: the coal
+        // glows and LINGERS, then visibly CATCHES into open flame, then the flame
+        // swells to full and settles. An ease-in-out curve keeps the ember on
+        // screen long enough to read (the old curve shot past it in a blink) and
+        // eases into the settle — the ReignitingFlameView crossfade + catch-flash
+        // are timed to this shape (catch peaks around progress 0.34).
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.30) {
+            MADHaptics.tap() // the coal begins to catch
+            withAnimation(.timingCurve(0.66, 0.0, 0.34, 1.0, duration: 1.5)) {
                 ignitionProgress = 1
             }
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.12) {
+        // Emphasis right as it ignites into open flame…
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.92) {
+            MADHaptics.emphasis()
+        }
+
+        // …and a success tick as the full flame settles.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.74) {
             MADHaptics.success()
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.28) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.86) {
             withAnimation(.spring(response: 0.40, dampingFraction: 0.72)) {
                 showStreak = true
             }
             animateStreakCounter()
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.68) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.24) {
             withAnimation(.spring(response: 0.42, dampingFraction: 0.82)) {
                 showDetails = true
             }
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.96) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.52) {
             withAnimation(.spring(response: 0.42, dampingFraction: 0.82)) {
                 showButtons = true
             }

--- a/app/Mile A Day/Views/Components/ReignitingFlameView.swift
+++ b/app/Mile A Day/Views/Components/ReignitingFlameView.swift
@@ -30,6 +30,13 @@ struct ReignitingFlameView: View {
                 }
             }
 
+            // The moment the coal catches: a bright burst of light that peaks as
+            // the ember ignites, then fades. This is the "it caught fire" beat the
+            // plain grow was missing. Only the reignite (sad) path has an ember.
+            if startsSad {
+                catchFlash
+            }
+
             ignitionSparks
         }
         .frame(width: size * 1.34, height: size * 1.24)
@@ -39,28 +46,91 @@ struct ReignitingFlameView: View {
 
     @ViewBuilder
     private func flame(phase: CGFloat, blink: Bool) -> some View {
-        if startsSad && clampedProgress < 0.26 {
-            SadEmberBuddy(size: size * 0.46, progress: clampedProgress / 0.26)
-                .scaleEffect(0.86 + clampedProgress * 0.42, anchor: .bottom)
-                .offset(y: size * 0.24)
-                .opacity(1 - Double(max(0, clampedProgress - 0.18) / 0.08) * 0.35)
-        } else {
-            FlameBuddyFigure(
-                health: revivalHealth,
-                flickerPhase: phase,
-                blink: blink,
-                size: size,
-                showsFace: showsFace && (startsSad || clampedProgress > 0.58)
-            )
-            .scaleEffect(
-                x: flameScale * (1 + sin(phase * 0.42) * 0.014 * effectiveFlameProgress),
-                y: flameScale * (1 + cos(phase * 0.34) * 0.010 * effectiveFlameProgress),
-                anchor: .bottom
-            )
-            .opacity(flameOpacity)
-            .offset(y: (1 - easedFlameProgress) * size * 0.22 + sin(phase * 0.38) * 1.2 * effectiveFlameProgress)
-            .shadow(color: Color.orange.opacity(Double(effectiveFlameProgress) * Double(0.28 * intensity)), radius: size * 0.10 * intensity, x: 0, y: size * 0.04)
+        ZStack {
+            // The dying coal lingers, then hands off to the flame that catches
+            // over it — a crossfade instead of a hard swap, so the ember visibly
+            // BECOMES fire rather than popping into it. Only the reignite path
+            // has an ember; the plain (Modern) path renders the flame alone.
+            if startsSad {
+                SadEmberBuddy(size: size * 0.46, progress: min(1, clampedProgress / 0.24))
+                    .scaleEffect(0.86 + clampedProgress * 0.42, anchor: .bottom)
+                    .offset(y: size * 0.24)
+                    .opacity(emberOpacity)
+            }
+
+            flameFigure(phase: phase, blink: blink)
+                .opacity(flameFadeIn)
         }
+    }
+
+    private func flameFigure(phase: CGFloat, blink: Bool) -> some View {
+        FlameBuddyFigure(
+            health: revivalHealth,
+            flickerPhase: phase,
+            blink: blink,
+            size: size,
+            showsFace: showsFace && (startsSad || clampedProgress > 0.58)
+        )
+        .scaleEffect(
+            x: flameScale * (1 + sin(phase * 0.42) * 0.014 * effectiveFlameProgress),
+            y: flameScale * (1 + cos(phase * 0.34) * 0.010 * effectiveFlameProgress),
+            anchor: .bottom
+        )
+        .opacity(flameOpacity)
+        .offset(y: (1 - easedFlameProgress) * size * 0.22 + sin(phase * 0.38) * 1.2 * effectiveFlameProgress)
+        .shadow(color: Color.orange.opacity(Double(effectiveFlameProgress) * Double(0.28 * intensity)), radius: size * 0.10 * intensity, x: 0, y: size * 0.04)
+    }
+
+    /// Coal opacity: full while it lingers, gone once the flame has caught over
+    /// it. Crossfaded against `flameFadeIn` across the same window for a smooth
+    /// hand-off. Reignite (sad) path only.
+    private var emberOpacity: Double {
+        guard startsSad else { return 0 }
+        return Double(1 - smoothstep(0.16, 0.40, clampedProgress))
+    }
+
+    /// Flame fade-in as it catches over the ember. The plain (Modern) path shows
+    /// the flame at full opacity throughout — it IS the whole animation.
+    private var flameFadeIn: Double {
+        guard startsSad else { return 1 }
+        return Double(smoothstep(0.16, 0.40, clampedProgress))
+    }
+
+    /// Triangular pulse that peaks as the coal ignites (~progress 0.34), driving
+    /// the catch-flash burst. Squared for a sharper, more ignition-like peak.
+    private var catchIntensity: Double {
+        let center: CGFloat = 0.34
+        let halfWidth: CGFloat = 0.22
+        let raw = max(0, 1 - abs(clampedProgress - center) / halfWidth)
+        return Double(raw * raw)
+    }
+
+    private var catchFlash: some View {
+        let scale = 0.44 + CGFloat(catchIntensity) * 1.05
+        return RadialGradient(
+            gradient: Gradient(colors: [
+                Color.white.opacity(0.92),
+                Color(red: 1.0, green: 0.80, blue: 0.34).opacity(0.58),
+                Color.orange.opacity(0)
+            ]),
+            center: .center,
+            startRadius: 0,
+            endRadius: size * 0.5
+        )
+        .frame(width: size * scale, height: size * scale)
+        .offset(y: size * 0.08)
+        .opacity(catchIntensity)
+        .blur(radius: size * 0.02)
+        .blendMode(.screen)
+        .allowsHitTesting(false)
+    }
+
+    /// Hermite smoothstep — eases a linear ramp between two edges into an
+    /// S-curve so crossfades start and end gently instead of clipping.
+    private func smoothstep(_ edge0: CGFloat, _ edge1: CGFloat, _ x: CGFloat) -> CGFloat {
+        guard edge1 > edge0 else { return x < edge0 ? 0 : 1 }
+        let t = min(max((x - edge0) / (edge1 - edge0), 0), 1)
+        return t * t * (3 - 2 * t)
     }
 
     private var easedProgress: CGFloat {

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -91,6 +91,21 @@ struct DashboardView: View {
     /// observers trigger the goal-celebration check at the same time.
     @State private var isPreparingGoalCelebration = false
 
+    /// The `yyyy-MM-dd` for which the goal-celebration SEQUENCE (flame →
+    /// leaderboard → photo prompt) has already been enqueued this session.
+    /// The goal check is now LEVEL-triggered — it re-runs on every fresh
+    /// today's-distance / workout-count update, not just the isCompleted
+    /// false→true edge, so a mile that lands after the edge already passed
+    /// (deferred behind the workout cover, or a re-fetch that keeps isCompleted
+    /// true) still fires. That means the check can run many times per day, and
+    /// the persistent `hasShownGoalCelebrationToday` flag only flips when the
+    /// user DISMISSES the flame — so between enqueue and dismissal it can't stop
+    /// a data update from re-adding the leaderboard + photo prompt. This
+    /// in-memory day stamp closes that window. It's `@State` (not persisted) so
+    /// it resets on relaunch: a celebration the user never actually saw still
+    /// replays next launch.
+    @State private var goalCelebrationEnqueuedDay = ""
+
     // Ask-mode pending friend notifications (stash sheet). The celebration
     // embed handles the mile-completed pending; this sheet catches everything
     // else (walks, extra workouts, background syncs).
@@ -226,6 +241,16 @@ struct DashboardView: View {
         }
     }
 
+    /// Today as a `yyyy-MM-dd` string in the device timezone — matches
+    /// CelebrationManager's date keying so the session/persistent dedup gates agree.
+    private static func celebrationDayStamp(_ date: Date = Date()) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.calendar = Calendar.current
+        formatter.timeZone = TimeZone.current
+        return formatter.string(from: date)
+    }
+
     /// Check if goal is completed and show celebration if appropriate
     private func checkAndShowGoalCelebration() {
         // Only show if:
@@ -265,6 +290,13 @@ struct DashboardView: View {
             return
         }
 
+        // Already enqueued this session for today → nothing to do. The check is
+        // level-triggered (see goalCelebrationEnqueuedDay), so it can be called
+        // repeatedly between enqueue and the user dismissing the flame; without
+        // this guard those repeat calls would stack duplicate leaderboard/photo
+        // celebrations (hasShownGoalCelebrationToday only flips at dismissal).
+        guard goalCelebrationEnqueuedDay != Self.celebrationDayStamp() else { return }
+
         // Avoid stacking redundant streak fetches when several observers fire at once.
         guard !isPreparingGoalCelebration else { return }
         isPreparingGoalCelebration = true
@@ -292,6 +324,11 @@ struct DashboardView: View {
                   !celebrationManager.hasShownGoalCelebrationToday else {
                 return
             }
+
+            // Stamp NOW, before enqueuing, so the level-triggered re-checks
+            // that fire while this sequence is on screen bail at the guard above
+            // instead of re-adding the leaderboard + photo prompt.
+            goalCelebrationEnqueuedDay = Self.celebrationDayStamp()
 
             // Baseline for extra-mile detection = workout count at goal completion.
             // Scoped to today (see CelebrationManager.lastPostGoalWorkoutCount) so it
@@ -770,12 +807,24 @@ struct DashboardView: View {
                 syncStreakRiskActivity()
             }
             .onChange(of: healthManager.todaysDistance) { oldValue, newValue in
+                // Level-triggered: re-evaluate the goal celebration on EVERY fresh
+                // distance update, not only the isCompleted false→true edge. The
+                // mile often lands after that edge already fired (deferred behind
+                // the workout cover, or a re-fetch that keeps isCompleted true) —
+                // with no re-trigger, the flame + photo prompt were silently lost.
+                // The check is idempotent and self-guarded (once per day/session),
+                // so calling it here is safe.
+                checkAndShowGoalCelebration()
                 // Check for extra mile when distance increases after goal already celebrated
                 if newValue > oldValue && newValue > 0 && celebrationManager.hasShownGoalCelebrationToday {
                     checkAndShowPostGoalEncouragement()
                 }
             }
             .onChange(of: healthManager.todaysWorkouts.count) { oldValue, newValue in
+                // Same level-triggered safety net as todaysDistance above: a newly
+                // synced workout (Watch, Apple Workout, in-app finish) that crosses
+                // the goal must fire the flame even when no isCompleted edge does.
+                checkAndShowGoalCelebration()
                 // When a new workout finishes (from Watch, Apple Workout, etc.), check for extra mile
                 if newValue > oldValue && celebrationManager.hasShownGoalCelebrationToday {
                     checkAndShowPostGoalEncouragement()


### PR DESCRIPTION
Two fixes for the mile-complete moment: (1) the celebration + photo prompt now fire reliably every time, and (2) the "reignite from an ember" flame animation on the Fun dashboard reads as a real catch-and-grow.

## 1. Reliability — celebration + photo prompt fire every time

**Problem:** After finishing a mile, the mile-complete flame and the post-run photo prompt did not reliably appear on their own — on either dashboard style, on any tab.

**Root cause:** The celebration *container* is correctly hosted at the `MainTabView` root (visible on every tab), but the goal-completion **trigger** in `DashboardView` was **edge-triggered**. `checkAndShowGoalCelebration()` only re-ran on the `isCompleted` false→true edge, on `hasFreshTodaysDistance` flipping true (which happens once per session — it never returns to false), or on a single 0.5s timer when the workout cover dismisses. Finishing a mile defers the celebration behind the workout tracker (`!showWorkoutView` guard), spending the `isCompleted` edge invisibly. After dismissal the only re-trigger was that 0.5s timer, which races the async HealthKit re-fetch — and the `todaysDistance` / `todaysWorkouts.count` observers only ran the *extra-mile* check, never the goal check. When fresh distance landed after the timer, nothing re-fired: no flame, and (enqueued in the same block) no photo prompt.

**Fix:** Make the goal check **level-triggered** — re-run it on every fresh `todaysDistance` and `todaysWorkouts.count` update. The check is already idempotent and cheaply guarded (fresh-for-today, completed, not-shown-today, not-preparing), so calling it more often only closes the race; it can't create false celebrations, and the stale-cold-launch guards are untouched. A new in-memory per-day stamp (`goalCelebrationEnqueuedDay`, set at enqueue time) stops the now-frequent calls from stacking duplicate leaderboard/photo celebrations before the user dismisses the flame. It's `@State` (not persisted), so a celebration the user never actually saw still replays next launch.

## 2. Animation — "reignite from an ember" on the Fun dashboard

**Problem:** The Fun reignite read poorly — a front-loaded timing curve shot past the ember in a blink, the coal **hard-swapped** to a flame at progress 0.26 (a pop, not a catch), and there was no clear "it caught fire" beat.

**Fix — a readable ember → catch → swell arc:**
- `ReignitingFlameView`: crossfade the dying coal into the flame that catches over it (smoothstep hand-off across progress 0.16–0.40) instead of the instant swap; add a bright radial **catch-flash** that peaks as the ember ignites (~progress 0.34).
- `FunGoalCompletedCelebrationView`: retime the ignition with an ease-in-out curve over 1.5s so the coal lingers long enough to read, then catches and settles; re-space the haptics (tap as it catches, emphasis at ignition, success as it settles) and the streak/detail/button reveals to the new arc.

The **Modern** path is untouched: it passes `startsSad:false`, so no ember is rendered, the flame fade-in is a no-op, and the catch-flash is gated off.

## Files
- `app/Mile A Day/Views/Dashboard/DashboardView.swift`
- `app/Mile A Day/Views/Components/ReignitingFlameView.swift`
- `app/Mile A Day/Views/Celebrations/FunGoalCompletedCelebrationView.swift`

## Testing notes
iOS builds via Xcode only (not covered by CI). Manual verification recommended:
- Finish a mile via **in-app tracking**, dismiss the recap → flame + photo prompt appear, in order.
- Finish a mile via **Apple Watch / Health import** while on a **non-Dashboard tab** → celebration appears over the current tab.
- No duplicate leaderboard/photo screens when extra distance lands while the flame is still on screen.
- A stale cold launch (locked device) does **not** re-fire yesterday's already-celebrated mile.
- On the **Fun** dashboard, the flame visibly starts as a coal, catches, and swells; **Modern** looks exactly as before.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSw9YZPiAbnz98cRMZBgDt