### PR TITLE
Rebuild the post composer around Instagram's two-screen flow

### DIFF
--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -135,6 +135,12 @@ final class PostComposerViewModel: ObservableObject {
     /// Publish was rejected server-side for unaccepted guidelines — the view
     /// re-presents the gate when this flips true.
     @Published var needsTermsGate = false
+    /// Display-only composite for the share step's thumbnail. Rendered from the
+    /// SAME `flatten()` the upload uses, so the thumbnail is literally the image
+    /// that ships — sticker baked in, cropped 4:5 exactly as the feed shows it.
+    /// Never read by `publish()`: that re-flattens, so the upload path stays
+    /// byte-for-byte what it has always been.
+    @Published var previewComposite: UIImage?
 
     let stats: RunStatsInput
     /// Captured on-screen canvas size (points), reused to render the composite.
@@ -161,6 +167,25 @@ final class PostComposerViewModel: ObservableObject {
 
     var canPublish: Bool {
         pickedImage != nil && destination != nil && !isPublishing
+    }
+
+    /// A photo on the canvas IS the draft — the caption and sticker ride with it.
+    /// Gates the discard confirmation.
+    var hasDraft: Bool { pickedImage != nil }
+
+    /// The sticker has been moved/resized/tilted off its default placement.
+    /// Epsilon-compared because pinch and twist land on irrational values.
+    var isStickerTransformed: Bool {
+        abs(stickerPos.x - 0.5) > 0.001
+            || abs(stickerPos.y - 0.82) > 0.001
+            || abs(stickerScale - 1) > 0.001
+            || abs(stickerRotation.degrees) > 0.001
+    }
+
+    func resetStickerPlacement() {
+        stickerPos = CGPoint(x: 0.5, y: 0.82)
+        stickerScale = 1
+        stickerRotation = .zero
     }
 
     /// Check whether the linked workout has GPS route data, enabling the
@@ -319,6 +344,10 @@ struct PostCanvas: View {
 /// The sticker is wrapped in `.equatable()` (outside the transforms) so its own
 /// body — drop shadow, number formatting — is rendered once and only its cheap
 /// transform matrix changes per frame.
+///
+/// Placement aids (centre snap, guides, selection ring) live ENTIRELY in here for
+/// the same reason: routing snap state up through a `@Binding` would re-render the
+/// whole composer mid-drag and undo the isolation this layer exists to provide.
 private struct StickerEditorLayer: View {
     let input: RunStatsInput
     let config: StickerConfig
@@ -335,10 +364,47 @@ private struct StickerEditorLayer: View {
     @GestureState private var dragTranslation: CGSize = .zero
     @GestureState private var magnifyFactor: CGFloat = 1
     @GestureState private var twist: Angle = .zero
+    @GestureState private var isManipulating = false
+
+    /// Natural, untransformed sticker size. Measured under the transforms, so it
+    /// only changes when the style / enabled stats change — never per frame.
+    @State private var natural: CGSize = .zero
+    /// One-shot latch so the snap haptic fires on ENTERING the centre zone rather
+    /// than on every frame spent inside it.
+    @State private var snappedX = false
+    @State private var snappedY = false
+
+    /// Finger travel (points) within which the sticker locks to a centre line.
+    private static let snapThreshold: CGFloat = 8
 
     var body: some View {
+        ZStack {
+            centerGuides
+            sticker
+        }
+        .frame(width: canvas.width, height: canvas.height)
+        // Corrects a position persisted by an older build (which clamped only the
+        // centre), and re-corrects whenever the sticker's own size changes — a
+        // style switch from the tray, a stat toggled on, or the branded Minimal
+        // pill growing. `reclamp()` writes only on a real change, so this is a
+        // no-op at rest and can't fire mid-gesture (`natural` is constant then).
+        .onChange(of: natural, initial: true) { _, _ in reclamp() }
+        .onChange(of: canvas) { _, _ in reclamp() }
+    }
+
+    private var sticker: some View {
         RunStatsStickerView(input: input, config: config)
             .equatable()                       // MUST stay OUTSIDE the transforms
+            // Probe sits OUTSIDE .equatable() but UNDER the transforms, so it
+            // reports the NATURAL size and settles instead of firing per frame.
+            .background(
+                GeometryReader { geo in
+                    Color.clear.preference(key: StickerNaturalSizeKey.self, value: geo.size)
+                }
+            )
+            // INSIDE the transforms so the ring tracks the sticker exactly; its
+            // stroke divides by liveScale to stay visually constant.
+            .overlay { selectionRing }
             .scaleEffect(liveScale)
             .rotationEffect(liveRotation)
             // Generous, invisible hit margin so a shrunk-down sticker stays easy
@@ -347,24 +413,118 @@ private struct StickerEditorLayer: View {
             .contentShape(Rectangle())
             .gesture(manipulation)             // BEFORE .position → grab the sticker itself
             .position(liveCenter)
+            .onPreferenceChange(StickerNaturalSizeKey.self) { natural = $0 }
+    }
+
+    /// Dashed outline while a gesture is in flight, so it's obvious the sticker —
+    /// not the photo — is what's being moved. It sits inside the transforms (so it
+    /// tracks scale and rotation) and divides its stroke and dash by `liveScale`,
+    /// which cancels the scale back out and keeps the outline visually constant at
+    /// any sticker size. Sized by the overlay itself, so it needs no measurement.
+    @ViewBuilder
+    private var selectionRing: some View {
+        if isManipulating {
+            let s = max(liveScale, 0.01)
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .strokeBorder(
+                    Color.white.opacity(0.85),
+                    style: StrokeStyle(lineWidth: 1.5 / s, dash: [5 / s, 4 / s])
+                )
+                .padding(-5)
+                .allowsHitTesting(false)
+        }
+    }
+
+    /// Thin centre lines that appear only while the sticker is locked to them.
+    @ViewBuilder
+    private var centerGuides: some View {
+        if isManipulating {
+            ZStack {
+                if isSnappedX {
+                    Rectangle()
+                        .fill(MADTheme.Colors.madRed)
+                        .frame(width: 1)
+                        .frame(maxHeight: .infinity)
+                }
+                if isSnappedY {
+                    Rectangle()
+                        .fill(MADTheme.Colors.madRed)
+                        .frame(height: 1)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            .opacity(0.9)
+            .allowsHitTesting(false)
+            .transition(.opacity)
+        }
     }
 
     // Live = committed ∘ transient, clamped IDENTICALLY to the `.onEnded` commit
     // so releasing never snaps the sticker to a different spot/size.
     private var liveScale: CGFloat {
-        (scale * magnifyFactor).clamped(to: StickerConfig.scaleRange)
+        (scale * magnifyFactor).clamped(to: fittedScaleRange)
     }
     private var liveRotation: Angle { rotation + twist }
+
+    /// `StickerConfig.scaleRange` narrowed to what actually fits the canvas, so a
+    /// pinch can't grow the sticker past the photo's edges.
+    private var fittedScaleRange: ClosedRange<CGFloat> {
+        StickerBounds.scaleRange(natural: natural, canvas: canvas)
+    }
     private var liveCenter: CGPoint {
         CGPoint(x: committedX(addingDrag: dragTranslation.width) * canvas.width,
                 y: committedY(addingDrag: dragTranslation.height) * canvas.height)
     }
 
+    /// Size-aware legal ranges, recomputed from the LIVE scale/rotation so an
+    /// in-flight pinch or twist is bounded exactly the way the release will be.
+    private var liveRanges: (x: ClosedRange<CGFloat>, y: ClosedRange<CGFloat>) {
+        StickerBounds.ranges(natural: natural, scale: liveScale,
+                             rotation: liveRotation, canvas: canvas)
+    }
+
+    private var isSnappedX: Bool { committedX(addingDrag: dragTranslation.width) == 0.5 }
+    private var isSnappedY: Bool { committedY(addingDrag: dragTranslation.height) == 0.5 }
+
+    // Snap BEFORE the clamp, in both the live value and the commit, so the
+    // sticker never jumps on release.
     private func committedX(addingDrag dx: CGFloat) -> CGFloat {
-        (pos.x + dx / max(canvas.width, 1)).clamped(to: StickerConfig.posXRange)
+        let raw = pos.x + dx / max(canvas.width, 1)
+        let snapped = abs(raw - 0.5) * canvas.width < Self.snapThreshold ? 0.5 : raw
+        return snapped.clamped(to: liveRanges.x)
     }
     private func committedY(addingDrag dy: CGFloat) -> CGFloat {
-        (pos.y + dy / max(canvas.height, 1)).clamped(to: StickerConfig.posYRange)
+        let raw = pos.y + dy / max(canvas.height, 1)
+        let snapped = abs(raw - 0.5) * canvas.height < Self.snapThreshold ? 0.5 : raw
+        return snapped.clamped(to: liveRanges.y)
+    }
+
+    /// Pull the committed scale and position back inside the current legal ranges.
+    /// Only writes when something actually moves, so it's inert at rest.
+    ///
+    /// Scale first, then position — the legal position range depends on the size,
+    /// so clamping in the other order would bound against a size that's about to
+    /// change. This is also what repairs a transform persisted by an older build,
+    /// which clamped the centre only and had no size cap at all.
+    private func reclamp() {
+        let fittedScale = scale.clamped(to: fittedScaleRange)
+        if fittedScale != scale { scale = fittedScale }
+
+        let r = StickerBounds.ranges(natural: natural, scale: fittedScale,
+                                     rotation: rotation, canvas: canvas)
+        let fixed = CGPoint(x: pos.x.clamped(to: r.x), y: pos.y.clamped(to: r.y))
+        if fixed != pos { pos = fixed }
+    }
+
+    /// Fire once per snap-line entry, not once per frame spent on it. Reads the
+    /// translation straight off the gesture value rather than `dragTranslation` —
+    /// `updating` and `onChanged` fire for the same event with no guaranteed
+    /// ordering, so the transient could still be a frame behind here.
+    private func updateSnapHaptics(for translation: CGSize) {
+        let x = committedX(addingDrag: translation.width) == 0.5
+        let y = committedY(addingDrag: translation.height) == 0.5
+        if x != snappedX { snappedX = x; if x { MADHaptics.tap() } }
+        if y != snappedY { snappedY = y; if y { MADHaptics.tap() } }
     }
 
     private var manipulation: some Gesture {
@@ -377,19 +537,29 @@ private struct StickerEditorLayer: View {
         // delta: smooth, straight, and rotation-independent.
         let drag = DragGesture(coordinateSpace: .global)
             .updating($dragTranslation) { value, state, _ in state = value.translation }
+            .updating($isManipulating) { _, state, _ in state = true }
+            .onChanged { value in updateSnapHaptics(for: value.translation) }
             .onEnded { value in
                 pos = CGPoint(x: committedX(addingDrag: value.translation.width),
                               y: committedY(addingDrag: value.translation.height))
+                snappedX = false
+                snappedY = false
             }
         let magnify = MagnifyGesture()
             .updating($magnifyFactor) { value, state, _ in state = value.magnification }
+            .updating($isManipulating) { _, state, _ in state = true }
             .onEnded { value in
-                scale = (scale * value.magnification).clamped(to: StickerConfig.scaleRange)
+                scale = (scale * value.magnification).clamped(to: fittedScaleRange)
+                // Growing while parked against an edge would otherwise leave the
+                // committed centre outside the (now tighter) legal range.
+                reclamp()
             }
         let rotate = RotateGesture()
             .updating($twist) { value, state, _ in state = value.rotation }
+            .updating($isManipulating) { _, state, _ in state = true }
             .onEnded { value in
                 rotation = rotation + value.rotation
+                reclamp()
             }
         return drag.simultaneously(with: magnify).simultaneously(with: rotate)
     }
@@ -403,14 +573,17 @@ struct PostComposerView: View {
     /// user's camera roll) — only composing/sharing waits for acceptance.
     private enum TermsState { case unknown, accepted, needsAcceptance }
 
+    /// The composer's second screen. Edit is the stack ROOT, so this enum only
+    /// needs the one case: `path` is `[]` on edit and `[.share]` on share.
+    private enum ComposerStep: Hashable { case share }
+
     @StateObject private var vm: PostComposerViewModel
     @StateObject private var friendService = FriendService()
-    @State private var showCoauthorPicker = false
     @State private var showCamera = false
     // Library import of a photo captured DURING this walk/run (window-filtered
     // for authenticity, same as the post-run prompt). Its cover rides the
-    // `canvasSection` node — a third cover on the ScrollView or the ZStack
-    // (which already own the terms + camera covers) would silently drop one.
+    // `canvasSection` node — a third cover on the ZStack or the background Color
+    // (which already own the camera + terms covers) would silently drop one.
     @State private var showLibraryImport = false
     /// Seeded from the local cache so a returning poster never waits on (or
     /// races) the network check in `resolveTermsIfNeeded`.
@@ -427,7 +600,10 @@ struct PostComposerView: View {
     @State private var didAutoOpenCamera = false
     /// "Saved to Photos" confirmation for the canvas Save button.
     @State private var showSavedToPhotos = false
-    @FocusState private var captionFocused: Bool
+    /// Guards against silently destroying a composed draft on Cancel.
+    @State private var showDiscardConfirm = false
+    /// Empty on the edit step, `[.share]` on the share step.
+    @State private var path: [ComposerStep] = []
     /// Launch straight into the camera on first appear (post-run prompt flow) —
     /// the user already tapped "Take a photo" once to get here.
     let autoOpenCamera: Bool
@@ -453,14 +629,16 @@ struct PostComposerView: View {
     }
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $path) {
             ZStack {
                 Color.black.ignoresSafeArea()
+
                 ScrollView {
                     VStack(spacing: MADTheme.Spacing.lg) {
                         canvasSection
-                            // Distinct node from the ScrollView (terms gate) and
-                            // the ZStack (camera) — see showLibraryImport.
+                            // Distinct node from the NavigationStack (terms gate),
+                            // the ZStack (camera) and the ScrollView (discard
+                            // dialog) — see showLibraryImport.
                             .fullScreenCover(isPresented: $showLibraryImport) {
                                 WorkoutPhotoImportPicker(window: importWindow) { result in
                                     showLibraryImport = false
@@ -482,14 +660,16 @@ struct PostComposerView: View {
                             chooseFromLibraryButton
                         }
                         if vm.pickedImage != nil {
-                            overlayEditor
-                            if vm.hasRoute { routeToggle }
-                            captionField
-                            // Collabs are a feed concept — shown once the user
-                            // picks a destination that includes the feed
-                            // (destination starts nil until they choose).
-                            if vm.destination?.toFeed == true { coauthorRow }
-                            destinationToggles
+                            StickerTrayView(
+                                input: vm.stats,
+                                config: $vm.config,
+                                isEnabled: $vm.stickerEnabled,
+                                isTransformed: vm.isStickerTransformed
+                            ) {
+                                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                                    vm.resetStickerPlacement()
+                                }
+                            }
                         }
                         if let error = vm.errorMessage {
                             Text(error)
@@ -501,31 +681,27 @@ struct PostComposerView: View {
                     .padding(MADTheme.Spacing.md)
                 }
                 .scrollDismissesKeyboard(.interactively)
-                // The guidelines gate rides on the ScrollView so it never
-                // collides with the camera cover attached to the ZStack —
-                // two covers on one node drop one of the presentations.
-                .fullScreenCover(isPresented: $showTermsGate, onDismiss: {
-                    if gateAccepted {
-                        gateAccepted = false
-                        termsState = .accepted
-                        vm.errorMessage = nil
-                    } else if vm.pickedImage == nil {
-                        // Declined with nothing composed — nothing to lose;
-                        // back out so the post-run prompt / feed takes over.
-                        onFinished(.cancelled)
-                        dismiss()
-                    } else {
-                        // Declined with a draft on screen: NEVER destroy it.
-                        // Share stays locked (tapping it re-opens the gate);
-                        // Cancel remains the deliberate way out.
-                        vm.errorMessage = "Accept the community guidelines to share your post."
-                    }
-                }) {
-                    PostTermsGateView { gateAccepted = true }
+                // The ScrollView's own presentation slot — the terms gate that used
+                // to live here moved up to the NavigationStack.
+                .confirmationDialog("Discard this post?", isPresented: $showDiscardConfirm,
+                                    titleVisibility: .visible) {
+                    Button("Discard", role: .destructive) { onFinished(.cancelled); dismiss() }
+                    Button("Keep editing", role: .cancel) { }
+                } message: {
+                    Text("Your photo and caption won't be saved.")
                 }
             }
             .navigationTitle("New Post")
             .navigationBarTitleDisplayMode(.inline)
+            .navigationDestination(for: ComposerStep.self) { _ in
+                PostShareStepView(
+                    vm: vm,
+                    friendService: friendService,
+                    shareEnabled: vm.canPublish && termsState == .accepted,
+                    onShare: share,
+                    onEditMedia: { if !path.isEmpty { path.removeLast() } }
+                )
+            }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     // Disabled while publishing: publish() has no cancellation
@@ -533,7 +709,7 @@ struct PostComposerView: View {
                     // onFinished twice with contradictory outcomes (the
                     // post-run prompt would auto-post the route card AND the
                     // photo post would land server-side).
-                    Button { onFinished(.cancelled); dismiss() } label: {
+                    Button(action: cancelTapped) {
                         if backNavigation {
                             HStack(spacing: 3) {
                                 Image(systemName: "chevron.left")
@@ -548,43 +724,21 @@ struct PostComposerView: View {
                     .disabled(vm.isPublishing)
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    if vm.isPublishing {
-                        ProgressView().tint(.white)
-                    } else {
-                        Button("Share") {
-                            switch termsState {
-                            case .accepted:
-                                Task {
-                                    let ok = await vm.publish()
-                                    if ok, let dest = vm.destination {
-                                        onFinished(.published(
-                                            toFeed: dest.toFeed,
-                                            toStory: dest.toStory
-                                        ))
-                                        dismiss()
-                                    }
-                                }
-                            case .needsAcceptance:
-                                // Not allowed to post yet — the button routes
-                                // to the guidelines instead of a dead upload.
-                                presentGateIfNeeded()
-                            case .unknown:
-                                // Still resolving; the gate auto-presents if
-                                // the answer comes back unaccepted.
-                                break
-                            }
-                        }
-                        .fontWeight(.bold)
-                        .foregroundColor(vm.canPublish && termsState == .accepted
+                    Button("Next", action: goToShareStep)
+                        .fontWeight(.semibold)
+                        .foregroundColor(vm.pickedImage != nil
                             ? MADTheme.Colors.madRed : .white.opacity(0.3))
-                        .disabled(!vm.canPublish)
-                    }
+                        .disabled(vm.pickedImage == nil)
                 }
             }
             .toolbarBackground(.black, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
             .fullScreenCover(isPresented: $showCamera) {
                 MADCameraView(image: $vm.pickedImage)
+            }
+            // A stale composite must never survive a trip back to the editor.
+            .onChange(of: path) { _, newPath in
+                if newPath.isEmpty { vm.previewComposite = nil }
             }
             .onAppear {
                 if autoOpenCamera, !didAutoOpenCamera, vm.pickedImage == nil {
@@ -616,6 +770,85 @@ struct PostComposerView: View {
                 presentGateIfNeeded()
             }
         }
+        // The guidelines gate hangs off the NavigationStack ITSELF, not the root
+        // content. Share can trigger it from the pushed share step, and a cover
+        // presented from a view that's been navigated away from is unreliable —
+        // the stack is the one node that's current on both steps. It's also a
+        // node of its own, which matters: the ZStack owns the camera cover, the
+        // ScrollView owns the discard dialog, and the canvas owns the library
+        // import. Two presentations on one node silently drop one.
+        .fullScreenCover(isPresented: $showTermsGate, onDismiss: {
+            if gateAccepted {
+                gateAccepted = false
+                termsState = .accepted
+                vm.errorMessage = nil
+            } else if vm.pickedImage == nil {
+                // Declined with nothing composed — nothing to lose;
+                // back out so the post-run prompt / feed takes over.
+                onFinished(.cancelled)
+                dismiss()
+            } else {
+                // Declined with a draft on screen: NEVER destroy it.
+                // Share stays locked (tapping it re-opens the gate);
+                // Cancel remains the deliberate way out.
+                vm.errorMessage = "Accept the community guidelines to share your post."
+            }
+        }) {
+            PostTermsGateView { gateAccepted = true }
+        }
+    }
+
+    // MARK: - Step actions
+
+    /// Advance to the share step, baking the thumbnail from the CURRENT canvas.
+    /// Guarded on `canvasSize` so a composite is never rendered before the canvas
+    /// has been laid out (which would produce a differently-scaled sticker than
+    /// the one that ultimately uploads).
+    private func goToShareStep() {
+        guard vm.pickedImage != nil, vm.canvasSize.width > 0 else { return }
+        MADHaptics.tap()
+        vm.previewComposite = vm.flatten()
+        path.append(.share)
+    }
+
+    /// The one terminal action. Lives HERE, never in `PostShareStepView`: inside a
+    /// `navigationDestination`, `dismiss()` pops the push instead of dismissing the
+    /// composer, so publishing from there would leave the user on the edit step with
+    /// a post already live.
+    private func share() {
+        switch termsState {
+        case .accepted:
+            Task {
+                let ok = await vm.publish()
+                if ok, let dest = vm.destination {
+                    onFinished(.published(toFeed: dest.toFeed, toStory: dest.toStory))
+                    dismiss()
+                }
+            }
+        case .needsAcceptance:
+            // Not allowed to post yet — the button routes to the guidelines
+            // instead of a dead upload.
+            presentGateIfNeeded()
+        case .unknown:
+            // Still resolving; the gate auto-presents if the answer comes back
+            // unaccepted.
+            break
+        }
+    }
+
+    /// Cancel with a draft asks first. `backNavigation` deliberately skips the
+    /// dialog: that button reads "‹ Back", a navigational affordance, and it returns
+    /// to the post-run prompt which still holds the mid-run snaps and re-offers them
+    /// — nothing is actually lost. "Cancel" was renamed to "Back" on that path
+    /// precisely because people feared losing photos; a destructive dialog there
+    /// would undo that fix.
+    private func cancelTapped() {
+        if backNavigation || !vm.hasDraft {
+            onFinished(.cancelled)
+            dismiss()
+        } else {
+            showDiscardConfirm = true
+        }
     }
 
     // MARK: - Guidelines gate
@@ -645,29 +878,6 @@ struct PostComposerView: View {
     private func presentGateIfNeeded() {
         guard termsState == .needsAcceptance, !showCamera, !showTermsGate else { return }
         showTermsGate = true
-    }
-
-    /// Offer to ride the run's GPS route along with the photo (shown as a
-    /// second, swipeable slide on the feed card). Only offered when the linked
-    /// workout actually has route data.
-    private var routeToggle: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Toggle(isOn: $vm.includeRoute.animation(.easeInOut)) {
-                Label("Include route map", systemImage: "map.fill")
-                    .font(.system(size: 15, weight: .semibold, design: .rounded))
-                    .foregroundColor(.white)
-            }
-            .tint(MADTheme.Colors.madRed)
-            Text("Friends can swipe to see your mile's path next to the photo.")
-                .font(.system(size: 12, weight: .medium, design: .rounded))
-                .foregroundColor(.white.opacity(0.5))
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .padding(MADTheme.Spacing.md)
-        .background(
-            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
-                .fill(Color.white.opacity(0.04))
-        )
     }
 
     // MARK: - Canvas
@@ -716,19 +926,7 @@ struct PostComposerView: View {
                         vm.canvasSize = size
                     }
                     .overlay(alignment: .topTrailing) {
-                        Button { requestCamera() } label: {
-                            HStack(spacing: 5) {
-                                Image(systemName: "camera.fill")
-                                    .font(.system(size: 12, weight: .bold))
-                                Text("Retake")
-                                    .font(.system(size: 12, weight: .bold, design: .rounded))
-                            }
-                            .foregroundColor(.white)
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 7)
-                            .background(Capsule().fill(.black.opacity(0.5)))
-                        }
-                        .padding(10)
+                        changePhotoControl.padding(10)
                     }
                     // Keep a copy exactly as composed — stats sticker baked
                     // in (the camera already saved the RAW shot at capture).
@@ -775,6 +973,43 @@ struct PostComposerView: View {
             }
         }
         .aspectRatio(4.0 / 5.0, contentMode: .fit)
+    }
+
+    /// Swapping the photo used to mean "Retake" and nothing else — the library
+    /// option vanished the moment a photo existed, so a user who'd picked the wrong
+    /// mid-run snap had to go through the camera to get back. A `Menu` offers both.
+    ///
+    /// `Menu` rides UIKit's context-menu machinery rather than the sheet/cover
+    /// presentation slot, so it costs no cover node (see the cover comments above).
+    @ViewBuilder
+    private var changePhotoControl: some View {
+        if vm.stats.workoutId != nil {
+            Menu {
+                Button { requestCamera() } label: {
+                    Label("Take a new photo", systemImage: "camera.fill")
+                }
+                Button { showLibraryImport = true } label: {
+                    Label("Choose from this walk or run", systemImage: "photo.on.rectangle")
+                }
+            } label: {
+                changePhotoPill
+            }
+        } else {
+            Button { requestCamera() } label: { changePhotoPill }
+        }
+    }
+
+    private var changePhotoPill: some View {
+        HStack(spacing: 5) {
+            Image(systemName: "camera.fill")
+                .font(.system(size: 12, weight: .bold))
+            Text("Change")
+                .font(.system(size: 12, weight: .bold, design: .rounded))
+        }
+        .foregroundColor(.white)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(Capsule().fill(.black.opacity(0.5)))
     }
 
     private var photoPlaceholder: some View {
@@ -868,314 +1103,6 @@ struct PostComposerView: View {
         return start...max(start, end)
     }
 
-    // MARK: - Overlay editor
-
-    private var overlayEditor: some View {
-        VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
-            Toggle(isOn: $vm.stickerEnabled.animation(.easeInOut)) {
-                Label("Show run stats", systemImage: "chart.bar.doc.horizontal")
-                    .font(.system(size: 15, weight: .semibold, design: .rounded))
-                    .foregroundColor(.white)
-            }
-            .tint(MADTheme.Colors.madRed)
-
-            if vm.stickerEnabled {
-                editorLabel("STYLE")
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: MADTheme.Spacing.sm) {
-                        ForEach(StickerStyle.allCases) { style in
-                            chip(
-                                title: style.title, icon: style.icon,
-                                selected: vm.config.style == style
-                            ) { vm.config.style = style }
-                        }
-                    }
-                }
-
-                editorLabel("SHOW")
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: MADTheme.Spacing.sm) {
-                        ForEach(vm.stats.availableStats()) { kind in
-                            chip(
-                                title: kind.label, icon: kind.icon,
-                                selected: vm.config.isOn(kind)
-                            ) { vm.config.toggle(kind) }
-                        }
-                    }
-                }
-
-                editorLabel("COLOR")
-                HStack(spacing: MADTheme.Spacing.md) {
-                    ForEach(StickerAccent.allCases) { accent in
-                        Button { vm.config.accent = accent } label: {
-                            Circle()
-                                .fill(accent.color)
-                                .frame(width: 26, height: 26)
-                                .overlay(
-                                    Circle().strokeBorder(
-                                        Color.white,
-                                        lineWidth: vm.config.accent == accent ? 2.5 : 0
-                                    )
-                                )
-                                .overlay(
-                                    Circle().strokeBorder(Color.white.opacity(0.2), lineWidth: 1)
-                                )
-                        }
-                        .buttonStyle(.plain)
-                    }
-                    Spacer()
-                }
-            }
-        }
-        .padding(MADTheme.Spacing.md)
-        .background(
-            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
-                .fill(Color.white.opacity(0.04))
-        )
-    }
-
-    private func editorLabel(_ text: String) -> some View {
-        Text(text)
-            .font(.system(size: 10, weight: .heavy, design: .rounded))
-            .tracking(1.2)
-            .foregroundColor(.white.opacity(0.4))
-    }
-
-    private func chip(title: String, icon: String, selected: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            HStack(spacing: 5) {
-                Image(systemName: icon).font(.system(size: 11, weight: .bold))
-                Text(title).font(.system(size: 13, weight: .bold, design: .rounded))
-            }
-            .foregroundColor(selected ? .white : .white.opacity(0.6))
-            .padding(.horizontal, 12).padding(.vertical, 7)
-            .background(
-                Capsule().fill(selected ? AnyShapeStyle(MADTheme.Colors.redGradient) : AnyShapeStyle(Color.white.opacity(0.07)))
-            )
-            .overlay(
-                Capsule().strokeBorder(Color.white.opacity(selected ? 0 : 0.12), lineWidth: 1)
-            )
-        }
-        .buttonStyle(.plain)
-    }
-
-    /// Friends matching an @token being typed at the end of the caption.
-    /// Explicit types — inference across filter/prefix chains slows the
-    /// type checker to a crawl.
-    private var captionMentionCandidates: [BackendUser] {
-        guard let token = vm.caption.split(separator: " ").last, token.hasPrefix("@") else { return [] }
-        let query: String = String(token.dropFirst()).lowercased()
-        let matches: [BackendUser] = friendService.friends.filter { friend in
-            guard let name = friend.username?.lowercased() else { return false }
-            return query.isEmpty || name.hasPrefix(query)
-        }
-        return Array(matches.prefix(8))
-    }
-
-    private func completeCaptionMention(_ friend: BackendUser) {
-        var parts = vm.caption.split(separator: " ", omittingEmptySubsequences: false)
-        if let last = parts.last, last.hasPrefix("@") { parts.removeLast() }
-        vm.caption = (parts + ["@\(friend.username ?? "") "]).joined(separator: " ")
-    }
-
-    private func mentionChip(_ friend: BackendUser) -> some View {
-        Button {
-            completeCaptionMention(friend)
-        } label: {
-            HStack(spacing: 6) {
-                AvatarView(name: friend.username ?? "?",
-                           imageURL: friend.profile_image_url, size: 22)
-                Text("@\(friend.username ?? "")")
-                    .font(.system(size: 13, weight: .bold, design: .rounded))
-                    .foregroundColor(.white)
-            }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(Capsule().fill(Color.white.opacity(0.08)))
-        }
-        .buttonStyle(.plain)
-    }
-
-    private var captionField: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            TextField("", text: $vm.caption, prompt: Text("Add a caption… (@ to tag a friend)").foregroundColor(.white.opacity(0.4)), axis: .vertical)
-                .lineLimit(1...4)
-                .focused($captionFocused)
-                .font(.system(size: 15, weight: .medium, design: .rounded))
-                .foregroundColor(.white)
-                .padding(MADTheme.Spacing.md)
-                .background(
-                    RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
-                        .fill(Color.white.opacity(0.06))
-                )
-            if !captionMentionCandidates.isEmpty {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 8) {
-                        ForEach(captionMentionCandidates, id: \.user_id) { friend in
-                            mentionChip(friend)
-                        }
-                    }
-                }
-            }
-            HStack {
-                // Anchored to the field it dismisses (a keyboard-toolbar Done
-                // floated as a detached pill over the counter on iOS 26) —
-                // Return adds newlines in this multi-line field, so this is
-                // THE way to put the keyboard away.
-                if captionFocused {
-                    Button {
-                        captionFocused = false
-                    } label: {
-                        HStack(spacing: 4) {
-                            Image(systemName: "keyboard.chevron.compact.down")
-                                .font(.system(size: 11, weight: .bold))
-                            Text("Done")
-                                .font(.system(size: 12, weight: .bold, design: .rounded))
-                        }
-                        .foregroundColor(.white)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 6)
-                        .background(Capsule().fill(MADTheme.Colors.redGradient))
-                    }
-                    .buttonStyle(.plain)
-                    .transition(.opacity.combined(with: .scale(scale: 0.9)))
-                }
-                Spacer()
-                Text("\(vm.caption.count)/280")
-                    .font(.system(size: 11, weight: .semibold, design: .rounded))
-                    .foregroundColor(vm.caption.count > 280 ? MADTheme.Colors.error : .white.opacity(0.4))
-            }
-            .animation(.easeInOut(duration: 0.15), value: captionFocused)
-        }
-        .onChange(of: vm.caption) { _, newValue in
-            if newValue.count > 280 { vm.caption = String(newValue.prefix(280)) }
-        }
-    }
-
-    /// "Ran it together?" — pick ONE friend to co-post with. They're invited
-    /// on share and the post goes dual-author once they accept.
-    private var coauthorRow: some View {
-        Button { showCoauthorPicker = true } label: {
-            HStack(spacing: 10) {
-                Image(systemName: "person.2.fill")
-                    .font(.system(size: 14, weight: .bold))
-                    .foregroundColor(MADTheme.Colors.madRed)
-                if let coauthor = vm.coauthor {
-                    AvatarView(name: coauthor.username ?? "?",
-                               imageURL: coauthor.profile_image_url, size: 26)
-                    Text("Co-posting with @\(coauthor.username ?? "")")
-                        .font(.system(size: 14, weight: .bold, design: .rounded))
-                        .foregroundColor(.white)
-                    Spacer()
-                    Button {
-                        vm.coauthor = nil
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.system(size: 16))
-                            .foregroundColor(.white.opacity(0.4))
-                    }
-                } else {
-                    Text("Ran it together? Add a co-poster")
-                        .font(.system(size: 14, weight: .semibold, design: .rounded))
-                        .foregroundColor(.white.opacity(0.7))
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 12, weight: .bold))
-                        .foregroundColor(.white.opacity(0.4))
-                }
-            }
-            .padding(MADTheme.Spacing.md)
-            .background(
-                RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
-                    .fill(Color.white.opacity(0.06))
-            )
-        }
-        .buttonStyle(.plain)
-        .sheet(isPresented: $showCoauthorPicker) {
-            CoauthorPickerSheet(friends: friendService.friends) { picked in
-                vm.coauthor = picked
-            }
-        }
-    }
-
-    /// Story / Feed / Both — a single deliberate destination choice, so the
-    /// story stays the ephemeral moment and the feed stays the curated record.
-    /// Nothing is preselected: Share stays disabled until the user picks, and
-    /// the picked card is unmistakable (gradient fill + checkmark badge).
-    private var destinationToggles: some View {
-        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
-            editorLabel("SHARE TO")
-            HStack(spacing: MADTheme.Spacing.sm) {
-                ForEach(PostDestination.allCases) { dest in
-                    destinationCard(dest, selected: vm.destination == dest)
-                }
-            }
-            if let dest = vm.destination {
-                Text(dest.footnote)
-                    .font(.system(size: 12, weight: .medium, design: .rounded))
-                    .foregroundColor(.white.opacity(0.5))
-                    .fixedSize(horizontal: false, vertical: true)
-            } else {
-                Label("Pick where this goes — Share unlocks once you choose.",
-                      systemImage: "hand.tap.fill")
-                    .font(.system(size: 12, weight: .semibold, design: .rounded))
-                    .foregroundColor(MADTheme.Colors.madRed.opacity(0.9))
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-        .padding(MADTheme.Spacing.md)
-        .background(
-            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
-                .fill(Color.white.opacity(0.04))
-        )
-        // Until a destination is chosen this section is the one thing left to
-        // do — a soft accent border pulls the eye to it.
-        .overlay(
-            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
-                .strokeBorder(
-                    MADTheme.Colors.madRed.opacity(vm.destination == nil ? 0.45 : 0),
-                    lineWidth: 1.5
-                )
-        )
-        .animation(.easeInOut(duration: 0.2), value: vm.destination)
-    }
-
-    private func destinationCard(_ dest: PostDestination, selected: Bool) -> some View {
-        Button {
-            MADHaptics.tap()
-            withAnimation(.easeInOut(duration: 0.15)) { vm.destination = dest }
-        } label: {
-            VStack(spacing: 4) {
-                Image(systemName: dest.icon)
-                    .font(.system(size: 16, weight: .bold))
-                Text(dest.title)
-                    .font(.system(size: 13, weight: .bold, design: .rounded))
-            }
-            .foregroundColor(selected ? .white : .white.opacity(0.55))
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 12)
-            .background(
-                RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
-                    .fill(selected
-                        ? AnyShapeStyle(MADTheme.Colors.redGradient)
-                        : AnyShapeStyle(Color.white.opacity(0.06)))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
-                    .strokeBorder(Color.white.opacity(selected ? 0 : 0.1), lineWidth: 1)
-            )
-            .overlay(alignment: .topTrailing) {
-                if selected {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 14, weight: .bold))
-                        .foregroundStyle(.white, .black.opacity(0.35))
-                        .padding(5)
-                        .transition(.scale.combined(with: .opacity))
-                }
-            }
-        }
-        .buttonStyle(.plain)
-    }
 }
 
 /// Pick one accepted friend as the post's co-author (Instagram collab style).

--- a/app/Mile A Day/Views/Feed/PostShareStepView.swift
+++ b/app/Mile A Day/Views/Feed/PostShareStepView.swift
@@ -1,0 +1,393 @@
+import SwiftUI
+
+/// Step 2 of the composer — Instagram's share screen.
+///
+/// The whole reason this screen exists: the caption used to be the fifth section of
+/// one long scroll, below the entire sticker editor, so on a phone it sat under the
+/// fold and people genuinely could not find it. Here it is the first thing on
+/// screen, sitting beside a thumbnail of what they just composed, with the
+/// destination picker — the control that actually gates Share — immediately below
+/// it rather than several scrolls down.
+struct PostShareStepView: View {
+    @ObservedObject var vm: PostComposerViewModel
+    @ObservedObject var friendService: FriendService
+    /// Terms accepted AND `vm.canPublish`. Resolved by the composer, which owns the
+    /// terms state machine.
+    let shareEnabled: Bool
+    /// Owned by `PostComposerView` — it holds the terms switch, `publish()`,
+    /// `onFinished` and `dismiss()`.
+    ///
+    /// NEVER call `dismiss()` from this view. Inside a `navigationDestination`,
+    /// `@Environment(\.dismiss)` POPS the push instead of dismissing the composer,
+    /// so a publish that dismissed from here would drop the user back on the edit
+    /// step with a post already live. Everything terminal stays in the parent.
+    let onShare: () -> Void
+    /// Pops back to the edit step (also wired to the thumbnail).
+    let onEditMedia: () -> Void
+
+    @FocusState private var captionFocused: Bool
+    @State private var showCoauthorPicker = false
+
+    /// Instagram auto-focuses its caption field. We deliberately don't: `destination`
+    /// starts nil on purpose and gates Share, so raising the keyboard on entry would
+    /// hide the destination picker — recreating, one screen down, the exact
+    /// below-the-fold problem this redesign fixes. The field is already first on
+    /// screen, which is the discoverability fix that actually mattered. Flip this
+    /// only if the destination ever gains a sensible default.
+    private let autoFocusCaption = false
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: MADTheme.Spacing.lg) {
+                    captionRow
+                    if !captionMentionCandidates.isEmpty { mentionRail }
+
+                    Divider().overlay(Color.white.opacity(0.08))
+
+                    destinationSection
+                    // Collabs are a feed concept — only offered once the chosen
+                    // destination actually includes the feed.
+                    if vm.destination?.toFeed == true { coauthorRow }
+                    if vm.hasRoute { routeToggle }
+
+                    if let error = vm.errorMessage {
+                        Text(error)
+                            .font(.system(size: 13, weight: .semibold, design: .rounded))
+                            .foregroundColor(MADTheme.Colors.error)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(MADTheme.Spacing.md)
+            }
+            .scrollDismissesKeyboard(.interactively)
+        }
+        .navigationTitle("Share")
+        .navigationBarTitleDisplayMode(.inline)
+        // Toolbar background does not reliably inherit across a push — re-declare it
+        // or this screen gets a translucent bar while the edit step has a solid one.
+        .toolbarBackground(.black, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                if vm.isPublishing {
+                    ProgressView().tint(.white)
+                } else {
+                    Button("Share", action: onShare)
+                        .fontWeight(.bold)
+                        .foregroundColor(shareEnabled
+                            ? MADTheme.Colors.madRed : .white.opacity(0.3))
+                        .disabled(!vm.canPublish)
+                }
+            }
+        }
+        .onAppear {
+            if autoFocusCaption { captionFocused = true }
+        }
+    }
+
+    // MARK: - Caption (the fix)
+
+    private var captionRow: some View {
+        HStack(alignment: .top, spacing: MADTheme.Spacing.md) {
+            thumbnail
+            VStack(alignment: .leading, spacing: 6) {
+                TextField(
+                    "",
+                    text: $vm.caption,
+                    prompt: Text("Write a caption… (@ to tag a friend)")
+                        .foregroundColor(.white.opacity(0.4)),
+                    axis: .vertical
+                )
+                .lineLimit(3...7)
+                .focused($captionFocused)
+                .font(.system(size: 15, weight: .medium, design: .rounded))
+                .foregroundColor(.white)
+                // No filled box: flat beside the thumbnail, the way Instagram's
+                // share screen reads.
+                .textInputAutocapitalization(.sentences)
+
+                HStack {
+                    // Anchored to the field it dismisses (a keyboard-toolbar Done
+                    // floated as a detached pill over the counter on iOS 26) —
+                    // Return adds newlines in this multi-line field, so this is
+                    // THE way to put the keyboard away.
+                    if captionFocused {
+                        Button {
+                            captionFocused = false
+                        } label: {
+                            HStack(spacing: 4) {
+                                Image(systemName: "keyboard.chevron.compact.down")
+                                    .font(.system(size: 11, weight: .bold))
+                                Text("Done")
+                                    .font(.system(size: 12, weight: .bold, design: .rounded))
+                            }
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(Capsule().fill(MADTheme.Colors.redGradient))
+                        }
+                        .buttonStyle(.plain)
+                        .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                    }
+                    Spacer()
+                    Text("\(vm.caption.count)/280")
+                        .font(.system(size: 11, weight: .semibold, design: .rounded))
+                        .foregroundColor(vm.caption.count > 280
+                            ? MADTheme.Colors.error : .white.opacity(0.4))
+                }
+                .animation(.easeInOut(duration: 0.15), value: captionFocused)
+            }
+        }
+        .onChange(of: vm.caption) { _, newValue in
+            if newValue.count > 280 { vm.caption = String(newValue.prefix(280)) }
+        }
+    }
+
+    /// Shows the FLATTENED composite, so the thumbnail is literally what gets
+    /// uploaded — sticker baked in, cropped to 4:5 exactly as the feed will show it.
+    private var thumbnail: some View {
+        Button {
+            MADHaptics.tap()
+            onEditMedia()
+        } label: {
+            Group {
+                if let image = vm.previewComposite ?? vm.pickedImage {
+                    Image(uiImage: image).resizable().scaledToFill()
+                } else {
+                    Color.white.opacity(0.06)
+                }
+            }
+            .frame(width: 68, height: 85)          // 4:5, matching the canvas
+            .clipShape(RoundedRectangle(cornerRadius: MADTheme.CornerRadius.small,
+                                        style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: MADTheme.CornerRadius.small,
+                                 style: .continuous)
+                    .strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
+            )
+            .overlay(alignment: .bottomTrailing) {
+                Image(systemName: "pencil")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundColor(.white)
+                    .padding(4)
+                    .background(Circle().fill(.black.opacity(0.65)))
+                    .padding(3)
+            }
+        }
+        .buttonStyle(ScaleButtonStyle())
+        .accessibilityLabel("Edit photo")
+    }
+
+    // MARK: - @mentions
+
+    /// Friends matching an @token being typed at the end of the caption.
+    /// Explicit types — inference across filter/prefix chains slows the
+    /// type checker to a crawl.
+    private var captionMentionCandidates: [BackendUser] {
+        guard let token = vm.caption.split(separator: " ").last,
+              token.hasPrefix("@") else { return [] }
+        let query: String = String(token.dropFirst()).lowercased()
+        let matches: [BackendUser] = friendService.friends.filter { friend in
+            guard let name = friend.username?.lowercased() else { return false }
+            return query.isEmpty || name.hasPrefix(query)
+        }
+        return Array(matches.prefix(8))
+    }
+
+    private func completeCaptionMention(_ friend: BackendUser) {
+        var parts = vm.caption.split(separator: " ", omittingEmptySubsequences: false)
+        if let last = parts.last, last.hasPrefix("@") { parts.removeLast() }
+        vm.caption = (parts + ["@\(friend.username ?? "") "]).joined(separator: " ")
+    }
+
+    private var mentionRail: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(captionMentionCandidates, id: \.user_id) { friend in
+                    Button {
+                        completeCaptionMention(friend)
+                    } label: {
+                        HStack(spacing: 6) {
+                            AvatarView(name: friend.username ?? "?",
+                                       imageURL: friend.profile_image_url, size: 22)
+                            Text("@\(friend.username ?? "")")
+                                .font(.system(size: 13, weight: .bold, design: .rounded))
+                                .foregroundColor(.white)
+                        }
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(Capsule().fill(Color.white.opacity(0.08)))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.vertical, 2)
+        }
+    }
+
+    // MARK: - Destination
+
+    /// Story / Feed / Both — a single deliberate destination choice, so the
+    /// story stays the ephemeral moment and the feed stays the curated record.
+    /// Nothing is preselected: Share stays disabled until the user picks. That was
+    /// always the intent; the problem was that this section used to sit below the
+    /// fold, so the reason Share was greyed out was invisible. Here it's the second
+    /// thing on the screen.
+    private var destinationSection: some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+            sectionLabel("SHARE TO")
+            HStack(spacing: MADTheme.Spacing.sm) {
+                ForEach(PostDestination.allCases) { dest in
+                    destinationCard(dest, selected: vm.destination == dest)
+                }
+            }
+            if let dest = vm.destination {
+                Text(dest.footnote)
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundColor(.white.opacity(0.5))
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Label("Pick where this goes — Share unlocks once you choose.",
+                      systemImage: "hand.tap.fill")
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                    .foregroundColor(MADTheme.Colors.madRed.opacity(0.9))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(MADTheme.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
+                .fill(Color.white.opacity(0.04))
+        )
+        // Until a destination is chosen this section is the one thing left to
+        // do — a soft accent border pulls the eye to it.
+        .overlay(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
+                .strokeBorder(
+                    MADTheme.Colors.madRed.opacity(vm.destination == nil ? 0.45 : 0),
+                    lineWidth: 1.5
+                )
+        )
+        .animation(.easeInOut(duration: 0.2), value: vm.destination)
+    }
+
+    private func destinationCard(_ dest: PostDestination, selected: Bool) -> some View {
+        Button {
+            MADHaptics.tap()
+            withAnimation(.easeInOut(duration: 0.15)) { vm.destination = dest }
+        } label: {
+            VStack(spacing: 4) {
+                Image(systemName: dest.icon)
+                    .font(.system(size: 16, weight: .bold))
+                Text(dest.title)
+                    .font(.system(size: 13, weight: .bold, design: .rounded))
+            }
+            .foregroundColor(selected ? .white : .white.opacity(0.55))
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
+                    .fill(selected
+                        ? AnyShapeStyle(MADTheme.Colors.redGradient)
+                        : AnyShapeStyle(Color.white.opacity(0.06)))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
+                    .strokeBorder(Color.white.opacity(selected ? 0 : 0.1), lineWidth: 1)
+            )
+            .overlay(alignment: .topTrailing) {
+                if selected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundStyle(.white, .black.opacity(0.35))
+                        .padding(5)
+                        .transition(.scale.combined(with: .opacity))
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Co-poster
+
+    /// "Ran it together?" — pick ONE friend to co-post with. They're invited
+    /// on share and the post goes dual-author once they accept.
+    private var coauthorRow: some View {
+        Button { showCoauthorPicker = true } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "person.2.fill")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundColor(MADTheme.Colors.madRed)
+                if let coauthor = vm.coauthor {
+                    AvatarView(name: coauthor.username ?? "?",
+                               imageURL: coauthor.profile_image_url, size: 26)
+                    Text("Co-posting with @\(coauthor.username ?? "")")
+                        .font(.system(size: 14, weight: .bold, design: .rounded))
+                        .foregroundColor(.white)
+                    Spacer()
+                    Button {
+                        vm.coauthor = nil
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 16))
+                            .foregroundColor(.white.opacity(0.4))
+                    }
+                } else {
+                    Text("Ran it together? Add a co-poster")
+                        .font(.system(size: 14, weight: .semibold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.7))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+            }
+            .padding(MADTheme.Spacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
+                    .fill(Color.white.opacity(0.06))
+            )
+        }
+        .buttonStyle(.plain)
+        .sheet(isPresented: $showCoauthorPicker) {
+            CoauthorPickerSheet(friends: friendService.friends) { picked in
+                vm.coauthor = picked
+            }
+        }
+    }
+
+    // MARK: - Route
+
+    /// Offer to ride the run's GPS route along with the photo (shown as a
+    /// second, swipeable slide on the feed card). Only offered when the linked
+    /// workout actually has route data.
+    private var routeToggle: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Toggle(isOn: $vm.includeRoute.animation(.easeInOut)) {
+                Label("Include route map", systemImage: "map.fill")
+                    .font(.system(size: 15, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white)
+            }
+            .tint(MADTheme.Colors.madRed)
+            Text("Friends can swipe to see your mile's path next to the photo.")
+                .font(.system(size: 12, weight: .medium, design: .rounded))
+                .foregroundColor(.white.opacity(0.5))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(MADTheme.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
+                .fill(Color.white.opacity(0.04))
+        )
+    }
+
+    private func sectionLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 10, weight: .heavy, design: .rounded))
+            .tracking(1.2)
+            .foregroundColor(.white.opacity(0.4))
+    }
+}

--- a/app/Mile A Day/Views/Feed/RunStatsStickerView.swift
+++ b/app/Mile A Day/Views/Feed/RunStatsStickerView.swift
@@ -33,6 +33,11 @@ enum RunStatKind: String, CaseIterable, Identifiable, Codable {
 }
 
 /// Visual templates for the overlay. The user can flip between them live.
+///
+/// These deliberately have no `icon`: the picker used to be text chips with
+/// abstract SF Symbols (`rectangle.fill`, `minus.rectangle.fill`, …), which told
+/// you nothing about what a style actually looked like. `StickerTrayView` renders
+/// a live miniature of each style instead, so the name is the only label needed.
 enum StickerStyle: String, CaseIterable, Identifiable, Codable {
     case card, minimal, stacked, streak
     var id: String { rawValue }
@@ -42,14 +47,6 @@ enum StickerStyle: String, CaseIterable, Identifiable, Codable {
         case .minimal: return "Minimal"
         case .stacked: return "Stacked"
         case .streak: return "Streak"
-        }
-    }
-    var icon: String {
-        switch self {
-        case .card: return "rectangle.fill"
-        case .minimal: return "minus.rectangle.fill"
-        case .stacked: return "list.bullet.rectangle.fill"
-        case .streak: return "flame.fill"
         }
     }
 }
@@ -207,6 +204,12 @@ struct RunStatsStickerView: View, Equatable {
 
     private var minimalStyle: some View {
         HStack(spacing: 8) {
+            // Every other style carries `brandLine`; without this one, Minimal was
+            // just a generic stats pill and didn't read as a Mile A Day sticker.
+            MADLogoMark(size: 15, opacity: 0.85, shadow: false)
+            Capsule()
+                .fill(Color.white.opacity(0.25))
+                .frame(width: 1, height: 12)
             ForEach(Array(data.enumerated()), id: \.element.id) { idx, datum in
                 if idx > 0 {
                     Circle().fill(Color.white.opacity(0.4)).frame(width: 3, height: 3)

--- a/app/Mile A Day/Views/Feed/SocialFeedView.swift
+++ b/app/Mile A Day/Views/Feed/SocialFeedView.swift
@@ -268,6 +268,30 @@ struct SocialFeedView: View {
     var body: some View {
         VStack(spacing: 0) {
             MADTabHeader(title: "Feed")
+                // The composer is a fullScreenCover, not a sheet: a sheet's
+                // swipe-down flipped this binding without ever calling
+                // onFinished, so a fully composed draft evaporated AND the
+                // shared-workout bookkeeping below never ran.
+                //
+                // It hangs off the header rather than the VStack because the
+                // VStack chain already owns the story-viewer cover — two covers
+                // on one node silently drop a presentation. The header is
+                // unconditional and always mounted, unlike composeButton, which
+                // disappears the moment a workout is shared and would take the
+                // cover down with it mid-dismissal.
+                .fullScreenCover(isPresented: $presentingComposer) {
+                    PostComposerView(stats: statsInput) { outcome in
+                        if case .published = outcome {
+                            // Lock this run's share slot immediately — refresh() is async
+                            // and its window previously let the composer re-open for the
+                            // same workout. (The backend also 409s a second share now.)
+                            if let wid = statsInput.workoutId {
+                                optimisticSharedWorkoutIds.insert(wid)
+                            }
+                            Task { await refresh() }
+                        }
+                    }
+                }
 
             ScrollViewReader { proxy in
             ScrollView {
@@ -418,19 +442,6 @@ struct SocialFeedView: View {
                     // Even a plain watch-through changes rail state (viewed
                     // rings) — refresh just the rail so rings gray out.
                     Task { await refreshRail() }
-                }
-            }
-        }
-        .sheet(isPresented: $presentingComposer) {
-            PostComposerView(stats: statsInput) { outcome in
-                if case .published = outcome {
-                    // Lock this run's share slot immediately — refresh() is async
-                    // and its window previously let the composer re-open for the
-                    // same workout. (The backend also 409s a second share now.)
-                    if let wid = statsInput.workoutId {
-                        optimisticSharedWorkoutIds.insert(wid)
-                    }
-                    Task { await refresh() }
                 }
             }
         }

--- a/app/Mile A Day/Views/Feed/StickerBounds.swift
+++ b/app/Mile A Day/Views/Feed/StickerBounds.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+/// Natural (untransformed) size of a sticker, reported up from a `GeometryReader`
+/// placed UNDER any `scaleEffect`/`rotationEffect`. Because the probe sits below the
+/// transforms, the value it reports is constant for a given style + config, so it
+/// settles once instead of firing every gesture frame.
+///
+/// iOS 17 deployment target — `onGeometryChange` is iOS 18+, so measurement goes
+/// through a preference key (same pattern as `RoadDateMarkerPreferenceKey`).
+struct StickerNaturalSizeKey: PreferenceKey {
+    static var defaultValue: CGSize = .zero
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+        let next = nextValue()
+        // A zero from a sibling/placeholder must never clobber a real measurement.
+        if next != .zero { value = next }
+    }
+}
+
+/// Position ranges that keep a sticker's ROTATED bounding box inside the canvas.
+///
+/// `StickerConfig.posXRange` / `posYRange` clamp the sticker's CENTER only, with no
+/// idea how big the sticker is — so a wide style (`stacked` has `minWidth: 180`) at
+/// max pinch (`StickerConfig.scaleRange` tops out at 1.9) dragged to the edge gets
+/// chopped by the canvas `.clipped()`. Those static ranges stay exactly as they are:
+/// they remain the coarse decode-time sanitizer for persisted values and the
+/// fallback when nothing has been measured yet. THIS is the live, size-aware truth
+/// that the editor actually clamps against.
+enum StickerBounds {
+    /// A few points of deliberate bleed so a sticker can kiss the canvas edge
+    /// instead of always floating with a hairline gap.
+    static let bleed: CGFloat = 4
+
+    /// Pinch range narrowed so the sticker can never grow wider or taller than the
+    /// canvas in the first place.
+    ///
+    /// `StickerConfig.scaleRange` tops out at 1.9, but a Card sticker's natural
+    /// width is already ~210pt — 1.9× is ~399pt on a ~360pt canvas, i.e. bigger
+    /// than the photo it sits on. No amount of position clamping can rescue that;
+    /// the size itself has to be bounded. Measured against the UNROTATED footprint
+    /// on purpose: deriving the cap from the rotated bounding box would make the
+    /// sticker shrink as you twist it, which feels broken.
+    static func scaleRange(natural: CGSize, canvas: CGSize) -> ClosedRange<CGFloat> {
+        let base = StickerConfig.scaleRange
+        guard natural.width > 0, natural.height > 0,
+              canvas.width > 0, canvas.height > 0 else { return base }
+        let fits = min((canvas.width - bleed * 2) / natural.width,
+                       (canvas.height - bleed * 2) / natural.height)
+        // Never let the cap fall below the floor — a sticker with no room at all
+        // still needs a valid (degenerate) range rather than an inverted one.
+        let upper = max(base.lowerBound, min(base.upperBound, fits))
+        return base.lowerBound...upper
+    }
+
+    /// Legal normalized center ranges for a sticker of `natural` size drawn at
+    /// `scale` and `rotation` on a `canvas`.
+    static func ranges(
+        natural: CGSize,
+        scale: CGFloat,
+        rotation: Angle,
+        canvas: CGSize
+    ) -> (x: ClosedRange<CGFloat>, y: ClosedRange<CGFloat>) {
+        guard natural.width > 0, natural.height > 0,
+              canvas.width > 0, canvas.height > 0 else {
+            return (StickerConfig.posXRange, StickerConfig.posYRange)
+        }
+
+        // Axis-aligned bounding box of the rotated sticker.
+        let c = abs(cos(rotation.radians))
+        let s = abs(sin(rotation.radians))
+        let boxW = (natural.width * c + natural.height * s) * scale
+        let boxH = (natural.width * s + natural.height * c) * scale
+
+        return (x: range(half: boxW / 2, span: canvas.width),
+                y: range(half: boxH / 2, span: canvas.height))
+    }
+
+    /// One axis. A sticker larger than the canvas has no legal interval, so it is
+    /// pinned dead center — handing `clamped(to:)` an inverted range would trap.
+    private static func range(half: CGFloat, span: CGFloat) -> ClosedRange<CGFloat> {
+        let margin = max(0, (half - bleed) / span)
+        return margin >= 0.5 ? 0.5...0.5 : margin...(1 - margin)
+    }
+}

--- a/app/Mile A Day/Views/Feed/StickerTrayView.swift
+++ b/app/Mile A Day/Views/Feed/StickerTrayView.swift
@@ -1,0 +1,263 @@
+import SwiftUI
+
+/// The composer's sticker picker.
+///
+/// Replaces the old "Show run stats" toggle + abstract-icon STYLE chip row. Each
+/// tile renders the REAL `RunStatsStickerView` for its style, using the user's
+/// current accent and enabled stats, scaled down to fit — so you can see what a
+/// style looks like before you pick it, the way Instagram's filter thumbnails work.
+/// The leading "Off" tile takes the place of the toggle.
+struct StickerTrayView: View {
+    let input: RunStatsInput
+    @Binding var config: StickerConfig
+    @Binding var isEnabled: Bool
+    /// True when the sticker has been dragged / pinched / twisted off its default
+    /// placement — gates the Reset control so it isn't permanent chrome.
+    let isTransformed: Bool
+    let onReset: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
+            HStack {
+                trayLabel("STICKER")
+                Spacer()
+                if isEnabled, isTransformed { resetButton }
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: MADTheme.Spacing.sm) {
+                    offTile
+                    ForEach(StickerStyle.allCases) { style in
+                        StickerStyleTile(
+                            input: input,
+                            config: tileConfig(for: style),
+                            selected: isEnabled && config.style == style
+                        ) {
+                            MADHaptics.tap()
+                            withAnimation(.easeInOut(duration: 0.15)) {
+                                isEnabled = true
+                                config.style = style
+                            }
+                        }
+                    }
+                }
+                // Room for the selected tile's ring + glow, which a ScrollView
+                // would otherwise clip at its bounds.
+                .padding(6)
+            }
+            // Pull the rail back out by the same amount so the first tile still
+            // lines up with the labels above it.
+            .padding(-6)
+
+            if isEnabled {
+                trayLabel("SHOW")
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: MADTheme.Spacing.sm) {
+                        ForEach(input.availableStats()) { kind in
+                            trayChip(title: kind.label, icon: kind.icon,
+                                     selected: config.isOn(kind)) {
+                                MADHaptics.tap()
+                                config.toggle(kind)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+
+                trayLabel("COLOR")
+                HStack(spacing: MADTheme.Spacing.md) {
+                    ForEach(StickerAccent.allCases) { accent in
+                        Button {
+                            MADHaptics.tap()
+                            config.accent = accent
+                        } label: {
+                            Circle()
+                                .fill(accent.color)
+                                .frame(width: 26, height: 26)
+                                .overlay(
+                                    Circle().strokeBorder(
+                                        Color.white,
+                                        lineWidth: config.accent == accent ? 2.5 : 0
+                                    )
+                                )
+                                .overlay(
+                                    Circle().strokeBorder(Color.white.opacity(0.2), lineWidth: 1)
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel(accent.rawValue)
+                    }
+                    Spacer()
+                }
+            }
+        }
+        .padding(MADTheme.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium)
+                .fill(Color.white.opacity(0.04))
+        )
+        .animation(.easeInOut(duration: 0.2), value: isEnabled)
+    }
+
+    /// The tile previews ITS style but keeps the user's live accent and stat
+    /// selection, so changing a colour or toggling a stat updates every tile.
+    private func tileConfig(for style: StickerStyle) -> StickerConfig {
+        var cfg = config
+        cfg.style = style
+        return cfg
+    }
+
+    private var offTile: some View {
+        Button {
+            MADHaptics.tap()
+            withAnimation(.easeInOut(duration: 0.15)) { isEnabled = false }
+        } label: {
+            VStack(spacing: 6) {
+                ZStack {
+                    StickerTileChrome(selected: !isEnabled)
+                    Image(systemName: "eye.slash")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundColor(.white.opacity(!isEnabled ? 0.9 : 0.4))
+                }
+                .frame(width: StickerStyleTile.tileSize.width,
+                       height: StickerStyleTile.tileSize.height)
+                Text("Off")
+                    .font(.system(size: 10, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(!isEnabled ? 0.95 : 0.5))
+            }
+        }
+        .buttonStyle(ScaleButtonStyle())
+        .accessibilityLabel("No sticker")
+    }
+
+    private var resetButton: some View {
+        Button {
+            MADHaptics.tap()
+            onReset()
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "arrow.counterclockwise")
+                    .font(.system(size: 10, weight: .bold))
+                Text("Reset")
+                    .font(.system(size: 11, weight: .bold, design: .rounded))
+            }
+            .foregroundColor(.white.opacity(0.85))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(Capsule().fill(Color.white.opacity(0.1)))
+        }
+        .buttonStyle(.plain)
+        .transition(.opacity.combined(with: .scale(scale: 0.9)))
+        .accessibilityLabel("Reset sticker position")
+    }
+
+    private func trayLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 10, weight: .heavy, design: .rounded))
+            .tracking(1.2)
+            .foregroundColor(.white.opacity(0.4))
+    }
+
+    private func trayChip(title: String, icon: String, selected: Bool,
+                          action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 5) {
+                Image(systemName: icon).font(.system(size: 11, weight: .bold))
+                Text(title).font(.system(size: 13, weight: .bold, design: .rounded))
+            }
+            .foregroundColor(selected ? .white : .white.opacity(0.6))
+            .padding(.horizontal, 12).padding(.vertical, 7)
+            .background(
+                Capsule().fill(selected
+                    ? AnyShapeStyle(MADTheme.Colors.redGradient)
+                    : AnyShapeStyle(Color.white.opacity(0.07)))
+            )
+            .overlay(
+                Capsule().strokeBorder(Color.white.opacity(selected ? 0 : 0.12), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Tile
+
+/// Shared tile backdrop so the Off tile and the style tiles are visually identical.
+private struct StickerTileChrome: View {
+    let selected: Bool
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .fill(Color.white.opacity(0.05))
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .strokeBorder(
+                        selected ? MADTheme.Colors.madRed : Color.white.opacity(0.1),
+                        lineWidth: selected ? 2 : 1
+                    )
+            )
+            .shadow(color: selected ? MADTheme.Colors.madRed.opacity(0.35) : .clear,
+                    radius: selected ? 8 : 0)
+    }
+}
+
+/// One style preview.
+///
+/// `RunStatsStickerView` is `.fixedSize()`, so it can't simply be handed a small
+/// frame. Instead the natural size is measured and the sticker is scaled down to
+/// fit: `scaleEffect` is layout-neutral, so the surrounding `.frame` still reports
+/// tile size upward and `.clipped()` trims anything left over — no layout blowup.
+///
+/// Rendering the live view (rather than pre-baking each style to a `UIImage`) means
+/// the tiles are genuinely WYSIWYG and update the instant the accent or a stat
+/// toggle changes, with no cache to invalidate.
+private struct StickerStyleTile: View {
+    let input: RunStatsInput
+    let config: StickerConfig
+    let selected: Bool
+    let action: () -> Void
+
+    static let tileSize = CGSize(width: 84, height: 105)   // 4:5, echoing the canvas
+    /// Breathing room so the sticker's own drop shadow doesn't hit the tile edge.
+    private static let inset: CGFloat = 14
+
+    @State private var natural: CGSize = .zero
+
+    private var fit: CGFloat {
+        guard natural.width > 0, natural.height > 0 else { return 0.001 }
+        return min((Self.tileSize.width - Self.inset) / natural.width,
+                   (Self.tileSize.height - Self.inset) / natural.height)
+    }
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 6) {
+                ZStack {
+                    StickerTileChrome(selected: selected)
+                    RunStatsStickerView(input: input, config: config)
+                        .equatable()                  // must sit directly on the sticker
+                        .background(                  // outside .equatable(), under the
+                            GeometryReader { geo in   // scale → reports NATURAL size once
+                                Color.clear.preference(
+                                    key: StickerNaturalSizeKey.self, value: geo.size)
+                            }
+                        )
+                        .scaleEffect(fit, anchor: .center)
+                        // Hide the single frame before the measurement lands, or the
+                        // sticker flashes at full size inside a 84pt tile.
+                        .opacity(natural == .zero ? 0 : 1)
+                }
+                .frame(width: Self.tileSize.width, height: Self.tileSize.height)
+                .clipped()
+                .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+
+                Text(config.style.title)
+                    .font(.system(size: 10, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(selected ? 0.95 : 0.5))
+            }
+        }
+        .buttonStyle(ScaleButtonStyle())
+        .onPreferenceChange(StickerNaturalSizeKey.self) { natural = $0 }
+        .accessibilityLabel("\(config.style.title) sticker")
+    }
+}


### PR DESCRIPTION
## Why

Users couldn't find the caption field when creating a post. The cause is structural, not cosmetic — the composer was one long scroll and the caption was the **5th of 8** sections, below the entire sticker style panel:

```
canvas (4:5) → sticker editor (toggle + STYLE + SHOW + COLOR) → route toggle
→ CAPTION → co-poster → Share to
```

On a phone the 4:5 canvas plus the sticker panel fill the whole first screen, so the caption *and* the destination picker were under the fold. That produced two separate confusions: "where do I write something?" and "why is Share greyed out?" (the destination picker is what gates Share, and the explanation was off-screen).

## What changed

### Two screens, Instagram's grammar

| Step 1 — Edit | Step 2 — Share |
|---|---|
| photo + sticker tools only, `Next` top-right | thumbnail + caption **side by side at the top**, then Share to / co-poster / route, `Share` top-right |

The caption is now the first thing on screen and the destination picker is second.

Implemented as `NavigationStack(path:)` + `navigationDestination` rather than an in-place step swap, so step 1 stays **mounted** — the canvas `GeometryReader` feeding `vm.canvasSize` and every `fullScreenCover` node survive the push — and back-swipe is native.

One trap this creates, and the mitigation: inside a `navigationDestination`, `@Environment(\.dismiss)` **pops the push instead of dismissing the composer**. `PostShareStepView` therefore has no dismiss capability at all — no `@Environment`, no `onFinished` — and receives closures only. The terms switch, `publish()`, `onFinished` and `dismiss()` all stay in `PostComposerView`.

Destination stays unselected by design (no accidental story posts); it's just no longer hidden.

### Sticker

- **Visual picker.** Each tile renders the *real* `RunStatsStickerView` for its style, scaled to fit, so you see a style before choosing it. Previously they were text chips labelled with abstract SF Symbols (`rectangle.fill`, `minus.rectangle.fill`, …) — you couldn't tell what "Stacked" looked like without selecting it and glancing back at the canvas. The leading **Off** tile replaces the "Show run stats" toggle.
- **Fixes edge clipping (real bug).** `StickerConfig.posXRange` clamped the sticker's *centre* while ignoring its size. A Stacked sticker at max pinch is ~342pt on a ~360pt canvas — centred at `0.88` its right edge landed at 488pt, **128pt past the canvas**, and got chopped by `.clipped()`. Bounds are now derived from the measured size and its rotated bounding box. That alone isn't enough: a Card sticker at 1.9× is ~399pt, genuinely wider than the canvas, so the pinch range is also capped to what fits. Verified numerically — every style, at max pinch, in every position, on both a 390pt phone and an SE-sized one, stays inside the canvas. Both clamps also repair a transform persisted by an older build.
- **Minimal is branded.** It was the only style with no `MADLogoMark`, so it read as a generic stats pill rather than a Mile A Day sticker.
- **Placement polish.** Centre snap with guides and a one-shot haptic, a selection ring while manipulating, and a reset control. Snapping is applied to the live value *and* the commit identically, so release never jumps — the same invariant the existing clamp already held.

### Bugs fixed along the way

- **Silent draft loss.** The feed presented the composer as a `.sheet`; a swipe-down flipped the binding **without calling `onFinished`**, so a fully composed draft evaporated *and* `optimisticSharedWorkoutIds` / `refresh()` never ran. Now a `fullScreenCover` — attached to the tab header node, because the `VStack` chain already owns the story-viewer cover and two covers on one node silently drop a presentation. Not `composeButton`: it's conditional and disappears the moment a workout is shared, which would take the cover down mid-dismissal.
- **No discard confirmation.** Cancel with a draft destroyed it instantly. It now confirms — except on the post-run `Back` path, which is navigational and returns to a prompt that still holds the mid-run snaps, so nothing is lost there (and "Cancel" was renamed to "Back" on that path precisely because people feared losing photos).
- **Couldn't switch to the library.** After picking a photo the only affordance was "Retake"; the workout-window library option vanished. A `Menu` now offers both — and `Menu` rides UIKit's context-menu machinery, so it costs no cover node.

## Presentation node map

Four presentations, four distinct nodes (`.claude/rules/ios.md`):

| Presentation | Node |
|---|---|
| Terms gate | `NavigationStack` — the only node current on **both** steps |
| Camera | root `ZStack` |
| Discard dialog | `ScrollView` |
| Library import | `canvasSection` |
| Change photo | `Menu` (no node cost) |

## Unchanged on purpose

Backend contract (`POST /posts` fields, sticker still baked client-side — no API change, no deploy ordering), `flatten()` ↔ `canvasSize` parity, the terms state machine (camera never gated; declining with a draft preserves it), the `onFinished` contract, the `StickerConfig` merge-back that keeps a remembered-but-unavailable stat from being erased by one treadmill day, and `StickerEditorLayer`'s `@GestureState`/commit-on-`onEnded`/global-coordinate-space design.

Public init is unchanged, so both call sites compile as-is apart from the feed's sheet→cover move.

## App Review

No new permissions, entitlements, SDKs or data collection. The UGC guidelines gate (1.2) is untouched and still enforced before publish. All SF Symbols used predate SF Symbols 5, so nothing renders as a blank box on the iOS 17 deployment target.

## Testing — please read

**I could not build or run this.** The iOS app builds in Xcode only (no `xcodebuild` from CLI per `.claude/rules/ios.md`) and there's no iOS test runner, and this environment has no Swift toolchain. What I *did* verify: brace/paren balance across all six files, no iOS 18+ APIs, no cross-file dangling references, the share step has no dismiss capability, four presentations on four distinct nodes, and the clamp math numerically (script output in the session). **Everything below is unverified and needs a device pass:**

1. Build in Xcode — zero warnings from the new files.
2. **Clamp:** pick **Stacked**, pinch to max, drag into all four corners — no edge clipped. Rotate ~45°, repeat. Relaunch with an old persisted transform; it should snap into range on the first frame.
3. **Tray:** all four styles recognizable at tile size, no first-frame flash; changing COLOR or SHOW updates every tile live; Off hides the sticker.
4. **Feed path:** compose → Next → caption is first on screen → `@` autocomplete → Share dimmed until a destination is picked → back to Edit and forward again with caption/sticker/destination intact → Share → posted image matches the on-canvas preview.
5. **Post-run prompt:** auto-camera fires exactly once; "‹ Back" returns to the prompt with snaps intact and **no** discard dialog; story-only publish still triggers the auto route/stats card.
6. **Terms:** gate presents on step 1, camera still reachable, declining keeps the draft, and Share from **step 2** re-raises the gate (this is the proof the cover move worked).
7. **Cover collision:** after using the composer, open a story from the rail — the story viewer must still present.
8. `workoutId == nil`: change-photo collapses to a plain camera button.

## Flagged, not changed

Feed cards render `PostStatStrip` beneath the image from `stats_snapshot` *and* the sticker is baked into the image, so with the sticker on, distance/streak appear twice on a card. Suppressing the strip needs a server-side "has sticker" signal (an additive `posts` field) and touches shipped feed rendering for live users — out of scope here, worth a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_018wgtLCn9nRJftWjj8rqo7K)_