### PR TITLE
Ghost races: real miles, a real coach, and the losses kept

### DIFF
--- a/app/Mile A Day/Services/BestEffortStore.swift
+++ b/app/Mile A Day/Services/BestEffortStore.swift
@@ -115,12 +115,23 @@ enum BestEffortStore {
             return nil
         }
 
-        /// A mile between 2 and 40 minutes. The floor is the same one
-        /// `recordFinish` uses to reject broken data; the ceiling keeps a
-        /// fat-fingered target from being unbeatable-by-standing-still.
+        /// A mile between 4:01 and 40:00.
+        ///
+        /// The floor is the mile world record (3:43) rounded up: anything at
+        /// or under it, from a consumer phone, is a car or a GPS glitch rather
+        /// than a person. It has to match the server's
+        /// `MIN_PLAUSIBLE_MILE_SECONDS` exactly — a target outside the band
+        /// would be armed, raced, won, and then dropped on upload, so the win
+        /// would simply never appear. The ceiling keeps a fat-fingered target
+        /// from being unbeatable-by-standing-still.
         static func isPlausible(_ seconds: Double) -> Bool {
-            seconds.isFinite && seconds >= 120 && seconds <= 2400
+            seconds.isFinite && seconds >= minPlausibleSeconds
+                && seconds <= maxPlausibleSeconds
         }
+
+        /// 4:01 — mirrors `backend/src/services/mileTime.ts`.
+        static let minPlausibleSeconds: Double = 241
+        static let maxPlausibleSeconds: Double = 2400
     }
 
     /// A resolved target: the effort to race plus how to talk about it.
@@ -195,7 +206,8 @@ enum BestEffortStore {
     /// Walks never inherit a RUN PR — a run PR is not a walk target, and
     /// offering it would be an unbeatable ghost dressed up as a fair one.
     private static func seededPace(activityKey: String, pace: Double?) -> Double? {
-        guard activityKey == "running", let pace, pace.isFinite, pace >= 180, pace <= 1800
+        guard activityKey == "running", let pace, pace.isFinite,
+            pace >= GhostTarget.minPlausibleSeconds, pace <= 1800
         else { return nil }
         return pace
     }
@@ -222,7 +234,7 @@ enum BestEffortStore {
         let stored = UserDefaults.standard.double(forKey: customKey(activityKey))
         if GhostTarget.isPlausible(stored) { return stored }
         if let recorded = best(for: activityKey)?.seconds {
-            return max(120, (recorded - 15).rounded())
+            return max(GhostTarget.minPlausibleSeconds, (recorded - 15).rounded())
         }
         return activityKey == "running" ? 540 : 720
     }
@@ -294,7 +306,11 @@ enum BestEffortStore {
             }
         }
         // Sub-2-minute "miles" are broken data, not efforts.
-        guard mileSeconds.isFinite, mileSeconds >= 120 else { return .notAMile }
+        // Same floor as everything else that reports a mile time: a sub-4:01
+        // "mile" is a drive, and letting one in here would make it the user's
+        // recorded best — the ghost they can then never beat.
+        guard mileSeconds.isFinite, mileSeconds >= GhostTarget.minPlausibleSeconds
+        else { return .notAMile }
 
         // Keep only the first mile, downsampled to ≤ 60 points, ending
         // exactly at 1.0 so timeAtDistance is exact at the finish line.

--- a/app/Mile A Day/Services/BestEffortStore.swift
+++ b/app/Mile A Day/Services/BestEffortStore.swift
@@ -134,6 +134,57 @@ enum BestEffortStore {
         static let maxPlausibleSeconds: Double = 2400
     }
 
+    /// One quarter of a raced mile: your split beside the ghost's.
+    struct RaceSplit: Identifiable, Equatable {
+        /// 0-based quarter index.
+        let index: Int
+        let yours: TimeInterval
+        let ghost: TimeInterval
+
+        var id: Int { index }
+        var label: String { "Q\(index + 1)" }
+        /// Seconds GAINED on the ghost in this quarter (negative = lost).
+        var delta: TimeInterval { ghost - yours }
+    }
+
+    /// Quarter-by-quarter comparison of a finished mile against its ghost.
+    ///
+    /// This is the story of the race — "3 down at halfway, took it in the last
+    /// quarter" — and it's the one thing the live chip can never show, because
+    /// the chip only knows the running total.
+    ///
+    /// Same inputs and the same scaling as `recordFinish`, so the splits
+    /// describe the exact mile that was recorded rather than a second opinion.
+    /// Returns empty unless the curve is a genuine full mile from a standing
+    /// start — a recovered workout resumes mid-distance and has no history for
+    /// the quarters it never saw.
+    static func raceSplits(
+        rawCurve: [(t: TimeInterval, d: Double)],
+        distanceScale: Double,
+        ghost: BestMileEffort
+    ) -> [RaceSplit] {
+        let scale = distanceScale.isFinite && distanceScale > 0 ? distanceScale : 1.0
+        let curve = rawCurve.map { CurvePoint(t: $0.t, d: $0.d * scale) }
+        guard let first = curve.first, let last = curve.last,
+            first.d <= 0.05, last.d >= 1.0
+        else { return [] }
+
+        let mine = BestMileEffort(dateISO: "", seconds: last.t, curve: curve)
+        var splits: [RaceSplit] = []
+        for quarter in 0..<4 {
+            let from = Double(quarter) * 0.25
+            let to = from + 0.25
+            splits.append(
+                RaceSplit(
+                    index: quarter,
+                    yours: timeAtDistance(to, in: mine) - timeAtDistance(from, in: mine),
+                    ghost: timeAtDistance(to, in: ghost) - timeAtDistance(from, in: ghost)
+                )
+            )
+        }
+        return splits
+    }
+
     /// A resolved target: the effort to race plus how to talk about it.
     struct ResolvedGhost: Equatable {
         var target: GhostTarget

--- a/app/Mile A Day/Services/GhostCoach.swift
+++ b/app/Mile A Day/Services/GhostCoach.swift
@@ -39,9 +39,24 @@ final class GhostCoach: NSObject, ObservableObject, AVSpeechSynthesizerDelegate 
 
     private let synthesizer = AVSpeechSynthesizer()
 
-    /// Hard floor between lines. Three quarter-mile callouts plus a lead change
-    /// on a nine-minute mile is about as much as anyone wants.
-    private static let minSecondsBetweenLines: TimeInterval = 25
+    /// How much a line is worth interrupting for.
+    ///
+    /// The floor adapts because a race decided by three seconds deserves more
+    /// talk than a rout: a fixed interval either nags during a blowout or goes
+    /// quiet exactly when it matters.
+    enum Urgency {
+        /// Lead changes, milestones, a close race — the moments worth hearing.
+        case high
+        /// Effort nudges in a race that isn't close.
+        case normal
+
+        var floor: TimeInterval {
+            switch self {
+            case .high: return 15
+            case .normal: return 40
+            }
+        }
+    }
 
     private var ghostName = "your ghost"
     private var isRacing = false
@@ -57,35 +72,73 @@ final class GhostCoach: NSObject, ObservableObject, AVSpeechSynthesizerDelegate 
 
     // MARK: - Lifecycle
 
-    func start(ghostName: String, isRun: Bool) {
+    func start(ghostName: String, isRun: Bool, ghostSeconds: Double) {
         guard Self.isEnabled else { return }
         self.ghostName = ghostName
         isRacing = true
         lastSpokeAt = .distantPast
         firedMilestones = []
         wasAhead = nil
-        say("Racing \(ghostName). \(isRun ? "Run" : "Walk") strong.", force: true)
+        // The brief. A target in the abstract is hard to run to; a quarter
+        // split is a number you can actually check yourself against.
+        let quarter = ghostSeconds / 4
+        say(
+            "Racing \(ghostName). \(BestEffortStore.formatSeconds(ghostSeconds)) "
+                + "for the mile — \(BestEffortStore.formatSeconds(quarter)) a quarter.",
+            force: true
+        )
+    }
+
+    /// Everything the coach needs, sampled at one instant.
+    ///
+    /// A struct rather than loose arguments because the lines are only honest
+    /// if the figures agree with each other — `delta` and `recentPace` read
+    /// from the same tick, so the coach can't say "slipping" off a stale pace
+    /// while quoting a fresh delta.
+    struct Sample {
+        /// Miles so far — `liveDistance`, the same number the ring shows.
+        let distance: Double
+        /// Race clock in seconds (moving time outdoors).
+        let raceClock: TimeInterval
+        /// Seconds ahead(+)/behind(−), the SAME figure the chip renders.
+        let delta: TimeInterval
+        /// The ghost's mile time.
+        let ghostSeconds: Double
+        /// Pace over roughly the last minute, seconds/mile. Nil when the
+        /// runner has gone quiet — the coach must then say nothing about
+        /// effort rather than guess.
+        let recentPace: Double?
+
+        /// Seconds per mile needed over what's left to finish level with the
+        /// ghost. Pure arithmetic — no curve lookup, because the finish line
+        /// is a fixed distance and the ghost's total is a fixed time.
+        var requiredPace: Double? {
+            let remaining = 1.0 - distance
+            guard remaining > 0.02 else { return nil }
+            let budget = ghostSeconds - raceClock
+            guard budget > 0 else { return nil }
+            return budget / remaining
+        }
     }
 
     /// Called from the tracker's existing 1 Hz tick — no timer of its own.
-    ///
-    /// `delta` is the SAME frozen-at-the-crossing figure the chip shows
-    /// (positive = ahead), so the voice can never contradict the screen.
-    func update(distance: Double, delta: TimeInterval?) {
-        guard Self.isEnabled, isRacing, let delta else { return }
+    func update(_ sample: Sample) {
+        guard Self.isEnabled, isRacing else { return }
+        let delta = sample.delta
         // Under 2 seconds either way is inside the noise — calling it a lead
         // would have the coach flip-flopping every few strides.
         let ahead = delta >= 2
         let behind = delta <= -2
 
-        // A lead CHANGE is the most useful thing to hear, so it outranks the
-        // distance milestones and is checked first.
+        // A lead CHANGE is the most useful thing to hear, so it outranks
+        // everything else.
         if ahead || behind {
             if let was = wasAhead, was != ahead {
                 say(
                     ahead
-                        ? "You're ahead of \(ghostName) by \(seconds(delta))."
-                        : "\(ghostName.capitalizedFirst) is up by \(seconds(delta)). Time to push."
+                        ? "You're ahead of \(ghostName) by \(seconds(delta)). \(holdLine(sample))"
+                        : "\(ghostName.capitalizedFirst) is up by \(seconds(delta)). \(chaseLine(sample))",
+                    urgency: .high
                 )
                 wasAhead = ahead
                 return
@@ -93,13 +146,57 @@ final class GhostCoach: NSObject, ObservableObject, AVSpeechSynthesizerDelegate 
             if wasAhead == nil { wasAhead = ahead }
         }
 
-        for milestone in Self.milestones where distance >= milestone.at {
+        // Distance milestones — each fires once, with the standing and, when
+        // it's known, what it now takes.
+        for milestone in Self.milestones where sample.distance >= milestone.at {
             guard !firedMilestones.contains(milestone.id) else { continue }
             firedMilestones.insert(milestone.id)
-            say("\(milestone.label) \(standing(delta))")
+            say("\(milestone.label) \(standing(delta)) \(chaseLine(sample))", urgency: .high)
             return
         }
+
+        // Effort. This is the line that makes it a coach rather than a
+        // scoreboard, and it's the one that needs a real pace derivative —
+        // silence is correct when `recentPace` is nil.
+        if let effort = effortLine(sample) {
+            say(effort, urgency: closeRace(delta) ? .high : .normal)
+        }
     }
+
+    /// Fading or holding, judged against what it currently takes to win.
+    ///
+    /// Only speaks when the gap is big enough to act on: telling someone
+    /// they're two seconds per mile off is noise, and being told to push when
+    /// you're already pushing is worse than silence.
+    private func effortLine(_ sample: Sample) -> String? {
+        guard let recent = sample.recentPace, let required = sample.requiredPace
+        else { return nil }
+        // Enough of the mile is left that a correction is still possible.
+        guard sample.distance >= 0.15, sample.distance <= 0.92 else { return nil }
+
+        let drift = recent - required
+        if drift > 20 {
+            return "You're slipping. \(paceWords(required)) to take it back."
+        }
+        if drift < -20, sample.delta > 0 {
+            return "That's the pace. You're pulling away."
+        }
+        return nil
+    }
+
+    /// What it takes from here, when that's still a real question.
+    private func chaseLine(_ sample: Sample) -> String {
+        guard let required = sample.requiredPace else { return "" }
+        return "\(paceWords(required)) to win."
+    }
+
+    private func holdLine(_ sample: Sample) -> String {
+        guard sample.requiredPace != nil else { return "" }
+        return "Hold it."
+    }
+
+    /// A race decided by a handful of seconds deserves more talk than a rout.
+    private func closeRace(_ delta: TimeInterval) -> Bool { abs(delta) < 6 }
 
     /// The verdict, spoken once. A loss stays silent by design.
     func finish(won: Bool, marginSeconds: TimeInterval) {
@@ -139,6 +236,16 @@ final class GhostCoach: NSObject, ObservableObject, AVSpeechSynthesizerDelegate 
         return "Dead even."
     }
 
+    /// "8:40 pace" — spoken, so the synthesizer reads it as a time rather than
+    /// two numbers.
+    private func paceWords(_ secondsPerMile: Double) -> String {
+        let whole = max(0, Int(secondsPerMile.rounded()))
+        let minutes = whole / 60
+        let secs = whole % 60
+        if secs == 0 { return "\(minutes) minute pace" }
+        return "\(minutes) \(secs < 10 ? "oh " : "")\(secs) pace"
+    }
+
     private func seconds(_ value: TimeInterval) -> String {
         let whole = max(1, Int(abs(value).rounded()))
         return whole == 1 ? "1 second" : "\(whole) seconds"
@@ -146,9 +253,9 @@ final class GhostCoach: NSObject, ObservableObject, AVSpeechSynthesizerDelegate 
 
     // MARK: - Speech
 
-    private func say(_ line: String, force: Bool = false) {
+    private func say(_ line: String, urgency: Urgency = .normal, force: Bool = false) {
         guard Self.isEnabled else { return }
-        if !force, Date().timeIntervalSince(lastSpokeAt) < Self.minSecondsBetweenLines {
+        if !force, Date().timeIntervalSince(lastSpokeAt) < urgency.floor {
             return
         }
         lastSpokeAt = Date()

--- a/app/Mile A Day/Services/GhostCoach.swift
+++ b/app/Mile A Day/Services/GhostCoach.swift
@@ -1,0 +1,223 @@
+import AVFoundation
+import Foundation
+
+/// The voice in your ear during a ghost race.
+///
+/// It exists because the delta chip is unreadable while you're actually
+/// running: the phone is in a pocket or a strap, and the one thing you want to
+/// know — am I ahead or behind — is the one thing you can't check without
+/// breaking stride. So the race says it out loud.
+///
+/// Design rules, in the order they matter:
+///
+///  - **Say little.** A coach that talks constantly gets muted, and a muted
+///    coach helps nobody. There is a hard floor between lines, milestones fire
+///    once each, and a loss at the finish stays silent — the same rule the
+///    celebration follows, because being told you lost isn't coaching.
+///  - **Never stop the music.** The session ducks (`.duckOthers`) rather than
+///    interrupting, and it is only ACTIVE while an utterance is in flight —
+///    holding it open for a whole workout would leave the user's music quiet
+///    the entire time.
+///  - **Every line is also text.** `lastLine` is published so the tracking
+///    screen can show what was said, which is what makes this usable with the
+///    volume down or the coach off.
+final class GhostCoach: NSObject, ObservableObject, AVSpeechSynthesizerDelegate {
+    static let shared = GhostCoach()
+
+    /// User preference. Default ON — most people want it, and it announces
+    /// itself in the first ten seconds so it's easy to find and turn off.
+    static let enabledKey = "ghostCoachEnabledV1"
+    static var isEnabled: Bool {
+        UserDefaults.standard.object(forKey: enabledKey) as? Bool ?? true
+    }
+    static func setEnabled(_ on: Bool) {
+        UserDefaults.standard.set(on, forKey: enabledKey)
+    }
+
+    /// The most recent line, for the on-screen echo. Cleared by `stop()`.
+    @Published private(set) var lastLine: String?
+
+    private let synthesizer = AVSpeechSynthesizer()
+
+    /// Hard floor between lines. Three quarter-mile callouts plus a lead change
+    /// on a nine-minute mile is about as much as anyone wants.
+    private static let minSecondsBetweenLines: TimeInterval = 25
+
+    private var ghostName = "your ghost"
+    private var isRacing = false
+    private var lastSpokeAt = Date.distantPast
+    private var firedMilestones: Set<String> = []
+    /// Nil until the first meaningful delta — the first few steps are noise.
+    private var wasAhead: Bool?
+
+    private override init() {
+        super.init()
+        synthesizer.delegate = self
+    }
+
+    // MARK: - Lifecycle
+
+    func start(ghostName: String, isRun: Bool) {
+        guard Self.isEnabled else { return }
+        self.ghostName = ghostName
+        isRacing = true
+        lastSpokeAt = .distantPast
+        firedMilestones = []
+        wasAhead = nil
+        say("Racing \(ghostName). \(isRun ? "Run" : "Walk") strong.", force: true)
+    }
+
+    /// Called from the tracker's existing 1 Hz tick — no timer of its own.
+    ///
+    /// `delta` is the SAME frozen-at-the-crossing figure the chip shows
+    /// (positive = ahead), so the voice can never contradict the screen.
+    func update(distance: Double, delta: TimeInterval?) {
+        guard Self.isEnabled, isRacing, let delta else { return }
+        // Under 2 seconds either way is inside the noise — calling it a lead
+        // would have the coach flip-flopping every few strides.
+        let ahead = delta >= 2
+        let behind = delta <= -2
+
+        // A lead CHANGE is the most useful thing to hear, so it outranks the
+        // distance milestones and is checked first.
+        if ahead || behind {
+            if let was = wasAhead, was != ahead {
+                say(
+                    ahead
+                        ? "You're ahead of \(ghostName) by \(seconds(delta))."
+                        : "\(ghostName.capitalizedFirst) is up by \(seconds(delta)). Time to push."
+                )
+                wasAhead = ahead
+                return
+            }
+            if wasAhead == nil { wasAhead = ahead }
+        }
+
+        for milestone in Self.milestones where distance >= milestone.at {
+            guard !firedMilestones.contains(milestone.id) else { continue }
+            firedMilestones.insert(milestone.id)
+            say("\(milestone.label) \(standing(delta))")
+            return
+        }
+    }
+
+    /// The verdict, spoken once. A loss stays silent by design.
+    func finish(won: Bool, marginSeconds: TimeInterval) {
+        guard Self.isEnabled, isRacing else { return }
+        isRacing = false
+        guard won else { return }
+        say("You beat \(ghostName) by \(seconds(marginSeconds)). Nice.", force: true)
+    }
+
+    func stop() {
+        isRacing = false
+        firedMilestones = []
+        wasAhead = nil
+        synthesizer.stopSpeaking(at: .immediate)
+        DispatchQueue.main.async { self.lastLine = nil }
+        deactivateSession()
+    }
+
+    // MARK: - Lines
+
+    private struct Milestone {
+        let id: String
+        let at: Double
+        let label: String
+    }
+
+    private static let milestones: [Milestone] = [
+        Milestone(id: "quarter", at: 0.25, label: "Quarter mile."),
+        Milestone(id: "half", at: 0.5, label: "Half way."),
+        Milestone(id: "threequarter", at: 0.75, label: "Three quarters."),
+        Milestone(id: "last", at: 0.9, label: "Last stretch."),
+    ]
+
+    private func standing(_ delta: TimeInterval) -> String {
+        if delta >= 2 { return "\(seconds(delta)) ahead." }
+        if delta <= -2 { return "\(seconds(delta)) behind." }
+        return "Dead even."
+    }
+
+    private func seconds(_ value: TimeInterval) -> String {
+        let whole = max(1, Int(abs(value).rounded()))
+        return whole == 1 ? "1 second" : "\(whole) seconds"
+    }
+
+    // MARK: - Speech
+
+    private func say(_ line: String, force: Bool = false) {
+        guard Self.isEnabled else { return }
+        if !force, Date().timeIntervalSince(lastSpokeAt) < Self.minSecondsBetweenLines {
+            return
+        }
+        lastSpokeAt = Date()
+        DispatchQueue.main.async { self.lastLine = line }
+
+        activateSession()
+        let utterance = AVSpeechUtterance(string: line)
+        utterance.rate = AVSpeechUtteranceDefaultSpeechRate
+        utterance.postUtteranceDelay = 0
+        utterance.voice = AVSpeechSynthesisVoice(language: Locale.current.identifier)
+            ?? AVSpeechSynthesisVoice(language: "en-US")
+        synthesizer.speak(utterance)
+    }
+
+    /// Activated only around an utterance. `.duckOthers` lowers music instead
+    /// of stopping it; `.mixWithOthers` keeps anything else playing alive.
+    ///
+    /// NOTE: for this to be audible with the phone LOCKED — i.e. for most of a
+    /// real run — the app target needs `audio` in `UIBackgroundModes`. Without
+    /// it, iOS silences the session on background and the coach only speaks
+    /// while the screen is on.
+    private func activateSession() {
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(
+                .playback,
+                mode: .voicePrompt,
+                options: [.duckOthers, .mixWithOthers]
+            )
+            try session.setActive(true)
+        } catch {
+            // Never let audio setup break a workout — the on-screen line still
+            // lands, which is the part that always works.
+            print("[GhostCoach] audio session failed: \(error)")
+        }
+    }
+
+    private func deactivateSession() {
+        do {
+            try AVAudioSession.sharedInstance()
+                .setActive(false, options: .notifyOthersOnDeactivation)
+        } catch {
+            // Deactivation failing just means music stays ducked a moment
+            // longer; not worth surfacing.
+        }
+    }
+
+    // MARK: - AVSpeechSynthesizerDelegate
+
+    func speechSynthesizer(
+        _ synthesizer: AVSpeechSynthesizer,
+        didFinish utterance: AVSpeechUtterance
+    ) {
+        // Hand the audio back so the user's music comes straight back up.
+        deactivateSession()
+    }
+
+    func speechSynthesizer(
+        _ synthesizer: AVSpeechSynthesizer,
+        didCancel utterance: AVSpeechUtterance
+    ) {
+        deactivateSession()
+    }
+}
+
+private extension String {
+    /// "your best" → "Your best", for a line that starts with the ghost's name.
+    var capitalizedFirst: String {
+        guard let first else { return self }
+        return String(first).uppercased() + dropFirst()
+    }
+}

--- a/app/Mile A Day/Services/RunPostService.swift
+++ b/app/Mile A Day/Services/RunPostService.swift
@@ -173,8 +173,11 @@ enum RunPostService {
         return workout.duration
     }
 
-    /// The ghost win stamped on this workout at finish, if it beat its ghost.
-    /// Only winning workouts carry the metadata, so presence IS the win.
+    /// The ghost WIN stamped on this workout, if it beat its ghost.
+    ///
+    /// The margin is signed and every completed race is stamped, so presence is
+    /// no longer the win — the `> 0` below is what keeps losses out of the
+    /// feed. That's deliberate: nobody wants their loss posted.
     private static func ghostWin(of workout: HKWorkout) -> (margin: Double, target: Double)? {
         guard
             let margin = workout.metadata?[WorkoutLocationManager.ghostMarginMetadataKey] as? Double,

--- a/app/Mile A Day/Views/Dashboard/GhostRaceOptionsContent.swift
+++ b/app/Mile A Day/Views/Dashboard/GhostRaceOptionsContent.swift
@@ -46,6 +46,7 @@ struct GhostRaceOptionsContent: View {
     @State private var hasPrimed = false
 
     @ObservedObject private var friendGhosts = FriendGhostService.shared
+    @AppStorage(GhostCoach.enabledKey) private var coachEnabled = true
 
     private var isRun: Bool { activityKey == "running" }
 
@@ -124,6 +125,7 @@ struct GhostRaceOptionsContent: View {
                     header
                     targetList
                     if isCustomSelected { customPicker }
+                    coachToggle
                     howItWorks
                     // Reserves scroll room under the pinned footer.
                     Color.clear.frame(height: 180)
@@ -379,7 +381,11 @@ struct GhostRaceOptionsContent: View {
     private var customPicker: some View {
         VStack(spacing: MADTheme.Spacing.sm) {
             HStack(spacing: 0) {
-                wheel(value: $customMinutes, range: 2...40, unit: "min")
+                // Starts at 4, not 2: everything below 4:01 is rejected as a
+                // drive, so offering those minutes was offering a dead end.
+                // 4:00 exactly stays selectable and simply disables the button,
+                // the same way the 40:01 corner already does.
+                wheel(value: $customMinutes, range: 4...40, unit: "min")
                 Text(":")
                     .font(.system(size: 26, weight: .bold, design: .rounded))
                     .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.5))
@@ -432,6 +438,36 @@ struct GhostRaceOptionsContent: View {
     private var referenceSeconds: Double? {
         BestEffortStore.best(for: activityKey)?.seconds
             ?? (isRun ? seedPaceSeconds : nil)
+    }
+
+    // MARK: - Coach
+
+    /// Lives HERE rather than in app settings because this is the screen where
+    /// someone decides to race — the only moment the setting means anything,
+    /// and the moment they'll look for it after hearing a voice they didn't
+    /// expect. Default on; one tap off, and it stays off.
+    private var coachToggle: some View {
+        Toggle(isOn: $coachEnabled) {
+            HStack(spacing: MADTheme.Spacing.md) {
+                Image(systemName: coachEnabled ? "speaker.wave.2.fill" : "speaker.slash.fill")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(coachEnabled ? accent : MADTheme.Colors.madWhite.opacity(0.5))
+                    .frame(width: 30)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Coach")
+                        .font(MADTheme.Typography.bodyBold)
+                        .foregroundStyle(MADTheme.Colors.madWhite)
+                    Text("Calls out where you stand at each quarter mile, and whenever the lead changes.")
+                        .font(MADTheme.Typography.caption)
+                        .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.6))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .tint(accent)
+        .padding(MADTheme.Spacing.md)
+        .ghostRaceSurface(selected: false, accent: accent)
+        .onChange(of: coachEnabled) { _, _ in MADHaptics.tap() }
     }
 
     // MARK: - Explainer

--- a/app/Mile A Day/Views/Dashboard/WorkoutDetailView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutDetailView.swift
@@ -148,6 +148,11 @@ struct WorkoutDetailView: View {
                         // The numbers — one home, no repeats across cards.
                         statsSection
 
+                        // The race, if this workout was one. Every completed
+                        // race appears here, won or lost — this is the only
+                        // surface that shows a loss, which is the point.
+                        ghostRaceSection
+
                         // Mile splits as a pace bar chart.
                         mileSplitsSection
 
@@ -477,6 +482,61 @@ struct WorkoutDetailView: View {
     /// The run's headline numbers, in ONE place — distance lives in the hero,
     /// everything else lives here (no more repeating pace/calories in a second
     /// "Performance" card).
+    /// The ghost race this workout was, read straight off the HealthKit
+    /// metadata the tracker stamped at finish — so it needs no backend, works
+    /// offline, and is available the instant the workout saves.
+    ///
+    /// Signed: positive means the ghost was beaten, negative means it wasn't.
+    /// A loss shows here and NOWHERE else — not the feed, not a celebration,
+    /// not a push. Recording it is what gives the feature a memory; broadcasting
+    /// it is what nobody asked for.
+    @ViewBuilder
+    private var ghostRaceSection: some View {
+        if let race = ghostRaceResult {
+            VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+                WorkoutDetailSectionHeader(title: "Ghost Race", icon: "flag.checkered")
+                VStack(spacing: 0) {
+                    DetailRow(
+                        icon: race.won ? "trophy.fill" : "flag.checkered",
+                        iconColor: race.won ? .green : .orange,
+                        title: race.won ? "Result" : "Result",
+                        value: race.won
+                            ? "Beat it by \(Int(race.margin.rounded()))s"
+                            : "\(Int(abs(race.margin).rounded()))s off"
+                    )
+                    DetailRow(
+                        icon: "stopwatch",
+                        title: "Ghost's mile",
+                        value: BestEffortStore.formatSeconds(race.target)
+                    )
+                    DetailRow(
+                        icon: "figure.run",
+                        title: "Your mile",
+                        value: BestEffortStore.formatSeconds(
+                            max(0, race.target - race.margin))
+                    )
+                }
+                .padding(MADTheme.Spacing.md)
+                .background(
+                    RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large)
+                        .fill(Color(.secondarySystemBackground))
+                )
+            }
+        }
+    }
+
+    /// Signed race result from the workout's own metadata, when it raced.
+    private var ghostRaceResult: (margin: Double, target: Double, won: Bool)? {
+        guard
+            let margin = workout.metadata?[
+                WorkoutLocationManager.ghostMarginMetadataKey] as? Double,
+            let target = workout.metadata?[
+                WorkoutLocationManager.ghostTargetMetadataKey] as? Double,
+            margin != 0, target > 0
+        else { return nil }
+        return (margin, target, margin > 0)
+    }
+
     private var statsSection: some View {
         WorkoutStatsCard(
             duration: workout.formattedDuration,

--- a/app/Mile A Day/Views/Dashboard/WorkoutLocationManager.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutLocationManager.swift
@@ -218,6 +218,55 @@ class WorkoutLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
         return movingSeconds
     }
 
+    /// Pace over roughly the last minute, in seconds per mile. Nil until the
+    /// curve holds two samples far enough apart to mean anything.
+    ///
+    /// This is the app's ONLY non-cumulative pace: every other pace figure —
+    /// the recap, the Live Activity, the splits — divides total time by total
+    /// distance, which can't tell you that someone who started fast is now
+    /// dying. The ghost coach needs the derivative to say "you're slipping"
+    /// instead of only "you're behind".
+    ///
+    /// Derived rather than plumbed: `effortCurve` is already sampled on every
+    /// odometer move, so this adds no timer, no state and nothing to the
+    /// accrual path. Two honest limits, both inherited from the curve:
+    ///
+    ///  - It only appends when distance strictly INCREASES, so a stopped
+    ///    runner produces no new points and this figure goes stale rather than
+    ///    falling. Callers must treat a stale value as "unknown", which is why
+    ///    the freshness check against `raceClockSeconds` is here and not
+    ///    optional.
+    ///  - Resolution is one sample per ~0.02 mi or ~10 s, so this is good for
+    ///    "fading over the last quarter" and useless for stride-level feedback.
+    var recentPaceSecondsPerMile: Double? {
+        guard effortCurve.count >= 2 else { return nil }
+        let now = raceClockSeconds
+        let newest = effortCurve[effortCurve.count - 1]
+
+        // Gone quiet: either standing still or the odometer has stalled. Either
+        // way the last window no longer describes what's happening NOW.
+        guard now - newest.t <= 30 else { return nil }
+
+        // Walk back for a window of at least 45s / 0.08 mi — enough to average
+        // out the curve's coarse sampling without smearing a whole quarter.
+        var anchor = newest
+        for index in stride(from: effortCurve.count - 2, through: 0, by: -1) {
+            anchor = effortCurve[index]
+            if newest.t - anchor.t >= 45 || newest.d - anchor.d >= 0.08 { break }
+        }
+
+        let seconds = newest.t - anchor.t
+        let miles = newest.d - anchor.d
+        guard seconds >= 20, miles >= 0.01 else { return nil }
+        let pace = seconds / miles
+        // A window this short can produce nonsense off one bad sample; bound it
+        // to the same window a real mile lives in.
+        guard pace >= BestEffortStore.GhostTarget.minPlausibleSeconds,
+            pace <= BestEffortStore.GhostTarget.maxPlausibleSeconds
+        else { return nil }
+        return pace
+    }
+
     /// Append an effort-curve point when enough distance or time has passed.
     /// Called on the main queue from `refreshLiveDistance` — i.e. from every
     /// path that moves the odometer, indoor and outdoor alike.

--- a/app/Mile A Day/Views/Dashboard/WorkoutRecapView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutRecapView.swift
@@ -15,6 +15,10 @@ struct WorkoutRecapView: View {
     let startingDistance: Double  // Miles already done today before this workout
     let goalDistance: Double      // Daily goal in miles
     let streak: Int               // Current streak in days
+    /// Quarter-by-quarter against the ghost, empty when this wasn't a race.
+    /// Defaulted so every existing construction site is unaffected.
+    var raceSplits: [BestEffortStore.RaceSplit] = []
+    var raceGhostName: String = "your ghost"
     let onDismiss: () -> Void
 
     // Staggered entrance
@@ -57,6 +61,72 @@ struct WorkoutRecapView: View {
         return String(format: "%d'%02d\"", minutes, seconds)
     }
 
+    /// Where the race was won or lost.
+    ///
+    /// The live chip could only ever show the running total, so "I was down at
+    /// halfway and took it in the last quarter" — the actual shape of the race
+    /// — was never visible anywhere. Four rows, your split against the ghost's,
+    /// with the quarter you gained tinted green and the one you gave away
+    /// orange.
+    @ViewBuilder
+    private var raceBreakdown: some View {
+        if !raceSplits.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 6) {
+                    Image(systemName: "flag.checkered")
+                        .font(.system(size: 12, weight: .bold))
+                    Text("VS \(raceGhostName.uppercased())")
+                        .font(.system(size: 12, weight: .black, design: .rounded))
+                        .tracking(0.8)
+                }
+                .foregroundColor(.white.opacity(0.6))
+
+                ForEach(raceSplits) { split in
+                    HStack(spacing: 12) {
+                        Text(split.label)
+                            .font(.system(size: 13, weight: .bold, design: .rounded))
+                            .foregroundColor(.white.opacity(0.7))
+                            .frame(width: 26, alignment: .leading)
+
+                        Text(BestEffortStore.formatSeconds(split.yours))
+                            .font(.system(size: 15, weight: .bold, design: .rounded))
+                            .monospacedDigit()
+                            .foregroundColor(.white)
+
+                        Text(BestEffortStore.formatSeconds(split.ghost))
+                            .font(.system(size: 13, weight: .medium, design: .rounded))
+                            .monospacedDigit()
+                            .foregroundColor(.white.opacity(0.45))
+
+                        Spacer()
+
+                        Text(deltaText(split.delta))
+                            .font(.system(size: 14, weight: .heavy, design: .rounded))
+                            .monospacedDigit()
+                            .foregroundColor(split.delta >= 0 ? .green : .orange)
+                    }
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color.white.opacity(0.1))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .strokeBorder(Color.white.opacity(0.18), lineWidth: 1)
+                    )
+            )
+        }
+    }
+
+    /// "+3s" / "−2s" — seconds gained on the ghost in that quarter.
+    private func deltaText(_ delta: TimeInterval) -> String {
+        let whole = Int(delta.rounded())
+        if whole == 0 { return "even" }
+        return whole > 0 ? "+\(whole)s" : "\(whole)s"
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             ScrollView {
@@ -67,6 +137,8 @@ struct WorkoutRecapView: View {
                     distanceSection
 
                     statsGrid
+
+                    raceBreakdown
 
                     goalCard
                 }

--- a/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
@@ -43,6 +43,8 @@ struct WorkoutTrackingView: View {
     @State private var selectedLocationType: HKWorkoutSessionLocationType = .outdoor
     @State private var countdownNumber = 3
     @State private var showCountdown = false
+    /// Retained so Cancel can invalidate it — see `startCountdown`.
+    @State private var countdownTimer: Timer?
     @State private var isTracking = false
     @State private var elapsedTime: TimeInterval = 0
     @State private var timer: Timer?
@@ -114,6 +116,8 @@ struct WorkoutTrackingView: View {
     // mid-walk. The consent interstitial runs ONCE (first tracked workout on
     // this build), between picking a location and the countdown.
     @ObservedObject private var livePresence = LivePresenceService.shared
+    /// Published coach lines, echoed on screen under the delta chip.
+    @ObservedObject private var coach = GhostCoach.shared
     @State private var showFriendsOutSheet = false
     @State private var hypeToast: String?
     @AppStorage("hasAnsweredLivePresenceConsent") private var hasAnsweredLivePresenceConsent = false
@@ -222,10 +226,12 @@ struct WorkoutTrackingView: View {
                 myMileSeconds = a.t + (b.t - a.t) * ((1.0 - a.d) / span)
             }
         }
+        let finalDelta = ghost.seconds - myMileSeconds
         withAnimation(.spring(response: 0.4)) {
-            raceFinalDelta = ghost.seconds - myMileSeconds
+            raceFinalDelta = finalDelta
         }
         MADHaptics.action()
+        GhostCoach.shared.finish(won: finalDelta > 0, marginSeconds: finalDelta)
     }
 
     // Workout distance only (starts at 0). `liveDistance` is THE number:
@@ -607,13 +613,47 @@ struct WorkoutTrackingView: View {
     // MARK: - Countdown
 
     private var countdownContent: some View {
-        VStack {
+        VStack(spacing: 0) {
+            Spacer()
+
             Text("\(countdownNumber)")
                 .font(.system(size: 120, weight: .bold, design: .rounded))
                 .foregroundColor(.white)
                 .scaleEffect(countdownNumber > 0 ? 1.0 : 0.5)
                 .opacity(countdownNumber > 0 ? 1.0 : 0.0)
                 .animation(.spring(response: 0.5, dampingFraction: 0.6), value: countdownNumber)
+
+            Spacer()
+
+            // The last exit before a workout exists. Tapping Run when you meant
+            // Walk, or opening this by accident, otherwise costs a junk workout
+            // that has to be deleted afterwards — and a deleted workout still
+            // churns the day's feed roles and streak recompute. Nothing has
+            // been created yet at this point, so cancelling here is clean.
+            //
+            // Deliberately large and low: it's on screen for three seconds and
+            // the user is often already moving.
+            Button {
+                cancelCountdown()
+            } label: {
+                Text("Cancel")
+                    .font(.system(size: 17, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 52)
+                    .background(
+                        Capsule()
+                            .fill(Color.white.opacity(0.15))
+                            .overlay(
+                                Capsule().strokeBorder(
+                                    Color.white.opacity(0.4), lineWidth: 1.5)
+                            )
+                    )
+                    .contentShape(Capsule())
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 48)
+            .padding(.bottom, 64)
         }
         .onAppear {
             startCountdown()
@@ -1258,9 +1298,24 @@ struct WorkoutTrackingView: View {
                 raceDeltaChip(delta: delta, frozen: raceFinalDelta != nil)
                     .transition(.opacity.combined(with: .scale))
             }
+
+            // Every coach line as text too. This is what makes the feature work
+            // with the volume down, with the coach switched off, or before the
+            // `audio` background mode lets it speak through a locked screen.
+            if raceGhost != nil, let line = coach.lastLine {
+                Text(line)
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.75))
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                    .padding(.horizontal, 24)
+                    .transition(.opacity)
+                    .id(line)
+            }
         }
         .animation(.spring(response: 0.3), value: locationManager.isAutoPaused)
         .animation(.spring(response: 0.3), value: raceFinalDelta != nil)
+        .animation(.easeInOut(duration: 0.25), value: coach.lastLine)
     }
 
     /// Ghost race readout: live ahead/behind while the mile is in progress,
@@ -1950,16 +2005,24 @@ struct WorkoutTrackingView: View {
         }
     }
 
+    /// The 3-2-1. Retained in `countdownTimer` so Cancel can actually stop it:
+    /// as a bare `scheduledTimer` it outlived the view, so tearing the screen
+    /// down still fired `startWorkout()` three seconds later.
     private func startCountdown() {
+        // onAppear can run again (re-entering after a cancel) — never leave a
+        // second timer racing the first.
+        countdownTimer?.invalidate()
+
         // Haptic feedback for countdown
         let impact = UIImpactFeedbackGenerator(style: .heavy)
 
-        Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
+        countdownTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
             if countdownNumber > 1 {
                 countdownNumber -= 1
                 impact.impactOccurred()
             } else {
                 timer.invalidate()
+                countdownTimer = nil
                 // Start workout
                 withAnimation {
                     showCountdown = false
@@ -1967,6 +2030,21 @@ struct WorkoutTrackingView: View {
                 }
                 startWorkout()
             }
+        }
+    }
+
+    /// Back out before anything is created. Returns to the first step rather
+    /// than dismissing, because the common reason to cancel is picking Run when
+    /// you meant Walk — and from there Back still leaves.
+    private func cancelCountdown() {
+        countdownTimer?.invalidate()
+        countdownTimer = nil
+        MADHaptics.tap()
+        wizardGoingBack = true
+        withAnimation(.easeInOut(duration: 0.28)) {
+            showCountdown = false
+            countdownNumber = 3
+            showActivitySelection = true
         }
     }
 
@@ -1986,6 +2064,10 @@ struct WorkoutTrackingView: View {
         if raceArmed, let ghost = resolvedGhost {
             raceGhost = ghost.effort
             raceGhostName = ghost.shortName
+            GhostCoach.shared.start(
+                ghostName: ghost.shortName,
+                isRun: selectedActivityType == .running
+            )
         } else {
             raceGhost = nil
             raceGhostName = "your best mile"
@@ -2072,6 +2154,16 @@ struct WorkoutTrackingView: View {
             guard !isStopping else { return }
             elapsedTime = Date().timeIntervalSince(startDate)
             updateLiveActivity()
+
+            // Ghost coach rides this tick rather than owning a timer. It reads
+            // the SAME delta the chip renders, so the voice can never say
+            // something the screen contradicts.
+            if raceGhost != nil {
+                GhostCoach.shared.update(
+                    distance: locationManager.liveDistance,
+                    delta: raceDeltaSeconds
+                )
+            }
             // Foreground heartbeat driver (self-throttled to ~45s). The
             // background driver is the location/pedometer callback path.
             livePresence.tick()
@@ -2322,6 +2414,7 @@ struct WorkoutTrackingView: View {
         raceGhostName = "your best mile"
         raceFinalDelta = nil
         pendingGhostWin = nil
+        GhostCoach.shared.stop()
 
         // Show result to user. The mile counts via GPS/pedometer sync whether
         // or not the HealthKit write succeeded, so a failed save is never a lost

--- a/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutTrackingView.swift
@@ -62,6 +62,9 @@ struct WorkoutTrackingView: View {
     @State private var recapDuration: TimeInterval = 0
     @State private var recapStartingDistance: Double = 0
     @State private var recapGoalDistance: Double = 0
+    /// Quarter splits vs the ghost, snapshotted before tracking tears down.
+    @State private var recapRaceSplits: [BestEffortStore.RaceSplit] = []
+    @State private var recapGhostName: String = "your ghost"
     @State private var showStopConfirmation = false // Confirmation before ending workout
     @State private var isStopping = false // Prevents double-stop and shows "Ending..." UI
     /// Whether the Live Activity goal-completed alert was already sent (or the
@@ -138,10 +141,15 @@ struct WorkoutTrackingView: View {
     /// How to name the ghost in copy ("your best mile", "your target").
     @State private var raceGhostName = "your best mile"
     @State private var raceFinalDelta: TimeInterval?
-    /// The win, from the moment it's decided until the HealthKit metadata
-    /// stamp carries it onto the saved workout (and from there to the server
-    /// and the feed).
-    @State private var pendingGhostWin: GhostRaceWin?
+    /// One completed race, held from the moment it's decided until the
+    /// HealthKit metadata stamp carries it onto the saved workout (and from
+    /// there to the server). Signed: positive won, negative lost.
+    struct RaceStamp {
+        let marginSeconds: Double
+        let ghostSeconds: Double
+        let friendUserId: String?
+    }
+    @State private var pendingRaceStamp: RaceStamp?
     /// Chosen target, per activity, remembered between sessions.
     @AppStorage("ghostTargetV1.running") private var runTargetStorage = ""
     @AppStorage("ghostTargetV1.walking") private var walkTargetStorage = ""
@@ -557,28 +565,42 @@ struct WorkoutTrackingView: View {
             }
         }()
 
-        // Raced and won: `raceFinalDelta` is the frozen verdict at the 1.0-mile
-        // crossing — the same number the chip showed, so the popup can't
-        // contradict what the user watched. Every figure below is derived from
-        // that one frozen delta for the same reason.
-        if let ghost = raceGhost, let delta = raceFinalDelta, delta > 0 {
-            let win = GhostRaceWin(
+        // Every COMPLETED race is recorded, win or loss. `raceFinalDelta` is the
+        // frozen verdict at the 1.0-mile crossing — the same number the chip
+        // showed — and its sign is the result: positive won, negative lost.
+        //
+        // Losses used to vanish entirely, which meant the feature could only
+        // ever show you your victories: no history, no "two seconds away", no
+        // reason to come back. The stamp is separate from the celebration for
+        // exactly that reason — one records, the other congratulates.
+        if let ghost = raceGhost, let delta = raceFinalDelta {
+            pendingRaceStamp = RaceStamp(
                 marginSeconds: delta,
-                mileSeconds: max(0, ghost.seconds - delta),
                 ghostSeconds: ghost.seconds,
-                ghostName: raceGhostName,
-                activityKey: raceActivityKey,
-                newRecordSeconds: recordSeconds,
                 // Whose ghost it was, when it was a friend's. Read from the
                 // armed target rather than the resolved one — `ResolvedGhost`
                 // deliberately keeps only a display name.
-                friendUserId: raceTarget.friendUserId,
-                workoutId: nil
+                friendUserId: raceTarget.friendUserId
             )
-            // Held for the HealthKit metadata stamp further down this same
-            // stop, which is what carries the win to the server.
-            pendingGhostWin = win
-            CelebrationManager.shared.addCelebration(.ghostBeaten(win: win))
+        }
+
+        // Won: the popup. A LOSS stays silent here on purpose — the frozen chip
+        // already told that story mid-workout and the ghost lives another day.
+        if let ghost = raceGhost, let delta = raceFinalDelta, delta > 0 {
+            CelebrationManager.shared.addCelebration(
+                .ghostBeaten(
+                    win: GhostRaceWin(
+                        marginSeconds: delta,
+                        mileSeconds: max(0, ghost.seconds - delta),
+                        ghostSeconds: ghost.seconds,
+                        ghostName: raceGhostName,
+                        activityKey: raceActivityKey,
+                        newRecordSeconds: recordSeconds,
+                        friendUserId: raceTarget.friendUserId,
+                        workoutId: nil
+                    )
+                )
+            )
             return
         }
 
@@ -1655,6 +1677,8 @@ struct WorkoutTrackingView: View {
                     startingDistance: recapStartingDistance,
                     goalDistance: recapGoalDistance,
                     streak: userManager.currentUser.streak,
+                    raceSplits: recapRaceSplits,
+                    raceGhostName: recapGhostName,
                     onDismiss: { dismiss() }
                 )
             } else {
@@ -2066,7 +2090,8 @@ struct WorkoutTrackingView: View {
             raceGhostName = ghost.shortName
             GhostCoach.shared.start(
                 ghostName: ghost.shortName,
-                isRun: selectedActivityType == .running
+                isRun: selectedActivityType == .running,
+                ghostSeconds: ghost.effort.seconds
             )
         } else {
             raceGhost = nil
@@ -2158,10 +2183,15 @@ struct WorkoutTrackingView: View {
             // Ghost coach rides this tick rather than owning a timer. It reads
             // the SAME delta the chip renders, so the voice can never say
             // something the screen contradicts.
-            if raceGhost != nil {
+            if let ghost = raceGhost, let delta = raceDeltaSeconds {
                 GhostCoach.shared.update(
-                    distance: locationManager.liveDistance,
-                    delta: raceDeltaSeconds
+                    GhostCoach.Sample(
+                        distance: locationManager.liveDistance,
+                        raceClock: locationManager.raceClockSeconds,
+                        delta: delta,
+                        ghostSeconds: ghost.seconds,
+                        recentPace: locationManager.recentPaceSecondsPerMile
+                    )
                 )
             }
             // Foreground heartbeat driver (self-throttled to ~45s). The
@@ -2209,6 +2239,20 @@ struct WorkoutTrackingView: View {
             workoutId: nil
         )
         celebrateRaceOutcome(raceOutcome)
+
+        // Quarter splits vs the ghost, captured HERE because stopTracking()
+        // below clears the effort curve — the recap renders after teardown, so
+        // by the time it exists the raw material is gone.
+        if let ghost = raceGhost {
+            recapRaceSplits = BestEffortStore.raceSplits(
+                rawCurve: locationManager.effortCurve,
+                distanceScale: curveDistance > 0 ? finalDistance / curveDistance : 1.0,
+                ghost: ghost
+            )
+            recapGhostName = raceGhostName
+        } else {
+            recapRaceSplits = []
+        }
 
         // Freeze the recap stats now, before anything refreshes underneath us
         recapDistance = finalDistance
@@ -2349,12 +2393,15 @@ struct WorkoutTrackingView: View {
         if movingSeconds > 0 {
             metadata[WorkoutLocationManager.movingSecondsMetadataKey] = movingSeconds
         }
-        if let win = pendingGhostWin {
-            metadata[WorkoutLocationManager.ghostMarginMetadataKey] = win.marginSeconds
-            metadata[WorkoutLocationManager.ghostTargetMetadataKey] = win.ghostSeconds
+        if let race = pendingRaceStamp {
+            // Signed — a negative margin is a race that was lost, and it is
+            // stored just as deliberately as a win.
+            metadata[WorkoutLocationManager.ghostMarginMetadataKey] = race.marginSeconds
+            metadata[WorkoutLocationManager.ghostTargetMetadataKey] = race.ghostSeconds
             // Only present when the ghost was a friend's — that's what lets
-            // the server tell them they were caught.
-            if let friendId = win.friendUserId {
+            // the server tell them they were caught (and only when it was a
+            // win; the server re-checks the sign).
+            if let friendId = race.friendUserId {
                 metadata[WorkoutLocationManager.ghostFriendMetadataKey] = friendId
             }
         }
@@ -2413,7 +2460,7 @@ struct WorkoutTrackingView: View {
         raceGhost = nil
         raceGhostName = "your best mile"
         raceFinalDelta = nil
-        pendingGhostWin = nil
+        pendingRaceStamp = nil
         GhostCoach.shared.stop()
 
         // Show result to user. The mile counts via GPS/pedometer sync whether

--- a/app/Mile A Day/Views/Profile/GhostRacesSection.swift
+++ b/app/Mile A Day/Views/Profile/GhostRacesSection.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+
+/// One finished ghost race. Signed margin: positive won, negative lost.
+///
+/// Plain snake_case with NO explicit `CodingKeys` — a struct with one loses
+/// Codable synthesis the moment a property is added without a matching case,
+/// and there is no iOS CI to catch it. `local_date` is a `date` column, so a
+/// plain string is safe here (only `timestamptz` carries the fractional-seconds
+/// trap that breaks `JSONDecoder.iso8601`).
+struct GhostRaceRecord: Codable, Identifiable, Equatable {
+    let workout_id: String
+    let margin_seconds: Double
+    let target_seconds: Double
+    let local_date: String
+    let workout_type: String?
+    /// Nil unless the ghost was a friend's mile AND they're still visible.
+    let friend_name: String?
+
+    var id: String { workout_id }
+    var won: Bool { margin_seconds > 0 }
+    var yourSeconds: Double { max(0, target_seconds - margin_seconds) }
+
+    var ghostLabel: String {
+        if let friend_name, !friend_name.isEmpty { return friend_name }
+        return "your ghost"
+    }
+
+    var resultText: String {
+        let whole = max(1, Int(abs(margin_seconds).rounded()))
+        return won ? "Beat \(ghostLabel) by \(whole)s" : "\(whole)s off \(ghostLabel)"
+    }
+}
+
+private struct GhostHistoryResponse: Decodable {
+    let races: [GhostRaceRecord]
+}
+
+/// Your ghost races, newest first — **wins and losses**.
+///
+/// The losses are the point. A trophy cabinet tells you nothing you didn't
+/// already know; "2 seconds off" is the line that gets someone back out. This
+/// is the only surface in the app that shows one — the feed, the celebration
+/// and the push are all deliberately wins-only.
+///
+/// Self-contained like `RacePRsSection` beside it: owns its own fetch and
+/// state, so the parent just drops it in.
+struct GhostRacesSection: View {
+    @State private var races: [GhostRaceRecord] = []
+    @State private var isLoading = true
+    @State private var loadFailed = false
+
+    private var wins: Int { races.filter(\.won).count }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
+            header
+
+            if isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, MADTheme.Spacing.lg)
+            } else if races.isEmpty {
+                emptyState
+            } else {
+                VStack(spacing: MADTheme.Spacing.sm) {
+                    ForEach(races.prefix(10)) { race in
+                        row(race)
+                    }
+                }
+            }
+        }
+        .task {
+            await load()
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: MADTheme.Spacing.sm) {
+            GhostSprite(size: 18, color: MADTheme.Colors.madWhite, floats: false)
+            Text("Ghost Races")
+                .font(MADTheme.Typography.headline)
+                .foregroundStyle(MADTheme.Colors.madWhite)
+            Spacer()
+            if !races.isEmpty {
+                Text("\(wins)–\(races.count - wins)")
+                    .font(.system(size: 14, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.6))
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        Text(
+            loadFailed
+                ? "Couldn't load your races."
+                : "No races yet. Pick Ghost Race when you start a mile."
+        )
+        .font(MADTheme.Typography.caption)
+        .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.6))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, MADTheme.Spacing.sm)
+    }
+
+    private func row(_ race: GhostRaceRecord) -> some View {
+        HStack(spacing: MADTheme.Spacing.md) {
+            Image(systemName: race.won ? "trophy.fill" : "flag.checkered")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(race.won ? Color.green : Color.orange)
+                .frame(width: 22)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(race.resultText)
+                    .font(MADTheme.Typography.smallBold)
+                    .foregroundStyle(MADTheme.Colors.madWhite)
+                    .lineLimit(1)
+                Text(race.local_date)
+                    .font(MADTheme.Typography.caption)
+                    .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.5))
+            }
+
+            Spacer(minLength: MADTheme.Spacing.sm)
+
+            Text(BestEffortStore.formatSeconds(race.yourSeconds))
+                .font(.system(size: 16, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(MADTheme.Colors.madWhite)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
+                .fill(Color.white.opacity(0.08))
+        )
+    }
+
+    private func load() async {
+        do {
+            let response: GhostHistoryResponse = try await APIClient.fancyFetch(
+                endpoint: "/ghosts/history",
+                method: .GET,
+                body: nil,
+                responseType: GhostHistoryResponse.self
+            )
+            races = response.races
+            loadFailed = false
+        } catch {
+            loadFailed = true
+        }
+        isLoading = false
+    }
+}

--- a/app/Mile A Day/Views/Profile/ProfileView.swift
+++ b/app/Mile A Day/Views/Profile/ProfileView.swift
@@ -328,6 +328,10 @@ struct ProfileView: View {
         VStack(spacing: MADTheme.Spacing.lg) {
             performanceSection
             RacePRsSection(userId: userManager.currentUser.backendUserId)
+            // Beside the PRs rather than on its own screen: both answer "how
+            // fast am I", and a race history buried a tap deeper is a race
+            // history nobody reads. Self-scoped, so it's own-profile only.
+            GhostRacesSection()
             routeHeatmapCard
         }
     }

--- a/app/Mile-A-Day-Info.plist
+++ b/app/Mile-A-Day-Info.plist
@@ -40,6 +40,10 @@
 		<string>fetch</string>
 		<string>processing</string>
 		<string>location</string>
+		<!-- Spoken ghost-race coaching. Without this the audio session is
+		     silenced the moment the screen locks, which is most of a real
+		     run — the coach would only ever work while you're watching it. -->
+		<string>audio</string>
 	</array>
 </dict>
 </plist>

--- a/backend/scripts/ci-smoke.mjs
+++ b/backend/scripts/ci-smoke.mjs
@@ -1309,6 +1309,24 @@ await updateNotificationPreferences(BOB, { workout_visibility: "friends" });
     `UPDATE workouts SET deleted_at = NULL WHERE workout_id = 'ci-ghost-bob-run'`,
   );
 
+  // A sub-4:01 mile is a car, not a person. It must not become anyone's
+  // ghost, PR, leaderboard entry or badge — the floor is shared, so this
+  // asserts the one surface and documents the rule for the rest.
+  await ghostWorkout(BOB, "ci-ghost-bob-car", "running", 1.0, 140);
+  const carGhosts = await getFriendGhosts(ALICE, "running");
+  assert.equal(
+    carGhosts.find((g) => g.user_id === BOB)?.mile_seconds,
+    540,
+    "a 2:20 mile is ignored; the real 9:00 stays the ghost",
+  );
+  await db.query(
+    `DELETE FROM workout_splits WHERE workout_id = 'ci-ghost-bob-run'`,
+  );
+  assert.ok(
+    !(await getFriendGhosts(ALICE, "running")).some((g) => g.user_id === BOB),
+    "with only the sub-4:01 split left, they drop out entirely",
+  );
+
   await db.query(`DELETE FROM workout_splits WHERE workout_id LIKE 'ci-ghost-%'`);
   await db.query(`DELETE FROM workouts WHERE workout_id LIKE 'ci-ghost-%'`);
 }

--- a/backend/scripts/ghost-race-check.mjs
+++ b/backend/scripts/ghost-race-check.mjs
@@ -14,7 +14,10 @@
  */
 import { PostgresService } from "../dist/services/DbService.js";
 import { uploadWorkouts } from "../dist/services/workoutService.js";
-import { notifyGhostsBeaten } from "../dist/services/ghostService.js";
+import {
+  notifyGhostsBeaten,
+  getGhostHistory,
+} from "../dist/services/ghostService.js";
 
 const db = PostgresService.getInstance();
 const USER = "ghost-check-user";
@@ -174,6 +177,77 @@ async function main() {
       WHERE workout_id = 'ghost-friend-win'`,
   );
   check("a non-friend claim is never notified", stranger?.done, false);
+
+  // ── Losses ──
+  //
+  // The margin is SIGNED and every completed race is stored. That makes
+  // `IS NOT NULL` stop meaning "won", so each consequence gets an assertion.
+  await db.query(
+    `UPDATE workouts SET ghost_notified_at = NULL, ghost_friend_user_id = $1
+      WHERE workout_id = 'ghost-friend-win'`,
+    [FRIEND],
+  );
+  await uploadWorkouts(USER, [
+    workout("ghost-loss", {
+      ghostMarginSeconds: -7,
+      ghostTargetSeconds: 600,
+      ghostFriendUserId: FRIEND,
+    }),
+  ]);
+  const [loss] = await db.query(
+    `SELECT ghost_margin_seconds AS m FROM workouts WHERE workout_id = 'ghost-loss'`,
+  );
+  check("a loss is stored, signed", Number(loss?.m), -7);
+
+  // ...and survives the same metadata-less re-upload a win does.
+  await uploadWorkouts(USER, [workout("ghost-loss")]);
+  const [lossAfter] = await db.query(
+    `SELECT ghost_margin_seconds AS m FROM workouts WHERE workout_id = 'ghost-loss'`,
+  );
+  check("a loss survives a metadata-less re-upload", Number(lossAfter?.m), -7);
+
+  // A loss must never be notified — that would tell someone their ghost was
+  // caught when it wasn't.
+  await notifyGhostsBeaten(USER, ["ghost-loss"]);
+  const [lossNotified] = await db.query(
+    `SELECT (ghost_notified_at IS NOT NULL) AS done FROM workouts
+      WHERE workout_id = 'ghost-loss'`,
+  );
+  check("a loss is never notified", lossNotified?.done, false);
+
+  // Medals count WINS. This is the subtle one: without `> 0` the MAX returns a
+  // NEGATIVE for a user who has only ever lost, and COALESCE won't catch it.
+  await db.query(`DELETE FROM workouts WHERE user_id = $1 AND workout_id <> 'ghost-loss'`, [USER]);
+  const [onlyLosses] = await db.query(
+    `SELECT COUNT(*)::int AS count,
+            COALESCE(MAX(ghost_margin_seconds), 0)::int AS best
+       FROM workouts
+      WHERE user_id = $1 AND deleted_at IS NULL AND ghost_margin_seconds > 0`,
+    [USER],
+  );
+  check("a loss does not count as a win", onlyLosses.count, 0);
+  check("bestGhostMargin is 0, not negative", onlyLosses.best, 0);
+
+  // History keeps the losses — the one surface that should.
+  const history = await getGhostHistory(USER);
+  check("history includes the loss", history.length, 1);
+  check(
+    "history reports the friend's name",
+    history[0]?.friend_name,
+    "Ghost",
+  );
+
+  // An implausible loss is still dropped, same as an implausible win.
+  await uploadWorkouts(USER, [
+    workout("ghost-loss-absurd", {
+      ghostMarginSeconds: -99999,
+      ghostTargetSeconds: 600,
+    }),
+  ]);
+  const [absurdLoss] = await db.query(
+    `SELECT ghost_margin_seconds AS m FROM workouts WHERE workout_id = 'ghost-loss-absurd'`,
+  );
+  check("an implausible loss is dropped", absurdLoss?.m, null);
 
   await db.query(
     `DELETE FROM friendships WHERE user_id = $1 OR friend_id = $1`,

--- a/backend/src/controllers/ghostController.ts
+++ b/backend/src/controllers/ghostController.ts
@@ -2,6 +2,7 @@ import { Response } from "express";
 import { AuthenticatedRequest } from "../middleware/auth.js";
 import {
   getFriendGhosts,
+  getGhostHistory,
   GHOST_ACTIVITIES,
   GhostActivity,
 } from "../services/ghostService.js";
@@ -27,5 +28,21 @@ export async function friendGhosts(req: AuthenticatedRequest, res: Response) {
   } catch (error: any) {
     console.error("Error loading friend ghosts:", error.message);
     return res.status(500).json({ error: "Error loading friend ghosts" });
+  }
+}
+
+/**
+ * GET /ghosts/history
+ *
+ * Every race this user finished, newest first, wins and losses alike.
+ * Self-scoped on `req.userId` — your own race history is yours.
+ */
+export async function ghostHistory(req: AuthenticatedRequest, res: Response) {
+  try {
+    const races = await getGhostHistory(req.userId!);
+    return res.status(200).json({ races });
+  } catch (error: any) {
+    console.error("Error loading ghost history:", error.message);
+    return res.status(500).json({ error: "Error loading ghost history" });
   }
 }

--- a/backend/src/routes/ghostRoutes.ts
+++ b/backend/src/routes/ghostRoutes.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { friendGhosts } from "../controllers/ghostController.js";
+import { friendGhosts, ghostHistory } from "../controllers/ghostController.js";
 
 const router = Router();
 
@@ -7,5 +7,7 @@ const router = Router();
 // Read-only: picking someone as your ghost tells them nothing and changes
 // nothing on their side — the only thing they ever hear about is being BEATEN.
 router.get("/friends", friendGhosts);
+// Your own races, wins and losses. Self-scoped on the token.
+router.get("/history", ghostHistory);
 
 export default router;

--- a/backend/src/services/badgeService.ts
+++ b/backend/src/services/badgeService.ts
@@ -271,9 +271,10 @@ async function computeSocialAggregates(userId: string): Promise<{
           [userId],
         )
         .catch(() => [{ count: "0" }]),
-      // Ghost races won. `ghost_margin_seconds` is stamped only on a WIN, so
-      // presence is the win — no comparison needed. Soft-deleted workouts
-      // don't count, same as everywhere else miles are tallied.
+      // Ghost races WON. `ghost_margin_seconds` is signed — every completed
+      // race is stored, losses included — so this must compare, not just test
+      // for presence. The MAX matters as much as the count: without `> 0` a
+      // user who has only ever lost would report a negative "best margin".
       db
         .query<{
           count: string;
@@ -284,7 +285,7 @@ async function computeSocialAggregates(userId: string): Promise<{
              FROM workouts
             WHERE user_id = $1
               AND deleted_at IS NULL
-              AND ghost_margin_seconds IS NOT NULL`,
+              AND ghost_margin_seconds > 0`,
           [userId],
         )
         .catch(() => [{ count: "0", best: "0" }]),

--- a/backend/src/services/badgeService.ts
+++ b/backend/src/services/badgeService.ts
@@ -1,4 +1,5 @@
 import { PostgresService } from "./DbService.js";
+import { MIN_PLAUSIBLE_MILE_SECONDS } from "./mileTime.js";
 import type {
   Badge,
   UserBadge,
@@ -103,7 +104,7 @@ export async function computeAggregates(
     db.query<{ min_pace: string | null }>(
       `SELECT MIN(s.split_pace)::text AS min_pace
 			FROM workout_splits s JOIN workouts w ON w.workout_id = s.workout_id
-			WHERE w.user_id = $1 AND s.split_pace > 0 AND s.split_distance >= 0.95 AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL`,
+			WHERE w.user_id = $1 AND s.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS} AND s.split_distance >= 0.95 AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL`,
       [userId],
     ),
     db.query<{ best_day: string | null }>(

--- a/backend/src/services/dailyChallengeService.ts
+++ b/backend/src/services/dailyChallengeService.ts
@@ -1,4 +1,5 @@
 import { PostgresService } from "./DbService.js";
+import { MIN_PLAUSIBLE_MILE_SECONDS } from "./mileTime.js";
 import {
   DailyChallenge,
   TodaysChallengeResponse,
@@ -381,7 +382,7 @@ async function computeProgress(
       }>(
         `SELECT
 					(SELECT MIN(s.split_pace) FROM workout_splits s JOIN workouts w ON w.workout_id = s.workout_id
-					 WHERE w.user_id = $1 AND w.local_date = $2 AND s.split_pace > 0 AND s.split_distance >= 0.95)::text AS min_pace,
+					 WHERE w.user_id = $1 AND w.local_date = $2 AND s.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS} AND s.split_distance >= 0.95)::text AS min_pace,
 					(SELECT COALESCE(SUM(distance),0) FROM workouts WHERE user_id = $1 AND local_date = $2 AND deleted_at IS NULL AND exclusion_reason IS NULL)::text AS day_total`,
         [userId, localDate],
       );
@@ -447,11 +448,11 @@ async function computeProgress(
         `WITH prior AS (
 					SELECT MIN(s.split_pace) AS p
 					FROM workout_splits s JOIN workouts w ON w.workout_id = s.workout_id
-					WHERE w.user_id = $1 AND w.local_date < $2 AND s.split_pace > 0 AND s.split_distance >= 0.95
+					WHERE w.user_id = $1 AND w.local_date < $2 AND s.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS} AND s.split_distance >= 0.95
 				), today AS (
 					SELECT MIN(s.split_pace) AS p
 					FROM workout_splits s JOIN workouts w ON w.workout_id = s.workout_id
-					WHERE w.user_id = $1 AND w.local_date = $2 AND s.split_pace > 0 AND s.split_distance >= 0.95
+					WHERE w.user_id = $1 AND w.local_date = $2 AND s.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS} AND s.split_distance >= 0.95
 				)
 				SELECT prior.p::text AS prior_min, today.p::text AS today_min FROM prior, today`,
         [userId, localDate],
@@ -594,7 +595,7 @@ async function evaluatePredicate(
 						SELECT 1 FROM workout_splits s
 						  JOIN workouts w ON w.workout_id = s.workout_id
 						WHERE w.user_id = $1 AND w.local_date = $2
-						  AND s.split_pace > 0
+						  AND s.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS}
 						  AND s.split_distance >= 0.95
 						  AND s.split_pace / 60.0 <= 12.0
 					)
@@ -616,11 +617,11 @@ async function evaluatePredicate(
         `WITH prior AS (
 					SELECT MIN(s.split_pace) AS p
 					FROM workout_splits s JOIN workouts w ON w.workout_id = s.workout_id
-					WHERE w.user_id = $1 AND w.local_date < $2 AND s.split_pace > 0 AND s.split_distance >= 0.95
+					WHERE w.user_id = $1 AND w.local_date < $2 AND s.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS} AND s.split_distance >= 0.95
 				), today AS (
 					SELECT MIN(s.split_pace) AS p
 					FROM workout_splits s JOIN workouts w ON w.workout_id = s.workout_id
-					WHERE w.user_id = $1 AND w.local_date = $2 AND s.split_pace > 0 AND s.split_distance >= 0.95
+					WHERE w.user_id = $1 AND w.local_date = $2 AND s.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS} AND s.split_distance >= 0.95
 				)
 				SELECT prior.p::text AS prior_min, today.p::text AS today_min FROM prior, today`,
         [userId, localDate],
@@ -1186,7 +1187,7 @@ async function renderDescription(
   const rows = await db.query<{ min_pace: string | null }>(
     `SELECT MIN(s.split_pace)::text AS min_pace
 		FROM workout_splits s JOIN workouts w ON w.workout_id = s.workout_id
-		WHERE w.user_id = $1 AND s.split_pace > 0 AND s.split_distance >= 0.95`,
+		WHERE w.user_id = $1 AND s.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS} AND s.split_distance >= 0.95`,
     [userId],
   );
   const secPerMile = rows[0]?.min_pace ? parseFloat(rows[0].min_pace) : 0;

--- a/backend/src/services/ghostService.ts
+++ b/backend/src/services/ghostService.ts
@@ -149,7 +149,10 @@ export async function notifyGhostsBeaten(
           AND racer.user_id = $1
           AND w.deleted_at IS NULL
           AND w.ghost_notified_at IS NULL
-          AND w.ghost_margin_seconds IS NOT NULL
+          -- Greater than zero, NOT merely non-null: the margin is signed and
+          -- losses are stored too. Telling someone their ghost was caught when
+          -- the racer actually lost would be the exact opposite of the truth.
+          AND w.ghost_margin_seconds > 0
           AND w.ghost_friend_user_id IS NOT NULL
           AND w.ghost_friend_user_id <> $1
           AND EXISTS (
@@ -201,4 +204,65 @@ export async function notifyGhostsBeaten(
       userId: racerId,
     });
   }
+}
+
+export interface GhostRaceRecord {
+  workout_id: string;
+  /** Signed: positive won by, negative lost by. */
+  margin_seconds: number;
+  /** The ghost's mile time. */
+  target_seconds: number;
+  /** `date` column, so a plain string is safe (no fractional-seconds trap). */
+  local_date: string;
+  workout_type: string | null;
+  /** Null unless the ghost was a friend's mile AND they're still visible. */
+  friend_name: string | null;
+}
+
+/**
+ * Every race this user has finished, newest first — WINS AND LOSSES.
+ *
+ * `IS NOT NULL` is correct here and nowhere else: history is the one surface
+ * that wants the losses. They're what makes it a record of racing rather than a
+ * trophy cabinet, and "2 seconds off" is the line most likely to get someone
+ * back out.
+ *
+ * The friend's NAME is re-gated on the friendship still existing and no block
+ * either way — you raced them, but that doesn't entitle you to their name
+ * forever. It degrades to null rather than dropping the row, so the race is
+ * still remembered as "a friend's mile".
+ */
+export async function getGhostHistory(
+  userId: string,
+  limit = 50,
+): Promise<GhostRaceRecord[]> {
+  return db.query<GhostRaceRecord>(
+    `SELECT w.workout_id,
+            w.ghost_margin_seconds AS margin_seconds,
+            w.ghost_target_seconds AS target_seconds,
+            to_char(w.local_date, 'YYYY-MM-DD') AS local_date,
+            w.workout_type,
+            CASE
+              WHEN f.user_id IS NULL THEN NULL
+              WHEN NOT EXISTS (
+                SELECT 1 FROM friendships fr
+                 WHERE fr.user_id = $1 AND fr.friend_id = f.user_id
+                   AND fr.status = 'accepted'
+              ) THEN NULL
+              WHEN EXISTS (
+                SELECT 1 FROM user_blocks b
+                 WHERE (b.blocker_id = $1 AND b.blocked_id = f.user_id)
+                    OR (b.blocker_id = f.user_id AND b.blocked_id = $1)
+              ) THEN NULL
+              ELSE COALESCE(f.first_name, f.username)
+            END AS friend_name
+       FROM workouts w
+       LEFT JOIN users f ON f.user_id = w.ghost_friend_user_id
+      WHERE w.user_id = $1
+        AND w.deleted_at IS NULL
+        AND w.ghost_margin_seconds IS NOT NULL
+      ORDER BY w.device_end_date DESC
+      LIMIT $2`,
+    [userId, Math.min(Math.max(limit, 1), 100)],
+  );
 }

--- a/backend/src/services/ghostService.ts
+++ b/backend/src/services/ghostService.ts
@@ -1,4 +1,8 @@
 import { PostgresService } from "./DbService.js";
+import {
+  MIN_PLAUSIBLE_MILE_SECONDS,
+  MAX_PLAUSIBLE_MILE_SECONDS,
+} from "./mileTime.js";
 import { CIRCLE_CTE } from "./postService.js";
 import { OWNER_NOT_PRIVATE_SQL } from "./visibilityService.js";
 import { sendPush } from "./pushNotificationService.js";
@@ -13,14 +17,13 @@ export const GHOST_ACTIVITIES = ["running", "walking"] as const;
 export type GhostActivity = (typeof GHOST_ACTIVITIES)[number];
 
 /**
- * A mile between 2:00 and 40:00 — the same window the client's
- * `BestEffortStore.GhostTarget.isPlausible` enforces, and the same one
- * `ghostRaceParams` uses when storing a result. Kept in sync deliberately: a
- * ghost outside this band would be armed, raced, won, and then silently
- * dropped on upload.
+ * A believable mile — the shared floor, so a friend's ghost can never be a
+ * drive. Matches the client's `BestEffortStore.GhostTarget.isPlausible` and
+ * the bounds `ghostRaceParams` stores results under: a ghost outside this band
+ * would be armed, raced, won, and then silently dropped on upload.
  */
-const MIN_GHOST_SECONDS = 120;
-const MAX_GHOST_SECONDS = 2400;
+const MIN_GHOST_SECONDS = MIN_PLAUSIBLE_MILE_SECONDS;
+const MAX_GHOST_SECONDS = MAX_PLAUSIBLE_MILE_SECONDS;
 
 /** Friend count worth offering in a picker. */
 const MAX_GHOSTS = 50;
@@ -82,7 +85,7 @@ export async function getFriendGhosts(
 			   AND w.workout_type = $2
 			   AND w.deleted_at IS NULL
 			   AND w.exclusion_reason IS NULL
-			   AND ws.split_pace > 0
+			   AND ws.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS}
 			   AND ws.split_distance >= 0.999
 			 GROUP BY w.user_id
 		)

--- a/backend/src/services/leaderboardService.ts
+++ b/backend/src/services/leaderboardService.ts
@@ -1,4 +1,5 @@
 import { PostgresService } from "./DbService.js";
+import { MIN_PLAUSIBLE_MILE_SECONDS } from "./mileTime.js";
 import {
   coverageActiveFor,
   computeCoveredStreak,
@@ -144,7 +145,7 @@ async function getStreakLeaderboard(
 				JOIN workouts w ON w.workout_id = ws.workout_id
 				WHERE w.user_id = u.user_id
 				  AND ws.split_distance >= 0.999
-				  AND ws.split_pace > 0
+				  AND ws.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS}
 			) AS period_best_pace,
 			RANK() OVER (ORDER BY u.current_streak DESC)::int AS rank
 		FROM users u
@@ -212,7 +213,7 @@ async function getCurrentUserStreakEntry(
 				JOIN workouts w ON w.workout_id = ws.workout_id
 				WHERE w.user_id = u.user_id
 				  AND ws.split_distance >= 0.999
-				  AND ws.split_pace > 0
+				  AND ws.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS}
 			) AS period_best_pace,
 			(
 				SELECT COUNT(*)::int FROM users u2
@@ -312,7 +313,7 @@ async function getMilesLeaderboard(
 				JOIN workouts w ON w.workout_id = ws.workout_id
 				WHERE w.user_id = u.user_id
 				  AND ws.split_distance >= 0.999
-				  AND ws.split_pace > 0
+				  AND ws.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS}
 				  ${bestPaceDateClause}
 			) AS period_best_pace,
 			RANK() OVER (ORDER BY t.value DESC)::int AS rank
@@ -417,7 +418,7 @@ async function getCurrentUserMilesEntry(
   const paceWheres: string[] = [
     `w.user_id = $1`,
     `ws.split_distance >= 0.999`,
-    `ws.split_pace > 0`,
+    `ws.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS}`,
   ];
   if (startDate) {
     paceParams.push(startDate);
@@ -479,7 +480,7 @@ async function getPaceLeaderboard(
   const wheres: string[] = [
     `w.user_id = ANY($1::text[])`,
     `ws.split_distance >= 0.999`,
-    `ws.split_pace > 0`,
+    `ws.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS}`,
   ];
   let dateParamIndex: number | null = null;
   if (startDate) {
@@ -582,7 +583,7 @@ async function getCurrentUserPaceEntry(
   const myWheres: string[] = [
     `w.user_id = $1`,
     `ws.split_distance >= 0.999`,
-    `ws.split_pace > 0`,
+    `ws.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS}`,
   ];
   if (startDate) {
     myParams.push(startDate);
@@ -605,7 +606,7 @@ async function getCurrentUserPaceEntry(
   const rankWheres: string[] = [
     `w.user_id = ANY($2::text[])`,
     `ws.split_distance >= 0.999`,
-    `ws.split_pace > 0`,
+    `ws.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS}`,
   ];
   if (startDate) {
     rankParams.push(startDate);

--- a/backend/src/services/mileTime.ts
+++ b/backend/src/services/mileTime.ts
@@ -1,0 +1,49 @@
+/**
+ * What counts as a real mile time.
+ *
+ * `workout_splits.split_pace` is seconds per mile, computed from whatever
+ * HealthKit hands us. Nothing upstream distinguishes a mile RUN from a mile
+ * COVERED — a walk left tracking in a car produces a perfectly well-formed
+ * split at 90 seconds, and until now every query that showed a "fastest mile"
+ * bounded it only by `split_pace > 0`. So that 90-second drive became the
+ * user's PR, topped the pace leaderboard, and unlocked pace badges.
+ *
+ * The floor is 4:01 because the mile world record is 3:43. Anything at or
+ * under 4:01 from a consumer phone is a vehicle, a GPS glitch, or a
+ * mis-segmented split — never a person. Deliberately generous in the sense
+ * that it lets through times no real user of this app will hit either; the
+ * point is to be unarguable rather than tight.
+ *
+ * This bounds what is DISPLAYED as a mile time. It deliberately does NOT
+ * exclude the workout's distance from miles or streaks — that's
+ * `exclusion_reason`'s job, decided per WORKOUT by average speed. A single
+ * bogus split inside an otherwise-real walk shouldn't cost someone their day.
+ */
+export const MIN_PLAUSIBLE_MILE_SECONDS = 241; // 4:01
+
+/** 40:00. A mile slower than this is a stroll that stopped being a mile. */
+export const MAX_PLAUSIBLE_MILE_SECONDS = 2400;
+
+/**
+ * SQL predicate for "this split is a believable mile time".
+ *
+ * `paceCol` is a column expression from the caller's own query (e.g.
+ * `ws.split_pace`) — a compile-time value, never request input.
+ *
+ * Pair it with the caller's own distance floor: the leaderboard and the ghost
+ * picker use `>= 0.999` (which excludes SplitCalculator's extrapolated
+ * trailing partial), while badges and PR detection use the legacy `>= 0.95`.
+ */
+export function realMileSplitSql(paceCol: string): string {
+  return `${paceCol} >= ${MIN_PLAUSIBLE_MILE_SECONDS}`;
+}
+
+/** The same check for values already in JS. */
+export function isPlausibleMileSeconds(seconds: unknown): boolean {
+  const value = Number(seconds);
+  return (
+    Number.isFinite(value) &&
+    value >= MIN_PLAUSIBLE_MILE_SECONDS &&
+    value <= MAX_PLAUSIBLE_MILE_SECONDS
+  );
+}

--- a/backend/src/services/postService.ts
+++ b/backend/src/services/postService.ts
@@ -1,4 +1,8 @@
 import { PostgresService } from "./DbService.js";
+import {
+  MIN_PLAUSIBLE_MILE_SECONDS,
+  MAX_PLAUSIBLE_MILE_SECONDS,
+} from "./mileTime.js";
 import { CLIENT_FEATURES, userSupports } from "./clientFeatures.js";
 import { sendPush } from "./pushNotificationService.js";
 import { shouldSendNotification } from "./notificationSettingsService.js";
@@ -62,7 +66,7 @@ export interface PostStatsSnapshot {
 
 /**
  * Drop a ghost claim that isn't plausible, keeping the rest of the snapshot.
- * Bounds mirror the client's `GhostTarget.isPlausible` (2:00…40:00); a margin
+ * Bounds mirror the client's `GhostTarget.isPlausible` (4:01…40:00); a margin
  * can never exceed the ghost it beat.
  */
 export function sanitizeGhostStats(
@@ -75,8 +79,8 @@ export function sanitizeGhostStats(
     Number.isFinite(margin) &&
     Number.isFinite(target) &&
     margin > 0 &&
-    target >= 120 &&
-    target <= 2400 &&
+    target >= MIN_PLAUSIBLE_MILE_SECONDS &&
+    target <= MAX_PLAUSIBLE_MILE_SECONDS &&
     margin <= target;
   if (ok) return stats;
   const { ghost_margin_seconds, ghost_target_seconds, ...rest } = stats;

--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -1,4 +1,8 @@
 import { Workout } from "../types/workouts.js";
+import {
+  MIN_PLAUSIBLE_MILE_SECONDS,
+  MAX_PLAUSIBLE_MILE_SECONDS,
+} from "./mileTime.js";
 import { PostgresService } from "./DbService.js";
 import { VIEWER_MAY_SEE_WORKOUT_CONTENT_SQL } from "./visibilityService.js";
 import {
@@ -17,7 +21,7 @@ const db = PostgresService.getInstance();
  * The tracker stamps these on the HKWorkout only when the ghost was BEATEN, so
  * a non-null margin IS a win — which is what the ghost medal family counts.
  * Implausible claims are dropped to null rather than stored: bounds mirror the
- * client's `GhostTarget.isPlausible` (2:00…40:00), and you cannot beat a ghost
+ * client's `GhostTarget.isPlausible` (4:01…40:00), and you cannot beat a ghost
  * by more than the ghost's own time.
  *
  * `friendUserId` is present only when the ghost was a FRIEND's mile. It is
@@ -35,8 +39,8 @@ function ghostRaceParams(
     Number.isFinite(margin) &&
     Number.isFinite(target) &&
     margin > 0 &&
-    target >= 120 &&
-    target <= 2400 &&
+    target >= MIN_PLAUSIBLE_MILE_SECONDS &&
+    target <= MAX_PLAUSIBLE_MILE_SECONDS &&
     margin <= target;
   if (!ok) return [null, null, null];
   const friend =
@@ -658,7 +662,7 @@ export async function getBestSplit(userId: string, startDate?: string) {
     WHERE w.user_id = $1
 	AND w.deleted_at IS NULL AND w.exclusion_reason IS NULL
 	AND split_distance >= 0.95
-	AND ws.split_pace > 0
+	AND ws.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS}
 	`;
 
   const params: (string | number)[] = [userId];
@@ -1047,7 +1051,7 @@ export async function getTodayStats(userId: string): Promise<TodayStats> {
 		SELECT MIN(ws.split_pace) AS pace
 		FROM today_workouts tw
 		JOIN workout_splits ws ON ws.workout_id = tw.workout_id
-		WHERE ws.split_distance >= 0.95 AND ws.split_pace > 0
+		WHERE ws.split_distance >= 0.95 AND ws.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS}
 	),
 	workout_best AS (
 		SELECT MIN(total_duration / NULLIF(distance, 0)) AS pace
@@ -1316,7 +1320,7 @@ export async function computePersonalRecords(
 	   FROM workout_splits s
 	   JOIN workouts w ON w.workout_id = s.workout_id
 	   WHERE w.user_id = $1
-	       AND s.split_pace > 0
+	       AND s.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS}
 	       AND s.split_distance >= 0.95
 	       ${excludeClause}
 	   ORDER BY s.split_pace ASC, w.local_date DESC

--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -18,11 +18,19 @@ const db = PostgresService.getInstance();
  * The ghost-race columns for one workout's upsert, as
  * `[margin, target, friendUserId]`.
  *
- * The tracker stamps these on the HKWorkout only when the ghost was BEATEN, so
- * a non-null margin IS a win — which is what the ghost medal family counts.
+ * `margin` is SIGNED: positive = won by that many seconds, negative = lost by
+ * them. It is stamped for every completed race, not just wins, because a race
+ * you lost by two seconds is the most motivating thing the feature can show you
+ * and it used to vanish without trace.
+ *
+ * The consequence, and the reason this comment is long: `IS NOT NULL` no longer
+ * means "won". Anything counting WINS must say `> 0` — the medal aggregate (both
+ * the count and the MAX, which would otherwise return a negative for someone who
+ * has only lost), and the "your ghost was caught" push.
+ *
  * Implausible claims are dropped to null rather than stored: bounds mirror the
- * client's `GhostTarget.isPlausible` (4:01…40:00), and you cannot beat a ghost
- * by more than the ghost's own time.
+ * client's `GhostTarget.isPlausible` (4:01…40:00), and no margin in either
+ * direction can exceed a whole plausible mile.
  *
  * `friendUserId` is present only when the ghost was a FRIEND's mile. It is
  * client-asserted and NOT validated here — it is validated where it matters,
@@ -38,10 +46,10 @@ function ghostRaceParams(
   const ok =
     Number.isFinite(margin) &&
     Number.isFinite(target) &&
-    margin > 0 &&
+    margin !== 0 &&
     target >= MIN_PLAUSIBLE_MILE_SECONDS &&
     target <= MAX_PLAUSIBLE_MILE_SECONDS &&
-    margin <= target;
+    Math.abs(margin) <= MAX_PLAUSIBLE_MILE_SECONDS;
   if (!ok) return [null, null, null];
   const friend =
     typeof workout.ghostFriendUserId === "string" &&


### PR DESCRIPTION
Two commits. The first was the 4:01 floor, the coach and the countdown cancel; the second answers "what else would make this better" with three things the code turned out to already support.

## ⚠️ One thing to decide before merging

This adds **`audio` to `UIBackgroundModes`**. Without it iOS silences the audio session the moment the screen locks — most of a real run — so the coach would only ever speak while you're watching it. It's an Info.plist change, **not** an entitlement, so there's no AMFI/provisioning risk; Background Modes is already enabled on the target. The risk is purely review-facing, and the answer to App Review is "spoken coaching during workouts". Back it out if you'd rather not carry it — everything else still works and the coach's lines still render on screen.

---

# Commit 1

### A sub-4:01 mile is a car, and every query showed them

`workout_splits.split_pace` was bounded only by `> 0` in **every** query reporting a "fastest mile" — leaderboard, badges, PRs, `/stats`, daily challenges, ghost picker. Nothing upstream distinguishes a mile *run* from a mile *covered*, so a walk left tracking in a car produced a well-formed 90-second split that became the user's PR, topped the pace leaderboard, and unlocked pace badges.

New `mileTime.ts` holds one floor — **241s**, the mile world record (3:43) rounded up — applied to all 19 sites plus the matching client floors. Bounds what is *shown* as a mile time; it does **not** exclude distance from miles or streaks (that's `exclusion_reason`'s job, per workout by average speed).

### A coach, and Cancel on the 3-2-1

The countdown timer was a bare `scheduledTimer` that **outlived the view** — tearing the screen down still fired `startWorkout()` three seconds later. It's retained now, which is what makes Cancel actually work.

---

# Commit 2

### 1. The coach can now read effort, not just position

It could only say "6 seconds ahead" because **there is no rolling pace anywhere in the app** — every pace figure, recap to Live Activity, is a whole-session average. So it couldn't say the one thing a coach says: *you're fading*.

`recentPaceSecondsPerMile` derives it from `effortCurve`, already sampled on every odometer move — no timer, no new state, nothing added to the accrual path. It goes **nil rather than stale** when the curve stops appending, because the curve only grows when distance does, and "unknown" is the honest answer while stopped.

With a derivative the coach gets the actionable line: **required pace**, which turns out to be arithmetic rather than a curve lookup — `(ghostSeconds − raceClock) / (1 − distance)`. *"You're slipping, 8:40 to take it back"* beats *"you're 6 down"*. Plus a pre-race brief with the quarter split, and a floor that tightens to 15s in a close race and loosens to 40s in a rout.

### 2. Losses are recorded

`ghost_margin_seconds` is now **signed** and stamped on every completed race. A race lost by two seconds used to vanish — no history, no near miss, nothing to come back for. For a racing feature, only keeping the wins was the biggest hole in it.

The cost: `IS NOT NULL` stops meaning "won", fixed in the four places that count wins. **The subtle one is the medal aggregate's `MAX`** — without `> 0`, a user who has only lost reports a *negative* best margin, and `COALESCE(..., 0)` doesn't catch it.

Wins-only stays wins-only — the feed, celebration and push all already required `> 0`. Nobody wants their loss broadcast. Losses appear on the workout detail screen (read straight from HealthKit metadata, **no backend**) and in a new **Ghost Races** section beside Race PRs, fed by `GET /ghosts/history`, which re-gates the friend's *name* on the friendship still existing.

### 3. The race has a story

Quarter-by-quarter against the ghost on the recap: your split, theirs, what you gained. The live chip only ever knew the running total, so *"3 down at halfway, took it in the last quarter"* was invisible. The curve is captured before `stopTracking()` clears it.

---

## Verification

Against a real migrated Postgres: `tsc`, `drizzle-kit check`, migrator twice, `ci-smoke`, and **`ghost-race-check` now at 19 assertions**. Every consequence of the signed margin has one:

- a loss is stored signed, and survives a metadata-less re-upload
- a loss is **never notified** (that would tell someone their ghost was caught when it wasn't)
- a loss **never counts as a win**
- `bestGhostMargin` is **0, not negative**, for a user who has only lost
- history **includes** the loss, with the friend's name
- an implausible loss is still dropped to null

Also statically verified every SQL interpolation landed inside a template literal — a `${...}` in a quoted string would have been literal SQL text.

**No migration**: the columns exist, only their meaning changed.

**iOS not compile-verified** — no Swift toolchain, Xcode-only. `GhostCoach` and `GhostRacesSection` are new files, and `WorkoutRecapView`/`WorkoutDetailView` gained sections, so those are the likeliest build errors.

## Not done, deliberately

Giving PR/custom/friend ghosts **real effort curves**. Three of the four ghost types are flat two-point lines today, so a friend's ghost doesn't surge where they surged — and a flat ghost is beatable by banking time early and fading, which isn't really racing them. Biggest fidelity win, most work: it needs best-mile curves stored server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxEp1wW88Y5PxyTxgAoE3L