### PR TITLE
Explain why a friend's streak can't be assisted instead of showing nothing

### DIFF
--- a/app/Mile A Day/Views/Friends/SaveFriendStreakView.swift
+++ b/app/Mile A Day/Views/Friends/SaveFriendStreakView.swift
@@ -48,6 +48,13 @@ struct SaveFriendStreakView: View {
                     icon: "arrow.down.circle",
                     text: "\(friendName) needs the latest update to be saved"
                 )
+            case .beyondRescue(let multiDay):
+                infoPill(
+                    icon: "clock.arrow.circlepath",
+                    text: multiDay
+                        ? "\(friendName) has missed more than one day — a Streak Assist only covers a single miss"
+                        : "\(friendName)'s miss is too old to rescue — Assists reach back 2 days"
+                )
             case .available(let status):
                 if status.viewer_holds_assist {
                     saveButton(status)
@@ -143,8 +150,9 @@ struct SaveFriendStreakView: View {
                 .font(.system(size: 11, weight: .bold))
             Text(text)
                 .font(.system(size: style == .compact ? 10 : 11, weight: .semibold, design: .rounded))
-                .lineLimit(2)
+                .lineLimit(3)
                 .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
         }
         .foregroundColor(.white.opacity(0.45))
         .padding(.horizontal, style == .compact ? 11 : 14)
@@ -261,6 +269,10 @@ final class SaveFriendStreakModel: ObservableObject {
         /// They DO have a coverable miss, but their build predates streak
         /// tokens, so nothing can be written on their behalf.
         case friendNeedsUpdate
+        /// Their streak IS broken, but no single covered day brings it back —
+        /// a multi-day hole, or a miss older than the rescue window. Shown as
+        /// an explanation, because silence here reads as a broken feature.
+        case beyondRescue(multiDay: Bool)
         case available(FriendRescueStatus)
         case saving
         case saved(Int)
@@ -287,7 +299,12 @@ final class SaveFriendStreakModel: ObservableObject {
 
     private static func resolvePhase(for status: FriendRescueStatus) -> Phase {
         if status.available { return .available(status) }
-        return status.friendNotEnrolled ? .friendNeedsUpdate : .unavailable
+        if status.friendNotEnrolled { return .friendNeedsUpdate }
+        switch status.reason {
+        case "gap_too_wide": return .beyondRescue(multiDay: true)
+        case "window_passed": return .beyondRescue(multiDay: false)
+        default: return .unavailable
+        }
     }
 
     /// Returns the restored streak on success, nil on failure.

--- a/backend/src/services/streakFeatureService.ts
+++ b/backend/src/services/streakFeatureService.ts
@@ -831,13 +831,24 @@ export interface FriendRescueStatus {
   viewer_holds_assist: boolean;
   /** The caller's Assist meter, so a locked CTA can show how far off it is. */
   viewer_meter: { progress: number; target: number };
-  /** Why nothing is offered, when `available` is false. */
+  /**
+   * Why nothing is offered, when `available` is false.
+   *
+   * `gap_too_wide` / `window_passed` mean a break EXISTS but no single
+   * coverage row can bring it back — distinct from `no_recent_break`, which
+   * means there's nothing wrong with them at all. The client renders those two
+   * as an explanation rather than as silence: "no rescue possible" and "this
+   * feature is broken" looked identical before, which is how a friend three
+   * days into a gap read as a bug.
+   */
   reason?:
     | "disabled"
     | "not_enrolled"
     | "friend_not_enrolled"
     | "forbidden"
     | "no_recent_break"
+    | "gap_too_wide"
+    | "window_passed"
     | "self";
 }
 
@@ -880,22 +891,36 @@ export async function getFriendRescueStatus(
     },
   };
 
+  // How far gone is this friend's streak? Computed once and reused for every
+  // "no, and here's why" answer below. The profile renders NOTHING when a
+  // rescue isn't possible, so a vague reason is indistinguishable from the
+  // feature being broken — which is exactly how it read in practice.
+  const friendToday = await getUserLocalToday(friendId);
+  const facts = await recentDayFacts(friendId, dateStrMinus(friendToday, 4));
+  const dayOk = (d: string) => facts.qualified.has(d) || facts.covered.has(d);
+  const d1 = dateStrMinus(friendToday, 1);
+  const d2 = dateStrMinus(friendToday, 2);
+  const d3 = dateStrMinus(friendToday, 3);
+  // The only two shapes a single missed day can take (yesterday, or the day
+  // before with yesterday made up). Anything else is a multi-day hole that no
+  // single coverage row can bridge.
+  const singleDayMiss =
+    (!dayOk(d1) && dayOk(d2)) || (dayOk(d1) && !dayOk(d2) && dayOk(d3));
+  const multiDayGap = !dayOk(d1) && !dayOk(d2);
+
   // An un-enrolled friend can't be covered (their streak walk is the legacy
   // one and would never see the coverage row). Report that only when they
   // ACTUALLY have a break, so the profile can say "they need the update" at the
   // one moment it matters instead of on every friend who hasn't updated.
   if (!friendRow?.streak_features_at) {
-    const friendToday = await getUserLocalToday(friendId);
-    const facts = await recentDayFacts(friendId, dateStrMinus(friendToday, 4));
-    const ok = (d: string) => facts.qualified.has(d) || facts.covered.has(d);
-    const d1 = dateStrMinus(friendToday, 1);
-    const d2 = dateStrMinus(friendToday, 2);
-    const d3 = dateStrMinus(friendToday, 3);
-    const hasBreak = (!ok(d1) && ok(d2)) || (ok(d1) && !ok(d2) && ok(d3));
     return {
       ...base,
       available: false,
-      reason: hasBreak ? "friend_not_enrolled" : "no_recent_break",
+      reason: singleDayMiss
+        ? "friend_not_enrolled"
+        : multiDayGap
+          ? "gap_too_wide"
+          : "no_recent_break",
     };
   }
 
@@ -912,7 +937,6 @@ export async function getFriendRescueStatus(
   if (allowed.length === 0)
     return { ...base, available: false, reason: "forbidden" };
 
-  const friendToday = await getUserLocalToday(friendId);
   const stamped = await db.query<{ local_date: string; prior_streak: number }>(
     `SELECT to_char(e.local_date, 'YYYY-MM-DD') AS local_date, e.prior_streak
      FROM streak_events e
@@ -927,6 +951,9 @@ export async function getFriendRescueStatus(
   );
 
   let breakInfo: LiveBreak | null = null;
+  // Set when a break EXISTS but can't be rescued — the difference between
+  // "nothing to do here" and "too late", which the user has to be told.
+  let blocked: FriendRescueStatus["reason"] = undefined;
   if (stamped[0]) {
     const prior = Number(stamped[0].prior_streak);
     const detail = await stampedBreakDetail(
@@ -934,14 +961,20 @@ export async function getFriendRescueStatus(
       stamped[0].local_date,
       prior,
     );
-    breakInfo = detail.bridged && detail.inWindow
-      ? {
-          local_date: stamped[0].local_date,
-          prior_streak: prior,
-          restored_streak: detail.restored,
-          self_recovery: null,
-        }
-      : null;
+    if (!detail.bridged) {
+      // Checked before the window: a second missed day is the more
+      // fundamental reason, and the more useful thing to say.
+      blocked = "gap_too_wide";
+    } else if (!detail.inWindow) {
+      blocked = "window_passed";
+    } else {
+      breakInfo = {
+        local_date: stamped[0].local_date,
+        prior_streak: prior,
+        restored_streak: detail.restored,
+        self_recovery: null,
+      };
+    }
   } else {
     breakInfo = await getLiveAssistableBreak(friendId, friendToday, friendRow);
   }
@@ -950,7 +983,14 @@ export async function getFriendRescueStatus(
     !breakInfo ||
     breakInfo.local_date < dateStrMinus(friendToday, ASSIST_RESCUE_WINDOW_DAYS)
   ) {
-    return { ...base, available: false, reason: "no_recent_break" };
+    return {
+      ...base,
+      available: false,
+      // A multi-day hole with no stamped event (the sweep never reached it, or
+      // the break predates the query window) still has to explain itself —
+      // that's the JoePo case, three missed days and a silent profile.
+      reason: blocked ?? (multiDayGap ? "gap_too_wide" : "no_recent_break"),
+    };
   }
 
   return {


### PR DESCRIPTION
## Why you're seeing nothing

Things I verified first, so we're not guessing:

- **Backend is deployed.** Probed the unauthenticated endpoint added in #269 — `/public/posts/<junk>` returns `{"error":"Post not found"}` (my new controller) rather than `{"error":"Not found"}` (the catch-all). All the #269 server changes are live.
- **iOS code is on `main`** (#269 merged as `23bae7b`); the two follow-up commits were merge fallout with #268's collab work, unrelated to streak assist.
- **Enrollment is covered on cold launch** — `DashboardView:639` calls `enrollIfNeeded()`, so the `willEnterForeground`-only path isn't the problem.

Which leaves the actual bug: **the CTA rendered `EmptyView` for every case except "available"**. So "there is nothing to rescue here" and "this feature is broken" looked exactly the same on a friend's profile. Opening someone with an obviously broken streak and getting no option and no reason is precisely the reported experience — and #269 made it *more* common, because the correctness fix (a rescue must actually reconnect the streak) filters out most of what used to show.

## What this changes

`getFriendRescueStatus` now distinguishes a break that **exists but can't be reached** from no break at all:

| reason | meaning | profile shows |
|---|---|---|
| `gap_too_wide` | more than one missed day — no single covered day bridges it | explanation |
| `window_passed` | miss is older than the 2-day rescue window | explanation |
| `no_recent_break` | their streak is fine | nothing (correct) |
| `friend_not_enrolled` | their build predates streak tokens | explanation (already) |

Both new reasons are derived from the friend's own day facts, not just stamped `streak_events`. That matters: JoePo's break was stamped on the 24th, which falls outside the status query's 2-day window, so the event-based path found nothing and the profile stayed silent even though he was visibly three days into a gap. The day-facts fallback catches exactly that.

The profile renders it as a muted line — *"JoePo has missed more than one day — a Streak Assist only covers a single miss"* — instead of nothing. `no_recent_break` still renders nothing, because a friend with an intact streak shouldn't carry rescue chrome.

Uses `clock.arrow.circlepath` rather than `clock.badge.xmark`; the latter is SF Symbols 5-era and renders as a blank box on the iOS 17 deployment target (`.claude/rules/ios.md`).

## Compatibility

Additive: two new values in an existing optional `reason` field. Older clients hit the `default:` branch and render nothing — exactly today's behavior. No schema change.

## Verification

- `npm run build` (backend tsc) — clean
- iOS builds via Xcode only; not compiled here.

## Still worth checking on your side

This makes the feature *explain* itself, but it can't manufacture a rescuable friend. Two things could still mean you see no CTA anywhere:

1. **Are you running a build with the new UI?** The profile CTA is client code merged after the current App Store build — it needs an Xcode build off `main`.
2. **Are your friends enrolled?** The stamp is only written by builds that ship the token UI. If that hasn't reached the App Store, none of your friends are enrolled and every profile answers `friend_not_enrolled`. Developer Settings has a streak-features diagnostic (`StreakFeatureService.diagnose()`) that reports enrollment and status for your own account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)