### PR TITLE
Fix the celebration preview after adding friendUserId

### DIFF
--- a/app/Mile A Day/Views/Celebrations/GhostBeatenCelebrationView.swift
+++ b/app/Mile A Day/Views/Celebrations/GhostBeatenCelebrationView.swift
@@ -305,6 +305,7 @@ struct GhostBeatenCelebrationView: View {
             ghostName: "your best",
             activityKey: "running",
             newRecordSeconds: 528,
+            friendUserId: nil,
             workoutId: "preview"
         )
     )

--- a/app/Mile A Day/Views/Feed/PostComposerView.swift
+++ b/app/Mile A Day/Views/Feed/PostComposerView.swift
@@ -20,8 +20,13 @@ struct RunStatsInput: Equatable {
     /// Ghost race, set only when this workout BEAT its ghost. Read straight off
     /// the HKWorkout's metadata, so it's keyed to the right workout by
     /// construction — no separate stash to fall out of sync.
-    var ghostMarginSeconds: Double?
-    var ghostTargetSeconds: Double?
+    /// Six of the eight `RunStatsInput` call sites don't pass these. A `var`
+    /// optional already gets an implicit nil in the memberwise init, so the
+    /// `= nil` is for the reader, not the compiler — unlike a `let` optional,
+    /// which is genuinely required (that's what broke the celebration's
+    /// #Preview when `GhostRaceWin.friendUserId` was added).
+    var ghostMarginSeconds: Double? = nil
+    var ghostTargetSeconds: Double? = nil
 
     var snapshot: PostStats {
         PostStats(


### PR DESCRIPTION
```
GhostBeatenCelebrationView.swift:307:34 Missing argument for parameter 'friendUserId' in call
```

The `#Preview` constructs a `GhostRaceWin` and wasn't updated when the struct gained `friendUserId` — so the build fails on a file that never ships.

## The rule underneath it

Worth writing down, because it decides which struct additions are breaking:

| Declaration | Memberwise init |
|---|---|
| `let x: T?` | **requires** an argument |
| `var x: T?` | gets an implicit nil — argument optional |

That's exactly why this one broke and its sibling didn't. `GhostRaceWin.friendUserId` is a `let`, so every construction site must pass it. `RunStatsInput.ghostMarginSeconds`, added in the same batch, is a `var` — so its six omitting call sites kept compiling silently.

I swept every construction site of all four structs this feature extended (`GhostRaceWin`, `RunStatsInput`, `PostStats`, `FriendGhost`). This preview was the only real miss; the only two `#Preview`s in files I touched are this one and `GhostSprite`'s, which uses only its own types.

## Also

Corrected a comment I'd written minutes earlier on `RunStatsInput` claiming its `= nil` was load-bearing. It isn't — a `var` optional already has one. It stays for the reader, and the comment now says so instead of asserting something false.

## Verification

Inspection only (no Swift toolchain here): the construction site sweep above, plus a brace/paren balance check on the edited file. Backend untouched.

Needs an Xcode build to confirm this clears and nothing further surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxEp1wW88Y5PxyTxgAoE3L

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxEp1wW88Y5PxyTxgAoE3L)_