### PR TITLE
Fix Connected Apps buttons landing in the wrong place

### DIFF
--- a/app/Mile A Day/Models/FitnessSourceCatalog.swift
+++ b/app/Mile A Day/Models/FitnessSourceCatalog.swift
@@ -39,9 +39,23 @@ struct FitnessSourcePlatform: Identifiable, Hashable {
     let bundleHints: [String]
     let nameHints: [String]
 
-    /// Optimistic deep link into the installed app. Wrong or missing schemes
-    /// degrade gracefully — `FitnessSourceLauncher` falls back to the App Store.
+    /// Optimistic deep link into the installed app.
+    ///
+    /// Vendor-controlled and not verifiable from here, so treat every one of
+    /// these as a guess that might already be stale. That's tolerable only
+    /// because `FitnessSourceLauncher.open` falls back to the App Store product
+    /// page below when the scheme doesn't resolve — never leave that fallback
+    /// pointing at a search, or a wrong guess here becomes a dead button.
     let urlScheme: String?
+
+    /// Numeric App Store id, used to build `apps.apple.com/app/id<N>`.
+    ///
+    /// A real product page, never a search URL: a search lands the user on a
+    /// results list (or, if the URL form is wrong, nowhere at all) and makes
+    /// them pick the right app themselves. This is also what makes a wrong or
+    /// missing `urlScheme` harmless — the fallback is always a correct
+    /// destination, and for an installed app the product page shows OPEN.
+    let appStoreId: String
 
     /// Where the Apple Health toggle lives, in that app's own words.
     let setupSteps: [String]
@@ -92,6 +106,7 @@ enum FitnessSourceCatalog {
             bundleHints: ["com.strava"],
             nameHints: ["strava"],
             urlScheme: "strava://",
+            appStoreId: "426826309",
             setupSteps: [
                 "Open Strava and go to the You tab.",
                 "Tap the settings gear, then Manage Apps and Devices.",
@@ -111,6 +126,7 @@ enum FitnessSourceCatalog {
             bundleHints: ["com.garmin"],
             nameHints: ["garmin"],
             urlScheme: "garminconnectmobile://",
+            appStoreId: "583446403",
             setupSteps: [
                 "Open Garmin Connect and tap More in the bottom-right.",
                 "Go to Settings, then Connected Apps.",
@@ -129,6 +145,7 @@ enum FitnessSourceCatalog {
             bundleHints: ["com.fitbit", "com.google.health"],
             nameHints: ["fitbit", "google health"],
             urlScheme: "fitbit://",
+            appStoreId: "462638897",
             setupSteps: [
                 "Open Google Health (formerly the Fitbit app).",
                 "Tap your profile icon in the top right.",
@@ -147,6 +164,7 @@ enum FitnessSourceCatalog {
             bundleHints: ["whoop"],
             nameHints: ["whoop"],
             urlScheme: "whoop://",
+            appStoreId: "933944389",
             setupSteps: [
                 "Open WHOOP and go to More, then App Settings.",
                 "Choose Integrations, then Apple Health.",
@@ -162,6 +180,7 @@ enum FitnessSourceCatalog {
             bundleHints: ["ouraring", "com.oura"],
             nameHints: ["oura"],
             urlScheme: "oura://",
+            appStoreId: "1043837948",
             setupSteps: [
                 "Open Oura and tap your profile icon.",
                 "Go to App integrations, then Apple Health.",
@@ -179,6 +198,7 @@ enum FitnessSourceCatalog {
             bundleHints: ["onepeloton"],
             nameHints: ["peloton"],
             urlScheme: "peloton://",
+            appStoreId: "792750948",
             setupSteps: [
                 "Open Peloton and tap your profile, then the settings gear.",
                 "Choose Apple Health and turn on the connection.",
@@ -196,6 +216,7 @@ enum FitnessSourceCatalog {
             bundleHints: ["com.nike"],
             nameHints: ["nike"],
             urlScheme: "nikerunclub://",
+            appStoreId: "387771637",
             setupSteps: [
                 "Open Nike Run Club and go to the Profile tab.",
                 "Tap the settings gear, then Health.",
@@ -211,6 +232,7 @@ enum FitnessSourceCatalog {
             bundleHints: ["coros"],
             nameHints: ["coros"],
             urlScheme: nil,
+            appStoreId: "1277625343",
             setupSteps: [
                 "Open the COROS app and go to the Profile tab.",
                 "Tap Settings, then Apple Health.",
@@ -226,6 +248,7 @@ enum FitnessSourceCatalog {
             bundleHints: ["polar"],
             nameHints: ["polar"],
             urlScheme: nil,
+            appStoreId: "717172678",
             setupSteps: [
                 "Open Polar Flow and tap the menu in the top left.",
                 "Go to Settings, then Apple Health.",
@@ -241,6 +264,7 @@ enum FitnessSourceCatalog {
             bundleHints: ["suunto", "amerbrands"],
             nameHints: ["suunto"],
             urlScheme: nil,
+            appStoreId: "1230327951",
             setupSteps: [
                 "Open Suunto and go to the profile tab.",
                 "Tap Settings, then Apple Health.",
@@ -256,6 +280,7 @@ enum FitnessSourceCatalog {
             bundleHints: ["runna"],
             nameHints: ["runna"],
             urlScheme: nil,
+            appStoreId: "1594204443",
             setupSteps: [
                 "Open Runna and go to the Profile tab.",
                 "Tap Settings, then Apple Health.",
@@ -265,12 +290,13 @@ enum FitnessSourceCatalog {
         ),
         FitnessSourcePlatform(
             id: "mapmyrun",
-            name: "MapMyRun",
+            name: "Map My Run",
             symbol: "map",
             tint: Color(red: 0.1, green: 0.6, blue: 0.85),
             bundleHints: ["mapmyrun", "mapmyfitness"],
             nameHints: ["mapmyrun", "map my run"],
             urlScheme: nil,
+            appStoreId: "291890420",
             setupSteps: [
                 "Open MapMyRun and go to More, then Settings.",
                 "Choose Apps & Devices, then Apple Health.",
@@ -286,6 +312,7 @@ enum FitnessSourceCatalog {
             bundleHints: ["runtastic", "adidas"],
             nameHints: ["adidas", "runtastic"],
             urlScheme: nil,
+            appStoreId: "336599882",
             setupSteps: [
                 "Open adidas Running and go to the Profile tab.",
                 "Tap the settings gear, then Apple Health.",

--- a/app/Mile A Day/Services/FitnessSourceService.swift
+++ b/app/Mile A Day/Services/FitnessSourceService.swift
@@ -204,16 +204,32 @@ enum FitnessSourceLauncher {
         }
     }
 
-    /// A SEARCH url rather than a hardcoded App Store id: ids differ by
-    /// storefront and get retired when a vendor re-publishes (Fitbit → Google
-    /// Health did exactly that), and a wrong id sends someone to the wrong app.
-    /// A search term stays correct everywhere.
-    private static func openAppStore(for platform: FitnessSourcePlatform) {
-        let term =
-            platform.name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
-            ?? platform.name
-        guard let url = URL(string: "https://apps.apple.com/search?term=\(term)") else { return }
-        UIApplication.shared.open(url)
+    /// The app's real App Store product page.
+    ///
+    /// This was a `?term=` SEARCH url, which is what made every one of these
+    /// buttons land somewhere wrong: `apps.apple.com/search` without a
+    /// storefront segment doesn't resolve to the App Store app at all, so a
+    /// failed scheme fell through to a dead end. And even when a search does
+    /// resolve it only produces a results list.
+    ///
+    /// `apps.apple.com/app/id<N>` is storefront-agnostic — Apple redirects to
+    /// the viewer's own store — opens the App Store app directly, and shows
+    /// OPEN rather than GET when the app is already installed. That reliable
+    /// destination is what lets the optimistic `urlScheme` above stay
+    /// best-effort: a scheme that is wrong, missing, or changed by the vendor
+    /// now costs a tap instead of stranding the user.
+    /// `itms-apps:` first, `https:` as the backstop. The itms scheme is handled
+    /// by the App Store app itself, so it can't be intercepted or land in
+    /// Safari the way an https universal link can when link handling is off or
+    /// the user opted the App Store out of it.
+    static func openAppStore(for platform: FitnessSourcePlatform) {
+        let path = "apps.apple.com/app/id\(platform.appStoreId)"
+        guard let storeURL = URL(string: "itms-apps://\(path)") else { return }
+
+        UIApplication.shared.open(storeURL, options: [:]) { opened in
+            guard !opened, let webURL = URL(string: "https://\(path)") else { return }
+            UIApplication.shared.open(webURL)
+        }
     }
 
     /// The Apple Health app, where every one of these connections ultimately

--- a/app/Mile A Day/Views/Profile/ProfileSettingsView.swift
+++ b/app/Mile A Day/Views/Profile/ProfileSettingsView.swift
@@ -24,8 +24,14 @@ struct ProfileSettingsView: View {
     let isRecalibratingStreak: Bool
     let isDeletingAccount: Bool
 
-    @State private var showingPrivacySettings = false
-    @State private var showingImportHistory = false
+    @State private var activeSheet: SettingsSheet?
+
+    /// The modals this page presents, so a single `.sheet(item:)` drives both.
+    enum SettingsSheet: String, Identifiable {
+        case privacy
+        case importHistory
+        var id: String { rawValue }
+    }
 
     var body: some View {
         ScrollView {
@@ -43,11 +49,17 @@ struct ProfileSettingsView: View {
         .background(MADTheme.Colors.appBackgroundGradient)
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.large)
-        .sheet(isPresented: $showingPrivacySettings) {
-            PrivacySettingsView()
-        }
-        .sheet(isPresented: $showingImportHistory) {
-            ImportHistoryView(userManager: userManager)
+        // ONE sheet modifier for both destinations. Two `.sheet`s on the same
+        // node compete and one silently never presents — the settings row then
+        // reads as a dead button. Same reason FitnessConnectionsView routes all
+        // of its modals through a single item.
+        .sheet(item: $activeSheet) { sheet in
+            switch sheet {
+            case .privacy:
+                PrivacySettingsView()
+            case .importHistory:
+                ImportHistoryView(userManager: userManager)
+            }
         }
         .alert("Sign Out", isPresented: $showingLogoutConfirmation) {
             Button("Cancel", role: .cancel) { }
@@ -130,7 +142,7 @@ struct ProfileSettingsView: View {
             // A sheet, not a NavigationLink: ImportHistoryView owns its own
             // NavigationStack and Cancel/Done button, which a pushed
             // destination would nest inside this one.
-            Button { showingImportHistory = true } label: {
+            Button { activeSheet = .importHistory } label: {
                 MADSettingsRow(
                     icon: "clock.arrow.circlepath",
                     title: "Import Past Workouts",
@@ -179,7 +191,7 @@ struct ProfileSettingsView: View {
 
             settingsDivider
 
-            Button { showingPrivacySettings = true } label: {
+            Button { activeSheet = .privacy } label: {
                 MADSettingsRow(
                     icon: "lock.shield.fill",
                     title: "Privacy Settings",

--- a/app/Mile A Day/Views/Settings/FitnessConnectionsView.swift
+++ b/app/Mile A Day/Views/Settings/FitnessConnectionsView.swift
@@ -56,12 +56,10 @@ struct FitnessConnectionsView: View {
     @ObservedObject var userManager: UserManager
 
     @State private var sourceService = FitnessSourceService()
-    @State private var selectedPlatform: FitnessSourcePlatform?
     @State private var duplicates: DuplicateSummary = .empty
     @State private var isResolvingDuplicates = false
     @State private var resolveMessage: String?
-    @State private var selectedLimitation: FitnessSourceLimitation?
-    @State private var showingImport = false
+    @State private var activeSheet: ConnectionSheet?
     @State private var searchText = ""
 
     var body: some View {
@@ -109,20 +107,51 @@ struct FitnessConnectionsView: View {
             await sourceService.refresh()
             await loadDuplicates()
         }
-        .sheet(item: $selectedPlatform) { platform in
-            FitnessSourceSetupSheet(platform: platform)
+        // ONE sheet modifier, driven by an enum.
+        //
+        // Three stacked `.sheet`s on the same node is the trap this repo
+        // already documents for fullScreenCover: they compete, and one of them
+        // silently never presents — a button that "does nothing". Routing every
+        // destination through a single Identifiable item removes the race
+        // entirely, and makes handing off between destinations explicit.
+        .sheet(item: $activeSheet) { sheet in
+            switch sheet {
+            case .setup(let platform):
+                FitnessSourceSetupSheet(platform: platform)
+            case .limitation(let limitation):
+                FitnessLimitationSheet(
+                    limitation: limitation,
+                    // Close this sheet, THEN open the importer — never swap the
+                    // item while presented. SwiftUI drops one of two
+                    // presentations made in the same transaction (the same race
+                    // PostDeepLink.openAfterDismiss exists to avoid), which
+                    // would leave "Import My History" doing nothing at all.
+                    onImport: {
+                        activeSheet = nil
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                            activeSheet = .importHistory
+                        }
+                    }
+                )
+            case .importHistory:
+                ImportHistoryView(userManager: userManager)
+            }
         }
-        .sheet(item: $selectedLimitation) { limitation in
-            FitnessLimitationSheet(
-                limitation: limitation,
-                onImport: {
-                    selectedLimitation = nil
-                    showingImport = true
-                }
-            )
-        }
-        .sheet(isPresented: $showingImport) {
-            ImportHistoryView(userManager: userManager)
+    }
+
+    /// Every modal this screen can show. Identifiable so one `.sheet(item:)`
+    /// can drive all of them.
+    enum ConnectionSheet: Identifiable {
+        case setup(FitnessSourcePlatform)
+        case limitation(FitnessSourceLimitation)
+        case importHistory
+
+        var id: String {
+            switch self {
+            case .setup(let p): return "setup-\(p.id)"
+            case .limitation(let l): return "limitation-\(l.id)"
+            case .importHistory: return "import"
+            }
         }
     }
 
@@ -139,7 +168,7 @@ struct FitnessConnectionsView: View {
     /// forward-only, and almost nobody expects that. Stated up front, with the
     /// fix attached rather than left as a dead end.
     private var importHistoryCard: some View {
-        Button { showingImport = true } label: {
+        Button { activeSheet = .importHistory } label: {
             VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
                 HStack(spacing: MADTheme.Spacing.sm) {
                     Image(systemName: "clock.arrow.circlepath")
@@ -216,7 +245,7 @@ struct FitnessConnectionsView: View {
 
             VStack(spacing: 0) {
                 ForEach(FitnessSourceCatalog.limitations) { limitation in
-                    Button { selectedLimitation = limitation } label: {
+                    Button { activeSheet = .limitation(limitation) } label: {
                         HStack(spacing: MADTheme.Spacing.md) {
                             ZStack {
                                 Circle()
@@ -415,7 +444,7 @@ struct FitnessConnectionsView: View {
                         .padding(.vertical, MADTheme.Spacing.sm)
                 }
                 ForEach(filteredPlatforms) { platform in
-                    Button { selectedPlatform = platform } label: {
+                    Button { activeSheet = .setup(platform) } label: {
                         availableRow(platform)
                     }
                     .buttonStyle(.plain)
@@ -716,6 +745,13 @@ struct FitnessSourceSetupSheet: View {
                         .madLiquidGlass()
                     }
 
+                    // Two paths on purpose. The primary tries to launch the app
+                    // directly, which is the fast route when its URL scheme is
+                    // right — but those schemes are vendor-controlled and can't
+                    // be verified from here, so the secondary is an explicit,
+                    // always-correct link to the App Store product page (which
+                    // itself shows OPEN when the app is installed). The user is
+                    // never left without a working destination.
                     Button {
                         FitnessSourceLauncher.open(platform)
                     } label: {
@@ -726,6 +762,20 @@ struct FitnessSourceSetupSheet: View {
                             .background(MADTheme.Colors.redGradient)
                             .foregroundColor(.white)
                             .clipShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+
+                    Button {
+                        FitnessSourceLauncher.openAppStore(for: platform)
+                    } label: {
+                        HStack(spacing: MADTheme.Spacing.xs) {
+                            Image(systemName: "arrow.up.forward.app")
+                                .font(.system(size: 12, weight: .semibold))
+                            Text("Find \(platform.name) in the App Store")
+                                .font(MADTheme.Typography.small)
+                        }
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.plain)
 


### PR DESCRIPTION
Reported: the "Open &lt;App&gt;" buttons don't go where they should. There were **three separate causes**, and the first explains why it was *every* app rather than a few.

## 1. The App Store fallback was broken (root cause)

The fallback was a **search URL** — `apps.apple.com/search?term=<name>` — which has no storefront segment and doesn't resolve to the App Store app at all.

That matters more than it looks, because the partner URL schemes (`strava://`, `whoop://`, …) are guesses: they're vendor-controlled and can't be verified from here. Most of them presumably don't resolve, so most launches fell through to the fallback — and the fallback went nowhere. One broken line made the whole set look broken.

**Fix:** every platform now carries its **real App Store id**, looked up per app and cross-checked (each was corroborated across ~8 independent storefront URLs), then verified in-tree to map to the right platform and be unique:

| | | | |
|---|---|---|---|
| Strava `426826309` | Garmin Connect `583446403` | Google Health `462638897` | WHOOP `933944389` |
| Oura `1043837948` | Peloton `792750948` | Nike Run Club `387771637` | COROS `1277625343` |
| Polar Flow `717172678` | Suunto `1230327951` | Runna `1594204443` | Map My Run `291890420` |
| adidas Running `336599882` | | | |

The fallback opens the actual product page via `itms-apps:` — handled by the App Store app itself, so it can't be intercepted into Safari the way an https universal link can — with the https link as a backstop.

That reliable destination is what makes a stale `urlScheme` cost *a tap* instead of stranding the user, and for an installed app the product page shows **OPEN**. I also added an explicit **"Find &lt;App&gt; in the App Store"** row so there's always a deterministic path that doesn't depend on a scheme guess at all.

## 2. Stacked `.sheet` modifiers

`FitnessConnectionsView` had **three** `.sheet` modifiers on one node; `ProfileSettingsView` had two. Stacked sheets compete and one silently never presents — a button that does nothing. This repo already documents the equivalent trap for `fullScreenCover` ("attach two covers to two different nodes or one drops").

Both now route every modal through a single `.sheet(item:)` driven by an enum.

## 3. Sheet-to-sheet handoff raced

The limitation sheet's "Import My History" swapped the sheet item *while presented*. Two presentations in one transaction race and SwiftUI drops one — the exact hazard `PostDeepLink.openAfterDismiss` already exists to avoid, in this codebase's own words: *"Two presentations in one transaction race and SwiftUI silently drops one."* It now dismisses first and presents the importer after.

## Also

Corrected Map My Run's name (reacquired from Under Armour, no longer "MapMyRun by Under Armour").

## Verification

- All 13 App Store ids map to the correct platform and are unique (scripted check against the expected table)
- No stacked sheet/cover modifiers remain in any of the three files
- No dangling references to the removed `@State` vars
- Every interactive element in both new views audited end-to-end: 11 in `FitnessConnectionsView`, 5 in `ImportHistoryView` — each traced to a working destination
- Backend untouched, still builds

**Not verified:** no macOS toolchain here, so the Swift needs an Xcode build. Worth tapping through each row on device — the App Store fallback is now deterministic, but the `urlScheme` values remain unverifiable guesses. Any that turn out wrong will quietly land on the App Store page instead, which is the intended safe behavior; if you find one that's actually correct-but-wrong-app, that's a scheme collision worth removing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRnaZko3QYYAu8GyRZLeLk)_