### PR TITLE
Fix the build, and turn the ghost push on

### DIFF
--- a/app/Mile A Day/Core/Services/ClientFeatures.swift
+++ b/app/Mile A Day/Core/Services/ClientFeatures.swift
@@ -22,7 +22,20 @@ enum ClientFeatures {
     /// buttons — it still opens the post, which is the safe direction.
     static let collabTagV1 = "collab_tag_v1"
 
+    /// This build understands the `ghost_beaten` push — "Alex beat your mile by
+    /// 6s" — and can race a friend's mile as its ghost in the first place.
+    ///
+    /// The meaning here is deliberately "won't be confused by the push", not
+    /// "can act on it": tapping it just opens the app, which is what every
+    /// other informational push does. A rematch deep-link is a later addition
+    /// and would need its OWN string if it ever needs gating, because reusing
+    /// this one with a new meaning would silently mis-describe every install
+    /// that already sent it.
+    static let ghostFriendRaceV1 = "ghost_friend_race_v1"
+
     /// Declared on registration. Add a string here only in the same build that
     /// actually implements the behavior.
-    static let supported: [String] = [friendRequestV2, collabTagV1]
+    static let supported: [String] = [
+        friendRequestV2, collabTagV1, ghostFriendRaceV1,
+    ]
 }

--- a/app/Mile A Day/Managers/CelebrationManager.swift
+++ b/app/Mile A Day/Managers/CelebrationManager.swift
@@ -643,7 +643,11 @@ class CelebrationManager: ObservableObject {
         pendingAction = .none
     }
 
-    /// Priority for ordering celebrations: lower = shown first
+    /// Priority for ordering celebrations: lower = shown first.
+    ///
+    /// Exhaustive on purpose — a new celebration must be given a deliberate
+    /// place in the running order, not silently land wherever a `default`
+    /// happened to put it. (This is the switch that caught `.ghostBeaten`.)
     private func priority(of celebration: CelebrationType) -> Int {
         switch celebration {
         case .badgeSummary: return -2 // One-time welcome — show first
@@ -651,12 +655,16 @@ class CelebrationManager: ObservableObject {
         case .goalCompleted: return 0
         case .newRecordStreak: return 1 // crown lands right after the flame
         case .comeback: return 2 // the emotional beat before the leaderboard
-        case .leaderboardMoveUp: return 3 // right after the fire/streak screen
-        case .postGoalWorkout: return 4
-        case .badgeUnlocked: return 5
-        case .milestone: return 6
-        case .challengeCompleted: return 7 // celebrate the daily challenge as a finale
-        case .postRunPhotoPrompt: return 8 // BeReal photo prompt — the very last step
+        // After the streak beats, which are rarer and carry more weight, but
+        // before the social ones: beating the ghost is about the workout that
+        // just ended, so it belongs next to it rather than after a badge.
+        case .ghostBeaten: return 3
+        case .leaderboardMoveUp: return 4 // right after the fire/streak screen
+        case .postGoalWorkout: return 5
+        case .badgeUnlocked: return 6
+        case .milestone: return 7
+        case .challengeCompleted: return 8 // celebrate the daily challenge as a finale
+        case .postRunPhotoPrompt: return 9 // BeReal photo prompt — the very last step
         }
     }
 


### PR DESCRIPTION
Two things the Xcode build found that nothing in CI could.

## 1. Build error: `priority(of:)` isn't exhaustive

`CelebrationManager.priority(of:)` switches over every `CelebrationType` with no `default:`, and `.ghostBeaten` wasn't in it:

```
CelebrationManager.swift:648:9 Switch must be exhaustive
```

When I added the case I checked `id` and `==` and missed the third switch. Swept the rest rather than fixing just this one:

| Switch | Status |
|---|---|
| `CelebrationType.id` | ✅ covered |
| `CelebrationType.==` | ✅ covered |
| `markConsumed` | has `default:` |
| add-guard (`.comeback, .newRecordStreak`) | has `default:` |
| `priority(of:)` | ❌ **this fix** |
| `GhostTarget` × 6 (storage, resolve, rowInfo, armedSeconds, targetsContain, matchesSelection) | ✅ all cover `.friend` |

Ghost wins sort **after** the streak beats — those are rarer and carry more weight — and **before** the social ones, since beating the ghost is about the workout that just ended rather than about other people. Everything below shifts by one.

## 2. The `ghost_beaten` push was dead code

The server gates it on the `ghost_friend_race_v1` client feature. **No build declared that string**, so `userSupports` returned false on every call and the push could never fire. Fail-closed, so nothing was broken — it just silently did nothing, which is the worst way for a feature to not work.

`ClientFeatures.supported` now declares it. The string means *"this build understands the push"*, not *"can act on it"*: tapping it opens the app, same as every other informational push. A rematch deep-link would need its **own** string later — reusing this one with a new meaning would mis-describe every install that already sent it.

## Worth knowing for the next enum change

iOS routes push types with `String` switches that have `default:` arms, so a new server-side `NotificationType` degrades gracefully rather than breaking the inbox decode. It's the **Swift enums with exhaustive switches** that bite — those are the ones to grep for.

## Verification

Verified by inspection (no Swift toolchain here): all 12 `CelebrationType` cases are now covered in `priority(of:)`, and the capability string is byte-identical on both sides. Backend is untouched by this change.

Needs an Xcode build to confirm the error is gone and no further ones surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxEp1wW88Y5PxyTxgAoE3L

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxEp1wW88Y5PxyTxgAoE3L)_