### PR TITLE
Fix red main: unified feed hid a private author's post from themselves

### DIFF
--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -1301,20 +1301,21 @@ export async function getUnifiedFeed(
 			WHERE p.share_to_feed AND p.deleted_at IS NULL
 				-- Accepted collab posts reach BOTH authors' circles (semi-join, not
 				-- a JOIN, so a post whose two authors share the viewer isn't doubled).
+				-- These are the SAME four gates getFeed applies, via the same
+				-- fragments. They drifted apart once and produced two different
+				-- answers for one post: this branch dropped a private author's post
+				-- from their OWN feed (bare OWNER_NOT_PRIVATE_SQL has no self
+				-- exception — "only me" has to still include me), and let a private
+				-- coauthor's reach through. Keep them spelled the same.
 				AND EXISTS (
 					SELECT 1 FROM circle c
 					WHERE c.uid = p.user_id
-						OR (p.coauthor_status = 'accepted' AND c.uid = p.coauthor_user_id)
+						OR (c.uid = p.coauthor_user_id AND ${COLLAB_REACH_SQL})
 				)
+				AND ${AUTHOR_VISIBLE_TO_VIEWER}
 				AND p.user_id NOT IN (SELECT uid FROM blocked)
-				AND (p.coauthor_status IS DISTINCT FROM 'accepted'
+				AND (NOT ${COLLAB_ACTIVE}
 					OR p.coauthor_user_id NOT IN (SELECT uid FROM blocked))
-				AND ${OWNER_NOT_PRIVATE_SQL("p.user_id")}
-				-- If post reaches viewer via coauthor, coauthor must not be private
-				AND (
-					EXISTS (SELECT 1 FROM circle c WHERE c.uid = p.user_id)
-					OR (p.coauthor_status = 'accepted' AND ${OWNER_NOT_PRIVATE_SQL("p.coauthor_user_id")})
-				)
 
 			UNION ALL
 


### PR DESCRIPTION
## main has been red since #268

| run | commit | |
|---|---|---|
| ❌ | `e4e0f590` | Fix: reorder PostCardView arguments |
| ❌ | `aef526ce` | Fix: add missing properties to PostCardView |
| ❌ | `f301e512` | Fix: handle accountMismatch |
| ❌ | `78ed93aa` | Fix: respect coauthor privacy in feed visibility |
| ❌ | `bc39825d` | **Merge #268** ← first red |
| ✅ | `9d8a138f` | Merge #267 |
| ✅ | `23bae7b9` | Merge #269 |

Every commit since #268 merged has failed the same smoke assertion:

```
AssertionError: a private author still sees their own post
    at backend/scripts/ci-smoke.mjs:349
```

## The bug

#268 introduced two SQL fragments that encode the rules correctly:

```ts
const AUTHOR_VISIBLE_TO_VIEWER = `(
	p.user_id = $1              -- "only me" still includes me…
	OR p.coauthor_user_id = $1  -- …and my coauthor
	OR ${OWNER_NOT_PRIVATE_SQL("p.user_id")}
)`;
```

and applied them to `getFeed`, `getUserPosts` and `getUserTaggedPosts`. But the **unified feed's `candidates` CTE was left on the bare `OWNER_NOT_PRIVATE_SQL("p.user_id")`**, which has no self-exception — so a private author's post dropped out of their own feed.

`78ed93a` then noticed the *coauthor* half was also wrong and layered an extra clause on top, without touching the line that was actually failing. main stayed red.

## The fix

Make the unified feed's four gates the same fragments `getFeed` already uses, and drop the extra clause — `COLLAB_REACH_SQL` inside the circle semi-join already subsumes it.

```diff
-				AND EXISTS (SELECT 1 FROM circle c
-					WHERE c.uid = p.user_id
-						OR (p.coauthor_status = 'accepted' AND c.uid = p.coauthor_user_id))
-				AND p.user_id NOT IN (SELECT uid FROM blocked)
-				AND (p.coauthor_status IS DISTINCT FROM 'accepted'
-					OR p.coauthor_user_id NOT IN (SELECT uid FROM blocked))
-				AND ${OWNER_NOT_PRIVATE_SQL("p.user_id")}
-				AND (EXISTS (SELECT 1 FROM circle c WHERE c.uid = p.user_id)
-					OR (p.coauthor_status = 'accepted' AND ${OWNER_NOT_PRIVATE_SQL("p.coauthor_user_id")}))
+				AND EXISTS (SELECT 1 FROM circle c
+					WHERE c.uid = p.user_id
+						OR (c.uid = p.coauthor_user_id AND ${COLLAB_REACH_SQL}))
+				AND ${AUTHOR_VISIBLE_TO_VIEWER}
+				AND p.user_id NOT IN (SELECT uid FROM blocked)
+				AND (NOT ${COLLAB_ACTIVE}
+					OR p.coauthor_user_id NOT IN (SELECT uid FROM blocked))
```

Two queries answering the same question in two different dialects is what let them drift. They're now spelled identically, with a comment saying why.

## Verification

No Docker or local Postgres on this machine, so CI is the real check. I walked every collab assertion in `ci-smoke.mjs` by hand against the new gates (ALICE author, BOB coauthor, CARL = Bob's friend only, DANA = Alice's friend only):

| state | CARL | DANA | ALICE | BOB |
|---|---|---|---|---|
| all `friends` | sees, tagged BOB | sees | sees | sees |
| BOB private | **loses it** | sees, tag withheld | sees | sees, tagged |
| ALICE private | **loses it** | **loses it** | **sees** ← was failing | sees |

`npm run build` clean.

## Deliberately not fixed

The **workout** branch of the same CTE still uses the bare `OWNER_NOT_PRIVATE_SQL("w.user_id")`, so a private user's own raw workouts are absent from their own unified feed. Same class of bug, but no smoke assertion pins the behavior either way (the "never from the owner" checks there go through `getUserPosts` / `getWorkoutRoute`), and quietly changing an untested hot-path query inside a red-CI fix is how the drift started. Flagged rather than folded in — happy to do it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)