### PR TITLE
Ghost picker: stop dropping an armed friend on open

### DIFF
--- a/app/Mile A Day/Views/Dashboard/GhostRaceOptionsContent.swift
+++ b/app/Mile A Day/Views/Dashboard/GhostRaceOptionsContent.swift
@@ -56,6 +56,32 @@ struct GhostRaceOptionsContent: View {
             .filter { $0.user_id != UserManager.shared.currentUser.backendUserId }
     }
 
+    /// Friend rows: the ones the server returned, plus the friend already
+    /// armed if they aren't in that list yet.
+    ///
+    /// That second part is load-bearing. `primeSelection` runs synchronously
+    /// in `onAppear`, while the friend list arrives over the network from
+    /// `.task` — so at prime time this list is EMPTY on a cold cache. Without
+    /// the armed friend pinned in, `targetsContain(current)` returns false and
+    /// the picker silently reverts an armed friend ghost to `defaultTarget`:
+    /// you chose Alex last session, you re-open the picker, and it has quietly
+    /// swapped you back to your own best. Same failure as matching friends by
+    /// kind, reached through a different door.
+    ///
+    /// Pinning it is safe because a `.friend` target is self-contained — it
+    /// carries its own seconds and name, so it stays raceable with no network
+    /// at all, and it survives the friend dropping off the list entirely
+    /// (unfriended, went private, switched activity).
+    private var friendTargets: [BestEffortStore.GhostTarget] {
+        var list = friends.map(\.target)
+        if let current, let armedId = current.friendUserId,
+            !list.contains(where: { $0.friendUserId == armedId })
+        {
+            list.insert(current, at: 0)
+        }
+        return list
+    }
+
     /// Your own targets, then friends, then `.custom`.
     ///
     /// `.custom` MUST stay last — it's the always-available fallback, and the
@@ -63,8 +89,10 @@ struct GhostRaceOptionsContent: View {
     private var targets: [BestEffortStore.GhostTarget] {
         var base = BestEffortStore.availableTargets(
             for: activityKey, seedPaceSecondsPerMile: seedPaceSeconds)
+        // `availableTargets` always ends with `.custom` — lift it off, insert
+        // the friends, put it back last.
         let custom = base.removeLast()
-        base.append(contentsOf: friends.map(\.target))
+        base.append(contentsOf: friendTargets)
         base.append(custom)
         return base
     }

--- a/backend/src/controllers/workoutController.ts
+++ b/backend/src/controllers/workoutController.ts
@@ -162,7 +162,12 @@ export async function uploadWorkouts(req: Request, res: Response) {
     // "Your ghost was caught" — only fires for a workout that raced a FRIEND's
     // mile and won. Claim-stamped inside, so the constant re-uploads of the
     // same workout can't re-push, and it never throws.
-    await notifyGhostsBeaten(userId, uploadedWorkoutIds);
+    //
+    // Deliberately NOT awaited, unlike the rewards above: nothing in the sync
+    // response depends on it, and every workout upload would otherwise pay for
+    // a query plus a preference check plus an APNs round trip before the
+    // client hears back.
+    void notifyGhostsBeaten(userId, uploadedWorkoutIds);
 
     // Check if user has now completed their mile and notify friends.
     // Skipped on the initial account-setup backfill (isFullSync) and when this

--- a/backend/src/services/ghostService.ts
+++ b/backend/src/services/ghostService.ts
@@ -61,8 +61,10 @@ export interface FriendGhost {
  * becomes a ghost nobody can catch. Same floor the pace leaderboard uses, so
  * the two agree.
  *
- * The viewer is included in their own list: the picker reads as a leaderboard,
- * and seeing your own time next to your friends' is the point.
+ * The viewer comes back in their own list (CIRCLE_CTE includes self) and the
+ * CLIENT drops them — their own mile is already offered twice over, as "best
+ * tracked in-app" and as their all-time PR, and a third row for the same
+ * person reads as a bug. Returning them anyway keeps that a client decision.
  */
 export async function getFriendGhosts(
   userId: string,


### PR DESCRIPTION
Follow-up to #287, which merged with a real bug in it.

## The bug

`primeSelection()` runs synchronously in `.onAppear`. The friend list arrives over the network from `.task`. So at prime time `friends` is **empty** on a cold cache, `targetsContain(current)` returns false for a `.friend` target, and the picker silently reverts to `defaultTarget`.

Concretely: you chose Alex's ghost last session, you re-open the picker, and it has quietly swapped you back to your own best. Tap Race and you race the wrong ghost, with no error and nothing on screen to suggest anything happened.

This is the same failure I'd already documented and guarded against in `targetsContain` and `matchesSelection` — matching friends by *kind* rather than by id. It just arrives through a different door: an empty list instead of a wrong comparison.

## The fix

`friendTargets` pins the armed friend into the list when the fetched list doesn't have them yet. Safe because a `.friend` target is self-contained — it carries its own seconds and name, so it stays raceable with no network at all, and it survives the friend dropping off the list entirely (unfriended, went private, switched activity). The row falls back to the person glyph until the avatar loads.

## Two smaller things while here

- **`notifyGhostsBeaten` is no longer awaited** on the workout-upload path. Nothing in the sync response depends on it, so every upload was paying for a query, a preference check and an APNs round trip before the client heard back.
- **Corrected a comment** in `ghostService` that claimed the viewer is returned "so the picker reads as a leaderboard". The client filters them out — their own mile is already offered as both "best tracked in-app" and their PR, and a third row for the same person reads as a bug.

## Verification

Re-ran the full gate against a real migrated Postgres 16: `tsc`, `drizzle-kit check`, the migrator twice (fresh + idempotent), `ci-smoke` (all assertions incl. the 9 ghost ones), `ghost-race-check` (11 assertions).

**iOS is still not compile-verified** — no Swift toolchain here, Xcode-only project. The specific thing to check in Xcode: arm a friend's ghost, leave the picker, come back, and confirm that friend is still the selected row (this is the bug), then kill and relaunch and confirm it survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxEp1wW88Y5PxyTxgAoE3L

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxEp1wW88Y5PxyTxgAoE3L)_