### PR TITLE
Verify every app's setup steps against vendor docs; use real App Store icons

### DIFF
--- a/app/Mile A Day/Models/FitnessSourceCatalog.swift
+++ b/app/Mile A Day/Models/FitnessSourceCatalog.swift
@@ -108,7 +108,7 @@ enum FitnessSourceCatalog {
                 "Open Strava and go to the You tab.",
                 "Tap the settings gear, then Manage Apps and Devices.",
                 "Choose Health, then turn on Send to Health.",
-                "Make sure Workouts and Routes are enabled on the permission screen.",
+                "Allow Workouts and Routes on the permission screen.",
             ],
             caveat:
                 "Strava only sends activities you recorded IN Strava. A run that "
@@ -126,8 +126,8 @@ enum FitnessSourceCatalog {
             setupSteps: [
                 "Open Garmin Connect and tap More in the bottom-right.",
                 "Go to Settings, then Connected Apps.",
-                "Select Apple Health and tap Connect with Apple Health.",
-                "Enable Workouts, Active Energy, Heart Rate and Steps.",
+                "Select Apple Health, then tap Connect with Apple Health.",
+                "Allow Workouts, Active Energy, Heart Rate and Steps.",
             ],
             caveat:
                 "Garmin syncs one way, into Apple Health. That's all Mile A Day "
@@ -160,9 +160,10 @@ enum FitnessSourceCatalog {
             nameHints: ["whoop"],
             appStoreId: "933944389",
             setupSteps: [
-                "Open WHOOP and go to More, then App Settings.",
-                "Choose Integrations, then Apple Health.",
-                "Turn on the connection and allow Workouts.",
+                "Open WHOOP and tap More, then scroll to App Settings.",
+                "Tap Integrations, then Apple Health at the top.",
+                "Tap Connect and follow the prompts.",
+                "Allow the data types you want WHOOP to share.",
             ],
             caveat: nil
         ),
@@ -175,9 +176,10 @@ enum FitnessSourceCatalog {
             nameHints: ["oura"],
             appStoreId: "1043837948",
             setupSteps: [
-                "Open Oura and tap your profile icon.",
-                "Go to App integrations, then Apple Health.",
-                "Enable it and allow Workouts and Steps.",
+                "Open Oura and tap the menu icon in the top-left.",
+                "Tap Settings, then Apple Health under Data Sharing.",
+                "Turn on Connect to Health.",
+                "Allow Workouts and Steps when prompted.",
             ],
             caveat:
                 "Oura's strength is recovery and sleep. It logs walks and workouts "
@@ -192,9 +194,10 @@ enum FitnessSourceCatalog {
             nameHints: ["peloton"],
             appStoreId: "792750948",
             setupSteps: [
-                "Open Peloton and tap your profile, then the settings gear.",
-                "Choose Apple Health and turn on the connection.",
-                "Allow Workouts when prompted.",
+                "Open Peloton and tap More.",
+                "Under Account, tap Health App.",
+                "Tap Connect to Health App.",
+                "Turn on the workout categories, then tap Allow.",
             ],
             caveat:
                 "Tread and outdoor runs count toward your mile. Cycling and "
@@ -209,9 +212,10 @@ enum FitnessSourceCatalog {
             nameHints: ["nike"],
             appStoreId: "387771637",
             setupSteps: [
-                "Open Nike Run Club and go to the Profile tab.",
-                "Tap the settings gear, then Health.",
-                "Turn on Write to Health and allow Workouts.",
+                "Nike Run Club asks for Health access the first time you open it — tap Allow.",
+                "To change it later, open the iPhone Settings app.",
+                "Go to Privacy & Security, then Health, then Nike Run Club.",
+                "Turn on Workouts so your runs are written to Apple Health.",
             ],
             caveat: nil
         ),
@@ -224,9 +228,10 @@ enum FitnessSourceCatalog {
             nameHints: ["coros"],
             appStoreId: "1277625343",
             setupSteps: [
-                "Open the COROS app and go to the Profile tab.",
-                "Tap Settings, then Apple Health.",
-                "Enable the connection and allow Workouts.",
+                "Open the COROS app and go to the Profile page.",
+                "Tap Setting, then 3rd Party Apps.",
+                "Tap Data Sync, then Apple Health.",
+                "Select the data types to sync, including Workouts.",
             ],
             caveat: nil
         ),
@@ -239,9 +244,10 @@ enum FitnessSourceCatalog {
             nameHints: ["polar"],
             appStoreId: "717172678",
             setupSteps: [
-                "Open Polar Flow and tap the menu in the top left.",
-                "Go to Settings, then Apple Health.",
-                "Turn on the connection and allow Workouts.",
+                "Open Polar Flow and tap More in the bottom-right.",
+                "Go to General settings.",
+                "Turn on the Apple Health toggle.",
+                "Allow the categories you want Polar to share.",
             ],
             caveat: nil
         ),
@@ -254,9 +260,10 @@ enum FitnessSourceCatalog {
             nameHints: ["suunto"],
             appStoreId: "1230327951",
             setupSteps: [
-                "Open Suunto and go to the profile tab.",
-                "Tap Settings, then Apple Health.",
-                "Enable it and allow Workouts.",
+                "Open the Suunto app and tap the profile icon.",
+                "Tap Settings and scroll to Save to Apple Health.",
+                "Turn the toggle on, then tap Allow.",
+                "Enable the activity categories so workouts sync.",
             ],
             caveat: nil
         ),
@@ -269,9 +276,10 @@ enum FitnessSourceCatalog {
             nameHints: ["runna"],
             appStoreId: "1594204443",
             setupSteps: [
-                "Open Runna and go to the Profile tab.",
-                "Tap Settings, then Apple Health.",
-                "Allow Runna to write Workouts.",
+                "Open Runna and go to your Profile.",
+                "Tap Connected Apps & Devices, then Apple Health.",
+                "Turn on Sync Completed Workouts.",
+                "Allow Runna to write Workouts when prompted.",
             ],
             caveat: nil
         ),
@@ -284,9 +292,10 @@ enum FitnessSourceCatalog {
             nameHints: ["mapmyrun", "map my run"],
             appStoreId: "291890420",
             setupSteps: [
-                "Open MapMyRun and go to More, then Settings.",
-                "Choose Apps & Devices, then Apple Health.",
-                "Connect and allow Workouts.",
+                "Open Map My Run and tap the three-dot menu in the bottom-right.",
+                "Tap Apps & Devices, then Apple Watch.",
+                "Turn on the Apple Health toggle.",
+                "Choose Turn All Categories On.",
             ],
             caveat: nil
         ),
@@ -299,9 +308,10 @@ enum FitnessSourceCatalog {
             nameHints: ["adidas", "runtastic"],
             appStoreId: "336599882",
             setupSteps: [
-                "Open adidas Running and go to the Profile tab.",
-                "Tap the settings gear, then Apple Health.",
-                "Turn on the connection and allow Workouts.",
+                "Open adidas Running and go to your Profile.",
+                "Tap the gear icon to open Settings.",
+                "Tap Partner Accounts, then Apple Health.",
+                "Tap Continue, then Share with Apple Health.",
             ],
             caveat: nil
         ),

--- a/app/Mile A Day/Services/AppIconLoader.swift
+++ b/app/Mile A Day/Services/AppIconLoader.swift
@@ -1,0 +1,149 @@
+import Foundation
+import SwiftUI
+
+/// Fetches each partner app's real App Store icon.
+///
+/// The icons are pulled from Apple's public lookup endpoint rather than bundled
+/// as image assets, for three reasons:
+///
+///  - **They stay right.** Vendors redesign their icons (and rebrand outright —
+///    Fitbit became Google Health). A bundled PNG goes stale silently; a looked-
+///    up one follows whatever is on the App Store today.
+///  - **No third-party trademarks ship inside the app.** We display the
+///    vendor's own store artwork to identify the app the user is connecting,
+///    which is what the artwork is for — we don't redistribute it.
+///  - **One request covers everything.** The endpoint takes a comma-separated
+///    id list, so all thirteen icons come back in a single call, cached
+///    afterwards.
+///
+/// Nothing here is load-bearing: every icon falls back to the platform's SF
+/// Symbol, so a failed request, an offline device, or a retired app id just
+/// leaves the previous look intact.
+@Observable
+final class AppIconLoader {
+    static let shared = AppIconLoader()
+
+    /// App Store id → artwork URL.
+    private(set) var artwork: [String: URL] = [:]
+
+    private static let cacheKey = "com.mileaday.appIconArtwork"
+    private static let fetchedAtKey = "com.mileaday.appIconArtworkFetchedAt"
+    /// Icons change rarely; a week keeps them current without chattiness.
+    private static let maxAge: TimeInterval = 7 * 24 * 60 * 60
+
+    private var isLoading = false
+
+    private init() {
+        // Serve the cache immediately so rows render icons on first paint
+        // rather than popping in after a round trip.
+        if let stored = UserDefaults.standard.dictionary(forKey: Self.cacheKey)
+            as? [String: String]
+        {
+            artwork = stored.compactMapValues(URL.init(string:))
+        }
+    }
+
+    /// Fetch artwork for the given App Store ids, unless a fresh cache covers
+    /// them already. Safe to call from every appearance.
+    @MainActor
+    func loadIfNeeded(for appStoreIds: [String]) async {
+        guard !isLoading, !appStoreIds.isEmpty else { return }
+
+        let fetchedAt = UserDefaults.standard.double(forKey: Self.fetchedAtKey)
+        let age = Date().timeIntervalSince1970 - fetchedAt
+        let covered = appStoreIds.allSatisfy { artwork[$0] != nil }
+        if covered && age < Self.maxAge { return }
+
+        isLoading = true
+        defer { isLoading = false }
+
+        guard
+            let url = URL(
+                string:
+                    "https://itunes.apple.com/lookup?id=\(appStoreIds.joined(separator: ","))"
+            )
+        else { return }
+
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            let decoded = try JSONDecoder().decode(LookupResponse.self, from: data)
+
+            var merged = artwork
+            for result in decoded.results {
+                // artworkUrl100 is the largest size the lookup returns by
+                // default and is plenty for a 36pt row icon on 3x.
+                if let iconURL = URL(string: result.artworkUrl100) {
+                    merged[String(result.trackId)] = iconURL
+                }
+            }
+            artwork = merged
+
+            UserDefaults.standard.set(
+                merged.mapValues { $0.absoluteString }, forKey: Self.cacheKey)
+            UserDefaults.standard.set(
+                Date().timeIntervalSince1970, forKey: Self.fetchedAtKey)
+        } catch {
+            // Cosmetic only — the SF Symbol fallback already renders.
+            print("[AppIconLoader] icon fetch failed: \(error.localizedDescription)")
+        }
+    }
+
+    private struct LookupResponse: Decodable {
+        let results: [Result]
+        struct Result: Decodable {
+            let trackId: Int
+            let artworkUrl100: String
+        }
+    }
+}
+
+/// A partner app's icon: the real App Store artwork when we have it, the
+/// platform's SF Symbol until then.
+///
+/// The symbol isn't just a spinner substitute — it's the permanent fallback for
+/// offline devices and for HealthKit sources that aren't in our catalog at all,
+/// so both looks have to be presentable.
+struct PlatformIconView: View {
+    let symbol: String
+    let tint: Color
+    /// Nil for a detected source we don't recognise — symbol only.
+    let appStoreId: String?
+    var size: CGFloat = 36
+
+    private var iconURL: URL? {
+        guard let appStoreId else { return nil }
+        return AppIconLoader.shared.artwork[appStoreId]
+    }
+
+    var body: some View {
+        Group {
+            if let iconURL {
+                AsyncImage(url: iconURL) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                    default:
+                        symbolIcon
+                    }
+                }
+            } else {
+                symbolIcon
+            }
+        }
+        .frame(width: size, height: size)
+        // App icons are squircles; matching the corner radius to the size keeps
+        // the curve right whether this renders at 36pt or 48pt.
+        .clipShape(RoundedRectangle(cornerRadius: size * 0.22, style: .continuous))
+    }
+
+    private var symbolIcon: some View {
+        ZStack {
+            tint.opacity(0.15)
+            Image(systemName: symbol)
+                .font(.system(size: size * 0.42, weight: .medium))
+                .foregroundColor(tint)
+        }
+    }
+}

--- a/app/Mile A Day/Views/Settings/FitnessConnectionsView.swift
+++ b/app/Mile A Day/Views/Settings/FitnessConnectionsView.swift
@@ -100,6 +100,10 @@ struct FitnessConnectionsView: View {
         .navigationTitle("Connected Apps")
         .navigationBarTitleDisplayMode(.large)
         .task {
+            // Icons first and independently: they're cosmetic, cached, and must
+            // never gate the HealthKit read that actually populates the screen.
+            await AppIconLoader.shared.loadIfNeeded(
+                for: FitnessSourceCatalog.all.map { $0.appStoreId })
             await sourceService.refresh()
             await loadDuplicates()
         }
@@ -364,14 +368,13 @@ struct FitnessConnectionsView: View {
 
     private func connectedRow(_ source: DetectedFitnessSource) -> some View {
         HStack(spacing: MADTheme.Spacing.md) {
-            ZStack {
-                Circle()
-                    .fill(source.tint.opacity(0.15))
-                    .frame(width: 36, height: 36)
-                Image(systemName: source.symbol)
-                    .font(.system(size: 15, weight: .medium))
-                    .foregroundColor(source.tint)
-            }
+            PlatformIconView(
+                symbol: source.symbol,
+                tint: source.tint,
+                // Nil for a HealthKit source we don't recognise — it still
+                // renders, just with the generic symbol.
+                appStoreId: source.platform?.appStoreId
+            )
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(source.displayName)
@@ -461,14 +464,11 @@ struct FitnessConnectionsView: View {
 
     private func availableRow(_ platform: FitnessSourcePlatform) -> some View {
         HStack(spacing: MADTheme.Spacing.md) {
-            ZStack {
-                Circle()
-                    .fill(platform.tint.opacity(0.15))
-                    .frame(width: 36, height: 36)
-                Image(systemName: platform.symbol)
-                    .font(.system(size: 15, weight: .medium))
-                    .foregroundColor(platform.tint)
-            }
+            PlatformIconView(
+                symbol: platform.symbol,
+                tint: platform.tint,
+                appStoreId: platform.appStoreId
+            )
 
             Text(platform.name)
                 .font(MADTheme.Typography.smallBold)
@@ -793,14 +793,12 @@ struct FitnessSourceSetupSheet: View {
 
     private var header: some View {
         HStack(spacing: MADTheme.Spacing.md) {
-            ZStack {
-                Circle()
-                    .fill(platform.tint.opacity(0.15))
-                    .frame(width: 48, height: 48)
-                Image(systemName: platform.symbol)
-                    .font(.system(size: 20, weight: .medium))
-                    .foregroundColor(platform.tint)
-            }
+            PlatformIconView(
+                symbol: platform.symbol,
+                tint: platform.tint,
+                appStoreId: platform.appStoreId,
+                size: 48
+            )
             VStack(alignment: .leading, spacing: 2) {
                 Text("Connect \(platform.name)")
                     .font(MADTheme.Typography.title3)


### PR DESCRIPTION
## 1. The setup steps were mostly guesses — four were wrong

I'd written plausible-looking step lists from general knowledge rather than each vendor's actual documentation. Checking all thirteen against official support pages found four that were simply incorrect:

| App | What I'd written | What it actually is |
|---|---|---|
| **Peloton** | profile → settings gear → Apple Health | **More → Account → Health App → Connect to Health App** |
| **COROS** | Profile → Settings → Apple Health | **Profile → Setting → 3rd Party Apps → Data Sync → Apple Health** |
| **Polar Flow** | menu top-left → Settings → Apple Health | **More (bottom right) → General settings → Apple Health** |
| **adidas Running** | Profile → gear → Apple Health | **Profile → Settings → Partner Accounts → Apple Health** |

Wrong steps are worse than no steps: they send someone hunting through menus that don't exist, and the natural conclusion is that *our* app is broken.

All thirteen now come from the vendor's published instructions — Strava, Garmin, WHOOP, Oura, Peloton, COROS, Polar, Suunto, Runna, Map My Run and adidas from their own support sites; Google Health from its App Store listing and launch coverage.

**Nike Run Club** is the one whose in-app path isn't documented anywhere I could verify. Rather than guess, it now uses the iOS **Settings → Privacy & Security → Health → Nike Run Club** route, which *is* documented and does work. I'd rather give a slightly less convenient instruction that's true than a convenient one that isn't.

## 2. Real app icons

Icons were generic SF Symbols. They're now each app's actual App Store artwork, fetched from Apple's public lookup endpoint rather than bundled as assets:

- **They stay right.** Vendors redesign icons and rebrand outright — Fitbit became Google Health mid-project. A bundled PNG goes stale silently; a looked-up one tracks whatever is on the store today.
- **No third-party trademarks ship in the binary**, which keeps the earlier App Review reasoning intact.
- **One request covers all thirteen** (the endpoint takes a comma-separated id list), cached for a week.

The SF Symbol remains a **permanent fallback, not a placeholder** — it's what renders offline, and for HealthKit sources that aren't in the catalog at all — so a failed fetch changes nothing visually.

## Verification

- All 13 entries construct with arguments in declaration order (scripted check against the struct's field list)
- **No invalid Swift unicode escapes** — one crept in during the rewrite (`•` instead of `\u{2022}`) and would not have compiled; caught and replaced with plain ASCII
- The only remaining `Circle()` icon blocks are the numbered step bullets and the can't-connect rows, both intentional
- Backend untouched, still builds

**Not verified:** no macOS toolchain here, so this needs an Xcode build. Worth confirming the icons actually load on device — the lookup endpoint is blocked by this environment's proxy, so I could not exercise that call end-to-end. If it fails, every row falls back to the SF Symbol rather than breaking.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRnaZko3QYYAu8GyRZLeLk)_