### PR TITLE
Ghost race: ask it as a wizard step, not a sheet

### DIFF
--- a/app/Mile A Day/Managers/CelebrationManager.swift
+++ b/app/Mile A Day/Managers/CelebrationManager.swift
@@ -267,6 +267,29 @@ struct ChallengeCelebrationInfo: Equatable {
     let challengeStreak: Int
 }
 
+/// Payload for the ghost-race win.
+///
+/// Snapshotted at the 1.00-mile crossing, so the celebration can only ever
+/// show the same numbers the live chip showed — the popup can't contradict
+/// what the user watched happen.
+struct GhostRaceWin: Equatable {
+    /// Seconds the user finished AHEAD by. Always positive; a loss stays
+    /// silent (the frozen chip already told that story).
+    let marginSeconds: Double
+    /// The user's mile time, interpolated at the exact crossing.
+    let mileSeconds: Double
+    /// The ghost's mile time.
+    let ghostSeconds: Double
+    /// How the ghost was named in copy ("your best", "your PR", "your target").
+    let ghostName: String
+    /// "running" | "walking" — drives the verb and the accent.
+    let activityKey: String
+    /// Set when this mile ALSO became the new best to beat.
+    let newRecordSeconds: Double?
+    /// Workout it belongs to, so the win can be attached to the post.
+    let workoutId: String?
+}
+
 /// Types of celebrations that can be shown
 enum CelebrationType: Identifiable, Equatable {
     case goalCompleted(stats: GoalCompletionStats)
@@ -291,6 +314,8 @@ enum CelebrationType: Identifiable, Equatable {
     case comeback(day: Int, priorLength: Int, recordLength: Int, eraNumber: Int, eraStart: String)
     /// The current streak just PASSED the user's all-time record.
     case newRecordStreak(days: Int, previousBest: Int, eraStart: String)
+    /// Beat the ghost you chose over the mile.
+    case ghostBeaten(win: GhostRaceWin)
 
     var id: String {
         switch self {
@@ -316,6 +341,8 @@ enum CelebrationType: Identifiable, Equatable {
             return "comeback-\(eraStart)-\(day)"
         case .newRecordStreak(_, _, let eraStart):
             return "record-\(eraStart)"
+        case .ghostBeaten(let win):
+            return "ghost-beaten-\(win.workoutId ?? "\(win.mileSeconds)")"
         }
     }
 
@@ -343,6 +370,8 @@ enum CelebrationType: Identifiable, Equatable {
             return d1 == d2 && s1 == s2 // one per era-day
         case (.newRecordStreak(_, _, let s1), .newRecordStreak(_, _, let s2)):
             return s1 == s2 // one record moment per era
+        case (.ghostBeaten(let w1), .ghostBeaten(let w2)):
+            return w1.workoutId == w2.workoutId // one win per raced workout
         default:
             return false
         }

--- a/app/Mile A Day/Managers/CelebrationManager.swift
+++ b/app/Mile A Day/Managers/CelebrationManager.swift
@@ -286,6 +286,9 @@ struct GhostRaceWin: Equatable {
     let activityKey: String
     /// Set when this mile ALSO became the new best to beat.
     let newRecordSeconds: Double?
+    /// The friend whose mile this was, when the ghost was theirs. Carried onto
+    /// the saved workout so the server can tell them they were caught.
+    let friendUserId: String?
     /// Workout it belongs to, so the win can be attached to the post.
     let workoutId: String?
 }

--- a/app/Mile A Day/Models/User.swift
+++ b/app/Mile A Day/Models/User.swift
@@ -457,7 +457,17 @@ struct User: Identifiable, Codable {
             ("buddy_won_10", "Pace Setter", "Won 10 buddy races")
         ]
 
-        for (badgeId, name, description) in buddyBadges {
+        // Ghost race medals — same deal as the buddy set above: mirrors of
+        // EXTRA_BADGES so they're discoverable before the first ghost falls.
+        let ghostBadges: [(String, String, String)] = [
+            ("ghost_beat_1", "Ghost Hunter", "Beat a ghost over the mile for the first time"),
+            ("ghost_beat_10", "Ghost Buster", "Beat your ghost 10 times"),
+            ("ghost_beat_50", "Unhaunted", "Beat your ghost 50 times"),
+            ("ghost_margin_15", "Clear Daylight", "Beat a ghost by 15 seconds or more"),
+            ("ghost_margin_45", "Vanishing Act", "Beat a ghost by 45 seconds or more")
+        ]
+
+        for (badgeId, name, description) in buddyBadges + ghostBadges {
             if !hasBadge(id: badgeId) {
                 lockedBadges.append(Badge(
                     id: badgeId,

--- a/app/Mile A Day/Services/BestEffortStore.swift
+++ b/app/Mile A Day/Services/BestEffortStore.swift
@@ -53,6 +53,14 @@ enum BestEffortStore {
         case personalRecord
         /// A time the user typed in. Constant pace, same as the PR ghost.
         case custom(seconds: Double)
+        /// A FRIEND's fastest mile, from `GET /ghosts/friends`.
+        ///
+        /// The seconds and the name ride in the case rather than being looked
+        /// up, because `resolve` is synchronous and offline — there is nowhere
+        /// to await a friend's time inside this store, and `shortName` is
+        /// produced there. The stored name is refreshed whenever the picker
+        /// reloads, so a rename shows up the next time they open it.
+        case friend(id: String, seconds: Double, name: String)
 
         /// Compact form for @AppStorage — the enum has an associated value, so
         /// it can't be RawRepresentable in the way AppStorage wants.
@@ -61,6 +69,10 @@ enum BestEffortStore {
             case .recordedBest: return "best"
             case .personalRecord: return "pr"
             case .custom(let seconds): return "custom:\(Int(seconds.rounded()))"
+            case .friend(let id, let seconds, let name):
+                // Name goes LAST so it may contain colons — the decoder splits
+                // with maxSplits and takes the remainder verbatim.
+                return "friend:\(id):\(Int(seconds.rounded())):\(name)"
             }
         }
 
@@ -69,12 +81,38 @@ enum BestEffortStore {
             case "best": self = .recordedBest
             case "pr": self = .personalRecord
             default:
+                // NOTE: this switches over a STRING, so a missing case here is
+                // silent — a stored target that doesn't decode just falls back
+                // to `defaultTarget` with no crash and no warning. Any new case
+                // added above must be given a branch here too.
+                if storage.hasPrefix("friend:") {
+                    let parts = storage.dropFirst("friend:".count)
+                        .split(separator: ":", maxSplits: 2,
+                               omittingEmptySubsequences: false)
+                    guard parts.count == 3,
+                        !parts[0].isEmpty,
+                        let seconds = Double(parts[1]),
+                        Self.isPlausible(seconds)
+                    else { return nil }
+                    self = .friend(
+                        id: String(parts[0]),
+                        seconds: seconds,
+                        name: String(parts[2])
+                    )
+                    return
+                }
                 guard storage.hasPrefix("custom:"),
                     let seconds = Double(storage.dropFirst("custom:".count)),
                     Self.isPlausible(seconds)
                 else { return nil }
                 self = .custom(seconds: seconds)
             }
+        }
+
+        /// The friend whose mile this races, when it races one.
+        var friendUserId: String? {
+            if case .friend(let id, _, _) = self { return id }
+            return nil
         }
 
         /// A mile between 2 and 40 minutes. The floor is the same one
@@ -129,6 +167,18 @@ enum BestEffortStore {
             guard GhostTarget.isPlausible(seconds) else { return nil }
             return ResolvedGhost(
                 target: target, effort: constantPace(seconds), shortName: "your target")
+        case .friend(_, let seconds, let name):
+            guard GhostTarget.isPlausible(seconds) else { return nil }
+            // A flat pace, like the PR and custom ghosts: the server only has
+            // the friend's fastest mile SPLIT, never their effort curve (that
+            // lives on their device). `shortName` is their name, so the live
+            // chip reads "12s ahead of Alex" and the celebration "ahead of
+            // Alex over the mile" with no copy changes anywhere.
+            return ResolvedGhost(
+                target: target,
+                effort: constantPace(seconds),
+                shortName: name.isEmpty ? "your friend" : name
+            )
         }
     }
 

--- a/app/Mile A Day/Services/FriendGhostService.swift
+++ b/app/Mile A Day/Services/FriendGhostService.swift
@@ -1,0 +1,100 @@
+import Foundation
+import SwiftUI
+
+/// One friend you can race, from `GET /ghosts/friends`.
+///
+/// Plain snake_case properties with NO explicit `CodingKeys` — a struct with
+/// one loses Codable synthesis the moment a stored property is added without a
+/// matching case, and there's no iOS CI to catch it.
+struct FriendGhost: Codable, Identifiable, Equatable {
+    let user_id: String
+    let username: String?
+    let first_name: String?
+    let last_name: String?
+    let profile_image_url: String?
+    /// Their fastest completed mile, in seconds.
+    let mile_seconds: Double
+
+    var id: String { user_id }
+
+    /// What to call them in the picker and, once armed, in the live chip and
+    /// the celebration — so it has to stay short.
+    var displayName: String {
+        if let first_name, !first_name.isEmpty { return first_name }
+        if let username, !username.isEmpty { return username }
+        return "A friend"
+    }
+
+    /// Full name for the avatar's initials fallback — usernames make noisy
+    /// initials, which is why the leaderboard rows do the same.
+    var avatarName: String {
+        let parts = [first_name, last_name].compactMap { $0 }.filter { !$0.isEmpty }
+        return parts.isEmpty ? displayName : parts.joined(separator: " ")
+    }
+
+    var target: BestEffortStore.GhostTarget {
+        .friend(id: user_id, seconds: mile_seconds, name: displayName)
+    }
+}
+
+private struct FriendGhostsResponse: Decodable {
+    let ghosts: [FriendGhost]
+}
+
+/// Loads the friends whose mile you can chase, cached per activity.
+///
+/// A shared singleton because `GhostRaceOptionsContent` renders in two places —
+/// the pre-start wizard step and the buddy lobby sheet — and both should hit
+/// one load path and one cache rather than each fetching on appear.
+@MainActor
+final class FriendGhostService: ObservableObject {
+    static let shared = FriendGhostService()
+
+    /// Cached per activity key ("running" / "walking"). The two are genuinely
+    /// different lists: a friend's fastest RUN mile is not a fair walk ghost,
+    /// and the server filters on `workout_type` for exactly that reason.
+    @Published private(set) var ghostsByActivity: [String: [FriendGhost]] = [:]
+    @Published private(set) var isLoading = false
+
+    /// Last successful load per activity, so re-opening the picker inside a
+    /// session doesn't re-fetch.
+    private var loadedAt: [String: Date] = [:]
+    private let cacheLifetime: TimeInterval = 5 * 60
+
+    private init() {}
+
+    func ghosts(for activityKey: String) -> [FriendGhost] {
+        ghostsByActivity[activityKey] ?? []
+    }
+
+    /// Load if the cache is cold or stale. Failures are silent by design: the
+    /// picker always has your own targets, so a friend list that didn't arrive
+    /// costs a row, not the feature.
+    func refreshIfNeeded(activityKey: String) async {
+        if let at = loadedAt[activityKey], Date().timeIntervalSince(at) < cacheLifetime {
+            return
+        }
+        await refresh(activityKey: activityKey)
+    }
+
+    func refresh(activityKey: String) async {
+        guard !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            // Enum-ish literal, no free text — nothing here needs percent
+            // encoding (same reasoning as LeaderboardService).
+            let response: FriendGhostsResponse = try await APIClient.fancyFetch(
+                endpoint: "/ghosts/friends?activity=\(activityKey)",
+                method: .GET,
+                body: nil,
+                responseType: FriendGhostsResponse.self
+            )
+            ghostsByActivity[activityKey] = response.ghosts
+            loadedAt[activityKey] = Date()
+        } catch {
+            // Leave whatever was cached in place.
+            print("[FriendGhostService] load failed: \(error)")
+        }
+    }
+}

--- a/app/Mile A Day/Services/PostService.swift
+++ b/app/Mile A Day/Services/PostService.swift
@@ -30,6 +30,25 @@ struct PostStats: Codable, Equatable {
     let date: String?
     var calories: Double?
     var steps: Int?
+    /// Ghost race, present ONLY when the ghost was beaten — seconds of margin
+    /// and the ghost's mile time.
+    ///
+    /// Rides in `stats_snapshot` rather than in its own column deliberately:
+    /// the snapshot is jsonb that every feed projection already returns
+    /// verbatim, so a ghost win reaches the feed, the profile grid, stories
+    /// and post detail without touching a single one of those guard-heavy
+    /// SELECTs. Defaulted so existing `PostStats(...)` call sites are
+    /// unaffected, and optional so older posts decode fine.
+    var ghost_margin_seconds: Double? = nil
+    var ghost_target_seconds: Double? = nil
+
+    /// The win, when this post carries one.
+    var ghostWin: (margin: Double, ghostSeconds: Double)? {
+        guard let margin = ghost_margin_seconds, margin > 0,
+              let target = ghost_target_seconds, target > 0
+        else { return nil }
+        return (margin, target)
+    }
 }
 
 /// One credited participant on a multi-person collab post (Buddy Walks).

--- a/app/Mile A Day/Services/RunPostService.swift
+++ b/app/Mile A Day/Services/RunPostService.swift
@@ -71,7 +71,11 @@ enum RunPostService {
             calories: calories > 0 ? calories : nil,
             steps: nil,
             workoutId: anchorId,
-            dateText: dateText(for: anchor.startDate)
+            dateText: dateText(for: anchor.startDate),
+            // The anchor IS the leg that crossed the mile, so its race result
+            // is the day's race result.
+            ghostMarginSeconds: ghostWin(of: anchor)?.margin,
+            ghostTargetSeconds: ghostWin(of: anchor)?.target
         )
     }
 
@@ -102,7 +106,9 @@ enum RunPostService {
                 steps: nil,
                 workoutId: workoutId,
                 dateText: dateText(for: workout.startDate),
-                isExtra: isExtraWorkout(workoutId)
+                isExtra: isExtraWorkout(workoutId),
+                ghostMarginSeconds: ghostWin(of: workout)?.margin,
+                ghostTargetSeconds: ghostWin(of: workout)?.target
             )
         }
 
@@ -165,6 +171,17 @@ enum RunPostService {
             return moving
         }
         return workout.duration
+    }
+
+    /// The ghost win stamped on this workout at finish, if it beat its ghost.
+    /// Only winning workouts carry the metadata, so presence IS the win.
+    private static func ghostWin(of workout: HKWorkout) -> (margin: Double, target: Double)? {
+        guard
+            let margin = workout.metadata?[WorkoutLocationManager.ghostMarginMetadataKey] as? Double,
+            let target = workout.metadata?[WorkoutLocationManager.ghostTargetMetadataKey] as? Double,
+            margin > 0, target > 0
+        else { return nil }
+        return (margin, target)
     }
 
     private static func workoutPaceSecondsPerMile(distance: Double, duration: TimeInterval) -> TimeInterval? {

--- a/app/Mile A Day/Services/WorkoutSyncService.swift
+++ b/app/Mile A Day/Services/WorkoutSyncService.swift
@@ -763,6 +763,14 @@ class WorkoutSyncService: ObservableObject {
                ghostMargin > 0, ghostTarget > 0 {
                 workoutDict["ghostMarginSeconds"] = ghostMargin
                 workoutDict["ghostTargetSeconds"] = ghostTarget
+                // Only set when the ghost was a FRIEND's mile. The server
+                // re-checks the friendship before telling them anything, so an
+                // id here is a claim, not an authorization.
+                if let ghostFriendId = workout.metadata?[
+                    WorkoutLocationManager.ghostFriendMetadataKey] as? String,
+                    !ghostFriendId.isEmpty {
+                    workoutDict["ghostFriendUserId"] = ghostFriendId
+                }
             }
 
             // Attach the simplified GPS path when the workout has one, so the

--- a/app/Mile A Day/Services/WorkoutSyncService.swift
+++ b/app/Mile A Day/Services/WorkoutSyncService.swift
@@ -754,6 +754,17 @@ class WorkoutSyncService: ObservableObject {
                 workoutDict["movingSeconds"] = movingSeconds
             }
 
+            // Ghost race, stamped by the tracker only when the ghost was
+            // BEATEN — so sending it at all is the win. The server COALESCEs
+            // these on re-upload, so a later route-less or fullSync push can't
+            // erase a win this one recorded.
+            if let ghostMargin = workout.metadata?[WorkoutLocationManager.ghostMarginMetadataKey] as? Double,
+               let ghostTarget = workout.metadata?[WorkoutLocationManager.ghostTargetMetadataKey] as? Double,
+               ghostMargin > 0, ghostTarget > 0 {
+                workoutDict["ghostMarginSeconds"] = ghostMargin
+                workoutDict["ghostTargetSeconds"] = ghostTarget
+            }
+
             // Attach the simplified GPS path when the workout has one, so the
             // backend can store it and feed cards can draw the mile's route.
             if fetchRoutes, let route = await simplifiedRoute(for: workout) {

--- a/app/Mile A Day/Views/BadgesView.swift
+++ b/app/Mile A Day/Views/BadgesView.swift
@@ -238,6 +238,11 @@ struct BadgesView: View {
             return allBadges
                 .filter { b in BadgeFilter.buddyPrefixes.contains { b.id.hasPrefix($0) } }
                 .sorted { Self.buddySortKey($0.id) < Self.buddySortKey($1.id) }
+        case .ghost:
+            return allBadges
+                .filter { b in BadgeFilter.ghostPrefixes.contains { b.id.hasPrefix($0) } }
+                .sorted { Self.familySortKey($0.id, BadgeFilter.ghostPrefixes)
+                    < Self.familySortKey($1.id, BadgeFilter.ghostPrefixes) }
         case .new:
             // Use the on-open snapshot so the list survives mark-as-viewed.
             let snapshot = newBadgeIdsAtOpen
@@ -247,8 +252,13 @@ struct BadgesView: View {
 
     /// Orders a buddy medal by family (walks → crew → races won), then tier.
     private static func buddySortKey(_ id: String) -> (Int, Int) {
-        let family = BadgeFilter.buddyPrefixes.firstIndex { id.hasPrefix($0) }
-            ?? BadgeFilter.buddyPrefixes.count
+        familySortKey(id, BadgeFilter.buddyPrefixes)
+    }
+
+    /// Orders a medal by its family's position in `prefixes`, then by the
+    /// numeric tier its id ends with.
+    private static func familySortKey(_ id: String, _ prefixes: [String]) -> (Int, Int) {
+        let family = prefixes.firstIndex { id.hasPrefix($0) } ?? prefixes.count
         let tier = Int(id.split(separator: "_").last ?? "") ?? 0
         return (family, tier)
     }
@@ -495,7 +505,7 @@ struct FilterChip: View {
 // MARK: - Badge Filter
 
 enum BadgeFilter: CaseIterable {
-    case all, streak, miles, speed, distance, challenges, social, buddy, new
+    case all, streak, miles, speed, distance, challenges, social, buddy, ghost, new
 
     var title: String {
         switch self {
@@ -507,6 +517,7 @@ enum BadgeFilter: CaseIterable {
         case .challenges: return "Challenges"
         case .social: return "Social"
         case .buddy: return "Buddy"
+        case .ghost: return "Ghost"
         case .new: return "New"
         }
     }
@@ -521,6 +532,7 @@ enum BadgeFilter: CaseIterable {
         case .challenges: return "trophy.fill"
         case .social: return "person.2.fill"
         case .buddy: return "figure.2"
+        case .ghost: return "flag.checkered"
         case .new: return "sparkles"
         }
     }
@@ -537,6 +549,10 @@ enum BadgeFilter: CaseIterable {
     /// someone, not by app-function activity, and burying seven of them at the
     /// end of the Social list is how a whole category goes unnoticed.
     static let buddyPrefixes = ["buddy_done_", "buddy_crew_", "buddy_won_"]
+
+    /// Ghost race medal families, in progression order: races won, then the
+    /// biggest single winning margin.
+    static let ghostPrefixes = ["ghost_beat_", "ghost_margin_"]
 }
 
 // MARK: - Badge Card Button Style

--- a/app/Mile A Day/Views/BuddyWalks/BuddyLobbyView.swift
+++ b/app/Mile A Day/Views/BuddyWalks/BuddyLobbyView.swift
@@ -147,10 +147,12 @@ struct BuddyLobbyView: View {
                                 : Color.white.opacity(0.10)
                         )
                         .frame(width: 34, height: 34)
-                    Image(systemName: "flag.checkered")
-                        .font(.system(size: 15, weight: .semibold))
-                        .foregroundStyle(
-                            buddyGhostArmed ? session.accentColor : .white.opacity(0.7))
+                    GhostSprite(
+                        size: 17,
+                        color: buddyGhostArmed ? session.accentColor : .white.opacity(0.7),
+                        floats: false,
+                        glancesBack: true
+                    )
                 }
 
                 VStack(alignment: .leading, spacing: 1) {

--- a/app/Mile A Day/Views/Celebrations/CelebrationContainerView.swift
+++ b/app/Mile A Day/Views/Celebrations/CelebrationContainerView.swift
@@ -70,6 +70,9 @@ struct CelebrationContainerView: View {
 
         case .newRecordStreak(let days, let previousBest, _):
             RecordStreakCelebrationView(days: days, previousBest: previousBest)
+
+        case .ghostBeaten(let win):
+            GhostBeatenCelebrationView(win: win)
         }
     }
 }

--- a/app/Mile A Day/Views/Celebrations/GhostBeatenCelebrationView.swift
+++ b/app/Mile A Day/Views/Celebrations/GhostBeatenCelebrationView.swift
@@ -1,0 +1,311 @@
+import SwiftUI
+
+/// The moment you beat the ghost.
+///
+/// This used to be a generic `.milestone` popup — the same purple screen with
+/// the same star sparkles that a baseline mile got. Two things were wrong with
+/// that. It had nothing to do with a race, and it was SEE-THROUGH: the shared
+/// milestone gradient is built from `.opacity(0.8)`/`.opacity(0.9)` color
+/// stops, so the dashboard showed through the bottom two-thirds of what is
+/// supposed to be a full-screen moment. (That bug is fixed at its source too,
+/// since every milestone celebration had it.)
+///
+/// What this shows instead is the race itself: the ghost you were chasing
+/// drifts away and dissolves, the margin lands as the hero number, and the two
+/// times sit side by side so the win is legible in one glance. Every number is
+/// the FROZEN verdict from the 1.00-mile crossing — the same figures the live
+/// chip showed, so the popup can't contradict what the user watched.
+struct GhostBeatenCelebrationView: View {
+    let win: GhostRaceWin
+
+    @ObservedObject var manager = CelebrationManager.shared
+    @Environment(\.scenePhase) private var scenePhase
+
+    @State private var hasStartedAnimation = false
+    @State private var backdrop: Double = 0
+    @State private var ghostDrift: CGFloat = 0
+    @State private var ghostGone = false
+    @State private var runnerIn = false
+    @State private var showMargin = false
+    @State private var showTimes = false
+    @State private var showButton = false
+    @State private var showBurst = false
+
+    private var accent: Color { MADTheme.workoutColor(win.activityKey) }
+    private var isRun: Bool { win.activityKey == "running" }
+    private var marginText: String { "\(max(1, Int(win.marginSeconds.rounded())))s" }
+
+    // MARK: - Body
+
+    var body: some View {
+        ZStack {
+            background
+
+            if showBurst {
+                BurstEffect(
+                    colors: [accent, .white, .cyan, .purple],
+                    particleCount: 30
+                )
+                .frame(height: 220)
+                .allowsHitTesting(false)
+            }
+
+            VStack(spacing: MADTheme.Spacing.lg) {
+                Spacer(minLength: MADTheme.Spacing.md)
+
+                chase
+
+                if showMargin { marginBlock.transition(.scale.combined(with: .opacity)) }
+                if showTimes { timesBlock.transition(.move(edge: .bottom).combined(with: .opacity)) }
+
+                Spacer(minLength: MADTheme.Spacing.md)
+
+                if showButton {
+                    continueButton
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+
+                // Clear the floating tab bar + home indicator (this overlay
+                // ignores the safe area).
+                Spacer().frame(height: 110)
+            }
+        }
+        .ignoresSafeArea()
+        .opacity(backdrop)
+        .onAppear { startAnimationIfActive() }
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active && !hasStartedAnimation { startAnimationIfActive() }
+        }
+    }
+
+    // MARK: - Background
+
+    /// OPAQUE by construction: a solid base color under the gradient, so no
+    /// amount of alpha in the stops above it can let the dashboard through.
+    private var background: some View {
+        ZStack {
+            Color(red: 0.05, green: 0.04, blue: 0.11)
+
+            LinearGradient(
+                colors: [
+                    Color(red: 0.16, green: 0.11, blue: 0.34),
+                    Color(red: 0.09, green: 0.07, blue: 0.22),
+                    Color(red: 0.04, green: 0.03, blue: 0.09)
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+
+            // A cold glow behind the chase, so the ghost reads as lit from
+            // within rather than pasted onto a flat field.
+            RadialGradient(
+                colors: [accent.opacity(0.35), .clear],
+                center: .init(x: 0.5, y: 0.32),
+                startRadius: 10,
+                endRadius: 320
+            )
+        }
+        .ignoresSafeArea()
+    }
+
+    // MARK: - The chase
+
+    /// The runner catches the ghost, which drifts off and dissolves. Reads
+    /// left-to-right the way the race did.
+    private var chase: some View {
+        ZStack {
+            GhostSprite(
+                size: 108,
+                color: .white.opacity(0.92),
+                glancesBack: true,
+                isVanishing: ghostGone
+            )
+            .offset(x: 62 + ghostDrift, y: -6)
+
+            Image(systemName: isRun ? "figure.run" : "figure.walk")
+                .font(.system(size: 66, weight: .semibold))
+                .foregroundStyle(
+                    LinearGradient(
+                        colors: [.white, accent],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+                .offset(x: runnerIn ? -46 : -160, y: 10)
+                .shadow(color: accent.opacity(0.7), radius: 18)
+        }
+        .frame(height: 170)
+        .padding(.horizontal, MADTheme.Spacing.lg)
+    }
+
+    // MARK: - Margin
+
+    private var marginBlock: some View {
+        VStack(spacing: 2) {
+            Text("GHOST BEATEN")
+                .font(.system(size: 13, weight: .black, design: .rounded))
+                .tracking(2.4)
+                .foregroundColor(.white.opacity(0.6))
+
+            HStack(alignment: .firstTextBaseline, spacing: 2) {
+                Text("+")
+                    .font(.system(size: 44, weight: .black, design: .rounded))
+                Text(marginText)
+                    .font(.system(size: 76, weight: .black, design: .rounded))
+                    .monospacedDigit()
+            }
+            .foregroundStyle(
+                LinearGradient(
+                    colors: [.white, accent],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+            .shadow(color: accent.opacity(0.55), radius: 22)
+
+            Text("ahead of \(win.ghostName) over the mile")
+                .font(.system(size: 16, weight: .medium, design: .rounded))
+                .foregroundColor(.white.opacity(0.75))
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, MADTheme.Spacing.lg)
+    }
+
+    // MARK: - Times
+
+    private var timesBlock: some View {
+        VStack(spacing: MADTheme.Spacing.md) {
+            HStack(spacing: 0) {
+                timeColumn(
+                    label: isRun ? "YOUR RUN" : "YOUR WALK",
+                    seconds: win.mileSeconds,
+                    highlighted: true
+                )
+
+                Rectangle()
+                    .fill(Color.white.opacity(0.15))
+                    .frame(width: 1, height: 44)
+
+                timeColumn(label: "THE GHOST", seconds: win.ghostSeconds, highlighted: false)
+            }
+            .padding(.vertical, MADTheme.Spacing.md)
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
+                    .fill(Color.white.opacity(0.09))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
+                            .strokeBorder(Color.white.opacity(0.16), lineWidth: 1)
+                    )
+            )
+
+            if let record = win.newRecordSeconds {
+                HStack(spacing: 7) {
+                    Image(systemName: "crown.fill")
+                        .font(.system(size: 12, weight: .bold))
+                    Text("\(BestEffortStore.formatSeconds(record)) is your new mile to beat")
+                        .font(.system(size: 13, weight: .bold, design: .rounded))
+                }
+                .foregroundColor(.black.opacity(0.85))
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(Capsule().fill(Color.yellow))
+                .transition(.scale.combined(with: .opacity))
+            }
+        }
+        .padding(.horizontal, MADTheme.Spacing.lg)
+    }
+
+    private func timeColumn(label: String, seconds: Double, highlighted: Bool) -> some View {
+        VStack(spacing: 3) {
+            Text(label)
+                .font(.system(size: 10, weight: .black, design: .rounded))
+                .tracking(1.2)
+                .foregroundColor(.white.opacity(0.5))
+            Text(BestEffortStore.formatSeconds(seconds))
+                .font(.system(size: 30, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .foregroundColor(highlighted ? .white : .white.opacity(0.55))
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Continue
+
+    private var continueButton: some View {
+        Button {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                manager.dismissCurrentCelebration()
+            }
+        } label: {
+            HStack(spacing: MADTheme.Spacing.sm) {
+                Text("Nice work")
+                    .font(.system(size: 20, weight: .semibold, design: .rounded))
+                Image(systemName: "arrow.right.circle.fill")
+                    .font(.system(size: 20))
+            }
+            .foregroundColor(Color(red: 0.09, green: 0.07, blue: 0.22))
+            .frame(maxWidth: .infinity)
+            .frame(height: 56)
+            .background(
+                RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large)
+                    .fill(.white)
+                    .shadow(color: accent.opacity(0.4), radius: 20, x: 0, y: 8)
+            )
+            .padding(.horizontal, MADTheme.Spacing.xl)
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Choreography
+
+    private func startAnimationIfActive() {
+        guard !hasStartedAnimation, scenePhase == .active else { return }
+        hasStartedAnimation = true
+        animateIn()
+    }
+
+    /// Beat, then overtake, then verdict — in that order, because that's the
+    /// order it happened.
+    private func animateIn() {
+        withAnimation(.easeOut(duration: 0.3)) { backdrop = 1 }
+
+        withAnimation(.spring(response: 0.75, dampingFraction: 0.8).delay(0.15)) {
+            runnerIn = true
+        }
+
+        // The ghost gets left behind, then dissolves.
+        withAnimation(.easeInOut(duration: 1.0).delay(0.45)) {
+            ghostDrift = 70
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.95) {
+            ghostGone = true
+            showBurst = true
+            MADHaptics.action()
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.15) {
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) { showMargin = true }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.45) {
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.85)) { showTimes = true }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.7) {
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.85)) { showButton = true }
+        }
+    }
+}
+
+#Preview {
+    GhostBeatenCelebrationView(
+        win: GhostRaceWin(
+            marginSeconds: 14,
+            mileSeconds: 528,
+            ghostSeconds: 542,
+            ghostName: "your best",
+            activityKey: "running",
+            newRecordSeconds: 528,
+            workoutId: "preview"
+        )
+    )
+}

--- a/app/Mile A Day/Views/Celebrations/MilestoneCelebrationView.swift
+++ b/app/Mile A Day/Views/Celebrations/MilestoneCelebrationView.swift
@@ -22,6 +22,15 @@ struct MilestoneCelebrationView: View {
 
     var body: some View {
         ZStack {
+            // OPAQUE base under the gradient. The stops below carry alpha
+            // (0.8 / 0.9), which made this full-screen celebration
+            // see-through over its bottom two-thirds — the dashboard read
+            // straight through the moment. Keeping the stops (they're what
+            // gives the gradient its depth) and putting a solid color behind
+            // them fixes every milestone celebration at once.
+            Color(red: 0.17, green: 0.09, blue: 0.28)
+                .ignoresSafeArea()
+
             // Gradient background
             LinearGradient(
                 colors: [

--- a/app/Mile A Day/Views/Components/GhostSprite.swift
+++ b/app/Mile A Day/Views/Components/GhostSprite.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+
+/// The ghost you race, as an actual character.
+///
+/// Drawn rather than symbol-based on purpose. SF Symbols has no ghost that
+/// exists on the iOS 17 deployment target — and a symbol that ships in a later
+/// release renders as a BLANK box on 17, not a fallback. Drawing it also means
+/// the ghost can act: bob, look back over its shoulder, and fade out when it
+/// gets beaten, none of which a glyph can do.
+///
+/// Used everywhere the race is: the pre-start option card, the options step,
+/// the live delta chip, the beaten celebration, and the feed chip.
+struct GhostSprite: View {
+    var size: CGFloat = 64
+    /// Body fill. White reads on every surface the race appears on.
+    var color: Color = .white
+    /// Gentle vertical bob. Off for static contexts (chips, feed cards).
+    var floats: Bool = true
+    /// Eyes shifted back over its shoulder — for "you're gaining on it".
+    var glancesBack: Bool = false
+    /// Fades and drifts away, for the moment it's beaten.
+    var isVanishing: Bool = false
+
+    @State private var bob: CGFloat = 0
+
+    private var eyeSize: CGFloat { size * 0.13 }
+
+    var body: some View {
+        ZStack {
+            GhostBodyShape()
+                .fill(color)
+
+            // Eyes sit high on the body; the head is a semicircle of radius
+            // size/2, so 0.36 keeps them clear of the crown and the hem.
+            HStack(spacing: size * 0.16) {
+                eye
+                eye
+            }
+            .offset(
+                x: glancesBack ? -size * 0.09 : 0,
+                y: -size * 0.14
+            )
+        }
+        .frame(width: size, height: size * 1.15)
+        .offset(y: bob)
+        .opacity(isVanishing ? 0 : 1)
+        .scaleEffect(isVanishing ? 1.35 : 1)
+        .blur(radius: isVanishing ? 6 : 0)
+        .animation(.easeOut(duration: 0.9), value: isVanishing)
+        .onAppear {
+            guard floats else { return }
+            withAnimation(.easeInOut(duration: 1.6).repeatForever(autoreverses: true)) {
+                bob = -size * 0.06
+            }
+        }
+    }
+
+    private var eye: some View {
+        Ellipse()
+            .fill(Color.black.opacity(0.72))
+            .frame(width: eyeSize, height: eyeSize * 1.25)
+    }
+}
+
+/// Classic sheet-ghost silhouette: domed head, straight sides, wavy hem.
+struct GhostBodyShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let w = rect.width
+        let h = rect.height
+        let radius = w / 2
+        // Hem amplitude. The baseline sits one amplitude above the bottom so
+        // the downward humps land exactly on `h` and nothing clips.
+        let amp = min(h * 0.06, w * 0.09)
+        let base = h - amp
+
+        var path = Path()
+        path.move(to: CGPoint(x: 0, y: base))
+        path.addLine(to: CGPoint(x: 0, y: radius))
+        path.addArc(
+            center: CGPoint(x: radius, y: radius),
+            radius: radius,
+            startAngle: .degrees(180),
+            endAngle: .degrees(0),
+            clockwise: false
+        )
+        path.addLine(to: CGPoint(x: w, y: base))
+
+        // Hem, walked right→left. A quad curve between two points on the
+        // baseline peaks at half its control offset, so ±2·amp controls give
+        // humps of exactly ±amp.
+        let humps = 4
+        let segment = w / CGFloat(humps)
+        for index in 0..<humps {
+            let startX = w - CGFloat(index) * segment
+            let endX = startX - segment
+            let downward = index.isMultiple(of: 2)
+            path.addQuadCurve(
+                to: CGPoint(x: endX, y: base),
+                control: CGPoint(
+                    x: (startX + endX) / 2,
+                    y: base + (downward ? 2 * amp : -2 * amp)
+                )
+            )
+        }
+
+        path.closeSubpath()
+        return path
+    }
+}
+
+/// Small ghost + time, for chips and rows. Sized to sit inline with text.
+struct GhostTimePill: View {
+    let seconds: Double
+    var tint: Color = .white
+    var background: Color = Color.white.opacity(0.15)
+
+    var body: some View {
+        HStack(spacing: 5) {
+            GhostSprite(size: 12, color: tint, floats: false)
+            Text(BestEffortStore.formatSeconds(seconds))
+                .font(.system(size: 12, weight: .bold, design: .rounded))
+                .monospacedDigit()
+        }
+        .foregroundColor(tint)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Capsule().fill(background))
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.black.ignoresSafeArea()
+        VStack(spacing: 40) {
+            GhostSprite(size: 96)
+            GhostSprite(size: 60, glancesBack: true)
+            GhostTimePill(seconds: 542)
+        }
+    }
+}

--- a/app/Mile A Day/Views/Dashboard/GhostRaceOptionsContent.swift
+++ b/app/Mile A Day/Views/Dashboard/GhostRaceOptionsContent.swift
@@ -137,10 +137,8 @@ struct GhostRaceOptionsContent: View {
     private var header: some View {
         VStack(spacing: MADTheme.Spacing.sm) {
             ZStack {
-                Circle().fill(accent.opacity(0.22)).frame(width: 56, height: 56)
-                Image(systemName: "flag.checkered")
-                    .font(.system(size: 24, weight: .semibold))
-                    .foregroundStyle(accent)
+                Circle().fill(accent.opacity(0.22)).frame(width: 64, height: 64)
+                GhostSprite(size: 34, color: accent, glancesBack: true)
             }
             Text("Race a ghost for one mile")
                 .font(.system(size: 24, weight: .bold, design: .rounded))

--- a/app/Mile A Day/Views/Dashboard/GhostRaceOptionsContent.swift
+++ b/app/Mile A Day/Views/Dashboard/GhostRaceOptionsContent.swift
@@ -1,0 +1,477 @@
+import SwiftUI
+
+/// Choose what to race — the picker itself, with no presentation chrome.
+///
+/// The rule this screen exists to guarantee: there is ALWAYS something to race.
+/// Before it, a walk with no recorded history had no ghost at all and the card
+/// just explained why you couldn't play. Now the custom target is always
+/// offered, so "race a time I pick" works on the very first walk.
+///
+/// Everything is on one screen, in the order the question actually gets asked:
+/// what am I chasing → how fast is it → what happens when I start.
+///
+/// Deliberately chrome-free (no NavigationStack, no toolbar, no `dismiss`, no
+/// background of its own) because it renders in two very different places: as a
+/// step INSIDE the walk/run wizard, over that screen's red gradient, and as a
+/// sheet from the buddy lobby (`GhostRaceSetupSheet`) over the app gradient.
+/// The host owns the background, the way back, and what "done" means.
+struct GhostRaceOptionsContent: View {
+    let activityKey: String
+    /// Backend fastest-mile PR in seconds, when there is one.
+    let seedPaceSeconds: Double?
+    /// Currently armed target, so re-opening shows what's already set.
+    let current: BestEffortStore.GhostTarget?
+    /// Tint for selection, glyphs and the primary button — supplied by the
+    /// host because the right answer depends on what's BEHIND this view. The
+    /// workout color is correct over the lobby's dark gradient, but
+    /// `workoutColor("running")` is literally the tracker gradient's own top
+    /// stop, so inline it would put a red button on a red screen.
+    let accent: Color
+    /// Label color on the primary button; must contrast with `accent`.
+    let accentForeground: Color
+    /// Wording for the secondary action — "carry on without a ghost" reads
+    /// differently inside a wizard than it does in a modal over a lobby.
+    let declineTitle: String
+    /// Race this. The custom time is already persisted by the time this fires.
+    let onRace: (BestEffortStore.GhostTarget) -> Void
+    /// Don't race this session.
+    let onDecline: () -> Void
+
+    @State private var selection: BestEffortStore.GhostTarget = .recordedBest
+    /// Custom target, held split so the wheels are independent.
+    @State private var customMinutes: Int = 9
+    @State private var customSeconds: Int = 0
+    /// `onAppear` fires again when a host re-presents this view; priming twice
+    /// would throw away wheel edits mid-decision.
+    @State private var hasPrimed = false
+
+    private var isRun: Bool { activityKey == "running" }
+
+    private var targets: [BestEffortStore.GhostTarget] {
+        BestEffortStore.availableTargets(
+            for: activityKey, seedPaceSecondsPerMile: seedPaceSeconds)
+    }
+
+    private var customTotalSeconds: Double {
+        Double(customMinutes * 60 + customSeconds)
+    }
+
+    private var isCustomSelected: Bool {
+        if case .custom = selection { return true }
+        return false
+    }
+
+    /// The selection as it would be armed — custom picks up the live wheels.
+    private var armedTarget: BestEffortStore.GhostTarget {
+        isCustomSelected ? .custom(seconds: customTotalSeconds) : selection
+    }
+
+    private var armedIsValid: Bool {
+        !isCustomSelected || BestEffortStore.GhostTarget.isPlausible(customTotalSeconds)
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            ScrollView {
+                VStack(spacing: MADTheme.Spacing.lg) {
+                    header
+                    targetList
+                    if isCustomSelected { customPicker }
+                    howItWorks
+                    // Reserves scroll room under the pinned footer.
+                    Color.clear.frame(height: 180)
+                }
+                .padding(.horizontal, MADTheme.Spacing.md)
+                .padding(.top, MADTheme.Spacing.sm)
+            }
+            .scrollIndicators(.hidden)
+
+            footer
+        }
+        .onAppear {
+            guard !hasPrimed else { return }
+            hasPrimed = true
+            primeSelection()
+        }
+    }
+
+    /// One-shot: seed the wheels and the selected row from what's already
+    /// armed, falling back to the best available target.
+    private func primeSelection() {
+        let seconds = BestEffortStore.customSeconds(for: activityKey)
+        customMinutes = Int(seconds) / 60
+        customSeconds = Int(seconds) % 60
+
+        if let current, targetsContain(current) {
+            selection = current
+            if case .custom(let s) = current {
+                customMinutes = Int(s) / 60
+                customSeconds = Int(s) % 60
+            }
+        } else {
+            selection = BestEffortStore.defaultTarget(
+                for: activityKey, seedPaceSecondsPerMile: seedPaceSeconds)
+        }
+    }
+
+    /// Custom matches on KIND, not on seconds — the wheels own the value.
+    private func targetsContain(_ target: BestEffortStore.GhostTarget) -> Bool {
+        targets.contains {
+            switch ($0, target) {
+            case (.recordedBest, .recordedBest), (.personalRecord, .personalRecord):
+                return true
+            case (.custom, .custom):
+                return true
+            default:
+                return false
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    /// Compact and scrolling, not a pinned card: this step has real content
+    /// under it, and the host already renders a title bar above.
+    private var header: some View {
+        VStack(spacing: MADTheme.Spacing.sm) {
+            ZStack {
+                Circle().fill(accent.opacity(0.22)).frame(width: 56, height: 56)
+                Image(systemName: "flag.checkered")
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundStyle(accent)
+            }
+            Text("Race a ghost for one mile")
+                .font(.system(size: 24, weight: .bold, design: .rounded))
+                .foregroundStyle(MADTheme.Colors.madWhite)
+                .multilineTextAlignment(.center)
+            Text(
+                "Pick a time to chase. You'll see how far ahead or behind you are the whole way."
+            )
+            .font(MADTheme.Typography.subheadline)
+            .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.7))
+            .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, MADTheme.Spacing.sm)
+    }
+
+    // MARK: - Targets
+
+    private var targetList: some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+            Text("What are you chasing?")
+                .font(MADTheme.Typography.headline)
+                .foregroundStyle(MADTheme.Colors.madWhite)
+
+            ForEach(Array(targets.enumerated()), id: \.offset) { _, target in
+                targetRow(target)
+            }
+
+            if let targetFootnote {
+                HStack(alignment: .top, spacing: 6) {
+                    Image(systemName: "info.circle")
+                        .font(.system(size: 11, weight: .semibold))
+                    Text(targetFootnote)
+                        .font(MADTheme.Typography.caption)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.5))
+                .padding(.top, 2)
+            }
+        }
+    }
+
+    private func targetRow(_ target: BestEffortStore.GhostTarget) -> some View {
+        let info = rowInfo(target)
+        let isOn = matchesSelection(target)
+        return Button {
+            MADHaptics.tap()
+            withAnimation(MADTheme.Animation.quick) { selection = target }
+        } label: {
+            HStack(spacing: MADTheme.Spacing.md) {
+                Image(systemName: info.icon)
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(isOn ? accent : MADTheme.Colors.madWhite.opacity(0.5))
+                    .frame(width: 30)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(info.title)
+                        .font(MADTheme.Typography.bodyBold)
+                        .foregroundStyle(MADTheme.Colors.madWhite)
+                    Text(info.detail)
+                        .font(MADTheme.Typography.caption)
+                        .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.6))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: MADTheme.Spacing.sm)
+
+                Text(info.time)
+                    .font(.system(size: 20, weight: .bold, design: .rounded))
+                    .foregroundStyle(isOn ? MADTheme.Colors.madWhite : MADTheme.Colors.madWhite.opacity(0.8))
+                    .monospacedDigit()
+            }
+            .padding(MADTheme.Spacing.md)
+            .ghostRaceSurface(selected: isOn, accent: accent)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func matchesSelection(_ target: BestEffortStore.GhostTarget) -> Bool {
+        switch (target, selection) {
+        case (.recordedBest, .recordedBest), (.personalRecord, .personalRecord):
+            return true
+        case (.custom, .custom):
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func rowInfo(
+        _ target: BestEffortStore.GhostTarget
+    ) -> (icon: String, title: String, detail: String, time: String) {
+        switch target {
+        case .recordedBest:
+            let seconds = BestEffortStore.best(for: activityKey)?.seconds ?? 0
+            return (
+                "figure.run.circle.fill",
+                "Best tracked in-app",
+                "Your fastest mile tracked with Start Mile, replayed at the real pace you ran it — surges and all.",
+                BestEffortStore.formatSeconds(seconds)
+            )
+        case .personalRecord:
+            return (
+                "bolt.fill",
+                "All-time PR",
+                "Your fastest mile from ANY workout, Apple Watch included. Held at one even pace.",
+                BestEffortStore.formatSeconds(seedPaceSeconds ?? 0)
+            )
+        case .custom:
+            return (
+                "slider.horizontal.3",
+                "A time you set",
+                isRun
+                    ? "Any target you like — a goal pace, or a friend's time."
+                    : "Any target you like. Works from your very first walk.",
+                BestEffortStore.formatSeconds(customTotalSeconds)
+            )
+        }
+    }
+
+    /// The two "bests" routinely disagree — badly enough that the screen has to
+    /// say why. The in-app best comes from this app's tracker only; the PR is
+    /// the fastest mile SPLIT across every synced workout, so a quick mile
+    /// inside a long Apple Watch run sets it. Someone whose fast running
+    /// happens on the Watch sees 9:47 next to 6:41 and, without this line, has
+    /// no way to know which number means what.
+    private var targetFootnote: String? {
+        guard targets.contains(where: { if case .recordedBest = $0 { return true }; return false }),
+            targets.contains(where: { if case .personalRecord = $0 { return true }; return false })
+        else { return nil }
+        return
+            "Your PR can be faster than your best tracked mile — it counts miles from Apple Watch and other apps, which this app's tracker never saw."
+    }
+
+    // MARK: - Custom picker
+
+    private var customPicker: some View {
+        VStack(spacing: MADTheme.Spacing.sm) {
+            HStack(spacing: 0) {
+                wheel(value: $customMinutes, range: 2...40, unit: "min")
+                Text(":")
+                    .font(.system(size: 26, weight: .bold, design: .rounded))
+                    .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.5))
+                wheel(value: $customSeconds, range: 0...59, unit: "sec")
+            }
+            .frame(height: 130)
+
+            Text(paceHint)
+                .font(MADTheme.Typography.caption)
+                .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.6))
+                .multilineTextAlignment(.center)
+        }
+        .padding(MADTheme.Spacing.md)
+        .frame(maxWidth: .infinity)
+        .ghostRaceSurface(selected: false, accent: accent)
+    }
+
+    private func wheel(value: Binding<Int>, range: ClosedRange<Int>, unit: String) -> some View {
+        VStack(spacing: 2) {
+            Picker(unit, selection: value) {
+                ForEach(Array(range), id: \.self) { n in
+                    Text(String(format: "%02d", n))
+                        .font(.system(size: 22, weight: .semibold, design: .rounded))
+                        .foregroundStyle(MADTheme.Colors.madWhite)
+                        .tag(n)
+                }
+            }
+            .pickerStyle(.wheel)
+            .labelsHidden()
+            Text(unit.uppercased())
+                .font(.system(size: 10, weight: .bold, design: .rounded))
+                .tracking(1)
+                .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.45))
+        }
+    }
+
+    /// Grounds the abstract number in something the user recognises. A target
+    /// they can't picture is a target they can't pick well.
+    private var paceHint: String {
+        guard let reference = referenceSeconds else {
+            return "That's a \(BestEffortStore.formatSeconds(customTotalSeconds)) mile pace."
+        }
+        let delta = Int((reference - customTotalSeconds).rounded())
+        if abs(delta) < 3 { return "Just about dead even with your best mile." }
+        return delta > 0
+            ? "\(delta)s faster than your best mile — a real push."
+            : "\(-delta)s easier than your best mile — a comfortable target."
+    }
+
+    private var referenceSeconds: Double? {
+        BestEffortStore.best(for: activityKey)?.seconds
+            ?? (isRun ? seedPaceSeconds : nil)
+    }
+
+    // MARK: - Explainer
+
+    private var howItWorks: some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+            Text("How it works")
+                .font(MADTheme.Typography.headline)
+                .foregroundStyle(MADTheme.Colors.madWhite)
+
+            explainerRow(
+                "gauge.with.needle",
+                "A live chip under your clock shows +/- seconds against the ghost."
+            )
+            explainerRow(
+                "flag.checkered",
+                isRun
+                    ? "It locks in the moment you hit 1.00 mi — the rest of the run is yours."
+                    : "It locks in the moment you hit 1.00 mi — the rest of the walk is yours."
+            )
+            explainerRow(
+                "stopwatch",
+                isRun
+                    ? "Only moving time counts, so stopping at a light can't cheat the race."
+                    : "Only moving time counts, so pausing to wait can't cheat the race."
+            )
+            explainerRow(
+                "arrow.clockwise",
+                "Every finished mile updates your best, whether you raced it or not."
+            )
+        }
+        .padding(MADTheme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .ghostRaceSurface(selected: false, accent: accent)
+    }
+
+    private func explainerRow(_ icon: String, _ text: String) -> some View {
+        HStack(alignment: .top, spacing: MADTheme.Spacing.sm) {
+            Image(systemName: icon)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(accent)
+                .frame(width: 20)
+            Text(text)
+                .font(MADTheme.Typography.footnote)
+                .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.75))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        VStack(spacing: MADTheme.Spacing.sm) {
+            Button {
+                MADHaptics.action()
+                commit()
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "flag.checkered")
+                    Text("Race \(BestEffortStore.formatSeconds(armedSeconds))")
+                }
+                .font(MADTheme.Typography.bodyBold)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, MADTheme.Spacing.md)
+                .background(Capsule().fill(accent))
+                .foregroundStyle(accentForeground)
+            }
+            .buttonStyle(.plain)
+            .disabled(!armedIsValid)
+            .opacity(armedIsValid ? 1 : 0.5)
+
+            Button {
+                MADHaptics.tap()
+                onDecline()
+            } label: {
+                Text(declineTitle)
+                    .font(MADTheme.Typography.small)
+                    .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.7))
+                    .padding(.vertical, 6)
+                    .frame(maxWidth: .infinity)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, MADTheme.Spacing.md)
+        // The generous top padding is what gives the scrim room to fade in, so
+        // content dissolves under the footer instead of hitting a hard edge.
+        .padding(.top, MADTheme.Spacing.xl)
+        .padding(.bottom, MADTheme.Spacing.sm)
+        .background(
+            LinearGradient(
+                colors: [Color.black.opacity(0), Color.black.opacity(0.55)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea(edges: .bottom)
+            .allowsHitTesting(false)
+        )
+    }
+
+    private var armedSeconds: Double {
+        switch armedTarget {
+        case .recordedBest: return BestEffortStore.best(for: activityKey)?.seconds ?? 0
+        case .personalRecord: return seedPaceSeconds ?? 0
+        case .custom(let seconds): return seconds
+        }
+    }
+
+    private func commit() {
+        guard armedIsValid else { return }
+        if case .custom(let seconds) = armedTarget {
+            BestEffortStore.saveCustomSeconds(seconds, for: activityKey)
+        }
+        onRace(armedTarget)
+    }
+}
+
+// MARK: - Card surface
+
+private extension View {
+    /// The card treatment for this screen.
+    ///
+    /// Deliberately NOT `madLiquidGlass`: this content now renders over the
+    /// tracker's red gradient as well as the lobby's dark one, and a
+    /// translucent white card is the one treatment that reads correctly on
+    /// both — and matches the Run/Walk option cards it now sits beside in the
+    /// wizard. Selection is carried by a fill AND a stroke, since a stroke
+    /// alone is easy to miss on a busy gradient.
+    func ghostRaceSurface(selected: Bool, accent: Color) -> some View {
+        background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
+                .fill(selected ? accent.opacity(0.22) : Color.white.opacity(0.12))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
+                .strokeBorder(
+                    selected ? accent : Color.white.opacity(0.18),
+                    lineWidth: selected ? 2 : 1
+                )
+        )
+    }
+}

--- a/app/Mile A Day/Views/Dashboard/GhostRaceOptionsContent.swift
+++ b/app/Mile A Day/Views/Dashboard/GhostRaceOptionsContent.swift
@@ -45,11 +45,28 @@ struct GhostRaceOptionsContent: View {
     /// would throw away wheel edits mid-decision.
     @State private var hasPrimed = false
 
+    @ObservedObject private var friendGhosts = FriendGhostService.shared
+
     private var isRun: Bool { activityKey == "running" }
 
+    /// Friends you can chase, fastest first (the server orders them), minus
+    /// yourself — your own mile is already offered as "best tracked in-app".
+    private var friends: [FriendGhost] {
+        friendGhosts.ghosts(for: activityKey)
+            .filter { $0.user_id != UserManager.shared.currentUser.backendUserId }
+    }
+
+    /// Your own targets, then friends, then `.custom`.
+    ///
+    /// `.custom` MUST stay last — it's the always-available fallback, and the
+    /// picker's promise is that there is always something to race.
     private var targets: [BestEffortStore.GhostTarget] {
-        BestEffortStore.availableTargets(
+        var base = BestEffortStore.availableTargets(
             for: activityKey, seedPaceSecondsPerMile: seedPaceSeconds)
+        let custom = base.removeLast()
+        base.append(contentsOf: friends.map(\.target))
+        base.append(custom)
+        return base
     }
 
     private var customTotalSeconds: Double {
@@ -95,6 +112,12 @@ struct GhostRaceOptionsContent: View {
             hasPrimed = true
             primeSelection()
         }
+        // Friends load AFTER the first prime, so a stored friend target is
+        // resolved from its own persisted seconds rather than waiting on the
+        // network — the picker is never blank and never blocks.
+        .task(id: activityKey) {
+            await friendGhosts.refreshIfNeeded(activityKey: activityKey)
+        }
     }
 
     /// One-shot: seed the wheels and the selected row from what's already
@@ -117,6 +140,9 @@ struct GhostRaceOptionsContent: View {
     }
 
     /// Custom matches on KIND, not on seconds — the wheels own the value.
+    /// A friend matches on ID: two friends are not interchangeable, and this
+    /// is what lets a re-opened picker recognise the friend already armed
+    /// instead of silently dropping the selection.
     private func targetsContain(_ target: BestEffortStore.GhostTarget) -> Bool {
         targets.contains {
             switch ($0, target) {
@@ -124,6 +150,8 @@ struct GhostRaceOptionsContent: View {
                 return true
             case (.custom, .custom):
                 return true
+            case (.friend(let a, _, _), .friend(let b, _, _)):
+                return a == b
             default:
                 return false
             }
@@ -163,7 +191,16 @@ struct GhostRaceOptionsContent: View {
                 .font(MADTheme.Typography.headline)
                 .foregroundStyle(MADTheme.Colors.madWhite)
 
-            ForEach(Array(targets.enumerated()), id: \.offset) { _, target in
+            ForEach(Array(targets.enumerated()), id: \.offset) { index, target in
+                // The friend block gets its own heading so the list reads as
+                // two ideas — your times, then theirs — instead of one long
+                // undifferentiated column.
+                if case .friend = target, isFirstFriendRow(at: index) {
+                    Text("Chase a friend")
+                        .font(MADTheme.Typography.headline)
+                        .foregroundStyle(MADTheme.Colors.madWhite)
+                        .padding(.top, MADTheme.Spacing.sm)
+                }
                 targetRow(target)
             }
 
@@ -181,6 +218,11 @@ struct GhostRaceOptionsContent: View {
         }
     }
 
+    /// True for the first friend in `targets` — drives the section heading.
+    private func isFirstFriendRow(at index: Int) -> Bool {
+        targets.firstIndex { if case .friend = $0 { return true }; return false } == index
+    }
+
     private func targetRow(_ target: BestEffortStore.GhostTarget) -> some View {
         let info = rowInfo(target)
         let isOn = matchesSelection(target)
@@ -189,10 +231,27 @@ struct GhostRaceOptionsContent: View {
             withAnimation(MADTheme.Animation.quick) { selection = target }
         } label: {
             HStack(spacing: MADTheme.Spacing.md) {
-                Image(systemName: info.icon)
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundStyle(isOn ? accent : MADTheme.Colors.madWhite.opacity(0.5))
+                // A friend gets their face where the other targets get a
+                // symbol — it's the whole reason this row reads differently.
+                if case .friend(let id, _, _) = target,
+                    let friend = friends.first(where: { $0.user_id == id })
+                {
+                    AvatarView(
+                        name: friend.avatarName,
+                        imageURL: friend.profile_image_url,
+                        size: 30
+                    )
+                    .overlay(
+                        Circle().strokeBorder(
+                            isOn ? accent : Color.clear, lineWidth: 1.5)
+                    )
                     .frame(width: 30)
+                } else {
+                    Image(systemName: info.icon)
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(isOn ? accent : MADTheme.Colors.madWhite.opacity(0.5))
+                        .frame(width: 30)
+                }
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(info.title)
@@ -223,6 +282,10 @@ struct GhostRaceOptionsContent: View {
             return true
         case (.custom, .custom):
             return true
+        // By ID. Matching on kind here would highlight EVERY friend row at
+        // once, since they're all `.friend`.
+        case (.friend(let a, _, _), .friend(let b, _, _)):
+            return a == b
         default:
             return false
         }
@@ -246,6 +309,16 @@ struct GhostRaceOptionsContent: View {
                 "All-time PR",
                 "Your fastest mile from ANY workout, Apple Watch included. Held at one even pace.",
                 BestEffortStore.formatSeconds(seedPaceSeconds ?? 0)
+            )
+        case .friend(_, let seconds, let name):
+            return (
+                "person.fill",
+                name,
+                // Same caveat the footnote gives for the user's own PR: this is
+                // their fastest mile from ANY synced workout, so it can be
+                // faster than anything they've tracked in this app.
+                "Their fastest mile from any synced workout. Held at one even pace.",
+                BestEffortStore.formatSeconds(seconds)
             )
         case .custom:
             return (
@@ -436,6 +509,7 @@ struct GhostRaceOptionsContent: View {
         case .recordedBest: return BestEffortStore.best(for: activityKey)?.seconds ?? 0
         case .personalRecord: return seedPaceSeconds ?? 0
         case .custom(let seconds): return seconds
+        case .friend(_, let seconds, _): return seconds
         }
     }
 

--- a/app/Mile A Day/Views/Dashboard/GhostRaceSetupSheet.swift
+++ b/app/Mile A Day/Views/Dashboard/GhostRaceSetupSheet.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 
-/// Choose what to race this session.
+/// Modal presentation of the ghost-race picker.
 ///
-/// The rule this screen exists to guarantee: there is ALWAYS something to race.
-/// Before it, a walk with no recorded history had no ghost at all and the card
-/// just explained why you couldn't play. Now the custom target is always
-/// offered, so "race a time I pick" works on the very first walk.
+/// The picker itself lives in `GhostRaceOptionsContent` — this is only the
+/// chrome for showing it as a sheet. The walk/run wizard renders that same
+/// content as an inline step instead (no sheet), so the two surfaces can never
+/// drift: change the picker once, both get it.
 ///
-/// Everything is on one screen, in the order the question actually gets asked:
-/// what am I chasing → how fast is it → what happens when I start.
+/// Kept as a sheet for the buddy lobby, whose job is getting someone into the
+/// room; the race is one row on it, not a step in a flow.
 struct GhostRaceSetupSheet: View {
     let activityKey: String
     /// Backend fastest-mile PR in seconds, when there is one.
@@ -20,410 +20,36 @@ struct GhostRaceSetupSheet: View {
 
     @Environment(\.dismiss) private var dismiss
 
-    @State private var selection: BestEffortStore.GhostTarget = .recordedBest
-    /// Custom target, held split so the wheels are independent.
-    @State private var customMinutes: Int = 9
-    @State private var customSeconds: Int = 0
-
-    private var accent: Color { MADTheme.workoutColor(activityKey) }
-    private var isRun: Bool { activityKey == "running" }
-
-    private var targets: [BestEffortStore.GhostTarget] {
-        BestEffortStore.availableTargets(
-            for: activityKey, seedPaceSecondsPerMile: seedPaceSeconds)
-    }
-
-    private var customTotalSeconds: Double {
-        Double(customMinutes * 60 + customSeconds)
-    }
-
-    private var isCustomSelected: Bool {
-        if case .custom = selection { return true }
-        return false
-    }
-
-    /// The selection as it would be armed — custom picks up the live wheels.
-    private var armedTarget: BestEffortStore.GhostTarget {
-        isCustomSelected ? .custom(seconds: customTotalSeconds) : selection
-    }
-
-    private var armedIsValid: Bool {
-        !isCustomSelected || BestEffortStore.GhostTarget.isPlausible(customTotalSeconds)
-    }
-
-    // MARK: - Body
-
     var body: some View {
         NavigationStack {
-            ZStack(alignment: .bottom) {
+            ZStack {
                 MADTheme.Colors.appBackgroundGradient.ignoresSafeArea()
 
-                ScrollView {
-                    VStack(spacing: MADTheme.Spacing.lg) {
-                        header
-                        targetList
-                        if isCustomSelected { customPicker }
-                        howItWorks
-                        Color.clear.frame(height: 180)
+                GhostRaceOptionsContent(
+                    activityKey: activityKey,
+                    seedPaceSeconds: seedPaceSeconds,
+                    current: current,
+                    accent: MADTheme.workoutColor(activityKey),
+                    accentForeground: MADTheme.Colors.madWhite,
+                    declineTitle: current == nil ? "Not this time" : "Turn off racing",
+                    onRace: { target in
+                        onDone(target)
+                        dismiss()
+                    },
+                    onDecline: {
+                        onDone(nil)
+                        dismiss()
                     }
-                    .padding(.horizontal, MADTheme.Spacing.md)
-                    .padding(.top, MADTheme.Spacing.sm)
-                }
-
-                footer
+                )
             }
             .navigationTitle("Ghost Race")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
+                    // Pure abort: leaves whatever is already armed untouched.
                     Button("Cancel") { dismiss() }
                 }
             }
-            .onAppear(perform: primeSelection)
         }
-    }
-
-    /// One-shot: seed the wheels and the selected row from what's already
-    /// armed, falling back to the best available target.
-    private func primeSelection() {
-        let seconds = BestEffortStore.customSeconds(for: activityKey)
-        customMinutes = Int(seconds) / 60
-        customSeconds = Int(seconds) % 60
-
-        if let current, targetsContain(current) {
-            selection = current
-            if case .custom(let s) = current {
-                customMinutes = Int(s) / 60
-                customSeconds = Int(s) % 60
-            }
-        } else {
-            selection = BestEffortStore.defaultTarget(
-                for: activityKey, seedPaceSecondsPerMile: seedPaceSeconds)
-        }
-    }
-
-    /// Custom matches on KIND, not on seconds — the wheels own the value.
-    private func targetsContain(_ target: BestEffortStore.GhostTarget) -> Bool {
-        targets.contains {
-            switch ($0, target) {
-            case (.recordedBest, .recordedBest), (.personalRecord, .personalRecord):
-                return true
-            case (.custom, .custom):
-                return true
-            default:
-                return false
-            }
-        }
-    }
-
-    // MARK: - Header
-
-    private var header: some View {
-        VStack(spacing: MADTheme.Spacing.sm) {
-            ZStack {
-                Circle().fill(accent.opacity(0.18)).frame(width: 72, height: 72)
-                Image(systemName: "flag.checkered")
-                    .font(.system(size: 30, weight: .semibold))
-                    .foregroundStyle(accent)
-            }
-            Text("Race a ghost for one mile")
-                .font(MADTheme.Typography.title3)
-                .foregroundStyle(MADTheme.Colors.madWhite)
-            Text(
-                "Pick a time to chase. You'll see how far ahead or behind you are the whole way."
-            )
-            .font(MADTheme.Typography.subheadline)
-            .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.65))
-            .multilineTextAlignment(.center)
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, MADTheme.Spacing.lg)
-        .padding(.horizontal, MADTheme.Spacing.md)
-        .madLiquidGlass(cornerRadius: MADTheme.CornerRadius.extraLarge)
-    }
-
-    // MARK: - Targets
-
-    private var targetList: some View {
-        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
-            Text("What are you chasing?")
-                .font(MADTheme.Typography.headline)
-                .foregroundStyle(MADTheme.Colors.madWhite)
-
-            ForEach(Array(targets.enumerated()), id: \.offset) { _, target in
-                targetRow(target)
-            }
-
-            if let targetFootnote {
-                HStack(alignment: .top, spacing: 6) {
-                    Image(systemName: "info.circle")
-                        .font(.system(size: 11, weight: .semibold))
-                    Text(targetFootnote)
-                        .font(MADTheme.Typography.caption)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.5))
-                .padding(.top, 2)
-            }
-        }
-    }
-
-    private func targetRow(_ target: BestEffortStore.GhostTarget) -> some View {
-        let info = rowInfo(target)
-        let isOn = matchesSelection(target)
-        return Button {
-            MADHaptics.tap()
-            withAnimation(MADTheme.Animation.quick) { selection = target }
-        } label: {
-            HStack(spacing: MADTheme.Spacing.md) {
-                Image(systemName: info.icon)
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundStyle(isOn ? accent : MADTheme.Colors.madWhite.opacity(0.5))
-                    .frame(width: 30)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(info.title)
-                        .font(MADTheme.Typography.bodyBold)
-                        .foregroundStyle(MADTheme.Colors.madWhite)
-                    Text(info.detail)
-                        .font(MADTheme.Typography.caption)
-                        .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.6))
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                Spacer(minLength: MADTheme.Spacing.sm)
-
-                Text(info.time)
-                    .font(.system(size: 20, weight: .bold, design: .rounded))
-                    .foregroundStyle(isOn ? accent : MADTheme.Colors.madWhite.opacity(0.8))
-                    .monospacedDigit()
-            }
-            .padding(MADTheme.Spacing.md)
-            .madLiquidGlass(cornerRadius: MADTheme.CornerRadius.large)
-            .overlay(
-                RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large)
-                    .stroke(isOn ? accent : Color.clear, lineWidth: 2)
-            )
-        }
-        .buttonStyle(.plain)
-    }
-
-    private func matchesSelection(_ target: BestEffortStore.GhostTarget) -> Bool {
-        switch (target, selection) {
-        case (.recordedBest, .recordedBest), (.personalRecord, .personalRecord):
-            return true
-        case (.custom, .custom):
-            return true
-        default:
-            return false
-        }
-    }
-
-    private func rowInfo(
-        _ target: BestEffortStore.GhostTarget
-    ) -> (icon: String, title: String, detail: String, time: String) {
-        switch target {
-        case .recordedBest:
-            let seconds = BestEffortStore.best(for: activityKey)?.seconds ?? 0
-            return (
-                "figure.run.circle.fill",
-                "Best tracked in-app",
-                "Your fastest mile tracked with Start Mile, replayed at the real pace you ran it — surges and all.",
-                BestEffortStore.formatSeconds(seconds)
-            )
-        case .personalRecord:
-            return (
-                "bolt.fill",
-                "All-time PR",
-                "Your fastest mile from ANY workout, Apple Watch included. Held at one even pace.",
-                BestEffortStore.formatSeconds(seedPaceSeconds ?? 0)
-            )
-        case .custom:
-            return (
-                "slider.horizontal.3",
-                "A time you set",
-                isRun
-                    ? "Any target you like — a goal pace, or a friend's time."
-                    : "Any target you like. Works from your very first walk.",
-                BestEffortStore.formatSeconds(customTotalSeconds)
-            )
-        }
-    }
-
-    /// The two "bests" routinely disagree — badly enough that the screen has to
-    /// say why. The in-app best comes from this app's tracker only; the PR is
-    /// the fastest mile SPLIT across every synced workout, so a quick mile
-    /// inside a long Apple Watch run sets it. Someone whose fast running
-    /// happens on the Watch sees 9:47 next to 6:41 and, without this line, has
-    /// no way to know which number means what.
-    private var targetFootnote: String? {
-        guard targets.contains(where: { if case .recordedBest = $0 { return true }; return false }),
-            targets.contains(where: { if case .personalRecord = $0 { return true }; return false })
-        else { return nil }
-        return
-            "Your PR can be faster than your best tracked mile — it counts miles from Apple Watch and other apps, which this app's tracker never saw."
-    }
-
-    // MARK: - Custom picker
-
-    private var customPicker: some View {
-        VStack(spacing: MADTheme.Spacing.sm) {
-            HStack(spacing: 0) {
-                wheel(value: $customMinutes, range: 2...40, unit: "min")
-                Text(":")
-                    .font(.system(size: 26, weight: .bold, design: .rounded))
-                    .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.5))
-                wheel(value: $customSeconds, range: 0...59, unit: "sec")
-            }
-            .frame(height: 130)
-
-            Text(paceHint)
-                .font(MADTheme.Typography.caption)
-                .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.6))
-                .multilineTextAlignment(.center)
-        }
-        .padding(MADTheme.Spacing.md)
-        .frame(maxWidth: .infinity)
-        .madLiquidGlass(cornerRadius: MADTheme.CornerRadius.large)
-    }
-
-    private func wheel(value: Binding<Int>, range: ClosedRange<Int>, unit: String) -> some View {
-        VStack(spacing: 2) {
-            Picker(unit, selection: value) {
-                ForEach(Array(range), id: \.self) { n in
-                    Text(String(format: "%02d", n))
-                        .font(.system(size: 22, weight: .semibold, design: .rounded))
-                        .foregroundStyle(MADTheme.Colors.madWhite)
-                        .tag(n)
-                }
-            }
-            .pickerStyle(.wheel)
-            .labelsHidden()
-            Text(unit.uppercased())
-                .font(.system(size: 10, weight: .bold, design: .rounded))
-                .tracking(1)
-                .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.45))
-        }
-    }
-
-    /// Grounds the abstract number in something the user recognises. A target
-    /// they can't picture is a target they can't pick well.
-    private var paceHint: String {
-        guard let reference = referenceSeconds else {
-            return "That's a \(BestEffortStore.formatSeconds(customTotalSeconds)) mile pace."
-        }
-        let delta = Int((reference - customTotalSeconds).rounded())
-        if abs(delta) < 3 { return "Just about dead even with your best mile." }
-        return delta > 0
-            ? "\(delta)s faster than your best mile — a real push."
-            : "\(-delta)s easier than your best mile — a comfortable target."
-    }
-
-    private var referenceSeconds: Double? {
-        BestEffortStore.best(for: activityKey)?.seconds
-            ?? (isRun ? seedPaceSeconds : nil)
-    }
-
-    // MARK: - Explainer
-
-    private var howItWorks: some View {
-        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
-            Text("How it works")
-                .font(MADTheme.Typography.headline)
-                .foregroundStyle(MADTheme.Colors.madWhite)
-
-            explainerRow(
-                "gauge.with.needle",
-                "A live chip under your clock shows +/- seconds against the ghost."
-            )
-            explainerRow(
-                "flag.checkered",
-                isRun
-                    ? "It locks in the moment you hit 1.00 mi — the rest of the run is yours."
-                    : "It locks in the moment you hit 1.00 mi — the rest of the walk is yours."
-            )
-            explainerRow(
-                "stopwatch",
-                isRun
-                    ? "Only moving time counts, so stopping at a light can't cheat the race."
-                    : "Only moving time counts, so pausing to wait can't cheat the race."
-            )
-            explainerRow(
-                "arrow.clockwise",
-                "Every finished mile updates your best, whether you raced it or not."
-            )
-        }
-        .padding(MADTheme.Spacing.md)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .madLiquidGlass(cornerRadius: MADTheme.CornerRadius.large)
-    }
-
-    private func explainerRow(_ icon: String, _ text: String) -> some View {
-        HStack(alignment: .top, spacing: MADTheme.Spacing.sm) {
-            Image(systemName: icon)
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(accent)
-                .frame(width: 20)
-            Text(text)
-                .font(MADTheme.Typography.footnote)
-                .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.75))
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-
-    // MARK: - Footer
-
-    private var footer: some View {
-        VStack(spacing: MADTheme.Spacing.sm) {
-            Button {
-                MADHaptics.action()
-                commit()
-            } label: {
-                HStack(spacing: 8) {
-                    Image(systemName: "flag.checkered")
-                    Text("Race \(BestEffortStore.formatSeconds(armedSeconds))")
-                }
-                .font(MADTheme.Typography.bodyBold)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, MADTheme.Spacing.md)
-                .background(Capsule().fill(accent))
-                .foregroundStyle(MADTheme.Colors.madWhite)
-            }
-            .buttonStyle(.plain)
-            .disabled(!armedIsValid)
-            .opacity(armedIsValid ? 1 : 0.5)
-
-            Button {
-                MADHaptics.tap()
-                onDone(nil)
-                dismiss()
-            } label: {
-                Text(current == nil ? "Not this time" : "Turn off racing")
-                    .font(MADTheme.Typography.small)
-                    .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.65))
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(.horizontal, MADTheme.Spacing.md)
-        .padding(.top, MADTheme.Spacing.sm)
-        .padding(.bottom, MADTheme.Spacing.sm)
-        .background(MADTheme.Colors.madBlack.opacity(0.9))
-    }
-
-    private var armedSeconds: Double {
-        switch armedTarget {
-        case .recordedBest: return BestEffortStore.best(for: activityKey)?.seconds ?? 0
-        case .personalRecord: return seedPaceSeconds ?? 0
-        case .custom(let seconds): return seconds
-        }
-    }
-
-    private func commit() {
-        guard armedIsValid else { return }
-        if case .custom(let seconds) = armedTarget {
-            BestEffortStore.saveCustomSeconds(seconds, for: activityKey)
-        }
-        onDone(armedTarget)
-        dismiss()
     }
 }

--- a/app/Mile A Day/Views/Dashboard/WorkoutLocationManager.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutLocationManager.swift
@@ -31,6 +31,10 @@ class WorkoutLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
     /// that wasn't raced or wasn't won, so "present" means "won".
     static let ghostMarginMetadataKey = "MAD_ghost_margin_seconds"
     static let ghostTargetMetadataKey = "MAD_ghost_target_seconds"
+    /// Set alongside the two above when the ghost was a FRIEND's mile. This is
+    /// what lets the server tell them they were caught — without it the win is
+    /// recorded but anonymous.
+    static let ghostFriendMetadataKey = "MAD_ghost_friend_id"
 
     private let locationManager = CLLocationManager()
     private let pedometer = CMPedometer()

--- a/app/Mile A Day/Views/Dashboard/WorkoutLocationManager.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutLocationManager.swift
@@ -25,6 +25,12 @@ class WorkoutLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
     /// Written at save, read back by the sync (display pace divides by it) —
     /// Watch/third-party workouts simply don't have it.
     static let movingSecondsMetadataKey = "MAD_moving_seconds"
+    /// Ghost race, stamped only when the ghost was BEATEN. Same travel path as
+    /// moving seconds: HKWorkout metadata → sync → a `workouts` column, which
+    /// is what lets the server count wins for medals. Absent on every workout
+    /// that wasn't raced or wasn't won, so "present" means "won".
+    static let ghostMarginMetadataKey = "MAD_ghost_margin_seconds"
+    static let ghostTargetMetadataKey = "MAD_ghost_target_seconds"
 
     private let locationManager = CLLocationManager()
     private let pedometer = CMPedometer()

--- a/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
@@ -27,8 +27,18 @@ struct WorkoutTrackingView: View {
     // Shared singleton — tracking keeps running when this view is dismissed
     // (e.g. user navigates back to the dashboard mid-workout).
     @ObservedObject private var locationManager = WorkoutLocationManager.shared
+    // Pre-start wizard, in order: activity → location → race mode → ghost
+    // options (only when the race is chosen) → presence consent (once ever) →
+    // countdown. Each step owns exactly one question, and every one of these
+    // flags must be cleared by anything that jumps straight to tracking (the
+    // buddy hand-off and workout recovery both do).
     @State private var showActivitySelection = true
     @State private var showLocationTypeSelection = false
+    @State private var showRaceModeSelection = false
+    @State private var showGhostOptions = false
+    /// Which way the next step transition should slide. Set immediately before
+    /// the `withAnimation` that changes the step.
+    @State private var wizardGoingBack = false
     @State private var selectedActivityType: HKWorkoutActivityType?
     @State private var selectedLocationType: HKWorkoutSessionLocationType = .outdoor
     @State private var countdownNumber = 3
@@ -116,23 +126,22 @@ struct WorkoutTrackingView: View {
     // workout never races (its effort curve starts mid-distance anyway).
     //
     // WHAT is raced is the user's choice — recorded best, PR pace, or a time
-    // they typed — held in `raceTarget` and set in GhostRaceSetupSheet. It
-    // persists across sessions per activity, so a walker who races 12:00 gets
-    // 12:00 offered again next time rather than re-deciding every walk.
+    // they typed — held in `raceTarget` and picked on the ghost-options step.
+    // It persists across sessions per activity, so a walker who races 12:00
+    // gets 12:00 offered again next time rather than re-deciding every walk.
     @State private var raceArmed = false
     @State private var raceGhost: BestEffortStore.BestMileEffort?
     /// How to name the ghost in copy ("your best mile", "your target").
     @State private var raceGhostName = "your best mile"
     @State private var raceFinalDelta: TimeInterval?
-    @State private var showGhostSetup = false
     /// Chosen target, per activity, remembered between sessions.
     @AppStorage("ghostTargetV1.running") private var runTargetStorage = ""
     @AppStorage("ghostTargetV1.walking") private var walkTargetStorage = ""
     /// Drops the NEW pill on the arming card until the race is first set up.
     @AppStorage("hasArmedGhostRaceOnce") private var hasArmedGhostRaceOnce = false
     /// Set in `BuddyLobbyView` — the only screen a buddy session passes
-    /// through, since the hand-off below skips the location picker where the
-    /// solo arming card lives. Read once on the buddy hand-off.
+    /// through, since the hand-off below skips the whole pre-start wizard
+    /// where the solo race steps live. Read once on the buddy hand-off.
     @AppStorage("buddyGhostArmedV1") private var buddyGhostArmed = false
 
     private var raceActivityKey: String {
@@ -240,12 +249,16 @@ struct WorkoutTrackingView: View {
         return String(format: "%02d:%02d", minutes, seconds)
     }
 
-    // MARK: - Activity Selection
+    // MARK: - Pre-start wizard chrome
 
-    private var activitySelectionContent: some View {
-        VStack(spacing: 0) {
+    /// Back chevron + progress. Every pre-start step uses this so the three
+    /// screens read as one flow rather than three views that happen to share a
+    /// gradient. `step` is 1-based; the ghost-options screen passes 3 as well,
+    /// because it's a sub-step of the race choice, not a fourth question.
+    private func wizardTopBar(step: Int, onBack: @escaping () -> Void) -> some View {
+        ZStack {
             HStack {
-                Button(action: { dismiss() }) {
+                Button(action: onBack) {
                     HStack(spacing: 8) {
                         Image(systemName: "chevron.left")
                             .font(.title3)
@@ -265,211 +278,188 @@ struct WorkoutTrackingView: View {
                 .buttonStyle(.plain)
                 Spacer()
             }
-            .padding(.top, 16)
+
+            HStack(spacing: 6) {
+                ForEach(1...3, id: \.self) { index in
+                    Capsule()
+                        .fill(Color.white.opacity(index <= step ? 0.9 : 0.25))
+                        .frame(width: 22, height: 4)
+                }
+            }
+            .allowsHitTesting(false)
+        }
+        .padding(.top, 16)
+    }
+
+    /// Glyph + question, identical on every step.
+    private func wizardHeader(glyph: String, title: String, subtitle: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: glyph)
+                .font(.system(size: 60))
+                .foregroundColor(.white)
+
+            Text(title)
+                .font(.system(size: 32, weight: .bold, design: .rounded))
+                .foregroundColor(.white)
+                .multilineTextAlignment(.center)
+
+            Text(subtitle)
+                .font(.title3)
+                .foregroundColor(.white.opacity(0.8))
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, 32)
+    }
+
+    /// The shared layout of a "pick one of these" step.
+    private func wizardStep<Options: View>(
+        step: Int,
+        glyph: String,
+        title: String,
+        subtitle: String,
+        onBack: @escaping () -> Void,
+        @ViewBuilder options: () -> Options
+    ) -> some View {
+        VStack(spacing: 0) {
+            wizardTopBar(step: step, onBack: onBack)
 
             VStack(spacing: 40) {
                 Spacer()
-
-                VStack(spacing: 16) {
-                    Image(systemName: "figure.walk")
-                        .font(.system(size: 60))
-                        .foregroundColor(.white)
-
-                    Text("Choose Activity Type")
-                        .font(.system(size: 32, weight: .bold, design: .rounded))
-                        .foregroundColor(.white)
-                        .multilineTextAlignment(.center)
-
-                    Text("Select how you'll complete your mile")
-                        .font(.title3)
-                        .foregroundColor(.white.opacity(0.8))
-                        .multilineTextAlignment(.center)
-                }
-                .padding(.horizontal, 32)
-
+                wizardHeader(glyph: glyph, title: title, subtitle: subtitle)
                 Spacer()
-
-                VStack(spacing: 20) {
-                    workoutOptionButton(icon: "figure.run", title: "Run", subtitle: "Track as a running workout") {
-                        selectActivity(.running)
-                    }
-                    workoutOptionButton(icon: "figure.walk", title: "Walk", subtitle: "Track as a walking workout") {
-                        selectActivity(.walking)
-                    }
-                }
-                .padding(.horizontal, 32)
-
+                VStack(spacing: 20) { options() }
+                    .padding(.horizontal, 32)
                 Spacer()
             }
         }
     }
 
-    // MARK: - Location Type Selection
+    /// Forward slides in from the trailing edge, Back from the leading edge —
+    /// so the wizard reads as depth rather than as unrelated crossfades.
+    private var wizardTransition: AnyTransition {
+        .asymmetric(
+            insertion: .move(edge: wizardGoingBack ? .leading : .trailing)
+                .combined(with: .opacity),
+            removal: .move(edge: wizardGoingBack ? .trailing : .leading)
+                .combined(with: .opacity)
+        )
+    }
+
+    // MARK: - Step 1: Activity
+
+    private var activitySelectionContent: some View {
+        wizardStep(
+            step: 1,
+            glyph: "figure.walk",
+            title: "Choose Activity Type",
+            subtitle: "Select how you'll complete your mile",
+            onBack: { dismiss() }
+        ) {
+            workoutOptionButton(icon: "figure.run", title: "Run", subtitle: "Track as a running workout") {
+                selectActivity(.running)
+            }
+            workoutOptionButton(icon: "figure.walk", title: "Walk", subtitle: "Track as a walking workout") {
+                selectActivity(.walking)
+            }
+        }
+    }
+
+    // MARK: - Step 2: Location
 
     private var locationTypeSelectionContent: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Button(action: {
-                    withAnimation {
-                        showLocationTypeSelection = false
-                        showActivitySelection = true
-                    }
-                }) {
-                    HStack(spacing: 8) {
-                        Image(systemName: "chevron.left")
-                            .font(.title3)
-                            .fontWeight(.semibold)
-                        Text("Back")
-                            .font(.body)
-                            .fontWeight(.medium)
-                    }
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 12)
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                Spacer()
+        wizardStep(
+            step: 2,
+            glyph: selectedActivityType == .running ? "figure.run" : "figure.walk",
+            title: "Choose Location",
+            subtitle: "Where will you be working out?",
+            onBack: { goBack(to: { showActivitySelection = true }, from: { showLocationTypeSelection = false }) }
+        ) {
+            workoutOptionButton(icon: "location.fill", title: "Outdoor", subtitle: "Uses GPS for accurate tracking") {
+                selectLocationType(.outdoor)
             }
-            .padding(.top, 16)
-
-            VStack(spacing: 40) {
-                Spacer()
-
-                VStack(spacing: 16) {
-                    Image(systemName: selectedActivityType == .running ? "figure.run" : "figure.walk")
-                        .font(.system(size: 60))
-                        .foregroundColor(.white)
-
-                    Text("Choose Location")
-                        .font(.system(size: 32, weight: .bold, design: .rounded))
-                        .foregroundColor(.white)
-                        .multilineTextAlignment(.center)
-
-                    Text("Where will you be working out?")
-                        .font(.title3)
-                        .foregroundColor(.white.opacity(0.8))
-                        .multilineTextAlignment(.center)
-                }
-                .padding(.horizontal, 32)
-
-                Spacer()
-
-                VStack(spacing: 20) {
-                    workoutOptionButton(icon: "location.fill", title: "Outdoor", subtitle: "Uses GPS for accurate tracking") {
-                        selectLocationType(.outdoor)
-                    }
-                    workoutOptionButton(icon: indoorLocationIcon, title: "Indoor", subtitle: "Treadmill or indoors — uses motion sensors") {
-                        selectLocationType(.indoor)
-                    }
-
-                    ghostRaceCard
-                }
-                .padding(.horizontal, 32)
-
-                Spacer()
-            }
-        }
-        .sheet(isPresented: $showGhostSetup) {
-            GhostRaceSetupSheet(
-                activityKey: raceActivityKey,
-                seedPaceSeconds: raceSeedPaceSeconds,
-                current: raceArmed ? raceTarget : nil
-            ) { chosen in
-                withAnimation(.spring(response: 0.3)) {
-                    if let chosen {
-                        storeRaceTarget(chosen)
-                        raceArmed = true
-                        hasArmedGhostRaceOnce = true
-                    } else {
-                        raceArmed = false
-                    }
-                }
+            workoutOptionButton(icon: indoorLocationIcon, title: "Indoor", subtitle: "Treadmill or indoors — uses motion sensors") {
+                selectLocationType(.indoor)
             }
         }
     }
 
-    /// Ghost-race entry point on the pre-start path. Always present, always
-    /// showing the exact time it would race, and never arming itself.
+    // MARK: - Step 3: Race mode
+
+    /// "Am I racing?" as a step of its own.
     ///
-    /// It used to be a toggle over whatever single ghost the store happened to
-    /// have — which meant a walker with no history had nothing to race and got
-    /// an explanation instead of a feature. Now it opens a picker, and a
-    /// custom time is always one of the choices, so the answer to "can I race
-    /// this?" is yes on the very first walk.
-    private var ghostRaceCard: some View {
-        Button {
-            MADHaptics.action()
-            showGhostSetup = true
-        } label: {
-            HStack(spacing: 14) {
-                ZStack {
-                    Circle()
-                        .fill(raceArmed ? Color.white.opacity(0.2) : MADTheme.Colors.madRed.opacity(0.18))
-                        .frame(width: 40, height: 40)
-                    Image(systemName: "flag.checkered")
-                        .font(.system(size: 19, weight: .semibold))
-                        .foregroundColor(raceArmed ? .white : MADTheme.Colors.madRed)
-                }
-
-                VStack(alignment: .leading, spacing: 3) {
-                    HStack(spacing: 6) {
-                        Text("Ghost Race")
-                            .font(.system(size: 16, weight: .bold, design: .rounded))
-                            .foregroundColor(.white)
-                        if !hasArmedGhostRaceOnce {
-                            Text("NEW")
-                                .font(.system(size: 9, weight: .black, design: .rounded))
-                                .tracking(0.8)
-                                .foregroundColor(.black.opacity(0.8))
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 3)
-                                .background(Capsule().fill(Color.yellow))
-                        }
-                    }
-                    Text(ghostRaceSubtitle)
-                        .font(.system(size: 12, weight: .medium, design: .rounded))
-                        .foregroundColor(.white.opacity(0.78))
-                        .lineLimit(2)
-                        .multilineTextAlignment(.leading)
-                }
-
-                Spacer(minLength: 8)
-
-                if raceArmed, let ghost = resolvedGhost {
-                    VStack(spacing: 0) {
-                        Text(BestEffortStore.formatSeconds(ghost.effort.seconds))
-                            .font(.system(size: 18, weight: .bold, design: .rounded))
-                            .foregroundColor(.white)
-                            .monospacedDigit()
-                        Text("TO BEAT")
-                            .font(.system(size: 8, weight: .black, design: .rounded))
-                            .tracking(0.6)
-                            .foregroundColor(.white.opacity(0.65))
-                    }
-                } else {
-                    Text("Set up")
-                        .font(.system(size: 13, weight: .bold, design: .rounded))
-                        .foregroundColor(.white.opacity(0.9))
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 6)
-                        .background(Capsule().fill(Color.white.opacity(0.15)))
-                }
+    /// It used to be a small card wedged under the Indoor/Outdoor buttons on a
+    /// screen about something else, opening a modal sheet — which read as an
+    /// add-on rather than a choice the flow cares about. Asking it here also
+    /// means the activity is already locked in, so the target on offer is
+    /// always the one for the activity being started.
+    private var raceModeSelectionContent: some View {
+        wizardStep(
+            step: 3,
+            glyph: "flag.checkered",
+            title: "Choose Your Mode",
+            subtitle: "Race a time, or just log the miles.",
+            onBack: { goBack(to: { showLocationTypeSelection = true }, from: { showRaceModeSelection = false }) }
+        ) {
+            workoutOptionButton(
+                icon: selectedActivityType == .running ? "figure.run" : "figure.walk",
+                title: "Just Track It",
+                subtitle: "No clock to chase — every mile still counts."
+            ) {
+                chooseRaceMode(ghost: false)
             }
-            .padding(16)
-            .background(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(raceArmed ? MADTheme.Colors.madRed.opacity(0.85) : Color.white.opacity(0.10))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 16, style: .continuous)
-                            .strokeBorder(
-                                raceArmed ? Color.white.opacity(0.35) : Color.white.opacity(0.15),
-                                lineWidth: 1
-                            )
-                    )
+
+            workoutOptionButton(
+                icon: "flag.checkered",
+                title: "Ghost Race",
+                subtitle: ghostRaceSubtitle,
+                featured: true,
+                badge: hasArmedGhostRaceOnce ? nil : "NEW",
+                accessory: {
+                    if let ghost = resolvedGhost {
+                        VStack(spacing: 0) {
+                            Text(BestEffortStore.formatSeconds(ghost.effort.seconds))
+                                .font(.system(size: 18, weight: .bold, design: .rounded))
+                                .foregroundColor(.white)
+                                .monospacedDigit()
+                            Text("TO BEAT")
+                                .font(.system(size: 8, weight: .black, design: .rounded))
+                                .tracking(0.6)
+                                .foregroundColor(.white.opacity(0.65))
+                        }
+                    } else {
+                        optionChevron
+                    }
+                }
+            ) {
+                chooseRaceMode(ghost: true)
+            }
+        }
+    }
+
+    // MARK: - Step 4: Ghost options
+
+    /// The picker, inline. Same content the buddy lobby shows as a sheet — it
+    /// just gets the wizard's back bar and background instead of modal chrome.
+    private var ghostOptionsContent: some View {
+        VStack(spacing: 0) {
+            wizardTopBar(step: 3) {
+                goBack(to: { showRaceModeSelection = true }, from: { showGhostOptions = false })
+            }
+
+            GhostRaceOptionsContent(
+                activityKey: raceActivityKey,
+                seedPaceSeconds: raceSeedPaceSeconds,
+                current: raceArmed ? raceTarget : nil,
+                // White, not the workout color: this renders on the tracker's
+                // red gradient, where a red CTA would vanish. Matches the
+                // presence-consent step's primary button on the same screen.
+                accent: .white,
+                accentForeground: Color(red: 0.5, green: 0.15, blue: 0.2),
+                declineTitle: "Skip the race",
+                onRace: { armGhost($0) },
+                onDecline: { chooseRaceMode(ghost: false) }
             )
         }
-        .buttonStyle(.plain)
     }
 
     /// What to say about the finished mile.
@@ -522,11 +512,14 @@ struct WorkoutTrackingView: View {
             ))
     }
 
+    /// Copy for the Ghost Race option. `resolvedGhost` is what makes the
+    /// promise concrete — the card shows the exact time it would race, so a
+    /// repeat racer knows what tapping means before they tap.
     private var ghostRaceSubtitle: String {
-        guard raceArmed, let ghost = resolvedGhost else {
+        guard let ghost = resolvedGhost else {
             return "Chase your best mile, your PR, or a time you pick."
         }
-        return "Racing \(ghost.shortName) — live ahead/behind on screen."
+        return "Chase \(ghost.shortName) for one mile — live ahead/behind on screen."
     }
 
     // MARK: - Countdown
@@ -1401,6 +1394,32 @@ struct WorkoutTrackingView: View {
     }
 
     private func workoutOptionButton(icon: String, title: String, subtitle: String, action: @escaping () -> Void) -> some View {
+        workoutOptionButton(
+            icon: icon, title: title, subtitle: subtitle,
+            accessory: { optionChevron }, action: action)
+    }
+
+    /// The wizard's option card.
+    ///
+    /// `featured` brightens the surface so one option can read as the special
+    /// one, `badge` is the small pill beside the title (the ghost race's NEW
+    /// flag), and `accessory` replaces the trailing chevron with a readout.
+    /// All three default off, so the plain overload above renders exactly what
+    /// the Run/Walk and Indoor/Outdoor steps have always shown.
+    ///
+    /// Featuring is deliberately a BRIGHTNESS shift, not a hue one: this whole
+    /// screen sits on the red gradient, and `MADTheme.workoutColor("running")`
+    /// is that gradient's own top stop — a red-tinted border and glyph would
+    /// go muddy on exactly the workout type most people pick.
+    private func workoutOptionButton<Accessory: View>(
+        icon: String,
+        title: String,
+        subtitle: String,
+        featured: Bool = false,
+        badge: String? = nil,
+        @ViewBuilder accessory: () -> Accessory,
+        action: @escaping () -> Void
+    ) -> some View {
         Button(action: action) {
             HStack(spacing: 16) {
                 Image(systemName: icon)
@@ -1408,31 +1427,48 @@ struct WorkoutTrackingView: View {
                     .frame(width: 50)
 
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(title)
-                        .font(.system(size: 28, weight: .bold, design: .rounded))
+                    HStack(spacing: 8) {
+                        Text(title)
+                            .font(.system(size: 28, weight: .bold, design: .rounded))
+                        if let badge {
+                            Text(badge)
+                                .font(.system(size: 9, weight: .black, design: .rounded))
+                                .tracking(0.8)
+                                .foregroundColor(.black.opacity(0.8))
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 3)
+                                .background(Capsule().fill(Color.yellow))
+                        }
+                    }
                     Text(subtitle)
                         .font(.subheadline)
                         .opacity(0.9)
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
-                Spacer()
+                Spacer(minLength: 8)
 
-                Image(systemName: "chevron.right")
-                    .font(.title2)
-                    .fontWeight(.semibold)
+                accessory()
             }
             .foregroundColor(.white)
             .padding(24)
             .background(
                 RoundedRectangle(cornerRadius: 20)
-                    .fill(Color.white.opacity(0.15))
+                    .fill(Color.white.opacity(featured ? 0.24 : 0.15))
                     .overlay(
                         RoundedRectangle(cornerRadius: 20)
-                            .stroke(Color.white.opacity(0.3), lineWidth: 2)
+                            .stroke(Color.white.opacity(featured ? 0.6 : 0.3), lineWidth: 2)
                     )
             )
         }
         .buttonStyle(PlainButtonStyle())
+    }
+
+    private var optionChevron: some View {
+        Image(systemName: "chevron.right")
+            .font(.title2)
+            .fontWeight(.semibold)
     }
 
     var body: some View {
@@ -1452,8 +1488,16 @@ struct WorkoutTrackingView: View {
 
             if showActivitySelection {
                 activitySelectionContent
+                    .transition(wizardTransition)
             } else if showLocationTypeSelection {
                 locationTypeSelectionContent
+                    .transition(wizardTransition)
+            } else if showRaceModeSelection {
+                raceModeSelectionContent
+                    .transition(wizardTransition)
+            } else if showGhostOptions {
+                ghostOptionsContent
+                    .transition(wizardTransition)
             } else if showPresenceConsent {
                 presenceConsentContent
             } else if showCountdown {
@@ -1579,13 +1623,11 @@ struct WorkoutTrackingView: View {
                 selectedActivityType =
                     (buddyService.session?.isRunning ?? false) ? .running : .walking
                 selectedLocationType = .outdoor
-                showActivitySelection = false
-                showLocationTypeSelection = false
-                showCountdown = false
-                // Ghost race, armed from the lobby. This branch skips the
-                // location screen, which is the only place `ghostRaceCard`
-                // lives — so without this a buddy walk could never race,
-                // even though it already feeds BestEffortStore on finish.
+                clearPreStartSteps()
+                // Ghost race, armed from the lobby. This branch skips the whole
+                // pre-start wizard, which is the only place the solo race steps
+                // live — so without this a buddy walk could never race, even
+                // though it already feeds BestEffortStore on finish.
                 // Everything downstream (resolvedGhost, the delta chip, the
                 // 1-mile freeze, the celebration) only ever needed raceArmed.
                 raceArmed = buddyGhostArmed
@@ -1611,9 +1653,7 @@ struct WorkoutTrackingView: View {
             }
 
             // Jump directly into the tracking UI
-            showActivitySelection = false
-            showLocationTypeSelection = false
-            showCountdown = false
+            clearPreStartSteps()
             isTracking = true
 
             // Restore the snap chip (count + thumbnail) — mid-run photos
@@ -1646,14 +1686,42 @@ struct WorkoutTrackingView: View {
         }
     }
 
+    // MARK: - Pre-start navigation
+
+    /// Every pre-start step off at once. Used by anything that jumps straight
+    /// to tracking (the buddy hand-off, workout recovery) — a single call so a
+    /// new step can never be forgotten in one of them.
+    private func clearPreStartSteps() {
+        showActivitySelection = false
+        showLocationTypeSelection = false
+        showRaceModeSelection = false
+        showGhostOptions = false
+        showPresenceConsent = false
+        showCountdown = false
+    }
+
+    /// Forward one step: haptic, slide direction, animate.
+    private func advance(_ change: @escaping () -> Void) {
+        MADHaptics.action()
+        wizardGoingBack = false
+        withAnimation(.easeInOut(duration: 0.28)) { change() }
+    }
+
+    /// Back one step. `from` turns the current step off, `to` turns the
+    /// previous one on — kept as two closures so call sites read in the
+    /// direction the user is travelling.
+    private func goBack(to: @escaping () -> Void, from: @escaping () -> Void) {
+        MADHaptics.tap()
+        wizardGoingBack = true
+        withAnimation(.easeInOut(duration: 0.28)) {
+            from()
+            to()
+        }
+    }
+
     private func selectActivity(_ activityType: HKWorkoutActivityType) {
         selectedActivityType = activityType
-
-        // Haptic feedback
-        MADHaptics.action()
-
-        // Hide activity selection and show location type selection
-        withAnimation {
+        advance {
             showActivitySelection = false
             showLocationTypeSelection = true
         }
@@ -1661,27 +1729,56 @@ struct WorkoutTrackingView: View {
 
     private func selectLocationType(_ locationType: HKWorkoutSessionLocationType) {
         selectedLocationType = locationType
+        advance {
+            showLocationTypeSelection = false
+            showRaceModeSelection = true
+        }
+    }
 
-        // Haptic feedback
-        MADHaptics.action()
-
-        // First tracked workout on this build: one explicit presence choice
-        // before the countdown. Asked exactly once, ever — after that the
-        // toggle lives in notification settings.
-        if !hasAnsweredLivePresenceConsent {
-            withAnimation {
-                showLocationTypeSelection = false
-                showPresenceConsent = true
+    /// Step 3's answer. Choosing the race opens its options rather than arming
+    /// anything — nothing is armed until a target is actually picked. Also the
+    /// "Skip the race" exit from step 4, hence both flags being cleared.
+    private func chooseRaceMode(ghost: Bool) {
+        guard ghost else {
+            raceArmed = false
+            advance {
+                showRaceModeSelection = false
+                showGhostOptions = false
+                proceedPastRaceChoice()
             }
             return
         }
-
-        // Hide location type selection and show countdown
-        withAnimation {
-            showLocationTypeSelection = false
-            showCountdown = true
-            countdownNumber = 3 // Reset countdown
+        advance {
+            showRaceModeSelection = false
+            showGhostOptions = true
         }
+    }
+
+    /// Step 4's answer: arm this target and start.
+    private func armGhost(_ target: BestEffortStore.GhostTarget) {
+        storeRaceTarget(target)
+        raceArmed = true
+        hasArmedGhostRaceOnce = true
+        advance {
+            showGhostOptions = false
+            proceedPastRaceChoice()
+        }
+    }
+
+    /// The single door out of the race choice, so the once-ever presence
+    /// question can't be skipped by whichever step happens to come last.
+    /// Called from INSIDE an `advance` block — it flips flags, it doesn't
+    /// animate.
+    private func proceedPastRaceChoice() {
+        // First tracked workout on this build: one explicit presence choice
+        // before the countdown. Asked exactly once, ever — after that the
+        // toggle lives in notification settings.
+        guard hasAnsweredLivePresenceConsent else {
+            showPresenceConsent = true
+            return
+        }
+        showCountdown = true
+        countdownNumber = 3 // Reset countdown
     }
 
     private func resolvePresenceConsent(share: Bool) {

--- a/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
@@ -513,6 +513,10 @@ struct WorkoutTrackingView: View {
                 ghostName: raceGhostName,
                 activityKey: raceActivityKey,
                 newRecordSeconds: recordSeconds,
+                // Whose ghost it was, when it was a friend's. Read from the
+                // armed target rather than the resolved one — `ResolvedGhost`
+                // deliberately keeps only a display name.
+                friendUserId: raceTarget.friendUserId,
                 workoutId: nil
             )
             // Held for the HealthKit metadata stamp further down this same
@@ -2212,6 +2216,11 @@ struct WorkoutTrackingView: View {
         if let win = pendingGhostWin {
             metadata[WorkoutLocationManager.ghostMarginMetadataKey] = win.marginSeconds
             metadata[WorkoutLocationManager.ghostTargetMetadataKey] = win.ghostSeconds
+            // Only present when the ghost was a friend's — that's what lets
+            // the server tell them they were caught.
+            if let friendId = win.friendUserId {
+                metadata[WorkoutLocationManager.ghostFriendMetadataKey] = friendId
+            }
         }
         if metadata.isEmpty {
             beginSave()

--- a/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
@@ -134,6 +134,10 @@ struct WorkoutTrackingView: View {
     /// How to name the ghost in copy ("your best mile", "your target").
     @State private var raceGhostName = "your best mile"
     @State private var raceFinalDelta: TimeInterval?
+    /// The win, from the moment it's decided until the HealthKit metadata
+    /// stamp carries it onto the saved workout (and from there to the server
+    /// and the feed).
+    @State private var pendingGhostWin: GhostRaceWin?
     /// Chosen target, per activity, remembered between sessions.
     @AppStorage("ghostTargetV1.running") private var runTargetStorage = ""
     @AppStorage("ghostTargetV1.walking") private var walkTargetStorage = ""
@@ -291,12 +295,27 @@ struct WorkoutTrackingView: View {
         .padding(.top, 16)
     }
 
+    /// What a step puts above its question. The ghost is drawn, not a symbol —
+    /// SF Symbols has none that exists on the iOS 17 deployment target.
+    enum WizardGlyph {
+        case symbol(String)
+        case ghost
+    }
+
     /// Glyph + question, identical on every step.
-    private func wizardHeader(glyph: String, title: String, subtitle: String) -> some View {
+    private func wizardHeader(glyph: WizardGlyph, title: String, subtitle: String) -> some View {
         VStack(spacing: 16) {
-            Image(systemName: glyph)
-                .font(.system(size: 60))
-                .foregroundColor(.white)
+            Group {
+                switch glyph {
+                case .symbol(let name):
+                    Image(systemName: name)
+                        .font(.system(size: 60))
+                case .ghost:
+                    GhostSprite(size: 62, glancesBack: true)
+                }
+            }
+            .foregroundColor(.white)
+            .frame(height: 72)
 
             Text(title)
                 .font(.system(size: 32, weight: .bold, design: .rounded))
@@ -314,7 +333,7 @@ struct WorkoutTrackingView: View {
     /// The shared layout of a "pick one of these" step.
     private func wizardStep<Options: View>(
         step: Int,
-        glyph: String,
+        glyph: WizardGlyph,
         title: String,
         subtitle: String,
         onBack: @escaping () -> Void,
@@ -350,7 +369,7 @@ struct WorkoutTrackingView: View {
     private var activitySelectionContent: some View {
         wizardStep(
             step: 1,
-            glyph: "figure.walk",
+            glyph: .symbol("figure.walk"),
             title: "Choose Activity Type",
             subtitle: "Select how you'll complete your mile",
             onBack: { dismiss() }
@@ -369,7 +388,7 @@ struct WorkoutTrackingView: View {
     private var locationTypeSelectionContent: some View {
         wizardStep(
             step: 2,
-            glyph: selectedActivityType == .running ? "figure.run" : "figure.walk",
+            glyph: .symbol(selectedActivityType == .running ? "figure.run" : "figure.walk"),
             title: "Choose Location",
             subtitle: "Where will you be working out?",
             onBack: { goBack(to: { showActivitySelection = true }, from: { showLocationTypeSelection = false }) }
@@ -395,7 +414,7 @@ struct WorkoutTrackingView: View {
     private var raceModeSelectionContent: some View {
         wizardStep(
             step: 3,
-            glyph: "flag.checkered",
+            glyph: .ghost,
             title: "Choose Your Mode",
             subtitle: "Race a time, or just log the miles.",
             onBack: { goBack(to: { showLocationTypeSelection = true }, from: { showRaceModeSelection = false }) }
@@ -409,7 +428,10 @@ struct WorkoutTrackingView: View {
             }
 
             workoutOptionButton(
-                icon: "flag.checkered",
+                leading: {
+                    GhostSprite(size: 34, glancesBack: true)
+                        .frame(width: 50)
+                },
                 title: "Ghost Race",
                 subtitle: ghostRaceSubtitle,
                 featured: true,
@@ -481,18 +503,22 @@ struct WorkoutTrackingView: View {
 
         // Raced and won: `raceFinalDelta` is the frozen verdict at the 1.0-mile
         // crossing — the same number the chip showed, so the popup can't
-        // contradict what the user watched.
-        if raceGhost != nil, let delta = raceFinalDelta, delta > 0 {
-            let margin = max(1, Int(delta.rounded()))
-            var description = "You beat \(raceGhostName) by \(margin)s."
-            if case .newBest(let seconds, _) = outcome {
-                description += " \(BestEffortStore.formatSeconds(seconds)) is your new mile to beat."
-            } else if case .baselineSet(let seconds) = outcome {
-                description += " \(BestEffortStore.formatSeconds(seconds)) is now your mile to beat."
-            }
-            CelebrationManager.shared.addCelebration(
-                .milestone(
-                    title: "Ghost Beaten!", description: description, icon: "flag.checkered"))
+        // contradict what the user watched. Every figure below is derived from
+        // that one frozen delta for the same reason.
+        if let ghost = raceGhost, let delta = raceFinalDelta, delta > 0 {
+            let win = GhostRaceWin(
+                marginSeconds: delta,
+                mileSeconds: max(0, ghost.seconds - delta),
+                ghostSeconds: ghost.seconds,
+                ghostName: raceGhostName,
+                activityKey: raceActivityKey,
+                newRecordSeconds: recordSeconds,
+                workoutId: nil
+            )
+            // Held for the HealthKit metadata stamp further down this same
+            // stop, which is what carries the win to the server.
+            pendingGhostWin = win
+            CelebrationManager.shared.addCelebration(.ghostBeaten(win: win))
             return
         }
 
@@ -1199,12 +1225,21 @@ struct WorkoutTrackingView: View {
             text = ahead ? "\(magnitude)s ahead of \(name)" : "\(magnitude)s behind \(name)"
         }
         return HStack(spacing: 5) {
-            Image(
-                systemName: frozen
-                    ? (ahead ? "trophy.fill" : "flag.checkered")
-                    : (ahead ? "arrowtriangle.up.fill" : "arrowtriangle.down.fill")
-            )
-            .font(.system(size: 9, weight: .bold))
+            // The ghost itself while the race is live — it glances back when
+            // you're gaining on it, which is the whole feeling of the feature
+            // in one glyph. The verdict swaps to a trophy/flag, because by
+            // then the ghost is beside the point.
+            if frozen {
+                Image(systemName: ahead ? "trophy.fill" : "flag.checkered")
+                    .font(.system(size: 9, weight: .bold))
+            } else {
+                GhostSprite(
+                    size: 11,
+                    color: ahead ? .green : .orange,
+                    floats: false,
+                    glancesBack: ahead
+                )
+            }
             Text(text)
                 .font(.system(size: 11, weight: .heavy, design: .rounded))
                 .tracking(0.4)
@@ -1395,24 +1430,32 @@ struct WorkoutTrackingView: View {
 
     private func workoutOptionButton(icon: String, title: String, subtitle: String, action: @escaping () -> Void) -> some View {
         workoutOptionButton(
-            icon: icon, title: title, subtitle: subtitle,
+            leading: { optionGlyph(icon) },
+            title: title, subtitle: subtitle,
             accessory: { optionChevron }, action: action)
+    }
+
+    private func optionGlyph(_ icon: String) -> some View {
+        Image(systemName: icon)
+            .font(.system(size: 32))
+            .frame(width: 50)
     }
 
     /// The wizard's option card.
     ///
     /// `featured` brightens the surface so one option can read as the special
     /// one, `badge` is the small pill beside the title (the ghost race's NEW
-    /// flag), and `accessory` replaces the trailing chevron with a readout.
-    /// All three default off, so the plain overload above renders exactly what
-    /// the Run/Walk and Indoor/Outdoor steps have always shown.
+    /// flag), `leading` is the glyph slot (a drawn ghost, not just a symbol),
+    /// and `accessory` replaces the trailing chevron with a readout. The plain
+    /// overload above renders exactly what the Run/Walk and Indoor/Outdoor
+    /// steps have always shown.
     ///
     /// Featuring is deliberately a BRIGHTNESS shift, not a hue one: this whole
     /// screen sits on the red gradient, and `MADTheme.workoutColor("running")`
     /// is that gradient's own top stop — a red-tinted border and glyph would
     /// go muddy on exactly the workout type most people pick.
-    private func workoutOptionButton<Accessory: View>(
-        icon: String,
+    private func workoutOptionButton<Leading: View, Accessory: View>(
+        @ViewBuilder leading: () -> Leading,
         title: String,
         subtitle: String,
         featured: Bool = false,
@@ -1422,9 +1465,7 @@ struct WorkoutTrackingView: View {
     ) -> some View {
         Button(action: action) {
             HStack(spacing: 16) {
-                Image(systemName: icon)
-                    .font(.system(size: 32))
-                    .frame(width: 50)
+                leading()
 
                 VStack(alignment: .leading, spacing: 4) {
                     HStack(spacing: 8) {
@@ -2159,16 +2200,25 @@ struct WorkoutTrackingView: View {
             }
         }
 
-        // Stamp the tracker's moving time on the workout itself — the sync
-        // reads HKWorkouts back, so this is how display pace's divisor
-        // travels. Best-effort: a metadata failure still saves the workout.
+        // Stamp the tracker's moving time (and a ghost win) on the workout
+        // itself — the sync reads HKWorkouts back, so this is how the display
+        // pace divisor and the race result travel. Best-effort: a metadata
+        // failure still saves the workout.
+        var metadata: [String: Any] = [:]
         let movingSeconds = locationManager.movingSeconds
         if movingSeconds > 0 {
-            builder.addMetadata([WorkoutLocationManager.movingSecondsMetadataKey: movingSeconds]) { _, _ in
+            metadata[WorkoutLocationManager.movingSecondsMetadataKey] = movingSeconds
+        }
+        if let win = pendingGhostWin {
+            metadata[WorkoutLocationManager.ghostMarginMetadataKey] = win.marginSeconds
+            metadata[WorkoutLocationManager.ghostTargetMetadataKey] = win.ghostSeconds
+        }
+        if metadata.isEmpty {
+            beginSave()
+        } else {
+            builder.addMetadata(metadata) { _, _ in
                 beginSave()
             }
-        } else {
-            beginSave()
         }
     }
 
@@ -2218,6 +2268,7 @@ struct WorkoutTrackingView: View {
         raceGhost = nil
         raceGhostName = "your best mile"
         raceFinalDelta = nil
+        pendingGhostWin = nil
 
         // Show result to user. The mile counts via GPS/pedometer sync whether
         // or not the HealthKit write succeeded, so a failed save is never a lost

--- a/app/Mile A Day/Views/Feed/PostCardView.swift
+++ b/app/Mile A Day/Views/Feed/PostCardView.swift
@@ -150,6 +150,35 @@ struct PostCardView: View {
         .fixedSize()
     }
 
+    /// "Beat the ghost" chip, shown when the post's workout won its race.
+    ///
+    /// The margin is the whole story — "GHOST −14s" says you beat the thing you
+    /// were chasing by fourteen seconds, in the width of a word. Sits next to
+    /// FRESH and is `fixedSize()` for the same reason: on a collab header
+    /// carrying two names, the chips must never be what gets squeezed.
+    private func ghostChip(margin: Double) -> some View {
+        HStack(spacing: 4) {
+            GhostSprite(size: 11, color: .white, floats: false)
+            Text("−\(max(1, Int(margin.rounded())))s")
+                .font(.system(size: 10, weight: .black, design: .rounded))
+                .monospacedDigit()
+        }
+        .foregroundColor(.white)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(
+            Capsule().fill(
+                LinearGradient(
+                    colors: [Color(red: 0.42, green: 0.31, blue: 0.85),
+                             Color(red: 0.24, green: 0.18, blue: 0.55)],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+        )
+        .fixedSize()
+    }
+
     /// Buddy Walk header: a stack of avatars plus a byline that collapses past
     /// three names. Deliberately a separate branch from the two-person collab
     /// header below rather than a generalization of it — that one is tuned and
@@ -258,6 +287,7 @@ struct PostCardView: View {
                 .disabled(onTapAuthor == nil)
             }
             if isFresh { freshChip }
+            if let win = post.stats_snapshot?.ghostWin { ghostChip(margin: win.margin) }
             Spacer()
             if let type = post.workout_type {
                 Image(systemName: ActivityCardView.icon(type))

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -17,6 +17,11 @@ struct RunStatsInput: Equatable {
     /// Post-goal bonus workout: the sticker bakes the distance as "+0.14 mi"
     /// so a short extra walk reads as ADDED miles, not the whole day.
     var isExtra: Bool = false
+    /// Ghost race, set only when this workout BEAT its ghost. Read straight off
+    /// the HKWorkout's metadata, so it's keyed to the right workout by
+    /// construction — no separate stash to fall out of sync.
+    var ghostMarginSeconds: Double?
+    var ghostTargetSeconds: Double?
 
     var snapshot: PostStats {
         PostStats(
@@ -26,7 +31,9 @@ struct RunStatsInput: Equatable {
             streak: streak,
             date: dateText,
             calories: calories,
-            steps: steps
+            steps: steps,
+            ghost_margin_seconds: ghostMarginSeconds,
+            ghost_target_seconds: ghostTargetSeconds
         )
     }
 

--- a/backend/scripts/ci-smoke.mjs
+++ b/backend/scripts/ci-smoke.mjs
@@ -28,6 +28,7 @@ const { signMediaUrl, verifyPostsMediaAccess, stripMediaQuery } =
   await import("../dist/services/mediaSigningService.js");
 const { getNotificationPreferences, updateNotificationPreferences } =
   await import("../dist/services/notificationSettingsService.js");
+const { getFriendGhosts } = await import("../dist/services/ghostService.js");
 // Hype authorization is controller-level (it's where the friend/visibility
 // gate lives), so the collab assertions below drive the real handlers.
 const { sendHype, getContextHypersController } =
@@ -1199,6 +1200,118 @@ await updateNotificationPreferences(BOB, { workout_visibility: "friends" });
     3.3,
     "a post with no linked workout keeps its stats (not nulled by the rollup join)",
   );
+
+
+// ─── Friend ghosts ────────────────────────────────────────────────────────
+//
+// The ghost picker offers a friend's fastest mile as a target. Every rule that
+// keeps that honest is a WHERE clause, so each one gets an assertion: this is
+// the query that decides whose time a stranger can chase.
+{
+  const ghostWorkout = async (userId, id, type, splitDistance, splitPace) => {
+    await db.query(
+      `INSERT INTO workouts (user_id, workout_id, distance, local_date, date,
+                             timezone_offset, workout_type, device_end_date,
+                             calories, total_duration)
+       VALUES ($1, $2, 1.0, $3, $4, 0, $5, $6, 50, 600)
+       ON CONFLICT (workout_id) DO NOTHING`,
+      // `date` and `local_date` are DATE columns; `device_end_date` is
+      // timestamptz. Reusing one param for a date and a timestamptz is a
+      // param-type conflict, not a coercion.
+      [userId, id, localDate, localDate, type, nowIso],
+    );
+    await db.query(
+      `INSERT INTO workout_splits (workout_id, split_number, split_duration,
+                                   split_distance, split_pace)
+       VALUES ($1, 1, $2, $3, $2)
+       ON CONFLICT (workout_id, split_number) DO UPDATE
+         SET split_distance = EXCLUDED.split_distance,
+             split_pace = EXCLUDED.split_pace`,
+      [id, splitPace, splitDistance],
+    );
+  };
+
+  await ghostWorkout(BOB, "ci-ghost-bob-run", "running", 1.0, 540);
+  await ghostWorkout(DANA, "ci-ghost-dana-run", "running", 1.0, 500);
+
+  let ghosts = await getFriendGhosts(ALICE, "running");
+  let ids = ghosts.map((g) => g.user_id);
+  assert.ok(ids.includes(BOB), "a friend's mile is offered as a ghost");
+  assert.equal(
+    ghosts.find((g) => g.user_id === BOB).mile_seconds,
+    540,
+    "the ghost time is the friend's fastest mile split, in seconds",
+  );
+
+  // DANA is Alice's friend too, and faster — the list is a leaderboard.
+  assert.deepEqual(
+    ghosts.map((g) => g.mile_seconds),
+    [...ghosts.map((g) => g.mile_seconds)].sort((a, b) => a - b),
+    "ghosts come back fastest-first",
+  );
+
+  // A non-friend is never offered. CARL is Bob's friend, not Alice's.
+  await ghostWorkout(CARL, "ci-ghost-carl-run", "running", 1.0, 400);
+  ghosts = await getFriendGhosts(ALICE, "running");
+  assert.ok(
+    !ghosts.some((g) => g.user_id === CARL),
+    "a non-friend's mile is never offered, however fast",
+  );
+
+  // Activity type: a RUN split must never become a WALK ghost.
+  const walkGhosts = await getFriendGhosts(ALICE, "walking");
+  assert.ok(
+    !walkGhosts.some((g) => g.user_id === BOB),
+    "a friend's run mile is not offered as a walk ghost",
+  );
+
+  // The 0.999 floor: a 0.96-mile split is an extrapolated partial, not a mile.
+  await ghostWorkout(DANA, "ci-ghost-dana-partial", "walking", 0.96, 300);
+  assert.ok(
+    !(await getFriendGhosts(ALICE, "walking")).some((g) => g.user_id === DANA),
+    "a sub-0.999 split is excluded (extrapolated partial, unbeatable)",
+  );
+
+  // Blocks hide the mile in BOTH directions.
+  await db.query(
+    `INSERT INTO user_blocks (blocker_id, blocked_id) VALUES ($1, $2)
+     ON CONFLICT DO NOTHING`,
+    [BOB, ALICE],
+  );
+  assert.ok(
+    !(await getFriendGhosts(ALICE, "running")).some((g) => g.user_id === BOB),
+    "a block hides the blocker's mile from the blocked user",
+  );
+  assert.ok(
+    !(await getFriendGhosts(BOB, "running")).some((g) => g.user_id === ALICE),
+    "a block hides the mile in the other direction too",
+  );
+  await db.query(`DELETE FROM user_blocks WHERE blocker_id = $1`, [BOB]);
+
+  // workout_visibility = 'private' removes you from being raceable. This is
+  // the privacy control the feature reuses instead of minting a new toggle.
+  await updateNotificationPreferences(BOB, { workout_visibility: "private" });
+  assert.ok(
+    !(await getFriendGhosts(ALICE, "running")).some((g) => g.user_id === BOB),
+    "a 'private' user is not offered as a ghost",
+  );
+  await updateNotificationPreferences(BOB, { workout_visibility: "friends" });
+
+  // A soft-deleted workout stops supplying the number.
+  await db.query(
+    `UPDATE workouts SET deleted_at = NOW() WHERE workout_id = 'ci-ghost-bob-run'`,
+  );
+  assert.ok(
+    !(await getFriendGhosts(ALICE, "running")).some((g) => g.user_id === BOB),
+    "a soft-deleted workout stops supplying a ghost time",
+  );
+  await db.query(
+    `UPDATE workouts SET deleted_at = NULL WHERE workout_id = 'ci-ghost-bob-run'`,
+  );
+
+  await db.query(`DELETE FROM workout_splits WHERE workout_id LIKE 'ci-ghost-%'`);
+  await db.query(`DELETE FROM workouts WHERE workout_id LIKE 'ci-ghost-%'`);
+}
 
   await db.query(`DELETE FROM posts WHERE user_id = $1`, [CARL]);
   await db.query(`DELETE FROM workouts WHERE user_id = $1`, [CARL]);

--- a/backend/scripts/ghost-race-check.mjs
+++ b/backend/scripts/ghost-race-check.mjs
@@ -1,0 +1,132 @@
+/**
+ * Ghost-race persistence check.
+ *
+ * Proves the three things the medal family depends on, against a real
+ * migrated database:
+ *   1. a winning workout's margin/target survive `uploadWorkouts`
+ *   2. an implausible claim is dropped to NULL rather than stored
+ *   3. a re-upload WITHOUT the fields (fullSync, recalibrate — neither reads
+ *      HealthKit metadata) does not erase a win already recorded
+ * plus the aggregate the ghost medals actually count.
+ *
+ * Usage (same env as ci-smoke):
+ *   DATABASE_URL=... node scripts/ghost-race-check.mjs
+ */
+import { PostgresService } from "../dist/services/DbService.js";
+import { uploadWorkouts } from "../dist/services/workoutService.js";
+
+const db = PostgresService.getInstance();
+const USER = "ghost-check-user";
+
+let failures = 0;
+function check(label, actual, expected) {
+  const ok = actual === expected;
+  if (!ok) failures++;
+  console.log(
+    `${ok ? "ok  " : "FAIL"}  ${label} → ${actual} (expected ${expected})`,
+  );
+}
+
+function workout(id, extra = {}) {
+  return {
+    workoutId: id,
+    distance: 1.2,
+    localDate: "2026-08-01",
+    date: "2026-08-01T12:00:00.000Z",
+    timezoneOffset: -14400,
+    workoutType: "running",
+    deviceEndDate: "2026-08-01T12:30:00.000Z",
+    calories: 120,
+    totalDuration: 1800,
+    movingSeconds: 1700,
+    splits: [],
+    ...extra,
+  };
+}
+
+async function main() {
+  await db.query(
+    `INSERT INTO users (user_id, apple_sub, email, username, first_name, last_name)
+     VALUES ($1, $2, $3, $4, 'Ghost', 'Check')
+     ON CONFLICT (user_id) DO NOTHING`,
+    [USER, `sub-${USER}`, `${USER}@example.com`, USER],
+  );
+  await db.query(`DELETE FROM workouts WHERE user_id = $1`, [USER]);
+
+  // 1. A real win persists.
+  await uploadWorkouts(USER, [
+    workout("ghost-win", { ghostMarginSeconds: 14, ghostTargetSeconds: 542 }),
+  ]);
+  const [win] = await db.query(
+    `SELECT ghost_margin_seconds AS m, ghost_target_seconds AS t
+       FROM workouts WHERE workout_id = 'ghost-win'`,
+  );
+  check("win margin stored", Number(win?.m), 14);
+  check("win target stored", Number(win?.t), 542);
+
+  // 2. Implausible claims are dropped, not stored.
+  await uploadWorkouts(USER, [
+    // margin larger than the ghost it supposedly beat
+    workout("ghost-absurd", {
+      ghostMarginSeconds: 9999,
+      ghostTargetSeconds: 542,
+    }),
+    // target outside GhostTarget.isPlausible (2:00…40:00)
+    workout("ghost-short", { ghostMarginSeconds: 5, ghostTargetSeconds: 30 }),
+  ]);
+  const dropped = await db.query(
+    `SELECT COUNT(*)::int AS n FROM workouts
+      WHERE user_id = $1 AND workout_id IN ('ghost-absurd','ghost-short')
+        AND ghost_margin_seconds IS NOT NULL`,
+    [USER],
+  );
+  check("implausible claims dropped", dropped[0].n, 0);
+
+  // 3. A re-upload that carries no ghost fields must NOT erase the win.
+  await uploadWorkouts(USER, [workout("ghost-win")]);
+  const [after] = await db.query(
+    `SELECT ghost_margin_seconds AS m FROM workouts WHERE workout_id = 'ghost-win'`,
+  );
+  check("win survives a metadata-less re-upload", Number(after?.m), 14);
+
+  // 4. The aggregate the medals count.
+  await uploadWorkouts(USER, [
+    workout("ghost-win-2", { ghostMarginSeconds: 48, ghostTargetSeconds: 700 }),
+  ]);
+  const [agg] = await db.query(
+    `SELECT COUNT(*)::int AS count,
+            COALESCE(MAX(ghost_margin_seconds), 0)::int AS best
+       FROM workouts
+      WHERE user_id = $1 AND deleted_at IS NULL
+        AND ghost_margin_seconds IS NOT NULL`,
+    [USER],
+  );
+  check("ghostsBeaten", agg.count, 2);
+  check("bestGhostMargin", agg.best, 48);
+
+  // A soft-deleted workout must stop counting.
+  await db.query(
+    `UPDATE workouts SET deleted_at = NOW() WHERE workout_id = 'ghost-win-2'`,
+  );
+  const [aggAfter] = await db.query(
+    `SELECT COUNT(*)::int AS count FROM workouts
+      WHERE user_id = $1 AND deleted_at IS NULL AND ghost_margin_seconds IS NOT NULL`,
+    [USER],
+  );
+  check("deleted workout stops counting", aggAfter.count, 1);
+
+  await db.query(`DELETE FROM workouts WHERE user_id = $1`, [USER]);
+  await db.query(`DELETE FROM users WHERE user_id = $1`, [USER]);
+
+  console.log(
+    failures === 0
+      ? "ghost-race-check: all assertions passed"
+      : `ghost-race-check: ${failures} FAILED`,
+  );
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/scripts/ghost-race-check.mjs
+++ b/backend/scripts/ghost-race-check.mjs
@@ -14,6 +14,7 @@
  */
 import { PostgresService } from "../dist/services/DbService.js";
 import { uploadWorkouts } from "../dist/services/workoutService.js";
+import { notifyGhostsBeaten } from "../dist/services/ghostService.js";
 
 const db = PostgresService.getInstance();
 const USER = "ghost-check-user";
@@ -115,8 +116,73 @@ async function main() {
   );
   check("deleted workout stops counting", aggAfter.count, 1);
 
+  // ── Friend ghosts: whose ghost was beaten, and telling them once ──
+  const FRIEND = "ghost-check-friend";
+  await db.query(
+    `INSERT INTO users (user_id, apple_sub, email, username, first_name, last_name)
+     VALUES ($1, $2, $3, $4, 'Ghost', 'Friend')
+     ON CONFLICT (user_id) DO NOTHING`,
+    [FRIEND, `sub-${FRIEND}`, `${FRIEND}@example.com`, FRIEND],
+  );
+  await db.query(
+    `INSERT INTO friendships (user_id, friend_id, status) VALUES ($1, $2, 'accepted')
+     ON CONFLICT (user_id, friend_id) DO NOTHING`,
+    [USER, FRIEND],
+  );
+
+  await uploadWorkouts(USER, [
+    workout("ghost-friend-win", {
+      ghostMarginSeconds: 9,
+      ghostTargetSeconds: 600,
+      ghostFriendUserId: FRIEND,
+    }),
+  ]);
+  const [friendRow] = await db.query(
+    `SELECT ghost_friend_user_id AS f FROM workouts WHERE workout_id = 'ghost-friend-win'`,
+  );
+  check("friend id stored", friendRow?.f, FRIEND);
+
+  // Same COALESCE protection as the margin: a fullSync re-upload carries no
+  // HealthKit metadata and must not anonymize a recorded win.
+  await uploadWorkouts(USER, [workout("ghost-friend-win")]);
+  const [afterResync] = await db.query(
+    `SELECT ghost_friend_user_id AS f FROM workouts WHERE workout_id = 'ghost-friend-win'`,
+  );
+  check("friend id survives a metadata-less re-upload", afterResync?.f, FRIEND);
+
+  // The notify pass claims the row exactly once, so the constant re-uploads of
+  // the same workout can never re-push.
+  await notifyGhostsBeaten(USER, ["ghost-friend-win"]);
+  const [claimed] = await db.query(
+    `SELECT (ghost_notified_at IS NOT NULL) AS done FROM workouts
+      WHERE workout_id = 'ghost-friend-win'`,
+  );
+  check("notify claims the row", claimed?.done, true);
+
+  await db.query(
+    `UPDATE workouts SET ghost_notified_at = NULL WHERE workout_id = 'ghost-friend-win'`,
+  );
+  // A workout naming someone who ISN'T a friend must not even be claimed —
+  // the id is client-asserted, so the friendship is re-checked at notify time.
+  await db.query(
+    `UPDATE workouts SET ghost_friend_user_id = 'ghost-check-stranger'
+      WHERE workout_id = 'ghost-friend-win'`,
+  );
+  await notifyGhostsBeaten(USER, ["ghost-friend-win"]);
+  const [stranger] = await db.query(
+    `SELECT (ghost_notified_at IS NOT NULL) AS done FROM workouts
+      WHERE workout_id = 'ghost-friend-win'`,
+  );
+  check("a non-friend claim is never notified", stranger?.done, false);
+
+  await db.query(
+    `DELETE FROM friendships WHERE user_id = $1 OR friend_id = $1`,
+    [FRIEND],
+  );
   await db.query(`DELETE FROM workouts WHERE user_id = $1`, [USER]);
-  await db.query(`DELETE FROM users WHERE user_id = $1`, [USER]);
+  await db.query(`DELETE FROM users WHERE user_id = ANY($1::text[])`, [
+    [USER, FRIEND],
+  ]);
 
   console.log(
     failures === 0

--- a/backend/src/controllers/ghostController.ts
+++ b/backend/src/controllers/ghostController.ts
@@ -1,0 +1,31 @@
+import { Response } from "express";
+import { AuthenticatedRequest } from "../middleware/auth.js";
+import {
+  getFriendGhosts,
+  GHOST_ACTIVITIES,
+  GhostActivity,
+} from "../services/ghostService.js";
+
+/**
+ * GET /ghosts/friends?activity=running|walking
+ *
+ * Friends whose fastest mile can be raced, fastest first. Self-scoped on
+ * `req.userId`, so no `requireSelfAccess` — there is no id in the path to
+ * mismatch.
+ */
+export async function friendGhosts(req: AuthenticatedRequest, res: Response) {
+  try {
+    const raw = String(req.query.activity ?? "running");
+    // Whitelisted like buddyController does for mode/activityType: an
+    // unvalidated value would reach the query as a workout_type filter and
+    // silently return nothing rather than telling the client it asked wrong.
+    if (!GHOST_ACTIVITIES.includes(raw as GhostActivity)) {
+      return res.status(400).json({ error: "invalid_activity" });
+    }
+    const ghosts = await getFriendGhosts(req.userId!, raw as GhostActivity);
+    return res.status(200).json({ ghosts });
+  } catch (error: any) {
+    console.error("Error loading friend ghosts:", error.message);
+    return res.status(500).json({ error: "Error loading friend ghosts" });
+  }
+}

--- a/backend/src/controllers/postsController.ts
+++ b/backend/src/controllers/postsController.ts
@@ -30,6 +30,7 @@ import {
   lockUnearnedPhotos,
   ALLOWED_STORY_REACTIONS,
   PostStatsSnapshot,
+  sanitizeGhostStats,
   type ViewerGoalGate,
 } from "../services/postService.js";
 import {
@@ -260,7 +261,9 @@ export async function createPostController(
     // could sit in the feed claiming a streak the author no longer has. Stamp
     // the server's value over it — only when the client sent one, so a post
     // that deliberately carries no streak chip stays that way.
-    let statsSnapshot = (stats_snapshot ?? null) as PostStatsSnapshot | null;
+    let statsSnapshot = sanitizeGhostStats(
+      (stats_snapshot ?? null) as PostStatsSnapshot | null,
+    );
     if (hasStats && statsSnapshot?.streak != null) {
       try {
         const { streak } = await getActiveStreak(userId);

--- a/backend/src/controllers/workoutController.ts
+++ b/backend/src/controllers/workoutController.ts
@@ -36,6 +36,7 @@ import {
   checkLeadChanges,
 } from "../services/notificationService.js";
 import { evaluateWorkoutRewards } from "../services/badgeService.js";
+import { notifyGhostsBeaten } from "../services/ghostService.js";
 import {
   fireBadgeEarnedPush,
   fanOutFriendBadgePush,
@@ -157,6 +158,11 @@ export async function uploadWorkouts(req: Request, res: Response) {
     } catch (rewardError: any) {
       console.error("Error evaluating workout rewards:", rewardError.message);
     }
+
+    // "Your ghost was caught" — only fires for a workout that raced a FRIEND's
+    // mile and won. Claim-stamped inside, so the constant re-uploads of the
+    // same workout can't re-push, and it never throws.
+    await notifyGhostsBeaten(userId, uploadedWorkoutIds);
 
     // Check if user has now completed their mile and notify friends.
     // Skipped on the initial account-setup backfill (isFullSync) and when this

--- a/backend/src/db/drizzle/0039_strange_jackal.sql
+++ b/backend/src/db/drizzle/0039_strange_jackal.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "workouts" ADD COLUMN "ghost_margin_seconds" double precision;--> statement-breakpoint
+ALTER TABLE "workouts" ADD COLUMN "ghost_target_seconds" double precision;

--- a/backend/src/db/drizzle/0040_thankful_roland_deschain.sql
+++ b/backend/src/db/drizzle/0040_thankful_roland_deschain.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "workouts" ADD COLUMN "ghost_friend_user_id" varchar(255);--> statement-breakpoint
+ALTER TABLE "workouts" ADD COLUMN "ghost_notified_at" timestamp with time zone;

--- a/backend/src/db/drizzle/meta/0039_snapshot.json
+++ b/backend/src/db/drizzle/meta/0039_snapshot.json
@@ -1,0 +1,5475 @@
+{
+  "id": "7dfc752d-f763-4ec5-89f2-6d4368f7442b",
+  "prevId": "c694315e-9211-4a7e-9e50-b5334a0a8e23",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.android_waitlist": {
+      "name": "android_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'website'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "android_waitlist_email_unique": {
+          "name": "android_waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_badges_category": {
+          "name": "idx_badges_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "badges_rarity_check": {
+          "name": "badges_rarity_check",
+          "value": "rarity = ANY (ARRAY['common'::text, 'rare'::text, 'legendary'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.buddy_session_events": {
+      "name": "buddy_session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_buddy_events_session_at": {
+          "name": "idx_buddy_events_session_at",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "buddy_session_events_session_id_fkey": {
+          "name": "buddy_session_events_session_id_fkey",
+          "tableFrom": "buddy_session_events",
+          "tableTo": "buddy_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "buddy_session_events_user_id_fkey": {
+          "name": "buddy_session_events_user_id_fkey",
+          "tableFrom": "buddy_session_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.buddy_session_participants": {
+      "name": "buddy_session_participants",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distance_miles": {
+          "name": "distance_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_progress_at": {
+          "name": "last_progress_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_distance_miles": {
+          "name": "final_distance_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place": {
+          "name": "place",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_buddy_participants_user_status": {
+          "name": "idx_buddy_participants_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "buddy_session_participants_session_id_fkey": {
+          "name": "buddy_session_participants_session_id_fkey",
+          "tableFrom": "buddy_session_participants",
+          "tableTo": "buddy_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "buddy_session_participants_user_id_fkey": {
+          "name": "buddy_session_participants_user_id_fkey",
+          "tableFrom": "buddy_session_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "buddy_session_participants_workout_id_fkey": {
+          "name": "buddy_session_participants_workout_id_fkey",
+          "tableFrom": "buddy_session_participants",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "buddy_session_participants_pkey": {
+          "name": "buddy_session_participants_pkey",
+          "columns": [
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "buddy_session_participants_status_check": {
+          "name": "buddy_session_participants_status_check",
+          "value": "status = ANY (ARRAY['invited'::text, 'joined'::text, 'ready'::text, 'active'::text, 'finished'::text, 'left'::text, 'declined'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.buddy_sessions": {
+      "name": "buddy_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "join_code": {
+          "name": "join_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_user_id": {
+          "name": "host_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_value": {
+          "name": "goal_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_start_at": {
+          "name": "scheduled_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_reminder_sent_at": {
+          "name": "scheduled_reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner_user_id": {
+          "name": "winner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_version": {
+          "name": "state_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_buddy_sessions_join_code_open": {
+          "name": "uq_buddy_sessions_join_code_open",
+          "columns": [
+            {
+              "expression": "join_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = ANY (ARRAY['lobby'::text, 'active'::text]))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_buddy_sessions_status_created": {
+          "name": "idx_buddy_sessions_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "buddy_sessions_host_user_id_fkey": {
+          "name": "buddy_sessions_host_user_id_fkey",
+          "tableFrom": "buddy_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "host_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "buddy_sessions_winner_user_id_fkey": {
+          "name": "buddy_sessions_winner_user_id_fkey",
+          "tableFrom": "buddy_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "buddy_sessions_mode_check": {
+          "name": "buddy_sessions_mode_check",
+          "value": "mode = ANY (ARRAY['together'::text, 'coop_goal'::text, 'race_goal'::text, 'race_time'::text])"
+        },
+        "buddy_sessions_status_check": {
+          "name": "buddy_sessions_status_check",
+          "value": "status = ANY (ARRAY['lobby'::text, 'active'::text, 'completed'::text, 'cancelled'::text])"
+        },
+        "buddy_sessions_origin_check": {
+          "name": "buddy_sessions_origin_check",
+          "value": "origin = ANY (ARRAY['invite'::text, 'code'::text, 'join_active'::text, 'nearby'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.close_friends": {
+      "name": "close_friends",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_friend_id": {
+          "name": "close_friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_close_friends_friend": {
+          "name": "idx_close_friends_friend",
+          "columns": [
+            {
+              "expression": "close_friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "close_friends_pkey": {
+          "name": "close_friends_pkey",
+          "columns": [
+            "user_id",
+            "close_friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_reports": {
+      "name": "comment_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comment_reports_dedupe_idx": {
+          "name": "comment_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_comment_reports_status": {
+          "name": "idx_comment_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_reports_comment_id_fkey": {
+          "name": "comment_reports_comment_id_fkey",
+          "tableFrom": "comment_reports",
+          "tableTo": "post_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "comment_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_reports_reporter_id_fkey": {
+          "name": "comment_reports_reporter_id_fkey",
+          "tableFrom": "comment_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "comment_reports_reason_check": {
+          "name": "comment_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_users": {
+      "name": "competition_users",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_rank": {
+          "name": "last_known_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_score": {
+          "name": "last_known_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rank_updated_at": {
+          "name": "last_rank_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_competition_users_comp": {
+          "name": "idx_competition_users_comp",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_competition": {
+          "name": "idx_competition_users_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_rank_cache": {
+          "name": "idx_competition_users_rank_cache",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_known_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((invite_status)::text = 'accepted'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user": {
+          "name": "idx_competition_users_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user_status": {
+          "name": "idx_competition_users_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invite_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_users_user_id_fkey": {
+          "name": "competition_users_user_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_users_competition_id_fkey": {
+          "name": "competition_users_competition_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_users_pkey": {
+          "name": "competition_users_pkey",
+          "columns": [
+            "competition_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_users_invite_status_check": {
+          "name": "competition_users_invite_status_check",
+          "value": "(invite_status)::text = ANY ((ARRAY['pending'::character varying, 'accepted'::character varying, 'declined'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workouts": {
+          "name": "workouts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams": {
+          "name": "teams",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_winner": {
+          "name": "idx_competitions_winner",
+          "columns": [
+            {
+              "expression": "winner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(winner IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_winner_fkey": {
+          "name": "competitions_winner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "competitions_owner_fkey": {
+          "name": "competitions_owner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitions_type_check": {
+          "name": "competitions_type_check",
+          "value": "(type)::text = ANY ((ARRAY['streaks'::character varying, 'apex'::character varying, 'clash'::character varying, 'targets'::character varying, 'race'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_challenges": {
+      "name": "daily_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_template": {
+          "name": "description_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_start": {
+          "name": "gradient_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_end": {
+          "name": "gradient_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rotation_index": {
+          "name": "rotation_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_challenges_rotation_index_key": {
+          "name": "daily_challenges_rotation_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rotation_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daily_challenges_type_check": {
+          "name": "daily_challenges_type_check",
+          "value": "type = ANY (ARRAY['pace'::text, 'distance'::text, 'time'::text, 'activity'::text, 'steps'::text, 'social'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_steps": {
+      "name": "daily_steps",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_steps_user_date": {
+          "name": "idx_daily_steps_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_steps_user_id_fkey": {
+          "name": "daily_steps_user_id_fkey",
+          "tableFrom": "daily_steps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_steps_pkey": {
+          "name": "daily_steps_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "daily_steps_steps_check": {
+          "name": "daily_steps_steps_check",
+          "value": "steps >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token": {
+          "name": "device_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "client_features": {
+          "name": "client_features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_tokens_user_id": {
+          "name": "idx_device_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_user_id_fkey": {
+          "name": "device_tokens_user_id_fkey",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_user_id_device_token_key": {
+          "name": "device_tokens_user_id_device_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_log": {
+      "name": "error_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_error_log_created_at": {
+          "name": "idx_error_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_error_log_category": {
+          "name": "idx_error_log_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flex_log": {
+      "name": "flex_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flex_log_lookup": {
+          "name": "idx_flex_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_notification_settings": {
+      "name": "friend_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted": {
+          "name": "muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nudges_muted": {
+          "name": "nudges_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "activity_muted": {
+          "name": "activity_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "friend_notification_settings_pkey": {
+          "name": "friend_notification_settings_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_nudge_log": {
+      "name": "friend_nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_nudge_log_lookup": {
+          "name": "idx_friend_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_request_log": {
+      "name": "friend_request_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_request_log_lookup": {
+          "name": "idx_friend_request_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "reminder_sent_at": {
+          "name": "reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_friendships_friend_status": {
+          "name": "idx_friendships_friend_status",
+          "columns": [
+            {
+              "expression": "friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_friendships_user_status": {
+          "name": "idx_friendships_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_user_id_fkey": {
+          "name": "friendships_user_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_friend_id_fkey": {
+          "name": "friendships_friend_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendships_pkey": {
+          "name": "friendships_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_friendship_pair": {
+          "name": "unique_friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.h2h_matchups": {
+      "name": "h2h_matchups",
+      "schema": "",
+      "columns": {
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rival_id": {
+          "name": "rival_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mutual": {
+          "name": "mutual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "won": {
+          "name": "won",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_notified_state": {
+          "name": "lead_notified_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_notified_at": {
+          "name": "lead_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "h2h_matchups_user_id_fkey": {
+          "name": "h2h_matchups_user_id_fkey",
+          "tableFrom": "h2h_matchups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "h2h_matchups_rival_id_fkey": {
+          "name": "h2h_matchups_rival_id_fkey",
+          "tableFrom": "h2h_matchups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "rival_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "h2h_matchups_pkey": {
+          "name": "h2h_matchups_pkey",
+          "columns": [
+            "local_date",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hype_log": {
+      "name": "hype_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_label": {
+          "name": "context_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hype_log_context_dedupe_idx": {
+          "name": "hype_log_context_dedupe_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_lookup": {
+          "name": "idx_hype_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_target_context": {
+          "name": "idx_hype_log_target_context",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_app_notifications": {
+      "name": "in_app_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_in_app_notifications_unread": {
+          "name": "idx_in_app_notifications_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_read = false)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_app_notifications_user": {
+          "name": "idx_in_app_notifications_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_app_notifications_user_id_fkey": {
+          "name": "in_app_notifications_user_id_fkey",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.live_tracking_sessions": {
+      "name": "live_tracking_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "live_tracking_sessions_user_id_fkey": {
+          "name": "live_tracking_sessions_user_id_fkey",
+          "tableFrom": "live_tracking_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_notifications": {
+      "name": "milestone_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_key": {
+          "name": "milestone_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_notifications_milestone_key_key": {
+          "name": "milestone_notifications_milestone_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_audience_settings": {
+      "name": "notification_audience_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_audience_settings_pkey": {
+          "name": "notification_audience_settings_pkey",
+          "columns": [
+            "user_id",
+            "direction",
+            "event_type",
+            "activity_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_audience_settings_direction_check": {
+          "name": "notification_audience_settings_direction_check",
+          "value": "direction = ANY (ARRAY['outgoing'::text, 'incoming'::text])"
+        },
+        "notification_audience_settings_audience_check": {
+          "name": "notification_audience_settings_audience_check",
+          "value": "audience = ANY (ARRAY['none'::text, 'close'::text, 'all'::text, 'ask'::text, 'match_run'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_user_date": {
+          "name": "idx_notification_log_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nudges_enabled": {
+          "name": "nudges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "flexes_enabled": {
+          "name": "flexes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_activity_enabled": {
+          "name": "friend_activity_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_invites_enabled": {
+          "name": "competition_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_updates_enabled": {
+          "name": "competition_updates_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_milestones_enabled": {
+          "name": "competition_milestones_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "hypes_enabled": {
+          "name": "hypes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "step_goal_enabled": {
+          "name": "step_goal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "friend_personal_best_enabled": {
+          "name": "friend_personal_best_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_enabled": {
+          "name": "daily_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_hour": {
+          "name": "daily_reminder_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 18
+        },
+        "h2h_close_friends_only": {
+          "name": "h2h_close_friends_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone_offset_minutes": {
+          "name": "timezone_offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_workouts_to_feed": {
+          "name": "share_workouts_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_posts_enabled": {
+          "name": "friend_posts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "share_route_maps": {
+          "name": "share_route_maps",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "share_live_presence": {
+          "name": "share_live_presence",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "weekly_recap_enabled": {
+          "name": "weekly_recap_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "workout_visibility": {
+          "name": "workout_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'friends'"
+        },
+        "friend_request_reminder_enabled": {
+          "name": "friend_request_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "buddy_invites_enabled": {
+          "name": "buddy_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "tagged_posts_on_profile": {
+          "name": "tagged_posts_on_profile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_settings_workout_visibility_check": {
+          "name": "notification_settings_workout_visibility_check",
+          "value": "workout_visibility = ANY (ARRAY['public'::text, 'friends'::text, 'private'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.nudge_log": {
+      "name": "nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_nudge_log_lookup": {
+          "name": "idx_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nudge_log_rate_limit": {
+          "name": "idx_nudge_log_rate_limit",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_friend_notifications": {
+      "name": "pending_friend_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "send_after_at": {
+          "name": "send_after_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_friend_notif_user": {
+          "name": "idx_pending_friend_notif_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_pending_friend_notif_workout": {
+          "name": "uq_pending_friend_notif_workout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((workout_id IS NOT NULL) AND (status = 'pending'::text))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pending_friend_notifications_status_check": {
+          "name": "pending_friend_notifications_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'sent'::text, 'dismissed'::text, 'expired'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_notifications": {
+      "name": "pending_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_notifications_unsent": {
+          "name": "idx_pending_notifications_unsent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(sent_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_notifications_user_id_fkey": {
+          "name": "pending_notifications_user_id_fkey",
+          "tableFrom": "pending_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_coauthors": {
+      "name": "post_coauthors",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buddy_session_id": {
+          "name": "buddy_session_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_post_coauthors_user": {
+          "name": "idx_post_coauthors_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_coauthors_post_id_fkey": {
+          "name": "post_coauthors_post_id_fkey",
+          "tableFrom": "post_coauthors",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_coauthors_user_id_fkey": {
+          "name": "post_coauthors_user_id_fkey",
+          "tableFrom": "post_coauthors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_coauthors_workout_id_fkey": {
+          "name": "post_coauthors_workout_id_fkey",
+          "tableFrom": "post_coauthors",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "post_coauthors_buddy_session_id_fkey": {
+          "name": "post_coauthors_buddy_session_id_fkey",
+          "tableFrom": "post_coauthors",
+          "tableTo": "buddy_sessions",
+          "columnsFrom": [
+            "buddy_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_coauthors_pkey": {
+          "name": "post_coauthors_pkey",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_coauthors_status_check": {
+          "name": "post_coauthors_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'accepted'::text, 'declined'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_comments": {
+      "name": "post_comments",
+      "schema": "",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_post_comments_post": {
+          "name": "idx_post_comments_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND post_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_comments_workout": {
+          "name": "idx_post_comments_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_comments_post_id_fkey": {
+          "name": "post_comments_post_id_fkey",
+          "tableFrom": "post_comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_workout_id_fkey": {
+          "name": "post_comments_workout_id_fkey",
+          "tableFrom": "post_comments",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_user_id_fkey": {
+          "name": "post_comments_user_id_fkey",
+          "tableFrom": "post_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_parent_fkey": {
+          "name": "post_comments_parent_fkey",
+          "tableFrom": "post_comments",
+          "tableTo": "post_comments",
+          "columnsFrom": [
+            "parent_comment_id"
+          ],
+          "columnsTo": [
+            "comment_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_comments_content_check": {
+          "name": "post_comments_content_check",
+          "value": "char_length(content) >= 1 AND char_length(content) <= 1000"
+        },
+        "post_comments_one_target_check": {
+          "name": "post_comments_one_target_check",
+          "value": "((post_id IS NOT NULL)::int + (workout_id IS NOT NULL)::int) = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_reports": {
+      "name": "post_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_reports_dedupe_idx": {
+          "name": "post_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_reports_status": {
+          "name": "idx_post_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_reports_post_id_fkey": {
+          "name": "post_reports_post_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_reports_reporter_id_fkey": {
+          "name": "post_reports_reporter_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_reports_reason_check": {
+          "name": "post_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_snapshot": {
+          "name": "stats_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_to_feed": {
+          "name": "share_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_to_story": {
+          "name": "share_to_story",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "story_expires_at": {
+          "name": "story_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto": {
+          "name": "is_auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_route": {
+          "name": "include_route",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "coauthor_user_id": {
+          "name": "coauthor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_status": {
+          "name": "coauthor_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_workout_id": {
+          "name": "coauthor_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_on_profile": {
+          "name": "coauthor_on_profile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_fresh": {
+          "name": "posted_fresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_posts_user_created": {
+          "name": "idx_posts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_feed": {
+          "name": "idx_posts_feed",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_story_active": {
+          "name": "idx_posts_story_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "story_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_story)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_active": {
+          "name": "uq_posts_workout_active",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_story": {
+          "name": "uq_posts_workout_story",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_story AND NOT share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_coauthor_workout": {
+          "name": "idx_posts_coauthor_workout",
+          "columns": [
+            {
+              "expression": "coauthor_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(coauthor_workout_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_coauthor_user": {
+          "name": "idx_posts_coauthor_user",
+          "columns": [
+            {
+              "expression": "coauthor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(coauthor_user_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_fkey": {
+          "name": "posts_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_workout_id_fkey": {
+          "name": "posts_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_coauthor_user_id_fkey": {
+          "name": "posts_coauthor_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "coauthor_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_coauthor_workout_id_fkey": {
+          "name": "posts_coauthor_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "coauthor_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "posts_coauthor_status_check": {
+          "name": "posts_coauthor_status_check",
+          "value": "coauthor_status IS NULL OR coauthor_status = ANY (ARRAY['pending'::text, 'accepted'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_family_id": {
+          "name": "token_family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_hash": {
+          "name": "replaced_by_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "token_family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_revoked_at": {
+          "name": "idx_refresh_tokens_revoked_at",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(revoked_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_token_hash": {
+          "name": "idx_refresh_tokens_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_fkey": {
+          "name": "refresh_tokens_user_id_fkey",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_key": {
+          "name": "refresh_tokens_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_reactions": {
+      "name": "story_reactions",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_reactions_post_id_fkey": {
+          "name": "story_reactions_post_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_reactions_user_id_fkey": {
+          "name": "story_reactions_user_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_reactions_pkey": {
+          "name": "story_reactions_pkey",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_views": {
+      "name": "story_views",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_views_post_id_fkey": {
+          "name": "story_views_post_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_views_viewer_id_fkey": {
+          "name": "story_views_viewer_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_views_pkey": {
+          "name": "story_views_pkey",
+          "columns": [
+            "post_id",
+            "viewer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streak_coverage": {
+      "name": "streak_coverage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_date": {
+          "name": "trigger_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_user": {
+          "name": "source_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "streak_coverage_user_id_fkey": {
+          "name": "streak_coverage_user_id_fkey",
+          "tableFrom": "streak_coverage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "streak_coverage_pkey": {
+          "name": "streak_coverage_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streak_events": {
+      "name": "streak_events",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prior_streak": {
+          "name": "prior_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "streak_events_user_id_fkey": {
+          "name": "streak_events_user_id_fkey",
+          "tableFrom": "streak_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "streak_events_pkey": {
+          "name": "streak_events_pkey",
+          "columns": [
+            "user_id",
+            "local_date",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggering_workout_id": {
+          "name": "triggering_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_snapshot": {
+          "name": "progress_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_slot": {
+          "name": "pin_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_badges_user": {
+          "name": "idx_user_badges_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_new": {
+          "name": "idx_user_badges_user_new",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_new = true)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_pin_slot": {
+          "name": "idx_user_badges_user_pin_slot",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(pin_slot IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_workout": {
+          "name": "idx_user_badges_workout",
+          "columns": [
+            {
+              "expression": "triggering_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_badges_user_id_fkey": {
+          "name": "user_badges_user_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_fkey": {
+          "name": "user_badges_badge_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "badge_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_triggering_workout_id_fkey": {
+          "name": "user_badges_triggering_workout_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "triggering_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_badges_user_id_badge_id_key": {
+          "name": "user_badges_user_id_badge_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "badge_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_badges_pin_slot_range": {
+          "name": "user_badges_pin_slot_range",
+          "value": "(pin_slot IS NULL) OR ((pin_slot >= 0) AND (pin_slot <= 2))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_blocks_blocked": {
+          "name": "idx_user_blocks_blocked",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_fkey": {
+          "name": "user_blocks_blocker_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_blocks_blocked_id_fkey": {
+          "name": "user_blocks_blocked_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_pkey": {
+          "name": "user_blocks_pkey",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenge_completions": {
+      "name": "user_challenge_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completing_workout_id": {
+          "name": "completing_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ucc_user": {
+          "name": "idx_ucc_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ucc_user_date": {
+          "name": "idx_ucc_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenge_completions_user_id_fkey": {
+          "name": "user_challenge_completions_user_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_challenge_key_fkey": {
+          "name": "user_challenge_completions_challenge_key_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "daily_challenges",
+          "columnsFrom": [
+            "challenge_key"
+          ],
+          "columnsTo": [
+            "challenge_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_completing_workout_id_fkey": {
+          "name": "user_challenge_completions_completing_workout_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "completing_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_challenge_completions_user_id_local_date_key": {
+          "name": "user_challenge_completions_user_id_local_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_sub": {
+          "name": "apple_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "goal_miles": {
+          "name": "goal_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "longest_streak": {
+          "name": "longest_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_source": {
+          "name": "referral_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_detail": {
+          "name": "referral_detail",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signup_goal": {
+          "name": "signup_goal",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience_level": {
+          "name": "experience_level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "streak_features_at": {
+          "name": "streak_features_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "double_down_last_used": {
+          "name": "double_down_last_used",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streak_save_last_used": {
+          "name": "streak_save_last_used",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streak_assist_last_used": {
+          "name": "streak_assist_last_used",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buddy_enrolled_at": {
+          "name": "buddy_enrolled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_current_streak_desc": {
+          "name": "idx_users_current_streak_desc",
+          "columns": [
+            {
+              "expression": "current_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_longest_streak_desc": {
+          "name": "idx_users_longest_streak_desc",
+          "columns": [
+            {
+              "expression": "longest_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email_trgm": {
+          "name": "idx_users_email_trgm",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_username_trgm": {
+          "name": "idx_users_username_trgm",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_apple_id_key": {
+          "name": "users_apple_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_apple_sub_key": {
+          "name": "users_apple_sub_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "apple_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_recap_log": {
+      "name": "weekly_recap_log",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "weekly_recap_log_pkey": {
+          "name": "weekly_recap_log_pkey",
+          "columns": [
+            "user_id",
+            "week_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_completion_notifications": {
+      "name": "workout_completion_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_date": {
+          "name": "notified_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_completion_notifications_user_id_notified_date_key": {
+          "name": "workout_completion_notifications_user_id_notified_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "notified_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_routes": {
+      "name": "workout_routes",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "point_count": {
+          "name": "point_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workout_routes_workout_id_fkey": {
+          "name": "workout_routes_workout_id_fkey",
+          "tableFrom": "workout_routes",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_splits": {
+      "name": "workout_splits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_number": {
+          "name": "split_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_duration": {
+          "name": "split_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_distance": {
+          "name": "split_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_pace": {
+          "name": "split_pace",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_splits_time": {
+          "name": "idx_splits_time",
+          "columns": [
+            {
+              "expression": "split_duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_splits_workout": {
+          "name": "idx_splits_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_splits_workout_id_fkey": {
+          "name": "workout_splits_workout_id_fkey",
+          "tableFrom": "workout_splits",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_splits_workout_id_split_number_key": {
+          "name": "workout_splits_workout_id_split_number_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "split_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workouts": {
+      "name": "workouts",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_end_date": {
+          "name": "device_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moving_seconds": {
+          "name": "moving_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghost_margin_seconds": {
+          "name": "ghost_margin_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghost_target_seconds": {
+          "name": "ghost_target_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthkit'"
+        },
+        "original_distance": {
+          "name": "original_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_duration": {
+          "name": "original_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_flagged": {
+          "name": "speed_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feed_role": {
+          "name": "feed_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'extra'"
+        }
+      },
+      "indexes": {
+        "idx_workouts_local_date_user_id": {
+          "name": "idx_workouts_local_date_user_id",
+          "columns": [
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_device_end": {
+          "name": "idx_workouts_user_device_end",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_local_date": {
+          "name": "idx_workouts_user_local_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_feed_candidates": {
+          "name": "idx_workouts_feed_candidates",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND exclusion_reason IS NULL AND feed_role IN ('daily_mile', 'extra'))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workouts_user_workout_unique": {
+          "name": "workouts_user_workout_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workouts_feed_role_check": {
+          "name": "workouts_feed_role_check",
+          "value": "\"workouts\".\"feed_role\" IN ('hidden', 'rolled_up', 'daily_mile', 'extra')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/drizzle/meta/0040_snapshot.json
+++ b/backend/src/db/drizzle/meta/0040_snapshot.json
@@ -1,0 +1,5487 @@
+{
+  "id": "67ec542f-342e-430d-ad58-27738203903b",
+  "prevId": "7dfc752d-f763-4ec5-89f2-6d4368f7442b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.android_waitlist": {
+      "name": "android_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'website'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "android_waitlist_email_unique": {
+          "name": "android_waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_badges_category": {
+          "name": "idx_badges_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "badges_rarity_check": {
+          "name": "badges_rarity_check",
+          "value": "rarity = ANY (ARRAY['common'::text, 'rare'::text, 'legendary'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.buddy_session_events": {
+      "name": "buddy_session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_buddy_events_session_at": {
+          "name": "idx_buddy_events_session_at",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "buddy_session_events_session_id_fkey": {
+          "name": "buddy_session_events_session_id_fkey",
+          "tableFrom": "buddy_session_events",
+          "tableTo": "buddy_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "buddy_session_events_user_id_fkey": {
+          "name": "buddy_session_events_user_id_fkey",
+          "tableFrom": "buddy_session_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.buddy_session_participants": {
+      "name": "buddy_session_participants",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distance_miles": {
+          "name": "distance_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_progress_at": {
+          "name": "last_progress_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_distance_miles": {
+          "name": "final_distance_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place": {
+          "name": "place",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_buddy_participants_user_status": {
+          "name": "idx_buddy_participants_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "buddy_session_participants_session_id_fkey": {
+          "name": "buddy_session_participants_session_id_fkey",
+          "tableFrom": "buddy_session_participants",
+          "tableTo": "buddy_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "buddy_session_participants_user_id_fkey": {
+          "name": "buddy_session_participants_user_id_fkey",
+          "tableFrom": "buddy_session_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "buddy_session_participants_workout_id_fkey": {
+          "name": "buddy_session_participants_workout_id_fkey",
+          "tableFrom": "buddy_session_participants",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "buddy_session_participants_pkey": {
+          "name": "buddy_session_participants_pkey",
+          "columns": [
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "buddy_session_participants_status_check": {
+          "name": "buddy_session_participants_status_check",
+          "value": "status = ANY (ARRAY['invited'::text, 'joined'::text, 'ready'::text, 'active'::text, 'finished'::text, 'left'::text, 'declined'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.buddy_sessions": {
+      "name": "buddy_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "join_code": {
+          "name": "join_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_user_id": {
+          "name": "host_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_value": {
+          "name": "goal_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_start_at": {
+          "name": "scheduled_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_reminder_sent_at": {
+          "name": "scheduled_reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner_user_id": {
+          "name": "winner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_version": {
+          "name": "state_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_buddy_sessions_join_code_open": {
+          "name": "uq_buddy_sessions_join_code_open",
+          "columns": [
+            {
+              "expression": "join_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = ANY (ARRAY['lobby'::text, 'active'::text]))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_buddy_sessions_status_created": {
+          "name": "idx_buddy_sessions_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "buddy_sessions_host_user_id_fkey": {
+          "name": "buddy_sessions_host_user_id_fkey",
+          "tableFrom": "buddy_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "host_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "buddy_sessions_winner_user_id_fkey": {
+          "name": "buddy_sessions_winner_user_id_fkey",
+          "tableFrom": "buddy_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "buddy_sessions_mode_check": {
+          "name": "buddy_sessions_mode_check",
+          "value": "mode = ANY (ARRAY['together'::text, 'coop_goal'::text, 'race_goal'::text, 'race_time'::text])"
+        },
+        "buddy_sessions_status_check": {
+          "name": "buddy_sessions_status_check",
+          "value": "status = ANY (ARRAY['lobby'::text, 'active'::text, 'completed'::text, 'cancelled'::text])"
+        },
+        "buddy_sessions_origin_check": {
+          "name": "buddy_sessions_origin_check",
+          "value": "origin = ANY (ARRAY['invite'::text, 'code'::text, 'join_active'::text, 'nearby'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.close_friends": {
+      "name": "close_friends",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_friend_id": {
+          "name": "close_friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_close_friends_friend": {
+          "name": "idx_close_friends_friend",
+          "columns": [
+            {
+              "expression": "close_friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "close_friends_pkey": {
+          "name": "close_friends_pkey",
+          "columns": [
+            "user_id",
+            "close_friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_reports": {
+      "name": "comment_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comment_reports_dedupe_idx": {
+          "name": "comment_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_comment_reports_status": {
+          "name": "idx_comment_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_reports_comment_id_fkey": {
+          "name": "comment_reports_comment_id_fkey",
+          "tableFrom": "comment_reports",
+          "tableTo": "post_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "comment_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_reports_reporter_id_fkey": {
+          "name": "comment_reports_reporter_id_fkey",
+          "tableFrom": "comment_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "comment_reports_reason_check": {
+          "name": "comment_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_users": {
+      "name": "competition_users",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_rank": {
+          "name": "last_known_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_score": {
+          "name": "last_known_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rank_updated_at": {
+          "name": "last_rank_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_competition_users_comp": {
+          "name": "idx_competition_users_comp",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_competition": {
+          "name": "idx_competition_users_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_rank_cache": {
+          "name": "idx_competition_users_rank_cache",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_known_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((invite_status)::text = 'accepted'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user": {
+          "name": "idx_competition_users_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user_status": {
+          "name": "idx_competition_users_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invite_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_users_user_id_fkey": {
+          "name": "competition_users_user_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_users_competition_id_fkey": {
+          "name": "competition_users_competition_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_users_pkey": {
+          "name": "competition_users_pkey",
+          "columns": [
+            "competition_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_users_invite_status_check": {
+          "name": "competition_users_invite_status_check",
+          "value": "(invite_status)::text = ANY ((ARRAY['pending'::character varying, 'accepted'::character varying, 'declined'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workouts": {
+          "name": "workouts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams": {
+          "name": "teams",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_winner": {
+          "name": "idx_competitions_winner",
+          "columns": [
+            {
+              "expression": "winner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(winner IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_winner_fkey": {
+          "name": "competitions_winner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "competitions_owner_fkey": {
+          "name": "competitions_owner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitions_type_check": {
+          "name": "competitions_type_check",
+          "value": "(type)::text = ANY ((ARRAY['streaks'::character varying, 'apex'::character varying, 'clash'::character varying, 'targets'::character varying, 'race'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_challenges": {
+      "name": "daily_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_template": {
+          "name": "description_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_start": {
+          "name": "gradient_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_end": {
+          "name": "gradient_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rotation_index": {
+          "name": "rotation_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_challenges_rotation_index_key": {
+          "name": "daily_challenges_rotation_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rotation_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daily_challenges_type_check": {
+          "name": "daily_challenges_type_check",
+          "value": "type = ANY (ARRAY['pace'::text, 'distance'::text, 'time'::text, 'activity'::text, 'steps'::text, 'social'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_steps": {
+      "name": "daily_steps",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_steps_user_date": {
+          "name": "idx_daily_steps_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_steps_user_id_fkey": {
+          "name": "daily_steps_user_id_fkey",
+          "tableFrom": "daily_steps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_steps_pkey": {
+          "name": "daily_steps_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "daily_steps_steps_check": {
+          "name": "daily_steps_steps_check",
+          "value": "steps >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token": {
+          "name": "device_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "client_features": {
+          "name": "client_features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_tokens_user_id": {
+          "name": "idx_device_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_user_id_fkey": {
+          "name": "device_tokens_user_id_fkey",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_user_id_device_token_key": {
+          "name": "device_tokens_user_id_device_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_log": {
+      "name": "error_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_error_log_created_at": {
+          "name": "idx_error_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_error_log_category": {
+          "name": "idx_error_log_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flex_log": {
+      "name": "flex_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flex_log_lookup": {
+          "name": "idx_flex_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_notification_settings": {
+      "name": "friend_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted": {
+          "name": "muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nudges_muted": {
+          "name": "nudges_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "activity_muted": {
+          "name": "activity_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "friend_notification_settings_pkey": {
+          "name": "friend_notification_settings_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_nudge_log": {
+      "name": "friend_nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_nudge_log_lookup": {
+          "name": "idx_friend_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_request_log": {
+      "name": "friend_request_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_request_log_lookup": {
+          "name": "idx_friend_request_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "reminder_sent_at": {
+          "name": "reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_friendships_friend_status": {
+          "name": "idx_friendships_friend_status",
+          "columns": [
+            {
+              "expression": "friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_friendships_user_status": {
+          "name": "idx_friendships_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_user_id_fkey": {
+          "name": "friendships_user_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_friend_id_fkey": {
+          "name": "friendships_friend_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendships_pkey": {
+          "name": "friendships_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_friendship_pair": {
+          "name": "unique_friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.h2h_matchups": {
+      "name": "h2h_matchups",
+      "schema": "",
+      "columns": {
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rival_id": {
+          "name": "rival_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mutual": {
+          "name": "mutual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "won": {
+          "name": "won",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_notified_state": {
+          "name": "lead_notified_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_notified_at": {
+          "name": "lead_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "h2h_matchups_user_id_fkey": {
+          "name": "h2h_matchups_user_id_fkey",
+          "tableFrom": "h2h_matchups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "h2h_matchups_rival_id_fkey": {
+          "name": "h2h_matchups_rival_id_fkey",
+          "tableFrom": "h2h_matchups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "rival_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "h2h_matchups_pkey": {
+          "name": "h2h_matchups_pkey",
+          "columns": [
+            "local_date",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hype_log": {
+      "name": "hype_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_label": {
+          "name": "context_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hype_log_context_dedupe_idx": {
+          "name": "hype_log_context_dedupe_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_lookup": {
+          "name": "idx_hype_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_target_context": {
+          "name": "idx_hype_log_target_context",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_app_notifications": {
+      "name": "in_app_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_in_app_notifications_unread": {
+          "name": "idx_in_app_notifications_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_read = false)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_app_notifications_user": {
+          "name": "idx_in_app_notifications_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_app_notifications_user_id_fkey": {
+          "name": "in_app_notifications_user_id_fkey",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.live_tracking_sessions": {
+      "name": "live_tracking_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "live_tracking_sessions_user_id_fkey": {
+          "name": "live_tracking_sessions_user_id_fkey",
+          "tableFrom": "live_tracking_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_notifications": {
+      "name": "milestone_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_key": {
+          "name": "milestone_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_notifications_milestone_key_key": {
+          "name": "milestone_notifications_milestone_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_audience_settings": {
+      "name": "notification_audience_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_audience_settings_pkey": {
+          "name": "notification_audience_settings_pkey",
+          "columns": [
+            "user_id",
+            "direction",
+            "event_type",
+            "activity_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_audience_settings_direction_check": {
+          "name": "notification_audience_settings_direction_check",
+          "value": "direction = ANY (ARRAY['outgoing'::text, 'incoming'::text])"
+        },
+        "notification_audience_settings_audience_check": {
+          "name": "notification_audience_settings_audience_check",
+          "value": "audience = ANY (ARRAY['none'::text, 'close'::text, 'all'::text, 'ask'::text, 'match_run'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_user_date": {
+          "name": "idx_notification_log_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nudges_enabled": {
+          "name": "nudges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "flexes_enabled": {
+          "name": "flexes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_activity_enabled": {
+          "name": "friend_activity_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_invites_enabled": {
+          "name": "competition_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_updates_enabled": {
+          "name": "competition_updates_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_milestones_enabled": {
+          "name": "competition_milestones_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "hypes_enabled": {
+          "name": "hypes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "step_goal_enabled": {
+          "name": "step_goal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "friend_personal_best_enabled": {
+          "name": "friend_personal_best_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_enabled": {
+          "name": "daily_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_hour": {
+          "name": "daily_reminder_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 18
+        },
+        "h2h_close_friends_only": {
+          "name": "h2h_close_friends_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone_offset_minutes": {
+          "name": "timezone_offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_workouts_to_feed": {
+          "name": "share_workouts_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_posts_enabled": {
+          "name": "friend_posts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "share_route_maps": {
+          "name": "share_route_maps",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "share_live_presence": {
+          "name": "share_live_presence",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "weekly_recap_enabled": {
+          "name": "weekly_recap_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "workout_visibility": {
+          "name": "workout_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'friends'"
+        },
+        "friend_request_reminder_enabled": {
+          "name": "friend_request_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "buddy_invites_enabled": {
+          "name": "buddy_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "tagged_posts_on_profile": {
+          "name": "tagged_posts_on_profile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_settings_workout_visibility_check": {
+          "name": "notification_settings_workout_visibility_check",
+          "value": "workout_visibility = ANY (ARRAY['public'::text, 'friends'::text, 'private'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.nudge_log": {
+      "name": "nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_nudge_log_lookup": {
+          "name": "idx_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nudge_log_rate_limit": {
+          "name": "idx_nudge_log_rate_limit",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_friend_notifications": {
+      "name": "pending_friend_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "send_after_at": {
+          "name": "send_after_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_friend_notif_user": {
+          "name": "idx_pending_friend_notif_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_pending_friend_notif_workout": {
+          "name": "uq_pending_friend_notif_workout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((workout_id IS NOT NULL) AND (status = 'pending'::text))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pending_friend_notifications_status_check": {
+          "name": "pending_friend_notifications_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'sent'::text, 'dismissed'::text, 'expired'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_notifications": {
+      "name": "pending_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_notifications_unsent": {
+          "name": "idx_pending_notifications_unsent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(sent_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_notifications_user_id_fkey": {
+          "name": "pending_notifications_user_id_fkey",
+          "tableFrom": "pending_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_coauthors": {
+      "name": "post_coauthors",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buddy_session_id": {
+          "name": "buddy_session_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_post_coauthors_user": {
+          "name": "idx_post_coauthors_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_coauthors_post_id_fkey": {
+          "name": "post_coauthors_post_id_fkey",
+          "tableFrom": "post_coauthors",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_coauthors_user_id_fkey": {
+          "name": "post_coauthors_user_id_fkey",
+          "tableFrom": "post_coauthors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_coauthors_workout_id_fkey": {
+          "name": "post_coauthors_workout_id_fkey",
+          "tableFrom": "post_coauthors",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "post_coauthors_buddy_session_id_fkey": {
+          "name": "post_coauthors_buddy_session_id_fkey",
+          "tableFrom": "post_coauthors",
+          "tableTo": "buddy_sessions",
+          "columnsFrom": [
+            "buddy_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_coauthors_pkey": {
+          "name": "post_coauthors_pkey",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_coauthors_status_check": {
+          "name": "post_coauthors_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'accepted'::text, 'declined'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_comments": {
+      "name": "post_comments",
+      "schema": "",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_post_comments_post": {
+          "name": "idx_post_comments_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND post_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_comments_workout": {
+          "name": "idx_post_comments_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_comments_post_id_fkey": {
+          "name": "post_comments_post_id_fkey",
+          "tableFrom": "post_comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_workout_id_fkey": {
+          "name": "post_comments_workout_id_fkey",
+          "tableFrom": "post_comments",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_user_id_fkey": {
+          "name": "post_comments_user_id_fkey",
+          "tableFrom": "post_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_parent_fkey": {
+          "name": "post_comments_parent_fkey",
+          "tableFrom": "post_comments",
+          "tableTo": "post_comments",
+          "columnsFrom": [
+            "parent_comment_id"
+          ],
+          "columnsTo": [
+            "comment_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_comments_content_check": {
+          "name": "post_comments_content_check",
+          "value": "char_length(content) >= 1 AND char_length(content) <= 1000"
+        },
+        "post_comments_one_target_check": {
+          "name": "post_comments_one_target_check",
+          "value": "((post_id IS NOT NULL)::int + (workout_id IS NOT NULL)::int) = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_reports": {
+      "name": "post_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_reports_dedupe_idx": {
+          "name": "post_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_reports_status": {
+          "name": "idx_post_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_reports_post_id_fkey": {
+          "name": "post_reports_post_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_reports_reporter_id_fkey": {
+          "name": "post_reports_reporter_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_reports_reason_check": {
+          "name": "post_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_snapshot": {
+          "name": "stats_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_to_feed": {
+          "name": "share_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_to_story": {
+          "name": "share_to_story",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "story_expires_at": {
+          "name": "story_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto": {
+          "name": "is_auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_route": {
+          "name": "include_route",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "coauthor_user_id": {
+          "name": "coauthor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_status": {
+          "name": "coauthor_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_workout_id": {
+          "name": "coauthor_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_on_profile": {
+          "name": "coauthor_on_profile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_fresh": {
+          "name": "posted_fresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_posts_user_created": {
+          "name": "idx_posts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_feed": {
+          "name": "idx_posts_feed",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_story_active": {
+          "name": "idx_posts_story_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "story_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_story)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_active": {
+          "name": "uq_posts_workout_active",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_story": {
+          "name": "uq_posts_workout_story",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_story AND NOT share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_coauthor_workout": {
+          "name": "idx_posts_coauthor_workout",
+          "columns": [
+            {
+              "expression": "coauthor_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(coauthor_workout_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_coauthor_user": {
+          "name": "idx_posts_coauthor_user",
+          "columns": [
+            {
+              "expression": "coauthor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(coauthor_user_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_fkey": {
+          "name": "posts_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_workout_id_fkey": {
+          "name": "posts_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_coauthor_user_id_fkey": {
+          "name": "posts_coauthor_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "coauthor_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_coauthor_workout_id_fkey": {
+          "name": "posts_coauthor_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "coauthor_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "posts_coauthor_status_check": {
+          "name": "posts_coauthor_status_check",
+          "value": "coauthor_status IS NULL OR coauthor_status = ANY (ARRAY['pending'::text, 'accepted'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_family_id": {
+          "name": "token_family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_hash": {
+          "name": "replaced_by_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "token_family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_revoked_at": {
+          "name": "idx_refresh_tokens_revoked_at",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(revoked_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_token_hash": {
+          "name": "idx_refresh_tokens_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_fkey": {
+          "name": "refresh_tokens_user_id_fkey",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_key": {
+          "name": "refresh_tokens_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_reactions": {
+      "name": "story_reactions",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_reactions_post_id_fkey": {
+          "name": "story_reactions_post_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_reactions_user_id_fkey": {
+          "name": "story_reactions_user_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_reactions_pkey": {
+          "name": "story_reactions_pkey",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_views": {
+      "name": "story_views",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_views_post_id_fkey": {
+          "name": "story_views_post_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_views_viewer_id_fkey": {
+          "name": "story_views_viewer_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_views_pkey": {
+          "name": "story_views_pkey",
+          "columns": [
+            "post_id",
+            "viewer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streak_coverage": {
+      "name": "streak_coverage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_date": {
+          "name": "trigger_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_user": {
+          "name": "source_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "streak_coverage_user_id_fkey": {
+          "name": "streak_coverage_user_id_fkey",
+          "tableFrom": "streak_coverage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "streak_coverage_pkey": {
+          "name": "streak_coverage_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streak_events": {
+      "name": "streak_events",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prior_streak": {
+          "name": "prior_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "streak_events_user_id_fkey": {
+          "name": "streak_events_user_id_fkey",
+          "tableFrom": "streak_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "streak_events_pkey": {
+          "name": "streak_events_pkey",
+          "columns": [
+            "user_id",
+            "local_date",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggering_workout_id": {
+          "name": "triggering_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_snapshot": {
+          "name": "progress_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_slot": {
+          "name": "pin_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_badges_user": {
+          "name": "idx_user_badges_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_new": {
+          "name": "idx_user_badges_user_new",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_new = true)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_pin_slot": {
+          "name": "idx_user_badges_user_pin_slot",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(pin_slot IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_workout": {
+          "name": "idx_user_badges_workout",
+          "columns": [
+            {
+              "expression": "triggering_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_badges_user_id_fkey": {
+          "name": "user_badges_user_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_fkey": {
+          "name": "user_badges_badge_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "badge_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_triggering_workout_id_fkey": {
+          "name": "user_badges_triggering_workout_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "triggering_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_badges_user_id_badge_id_key": {
+          "name": "user_badges_user_id_badge_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "badge_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_badges_pin_slot_range": {
+          "name": "user_badges_pin_slot_range",
+          "value": "(pin_slot IS NULL) OR ((pin_slot >= 0) AND (pin_slot <= 2))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_blocks_blocked": {
+          "name": "idx_user_blocks_blocked",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_fkey": {
+          "name": "user_blocks_blocker_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_blocks_blocked_id_fkey": {
+          "name": "user_blocks_blocked_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_pkey": {
+          "name": "user_blocks_pkey",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenge_completions": {
+      "name": "user_challenge_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completing_workout_id": {
+          "name": "completing_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ucc_user": {
+          "name": "idx_ucc_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ucc_user_date": {
+          "name": "idx_ucc_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenge_completions_user_id_fkey": {
+          "name": "user_challenge_completions_user_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_challenge_key_fkey": {
+          "name": "user_challenge_completions_challenge_key_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "daily_challenges",
+          "columnsFrom": [
+            "challenge_key"
+          ],
+          "columnsTo": [
+            "challenge_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_completing_workout_id_fkey": {
+          "name": "user_challenge_completions_completing_workout_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "completing_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_challenge_completions_user_id_local_date_key": {
+          "name": "user_challenge_completions_user_id_local_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_sub": {
+          "name": "apple_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "goal_miles": {
+          "name": "goal_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "longest_streak": {
+          "name": "longest_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_source": {
+          "name": "referral_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_detail": {
+          "name": "referral_detail",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signup_goal": {
+          "name": "signup_goal",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience_level": {
+          "name": "experience_level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "streak_features_at": {
+          "name": "streak_features_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "double_down_last_used": {
+          "name": "double_down_last_used",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streak_save_last_used": {
+          "name": "streak_save_last_used",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streak_assist_last_used": {
+          "name": "streak_assist_last_used",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buddy_enrolled_at": {
+          "name": "buddy_enrolled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_current_streak_desc": {
+          "name": "idx_users_current_streak_desc",
+          "columns": [
+            {
+              "expression": "current_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_longest_streak_desc": {
+          "name": "idx_users_longest_streak_desc",
+          "columns": [
+            {
+              "expression": "longest_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email_trgm": {
+          "name": "idx_users_email_trgm",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_username_trgm": {
+          "name": "idx_users_username_trgm",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_apple_id_key": {
+          "name": "users_apple_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_apple_sub_key": {
+          "name": "users_apple_sub_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "apple_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_recap_log": {
+      "name": "weekly_recap_log",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "weekly_recap_log_pkey": {
+          "name": "weekly_recap_log_pkey",
+          "columns": [
+            "user_id",
+            "week_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_completion_notifications": {
+      "name": "workout_completion_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_date": {
+          "name": "notified_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_completion_notifications_user_id_notified_date_key": {
+          "name": "workout_completion_notifications_user_id_notified_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "notified_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_routes": {
+      "name": "workout_routes",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "point_count": {
+          "name": "point_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workout_routes_workout_id_fkey": {
+          "name": "workout_routes_workout_id_fkey",
+          "tableFrom": "workout_routes",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_splits": {
+      "name": "workout_splits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_number": {
+          "name": "split_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_duration": {
+          "name": "split_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_distance": {
+          "name": "split_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_pace": {
+          "name": "split_pace",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_splits_time": {
+          "name": "idx_splits_time",
+          "columns": [
+            {
+              "expression": "split_duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_splits_workout": {
+          "name": "idx_splits_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_splits_workout_id_fkey": {
+          "name": "workout_splits_workout_id_fkey",
+          "tableFrom": "workout_splits",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_splits_workout_id_split_number_key": {
+          "name": "workout_splits_workout_id_split_number_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "split_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workouts": {
+      "name": "workouts",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_end_date": {
+          "name": "device_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moving_seconds": {
+          "name": "moving_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghost_margin_seconds": {
+          "name": "ghost_margin_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghost_target_seconds": {
+          "name": "ghost_target_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghost_friend_user_id": {
+          "name": "ghost_friend_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghost_notified_at": {
+          "name": "ghost_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthkit'"
+        },
+        "original_distance": {
+          "name": "original_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_duration": {
+          "name": "original_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_flagged": {
+          "name": "speed_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feed_role": {
+          "name": "feed_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'extra'"
+        }
+      },
+      "indexes": {
+        "idx_workouts_local_date_user_id": {
+          "name": "idx_workouts_local_date_user_id",
+          "columns": [
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_device_end": {
+          "name": "idx_workouts_user_device_end",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_local_date": {
+          "name": "idx_workouts_user_local_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_feed_candidates": {
+          "name": "idx_workouts_feed_candidates",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND exclusion_reason IS NULL AND feed_role IN ('daily_mile', 'extra'))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workouts_user_workout_unique": {
+          "name": "workouts_user_workout_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workouts_feed_role_check": {
+          "name": "workouts_feed_role_check",
+          "value": "\"workouts\".\"feed_role\" IN ('hidden', 'rolled_up', 'daily_mile', 'extra')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/drizzle/meta/_journal.json
+++ b/backend/src/db/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1785802475150,
       "tag": "0039_strange_jackal",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1785804310260,
+      "tag": "0040_thankful_roland_deschain",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/drizzle/meta/_journal.json
+++ b/backend/src/db/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1785797553210,
       "tag": "0038_rich_metal_master",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1785802475150,
+      "tag": "0039_strange_jackal",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/drizzle/schema.ts
+++ b/backend/src/db/drizzle/schema.ts
@@ -255,6 +255,21 @@ export const workouts = pgTable(
     // family counts. Null on every other workout, including raced-and-lost.
     ghostMarginSeconds: doublePrecision("ghost_margin_seconds"),
     ghostTargetSeconds: doublePrecision("ghost_target_seconds"),
+    // Whose ghost it was, when the target was a FRIEND's mile rather than the
+    // user's own best/PR/typed time. Null for a solo ghost — the margin and
+    // target columns above stay set either way, so this only ever answers
+    // "is there someone to tell about this?".
+    ghostFriendUserId: varchar("ghost_friend_user_id", { length: 255 }),
+    // Claim stamp for the "your ghost was beaten" push. Nullable with NO
+    // default on purpose: `ADD COLUMN ts timestamptz DEFAULT now()` stores one
+    // DDL-time missing-value for every pre-existing row, so a cron gating on
+    // it fires on the whole backlog at once. Claim-then-send (h2h_matchups
+    // pattern) is what stops the constant re-uploads of a workout — fullSync,
+    // recalibrate — from re-pushing.
+    ghostNotifiedAt: timestamp("ghost_notified_at", {
+      withTimezone: true,
+      mode: "string",
+    }),
     createdAt: timestamp("created_at", {
       withTimezone: true,
       mode: "string",

--- a/backend/src/db/drizzle/schema.ts
+++ b/backend/src/db/drizzle/schema.ts
@@ -249,6 +249,12 @@ export const workouts = pgTable(
     // walks don't read 82:47/mi — while total_duration stays the elapsed
     // truth for PRs, races, and recaps (a race clock doesn't pause).
     movingSeconds: doublePrecision("moving_seconds"),
+    // Ghost race, written ONLY when the ghost was beaten (in-app tracker
+    // stamps it as HKWorkout metadata at finish, the sync carries it here).
+    // Presence therefore means "won" — which is exactly what the ghost medal
+    // family counts. Null on every other workout, including raced-and-lost.
+    ghostMarginSeconds: doublePrecision("ghost_margin_seconds"),
+    ghostTargetSeconds: doublePrecision("ghost_target_seconds"),
     createdAt: timestamp("created_at", {
       withTimezone: true,
       mode: "string",

--- a/backend/src/routes/ghostRoutes.ts
+++ b/backend/src/routes/ghostRoutes.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { friendGhosts } from "../controllers/ghostController.js";
+
+const router = Router();
+
+// Self-scoped on req.userId (mounted after authenticateToken in server.ts).
+// Read-only: picking someone as your ghost tells them nothing and changes
+// nothing on their side — the only thing they ever hear about is being BEATEN.
+router.get("/friends", friendGhosts);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -20,6 +20,7 @@ import dailyChallengesRoutes from "./routes/dailyChallengesRoutes.js";
 import dailyStepsRoutes from "./routes/dailyStepsRoutes.js";
 import leaderboardRoutes from "./routes/leaderboardRoutes.js";
 import liveTrackingRoutes from "./routes/liveTrackingRoutes.js";
+import ghostRoutes from "./routes/ghostRoutes.js";
 import publicRoutes from "./routes/publicRoutes.js";
 import buddyRoutes from "./routes/buddyRoutes.js";
 import {
@@ -314,6 +315,7 @@ app.use("/blocks", blocksRoutes);
 app.use("/leaderboard", leaderboardRoutes);
 app.use("/buddy", buddyRoutes);
 app.use("/live", liveTrackingRoutes);
+app.use("/ghosts", ghostRoutes);
 
 app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
   console.error("Error:", err.message);

--- a/backend/src/services/badgeService.ts
+++ b/backend/src/services/badgeService.ts
@@ -148,6 +148,8 @@ async function computeSocialAggregates(userId: string): Promise<{
   buddySessionsCompleted: number;
   buddyDistinctPartners: number;
   buddySessionsWon: number;
+  ghostsBeaten: number;
+  bestGhostMargin: number;
 }> {
   const zero = {
     storyPostsCount: 0,
@@ -159,6 +161,8 @@ async function computeSocialAggregates(userId: string): Promise<{
     buddySessionsCompleted: 0,
     buddyDistinctPartners: 0,
     buddySessionsWon: 0,
+    ghostsBeaten: 0,
+    bestGhostMargin: 0,
   };
   try {
     const [
@@ -171,6 +175,7 @@ async function computeSocialAggregates(userId: string): Promise<{
       buddyDone,
       buddyPartners,
       buddyWon,
+      ghosts,
     ] = await Promise.all([
       db
         .query<{
@@ -265,6 +270,23 @@ async function computeSocialAggregates(userId: string): Promise<{
           [userId],
         )
         .catch(() => [{ count: "0" }]),
+      // Ghost races won. `ghost_margin_seconds` is stamped only on a WIN, so
+      // presence is the win — no comparison needed. Soft-deleted workouts
+      // don't count, same as everywhere else miles are tallied.
+      db
+        .query<{
+          count: string;
+          best: string | null;
+        }>(
+          `SELECT COUNT(*)::text AS count,
+                  COALESCE(MAX(ghost_margin_seconds), 0)::text AS best
+             FROM workouts
+            WHERE user_id = $1
+              AND deleted_at IS NULL
+              AND ghost_margin_seconds IS NOT NULL`,
+          [userId],
+        )
+        .catch(() => [{ count: "0", best: "0" }]),
     ]);
     return {
       storyPostsCount: parseInt(stories[0]?.count ?? "0", 10) || 0,
@@ -276,6 +298,8 @@ async function computeSocialAggregates(userId: string): Promise<{
       buddySessionsCompleted: parseInt(buddyDone[0]?.count ?? "0", 10) || 0,
       buddyDistinctPartners: parseInt(buddyPartners[0]?.count ?? "0", 10) || 0,
       buddySessionsWon: parseInt(buddyWon[0]?.count ?? "0", 10) || 0,
+      ghostsBeaten: parseInt(ghosts[0]?.count ?? "0", 10) || 0,
+      bestGhostMargin: Math.floor(Number(ghosts[0]?.best ?? 0)) || 0,
     };
   } catch {
     return zero;
@@ -488,6 +512,15 @@ function evaluatePredicate(
       // default: completed sessions
       return { earned: agg.buddySessionsCompleted >= req, aggregateOnly: true };
     }
+    case "ghost": {
+      // ghost_beat_* = races won, ghost_margin_* = biggest single margin in
+      // seconds. Same badgeId-prefix family shape as `buddy` above.
+      if (req === null) return { earned: false, aggregateOnly: true };
+      if (badge.badgeId.startsWith("ghost_margin_")) {
+        return { earned: agg.bestGhostMargin >= req, aggregateOnly: true };
+      }
+      return { earned: agg.ghostsBeaten >= req, aggregateOnly: true };
+    }
     default:
       return { earned: false, aggregateOnly: true };
   }
@@ -571,6 +604,9 @@ function isWorkoutDerived(category: BadgeCategory): boolean {
     // Deleting a workout must not strip the medal for a walk you genuinely
     // did with a friend — and the friend's copy of that session still exists.
     category === "buddy"
+    // Ghost medals are deliberately NOT listed here: the win lives on the
+    // workout row itself, so deleting that workout should take the medal
+    // with it, exactly like a pace badge.
   );
 }
 
@@ -911,6 +947,65 @@ const EXTRA_BADGES: Array<{
     rarity: "legendary",
     requirement: 10,
     sortOrder: 956,
+  },
+  // ── Ghost Races ──
+  // Two families by badgeId prefix (see evaluatePredicate's "ghost" case):
+  // ghost_beat_* = races won, ghost_margin_* = biggest single winning margin
+  // in seconds. A race is only counted when it was WON — the tracker stamps
+  // `workouts.ghost_margin_seconds` on a win and nothing else.
+  //
+  // SF Symbols note: there is no ghost symbol on the iOS 17 deployment target
+  // (a too-new symbol renders as a BLANK box, not a fallback), so these use
+  // shipped symbols. The app draws its own ghost where the character matters.
+  {
+    badgeId: "ghost_beat_1",
+    category: "ghost",
+    name: "Ghost Hunter",
+    description: "Beat a ghost over the mile for the first time",
+    icon: "flag.checkered",
+    rarity: "common",
+    requirement: 1,
+    sortOrder: 960,
+  },
+  {
+    badgeId: "ghost_beat_10",
+    category: "ghost",
+    name: "Ghost Buster",
+    description: "Beat your ghost 10 times",
+    icon: "flag.checkered",
+    rarity: "rare",
+    requirement: 10,
+    sortOrder: 961,
+  },
+  {
+    badgeId: "ghost_beat_50",
+    category: "ghost",
+    name: "Unhaunted",
+    description: "Beat your ghost 50 times",
+    icon: "flag.checkered",
+    rarity: "legendary",
+    requirement: 50,
+    sortOrder: 962,
+  },
+  {
+    badgeId: "ghost_margin_15",
+    category: "ghost",
+    name: "Clear Daylight",
+    description: "Beat a ghost by 15 seconds or more",
+    icon: "bolt.fill",
+    rarity: "rare",
+    requirement: 15,
+    sortOrder: 963,
+  },
+  {
+    badgeId: "ghost_margin_45",
+    category: "ghost",
+    name: "Vanishing Act",
+    description: "Beat a ghost by 45 seconds or more",
+    icon: "bolt.fill",
+    rarity: "legendary",
+    requirement: 45,
+    sortOrder: 964,
   },
 ];
 

--- a/backend/src/services/clientFeatures.ts
+++ b/backend/src/services/clientFeatures.ts
@@ -46,6 +46,18 @@ export const CLIENT_FEATURES = {
    * string stays `coauthor_invite` for everyone.
    */
   collabTagV1: "collab_tag_v1",
+
+  /**
+   * The build can race a FRIEND's mile as its ghost — it sends
+   * `ghostFriendUserId` on sync and routes the `ghost_beaten` push to a
+   * rematch.
+   *
+   * Gated on the RECIPIENT, not the racer: an older build has no handler for
+   * that push, so it would arrive as a notification whose tap does nothing.
+   * The race itself works fine against a friend on any build — being someone's
+   * ghost requires nothing of them.
+   */
+  ghostFriendRaceV1: "ghost_friend_race_v1",
 } as const;
 
 export type ClientFeature =

--- a/backend/src/services/ghostService.ts
+++ b/backend/src/services/ghostService.ts
@@ -1,0 +1,199 @@
+import { PostgresService } from "./DbService.js";
+import { CIRCLE_CTE } from "./postService.js";
+import { OWNER_NOT_PRIVATE_SQL } from "./visibilityService.js";
+import { sendPush } from "./pushNotificationService.js";
+import { shouldSendNotification } from "./notificationSettingsService.js";
+import { CLIENT_FEATURES, userSupports } from "./clientFeatures.js";
+import { logError } from "./errorLogService.js";
+
+const db = PostgresService.getInstance();
+
+/** Activity types a ghost can be raced for. */
+export const GHOST_ACTIVITIES = ["running", "walking"] as const;
+export type GhostActivity = (typeof GHOST_ACTIVITIES)[number];
+
+/**
+ * A mile between 2:00 and 40:00 — the same window the client's
+ * `BestEffortStore.GhostTarget.isPlausible` enforces, and the same one
+ * `ghostRaceParams` uses when storing a result. Kept in sync deliberately: a
+ * ghost outside this band would be armed, raced, won, and then silently
+ * dropped on upload.
+ */
+const MIN_GHOST_SECONDS = 120;
+const MAX_GHOST_SECONDS = 2400;
+
+/** Friend count worth offering in a picker. */
+const MAX_GHOSTS = 50;
+
+export interface FriendGhost {
+  user_id: string;
+  username: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  profile_image_url: string | null;
+  /** Their fastest completed mile, in seconds. */
+  mile_seconds: number;
+}
+
+/**
+ * Friends whose fastest mile can be raced as a ghost, fastest first.
+ *
+ * Deliberately NOT built on `leaderboardService.getPaceLeaderboard`, even
+ * though that already returns a friend-scoped `period_best_pace` in the right
+ * unit. Four reasons, in order of severity:
+ *
+ *  1. It has no activity dimension. `split_pace` is stored without one, so a
+ *     friend's 6:30 RUN split would be handed back as a WALK ghost. The client
+ *     already refuses to do this to a user with their OWN PR
+ *     (`BestEffortStore.seededPace` — "an unbeatable ghost dressed up as a
+ *     fair one"); doing it with someone else's time is the same bug with a
+ *     name attached.
+ *  2. It has no block filter — `rankingUserIds` gates on `status = 'accepted'`
+ *     alone, so a block that didn't tear down the friendship leaks through.
+ *  3. It has no `deleted_at` / `exclusion_reason` guard, so a soft-deleted or
+ *     vehicle-speed-flagged workout can supply the number.
+ *  4. It ignores `workout_visibility`, so a user who went 'private' is still
+ *     offered.
+ *
+ * The 0.999 distance floor (not the legacy 0.95 used by badges and PR
+ * detection) excludes the trailing partial split that SplitCalculator emits
+ * with an extrapolated per-mile pace — otherwise a half mile run "at 7:00 pace"
+ * becomes a ghost nobody can catch. Same floor the pace leaderboard uses, so
+ * the two agree.
+ *
+ * The viewer is included in their own list: the picker reads as a leaderboard,
+ * and seeing your own time next to your friends' is the point.
+ */
+export async function getFriendGhosts(
+  userId: string,
+  activity: GhostActivity,
+): Promise<FriendGhost[]> {
+  // CIRCLE_CTE hardcodes the viewer as $1, so the activity has to be $2.
+  return db.query<FriendGhost>(
+    `${CIRCLE_CTE},
+		bests AS (
+			SELECT w.user_id, MIN(ws.split_pace)::float AS mile_seconds
+			  FROM workout_splits ws
+			  JOIN workouts w ON w.workout_id = ws.workout_id
+			 WHERE w.user_id IN (SELECT uid FROM circle)
+			   AND w.user_id NOT IN (SELECT uid FROM blocked)
+			   AND w.workout_type = $2
+			   AND w.deleted_at IS NULL
+			   AND w.exclusion_reason IS NULL
+			   AND ws.split_pace > 0
+			   AND ws.split_distance >= 0.999
+			 GROUP BY w.user_id
+		)
+		-- Narrower than FRIEND_SAFE_USER_COLUMNS on purpose: a picker needs a
+		-- name, a face and a time. Never a star select -- that table carries
+		-- email and apple_sub, and this list is read by other users.
+		SELECT u.user_id, u.username, u.first_name, u.last_name,
+		       u.profile_image_url, b.mile_seconds
+		  FROM bests b
+		  JOIN users u ON u.user_id = b.user_id
+		 WHERE b.mile_seconds >= $3
+		   AND b.mile_seconds <= $4
+		   AND ${OWNER_NOT_PRIVATE_SQL("u.user_id")}
+		 ORDER BY b.mile_seconds ASC
+		 LIMIT ${MAX_GHOSTS}`,
+    [userId, activity, MIN_GHOST_SECONDS, MAX_GHOST_SECONDS],
+  );
+}
+
+/**
+ * Tell friends whose ghost was just beaten.
+ *
+ * Called from the workout-upload path with the ids that upload just wrote.
+ * Everything about this is claim-first and re-validated, because none of the
+ * inputs are trustworthy on their own:
+ *
+ *  - `ghost_friend_user_id` is CLIENT-ASSERTED. A crafted upload could name
+ *    anyone. So the friendship and the block state are re-checked here, in
+ *    SQL, against the same rules the picker used. Naming a stranger buys
+ *    nothing: the row simply doesn't come back.
+ *  - The same workout is re-uploaded constantly (fullSync, recalibrate, the
+ *    route re-push after `finishRoute`). `ghost_notified_at` is claimed in the
+ *    same UPDATE that selects the work, so a re-upload can never re-push.
+ *  - The claim is stamped even when the push is then suppressed by a
+ *    preference or an old build. That's deliberate — "we considered this
+ *    workout" is the thing being recorded, and re-considering it tomorrow
+ *    would just re-suppress it.
+ *
+ * Never throws: a failed push must not fail a workout sync.
+ */
+export async function notifyGhostsBeaten(
+  racerId: string,
+  workoutIds: string[],
+): Promise<void> {
+  if (workoutIds.length === 0) return;
+  try {
+    // Claim and select in one statement. The friendship/block re-check lives
+    // in the WHERE so an unverified id never even gets claimed — if the two
+    // aren't friends, the row stays unclaimed and a later legitimate state
+    // (they become friends) is still eligible.
+    const rows = await db.query<{
+      owner_id: string;
+      margin: number;
+      racer_name: string | null;
+    }>(
+      `UPDATE workouts w
+          SET ghost_notified_at = NOW()
+         FROM users racer
+        WHERE w.workout_id = ANY($2::text[])
+          AND w.user_id = $1
+          AND racer.user_id = $1
+          AND w.deleted_at IS NULL
+          AND w.ghost_notified_at IS NULL
+          AND w.ghost_margin_seconds IS NOT NULL
+          AND w.ghost_friend_user_id IS NOT NULL
+          AND w.ghost_friend_user_id <> $1
+          AND EXISTS (
+            SELECT 1 FROM friendships f
+             WHERE f.user_id = $1
+               AND f.friend_id = w.ghost_friend_user_id
+               AND f.status = 'accepted'
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM user_blocks b
+             WHERE (b.blocker_id = $1 AND b.blocked_id = w.ghost_friend_user_id)
+                OR (b.blocker_id = w.ghost_friend_user_id AND b.blocked_id = $1)
+          )
+       RETURNING w.ghost_friend_user_id AS owner_id,
+                 w.ghost_margin_seconds AS margin,
+                 COALESCE(racer.first_name, racer.username) AS racer_name`,
+      [racerId, workoutIds],
+    );
+
+    for (const row of rows) {
+      // Social pushes share the "hype" preference bucket by convention. That
+      // toggle genuinely mutes this, which is what makes it a real control
+      // (App Review 4.5.4). Buddy invites minted their own category only
+      // because they're high-priority and would otherwise be unmutable.
+      if (!(await shouldSendNotification(row.owner_id, racerId, "hype"))) {
+        continue;
+      }
+      // Gate on the RECIPIENT's build: an older one has no handler for this
+      // push, so it would arrive as a notification whose tap does nothing.
+      if (
+        !(await userSupports(row.owner_id, CLIENT_FEATURES.ghostFriendRaceV1))
+      ) {
+        continue;
+      }
+      const name = row.racer_name || "A friend";
+      const seconds = Math.max(1, Math.round(Number(row.margin)));
+      await sendPush(row.owner_id, {
+        title: "Your ghost was caught",
+        body: `${name} beat your mile by ${seconds}s`,
+        type: "ghost_beaten",
+        // Push data values must be STRING-valued — shipped builds decode the
+        // inbox as [String: String], so one number breaks the whole decode.
+        data: { racer_user_id: racerId, margin_seconds: String(seconds) },
+      });
+    }
+  } catch (error: any) {
+    // A workout sync must never fail because a push didn't go out.
+    logError("push", `notifyGhostsBeaten: ${error?.message ?? String(error)}`, {
+      userId: racerId,
+    });
+  }
+}

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -18,7 +18,12 @@ const db = PostgresService.getInstance();
 // Shared circle + symmetric-block fragment. `$1` is always the viewer id.
 // `circle` = the viewer's accepted friends plus the viewer themself; blocked
 // ids (either direction) are excluded so neither party sees the other.
-const CIRCLE_CTE = `
+//
+// Exported so other friend-scoped reads (ghostService) get the SAME circle and
+// the SAME symmetric block rule rather than re-deriving it — leaderboardService
+// re-derived it and quietly lost the block half. Because it hardcodes `$1`, any
+// query using it must keep the viewer as its first parameter.
+export const CIRCLE_CTE = `
 WITH circle AS (
 	SELECT friend_id AS uid FROM friendships WHERE user_id = $1 AND status = 'accepted'
 	UNION

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -36,6 +36,46 @@ export interface PostStatsSnapshot {
   duration?: number | null;
   streak?: number | null;
   date?: string | null;
+  /**
+   * Ghost race, present only when the ghost was BEATEN: seconds of margin and
+   * the ghost's mile time.
+   *
+   * Deliberately carried in the snapshot rather than in its own column. The
+   * snapshot is jsonb that every feed projection already returns verbatim, so
+   * a ghost win reaches the feed, the profile grid, stories and post detail
+   * without touching one of those guard-heavy SELECTs.
+   *
+   * Display only, and client-asserted — `sanitizeGhostStats` clamps it to
+   * plausible values so a bad client can only brag with a believable number on
+   * its OWN post. Anything that must be TRUSTED (medals) counts
+   * `workouts.ghost_margin_seconds` instead, which arrives from the synced
+   * HKWorkout on the same footing as distance.
+   */
+  ghost_margin_seconds?: number | null;
+  ghost_target_seconds?: number | null;
+}
+
+/**
+ * Drop a ghost claim that isn't plausible, keeping the rest of the snapshot.
+ * Bounds mirror the client's `GhostTarget.isPlausible` (2:00…40:00); a margin
+ * can never exceed the ghost it beat.
+ */
+export function sanitizeGhostStats(
+  stats: PostStatsSnapshot | null,
+): PostStatsSnapshot | null {
+  if (!stats) return stats;
+  const margin = Number(stats.ghost_margin_seconds);
+  const target = Number(stats.ghost_target_seconds);
+  const ok =
+    Number.isFinite(margin) &&
+    Number.isFinite(target) &&
+    margin > 0 &&
+    target >= 120 &&
+    target <= 2400 &&
+    margin <= target;
+  if (ok) return stats;
+  const { ghost_margin_seconds, ghost_target_seconds, ...rest } = stats;
+  return rest;
 }
 
 /**

--- a/backend/src/services/pushNotificationService.ts
+++ b/backend/src/services/pushNotificationService.ts
@@ -163,7 +163,11 @@ export type NotificationType =
   | "buddy_joined"
   | "buddy_started"
   | "buddy_finished"
-  | "buddy_friend_active";
+  | "buddy_friend_active"
+  // A friend beat YOUR mile as their ghost. Deliberately not high-priority and
+  // not cap-exempt: it's a flourish about someone else's workout, so quiet
+  // hours and the daily cap both apply.
+  | "ghost_beaten";
 
 interface PushPayload {
   title: string;

--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -11,15 +11,24 @@ import {
 const db = PostgresService.getInstance();
 
 /**
- * The ghost-race columns for one workout's upsert, as `[margin, target]`.
+ * The ghost-race columns for one workout's upsert, as
+ * `[margin, target, friendUserId]`.
  *
  * The tracker stamps these on the HKWorkout only when the ghost was BEATEN, so
  * a non-null margin IS a win — which is what the ghost medal family counts.
  * Implausible claims are dropped to null rather than stored: bounds mirror the
  * client's `GhostTarget.isPlausible` (2:00…40:00), and you cannot beat a ghost
  * by more than the ghost's own time.
+ *
+ * `friendUserId` is present only when the ghost was a FRIEND's mile. It is
+ * client-asserted and NOT validated here — it is validated where it matters,
+ * at notify time in `notifyGhostsBeaten`, which re-checks the friendship and
+ * the block state before telling anyone anything. Storing an unverified id is
+ * harmless; pushing on one would be a spoofing vector.
  */
-function ghostRaceParams(workout: Workout): [number | null, number | null] {
+function ghostRaceParams(
+  workout: Workout,
+): [number | null, number | null, string | null] {
   const margin = Number(workout.ghostMarginSeconds);
   const target = Number(workout.ghostTargetSeconds);
   const ok =
@@ -29,7 +38,14 @@ function ghostRaceParams(workout: Workout): [number | null, number | null] {
     target >= 120 &&
     target <= 2400 &&
     margin <= target;
-  return ok ? [margin, target] : [null, null];
+  if (!ok) return [null, null, null];
+  const friend =
+    typeof workout.ghostFriendUserId === "string" &&
+    workout.ghostFriendUserId.length > 0 &&
+    workout.ghostFriendUserId !== workout.workoutId
+      ? workout.ghostFriendUserId
+      : null;
+  return [margin, target, friend];
 }
 
 export async function uploadWorkouts(
@@ -92,11 +108,12 @@ export async function uploadWorkouts(
         moving_seconds,
         ghost_margin_seconds,
         ghost_target_seconds,
+        ghost_friend_user_id,
         source,
         exclusion_reason,
         speed_flagged
       )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
       ON CONFLICT (workout_id)
       DO UPDATE SET
         distance = EXCLUDED.distance,
@@ -113,6 +130,7 @@ export async function uploadWorkouts(
         -- the tracker already recorded. Same reasoning as workout_routes.
         ghost_margin_seconds = COALESCE(EXCLUDED.ghost_margin_seconds, workouts.ghost_margin_seconds),
         ghost_target_seconds = COALESCE(EXCLUDED.ghost_target_seconds, workouts.ghost_target_seconds),
+        ghost_friend_user_id = COALESCE(EXCLUDED.ghost_friend_user_id, workouts.ghost_friend_user_id),
         source = CASE
           WHEN workouts.source IN ('manual', 'edited') THEN workouts.source
           ELSE EXCLUDED.source

--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -10,6 +10,28 @@ import {
 
 const db = PostgresService.getInstance();
 
+/**
+ * The ghost-race columns for one workout's upsert, as `[margin, target]`.
+ *
+ * The tracker stamps these on the HKWorkout only when the ghost was BEATEN, so
+ * a non-null margin IS a win — which is what the ghost medal family counts.
+ * Implausible claims are dropped to null rather than stored: bounds mirror the
+ * client's `GhostTarget.isPlausible` (2:00…40:00), and you cannot beat a ghost
+ * by more than the ghost's own time.
+ */
+function ghostRaceParams(workout: Workout): [number | null, number | null] {
+  const margin = Number(workout.ghostMarginSeconds);
+  const target = Number(workout.ghostTargetSeconds);
+  const ok =
+    Number.isFinite(margin) &&
+    Number.isFinite(target) &&
+    margin > 0 &&
+    target >= 120 &&
+    target <= 2400 &&
+    margin <= target;
+  return ok ? [margin, target] : [null, null];
+}
+
 export async function uploadWorkouts(
   userId: string,
   workouts: Workout[],
@@ -68,11 +90,13 @@ export async function uploadWorkouts(
         calories,
         total_duration,
         moving_seconds,
+        ghost_margin_seconds,
+        ghost_target_seconds,
         source,
         exclusion_reason,
         speed_flagged
       )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
       ON CONFLICT (workout_id)
       DO UPDATE SET
         distance = EXCLUDED.distance,
@@ -84,6 +108,11 @@ export async function uploadWorkouts(
         calories = EXCLUDED.calories,
         total_duration = EXCLUDED.total_duration,
         moving_seconds = EXCLUDED.moving_seconds,
+        -- COALESCE, not overwrite: a re-upload from a path that doesn't carry
+        -- HealthKit metadata (fullSync, recalibrate) must never erase a win
+        -- the tracker already recorded. Same reasoning as workout_routes.
+        ghost_margin_seconds = COALESCE(EXCLUDED.ghost_margin_seconds, workouts.ghost_margin_seconds),
+        ghost_target_seconds = COALESCE(EXCLUDED.ghost_target_seconds, workouts.ghost_target_seconds),
         source = CASE
           WHEN workouts.source IN ('manual', 'edited') THEN workouts.source
           ELSE EXCLUDED.source
@@ -142,6 +171,11 @@ export async function uploadWorkouts(
           (workout.movingSeconds as number) > 0
             ? Math.min(workout.movingSeconds as number, workout.totalDuration)
             : null,
+          // Ghost race — stamped only on a WIN, so presence is the win. Bounds
+          // mirror the client's GhostTarget.isPlausible (2:00…40:00) and a
+          // margin can never exceed the ghost it beat; anything else is
+          // dropped rather than trusted.
+          ...ghostRaceParams(workout),
           workout.source || "healthkit",
           speed.exclusionReason,
           speed.speedFlagged,

--- a/backend/src/types/badge.ts
+++ b/backend/src/types/badge.ts
@@ -9,7 +9,8 @@ export type BadgeCategory =
   | "hype"
   | "nudge"
   | "competition"
-  | "buddy";
+  | "buddy"
+  | "ghost";
 export type BadgeRarity = "common" | "rare" | "legendary";
 export type DailyChallengeType =
   | "pace"
@@ -160,4 +161,9 @@ export interface UserAggregates {
   buddySessionsCompleted: number;
   buddyDistinctPartners: number;
   buddySessionsWon: number;
+  // Ghost races. `workouts.ghost_margin_seconds` is written only on a WIN, so
+  // the count is simply how many workouts carry one; `bestGhostMargin` is the
+  // biggest single margin, in seconds.
+  ghostsBeaten: number;
+  bestGhostMargin: number;
 }

--- a/backend/src/types/workouts.ts
+++ b/backend/src/types/workouts.ts
@@ -13,6 +13,10 @@ export type Workout = {
   // Seconds of actual movement (in-app tracker only) — display pace uses
   // this; totalDuration stays the elapsed truth for PRs/races/recaps.
   movingSeconds?: number;
+  // Ghost race, sent only when the in-app tracker BEAT its ghost over the
+  // mile: seconds of margin, and the ghost's own mile time.
+  ghostMarginSeconds?: number;
+  ghostTargetSeconds?: number;
   splits: WorkoutSplit[];
   source?: WorkoutSource;
   // Optional simplified GPS trace ([[lat, lng], ...]) for outdoor walks/runs.

--- a/backend/src/types/workouts.ts
+++ b/backend/src/types/workouts.ts
@@ -17,6 +17,9 @@ export type Workout = {
   // mile: seconds of margin, and the ghost's own mile time.
   ghostMarginSeconds?: number;
   ghostTargetSeconds?: number;
+  // Whose ghost it was, when the raced target was a friend's mile. Client-
+  // asserted; the friendship is re-checked before any push goes out.
+  ghostFriendUserId?: string;
   splits: WorkoutSplit[];
   source?: WorkoutSource;
   // Optional simplified GPS trace ([[lat, lng], ...]) for outdoor walks/runs.


### PR DESCRIPTION
## What changed

Starting a workout asked two questions in sequence (activity, location) and then hid a third — *"am I racing a ghost?"* — in a small card wedged under the Indoor/Outdoor buttons, which opened a modal sheet with its own nav stack, background gradient and card style. The race read as an add-on to a screen about something else, and picking a target left the flow entirely for ten seconds.

It's now two real steps in the same wizard:

```
activity → location → normal vs ghost → ghost options → countdown
```

The picker moves out of `GhostRaceSetupSheet` into a new **`GhostRaceOptionsContent`**, which carries no presentation chrome. The wizard renders it inline; the buddy lobby keeps showing it as a sheet — one picker, two hosts, no drift. **The lobby's call site is unchanged.**

## Details worth knowing

- `proceedPastRaceChoice()` is the single door out of the race choice, so the once-ever live-presence interstitial can't be skipped by whichever step happens to come last.
- `clearPreStartSteps()` replaces the three hand-cleared booleans in the buddy hand-off and the recovery block, so a future step can't be forgotten in one of them.
- Asking about the ghost *after* the activity is locked in also fixes an old oddity: going back and switching Run↔Walk used to silently re-point an already-armed target at the other activity's stored time.
- The featured option card and the inline picker highlight by **brightness, not hue**. `MADTheme.workoutColor("running")` is the tracker gradient's own top stop, so a red-tinted CTA on that screen would vanish. The inline picker takes `accent`/`accentForeground` from its host and uses the same white-on-dark-red primary button the presence step already uses; the lobby sheet still gets the workout color.
- Steps share `wizardTopBar`/`wizardHeader`/`wizardStep` and slide directionally (forward from the trailing edge, back from the leading), so the flow reads as depth rather than four crossfades.

## Not changed

`BestEffortStore` (all four UserDefaults keys keep their meaning), `raceArmed` → `startWorkout()` → delta chip → 1-mile freeze → `celebrateRaceOutcome`, `BuddyLobbyView`, and the entire backend.

## Verification

- `backend/npm run build` — clean (untouched, run as insurance).
- Grepped for every deleted symbol (`ghostRaceCard`, the old `showGhostSetup` state) and for every pre-start flag-clearing site.
- **Not compile-verified** — no Swift toolchain in this environment and the project is Xcode-only, so this needs an Xcode build before it's trusted.

Paths to walk in Xcode:

- Run → Outdoor → **Just Track It** → countdown, no delta chip.
- Walk → Indoor → **Ghost Race** → Race 12:00 → chip live, freezes at 1.00 mi, "Ghost Beaten!" on a win.
- Ghost Race → **Skip the race** → countdown, no chip.
- Back at every step (options → mode → location → activity → dismiss), including Run↔Walk after visiting the ghost step.
- Custom target: wheels, the 40:01 disabled corner, and that the picked time is offered again next workout.
- Fresh install: the presence-consent screen still appears, now after the race choice and immediately before the countdown.
- Buddy walk: arm the ghost in the lobby → the tracker skips all four picker steps and races; the lobby sheet still opens and looks right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxEp1wW88Y5PxyTxgAoE3L

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxEp1wW88Y5PxyTxgAoE3L)_