### PR TITLE
Turn Buddy Walks on, and make the lobby a room you can change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,13 @@ jobs:
         run: node dist/db/migrateCli.js
       - name: Seeded feed/story/hype/signing smoke test
         run: node scripts/ci-smoke.mjs
+      # Buddy Walks shipped fully built and then sat dead in production because
+      # a rollout flag defaulted off and every endpoint answered 404 in silence.
+      # These assertions pin the flag's direction, the enrollment that rides
+      # device registration, the opt-out (including the no-settings-row default)
+      # and the host-only lobby PATCH.
+      - name: Buddy gate + lobby-edit check
+        run: node scripts/buddy-gate-check.mjs
 
   website:
     name: Website (lint + build)

--- a/app/Mile A Day/Core/Services/ClientFeatures.swift
+++ b/app/Mile A Day/Core/Services/ClientFeatures.swift
@@ -44,9 +44,22 @@ enum ClientFeatures {
     /// to say why.
     static let postWindowV1 = "post_window_v1"
 
+    /// This build has the Buddy Walks & Runs screens — it can render a lobby, a
+    /// live roster and a recap, and it registers the BUDDY_INVITE category.
+    ///
+    /// This one does more than gate a payload: declaring it is what ENROLLS the
+    /// user (the server stamps `users.buddy_enrolled_at` on registration), and
+    /// an enrolled user is offered to their friends as someone who can be pulled
+    /// into a walk. So a build that sends this string without the screens would
+    /// have its owner invited to something their app cannot open.
+    ///
+    /// It is also the only thing standing between an older install and a buddy
+    /// invite now that the server-side `BUDDY_SESSIONS` flag defaults on.
+    static let buddyWalksV1 = "buddy_walks_v1"
+
     /// Declared on registration. Add a string here only in the same build that
     /// actually implements the behavior.
     static let supported: [String] = [
-        friendRequestV2, collabTagV1, ghostFriendRaceV1, postWindowV1,
+        friendRequestV2, collabTagV1, ghostFriendRaceV1, postWindowV1, buddyWalksV1,
     ]
 }

--- a/app/Mile A Day/Models/Competition.swift
+++ b/app/Mile A Day/Models/Competition.swift
@@ -992,6 +992,10 @@ struct NotificationSettingsResponse: Codable {
     /// (the grid is a SQL query), so this is the authority, not the local copy.
     /// Optional: absent on older server builds (treat as on).
     let tagged_posts_on_profile: Bool?
+    /// May friends invite me to a Buddy Walk? Server-enforced (it decides
+    /// whether I appear in their picker at all), so this is the authority.
+    /// Optional: absent on older server builds (treat as on).
+    let buddy_invites_enabled: Bool?
 }
 
 struct FriendNotificationSetting: Codable, Identifiable {

--- a/app/Mile A Day/Models/NotificationPreferences.swift
+++ b/app/Mile A Day/Models/NotificationPreferences.swift
@@ -124,6 +124,22 @@ struct NotificationPreferences: Codable {
         set { taggedPostsOnProfileRaw = newValue }
     }
 
+    /// Friends may invite me to Buddy Walks & Runs. ON by default — everyone
+    /// with the feature is opted in, and this is the opt-out.
+    ///
+    /// Synced to the backend rather than kept local, like
+    /// `friendRequestReminderEnabled`: the invite push is sent server-side, so
+    /// a local-only switch could not turn it off (App Review 4.5.4). Turning it
+    /// off also removes me from friends' invite pickers entirely, so it reads
+    /// as "I'm not doing buddy walks" rather than only muting the banner.
+    /// Same optional-backing pattern so prefs saved by older builds still
+    /// decode instead of resetting everything to defaults.
+    private var buddyInvitesEnabledRaw: Bool?
+    var buddyInvitesEnabled: Bool {
+        get { buddyInvitesEnabledRaw ?? true }
+        set { buddyInvitesEnabledRaw = newValue }
+    }
+
     /// Who can see my routes and photos. Same optional-backing pattern, and an
     /// unrecognised stored value falls back to `.friends` rather than to
     /// something more exposed.

--- a/app/Mile A Day/Services/BuddySessionService.swift
+++ b/app/Mile A Day/Services/BuddySessionService.swift
@@ -22,7 +22,8 @@ enum BuddyServiceError: LocalizedError {
         case "session_not_found": return "We couldn't find that buddy walk."
         case "not_friends_with_host": return "You need to be friends to join."
         case "blocked": return "You can't join this buddy walk."
-        case "not_host": return "Only the host can start."
+        case "not_host": return "Only the host can change this."
+        case "session_not_editable": return "This walk already started."
         case "not_a_participant": return "You're not in this buddy walk."
         case "goal_required": return "Pick a goal to continue."
         case "goal_too_large": return "That goal is a little too ambitious."
@@ -245,6 +246,55 @@ final class BuddySessionService: ObservableObject {
         )
         apply(state)
         startPolling()
+        return state
+    }
+
+    /// Change the lobby's settings, or pull more people in, before it starts.
+    ///
+    /// Host-only and lobby-only server-side. Only the fields you pass are
+    /// touched — which is why `scheduledStartAt` needs three states rather than
+    /// two: omitted leaves the booking alone, `.some(nil)` cancels it, and a
+    /// date moves it. A plain optional couldn't say "cancel".
+    ///
+    /// `goalValue` follows the mode. Sending a new mode without a goal makes
+    /// the server clear it, which is right for `together` and a 400
+    /// (`goal_required`) for the scored modes — so callers changing INTO a
+    /// scored mode must send both together.
+    func updateSession(
+        mode: BuddyMode? = nil,
+        goalValue: Double? = nil,
+        activityType: String? = nil,
+        scheduledStartAt: Date?? = nil,
+        inviteUserIds: [String]? = nil
+    ) async throws -> BuddySessionState {
+        guard let sessionId = session?.id else {
+            throw BuddyServiceError.api("session_not_found")
+        }
+        var payload: [String: Any] = [:]
+        if let mode { payload["mode"] = mode.rawValue }
+        if let goalValue { payload["goalValue"] = goalValue }
+        if let activityType { payload["activityType"] = activityType }
+        if let inviteUserIds { payload["inviteUserIds"] = inviteUserIds }
+        if let scheduledStartAt {
+            // Present-but-nil is the explicit cancel; NSNull is how that
+            // survives JSONSerialization, which drops a Swift nil entirely.
+            // Written as an if/else rather than `map(...) ?? NSNull()` because
+            // that form asks Swift to unify String and NSNull through `??`,
+            // which only resolves via Any and reads as ambiguous.
+            if let date = scheduledStartAt {
+                payload["scheduledStartAt"] = ISO8601DateFormatter().string(from: date)
+            } else {
+                payload["scheduledStartAt"] = NSNull()
+            }
+        }
+
+        let state = try await request(
+            "/buddy/sessions/\(sessionId)",
+            method: .PATCH,
+            json: payload,
+            responseType: BuddySessionState.self
+        )
+        apply(state)
         return state
     }
 

--- a/app/Mile A Day/Views/BuddyWalks/BuddyLobbySettingsSheet.swift
+++ b/app/Mile A Day/Views/BuddyWalks/BuddyLobbySettingsSheet.swift
@@ -1,0 +1,378 @@
+import SwiftUI
+
+/// Change a lobby's plan before it starts, and pull more people in.
+///
+/// The lobby used to be read-only: the settings you picked at creation were
+/// final, so "actually let's make it two miles" or "wait, Sam's coming too"
+/// meant abandoning the room and building a new one — which also invalidated
+/// the code you'd already sent. That's the whole reason this exists.
+///
+/// Deliberately NOT sharing controls with `BuddyStartSheet`. That screen is a
+/// guided first-run flow with a live summary sentence and a lane picker; this is
+/// a compact edit form over an object that already exists. The overlap is the
+/// vocabulary (modes, goals, walk/run), not the layout, and the two have
+/// genuinely different jobs — a shared component would end up with a `isEditing`
+/// flag threaded through every branch. What must not drift is the RULES, and
+/// those live server-side in `validateGoal`, which both paths post through.
+///
+/// Everything here is host-only; non-hosts never see the entry point, and the
+/// server enforces it anyway (`not_host`).
+struct BuddyLobbySettingsSheet: View {
+    let session: BuddySessionState
+
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject private var buddy = BuddySessionService.shared
+
+    @State private var mode: BuddyMode
+    @State private var goal: Double
+    @State private var isRun: Bool
+    @State private var isScheduled: Bool
+    @State private var scheduledDate: Date
+    @State private var newInvites: Set<String> = []
+    @State private var isSaving = false
+    @State private var errorText: String?
+
+    private static let controlHeight: CGFloat = 48
+
+    init(session: BuddySessionState) {
+        self.session = session
+        _mode = State(initialValue: session.mode)
+        // A goal-less mode still needs a sensible number parked behind it, so
+        // switching TO a scored mode doesn't land on 0 and fail validation.
+        _goal = State(initialValue: session.goalValue ?? (session.mode == .raceTime ? 20 : 1))
+        _isRun = State(initialValue: session.isRunning)
+        _isScheduled = State(initialValue: session.scheduledStartAtDate != nil)
+        _scheduledDate = State(
+            initialValue: session.scheduledStartAtDate ?? Date().addingTimeInterval(30 * 60))
+    }
+
+    private var accent: Color {
+        isRun ? MADTheme.workoutColor("running") : MADTheme.workoutColor("walking")
+    }
+
+    /// Friends not already in the room. Someone who declined or left is
+    /// excluded too — re-inviting them from here would be nagging, and the
+    /// server's `ON CONFLICT DO NOTHING` would drop it anyway.
+    private var invitable: [BuddyCandidate] {
+        let present = Set(session.participants.map(\.userId))
+        return buddy.candidates.filter { !present.contains($0.userId) }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                MADTheme.Colors.appBackgroundGradient.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: MADTheme.Spacing.lg) {
+                        activityToggle
+                        modeSection
+                        if mode.needsGoal { goalSection }
+                        scheduleSection
+                        if !invitable.isEmpty { inviteSection }
+                        Color.clear.frame(height: 8)
+                    }
+                    .padding(.horizontal, MADTheme.Spacing.md)
+                    .padding(.top, MADTheme.Spacing.sm)
+                }
+            }
+            .navigationTitle("Edit lobby")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(isSaving ? "Saving…" : "Save") { Task { await save() } }
+                        .font(MADTheme.Typography.bodyBold)
+                        .disabled(isSaving)
+                }
+            }
+            .task { await buddy.loadCandidates() }
+            .alert(
+                "Couldn't save",
+                isPresented: Binding(
+                    get: { errorText != nil },
+                    set: { if !$0 { errorText = nil } }
+                )
+            ) {
+                Button("OK", role: .cancel) { errorText = nil }
+            } message: {
+                Text(errorText ?? "")
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var activityToggle: some View {
+        HStack(spacing: 4) {
+            activityChip(run: false, icon: "figure.walk", label: "Walk")
+            activityChip(run: true, icon: "figure.run", label: "Run")
+        }
+        .padding(4)
+        .background(Capsule().fill(MADTheme.Colors.madWhite.opacity(0.10)))
+    }
+
+    private func activityChip(run: Bool, icon: String, label: String) -> some View {
+        let isOn = isRun == run
+        return Button {
+            MADHaptics.tap()
+            withAnimation(MADTheme.Animation.quick) { isRun = run }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: icon).font(.system(size: 13, weight: .semibold))
+                Text(label).font(MADTheme.Typography.bodyBold)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 40)
+            .background(Capsule().fill(isOn ? accent : .clear))
+            .foregroundStyle(
+                isOn ? MADTheme.Colors.madWhite : MADTheme.Colors.madWhite.opacity(0.6))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var modeSection: some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+            sectionTitle("Mode")
+            VStack(spacing: 0) {
+                ForEach(Array(BuddyMode.allCases.enumerated()), id: \.element) { index, option in
+                    if index > 0 {
+                        Divider().background(MADTheme.Colors.madWhite.opacity(0.08))
+                    }
+                    modeRow(option)
+                }
+            }
+            .background(card())
+        }
+    }
+
+    private func modeRow(_ option: BuddyMode) -> some View {
+        let isOn = mode == option
+        return Button {
+            MADHaptics.tap()
+            withAnimation(MADTheme.Animation.quick) {
+                mode = option
+                // Coming from a mode with a different unit, the stored number
+                // is meaningless — 20 miles, or a 1-minute race. Reset to the
+                // unit's own sensible default rather than carrying it across.
+                if option == .raceTime, goal > 180 || goal < 5 { goal = 20 }
+                if option != .raceTime, goal > 50 { goal = 2 }
+            }
+        } label: {
+            HStack(spacing: MADTheme.Spacing.md) {
+                Image(systemName: option.icon)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(isOn ? accent : MADTheme.Colors.madWhite.opacity(0.5))
+                    .frame(width: 26)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(option.title)
+                        .font(MADTheme.Typography.bodyBold)
+                        .foregroundStyle(MADTheme.Colors.madWhite)
+                    Text(option.subtitle)
+                        .font(MADTheme.Typography.caption)
+                        .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.55))
+                        .multilineTextAlignment(.leading)
+                }
+
+                Spacer(minLength: MADTheme.Spacing.sm)
+
+                Image(systemName: isOn ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 18))
+                    .foregroundStyle(isOn ? accent : MADTheme.Colors.madWhite.opacity(0.25))
+            }
+            .padding(MADTheme.Spacing.md)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var goalSection: some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+            sectionTitle(mode == .raceTime ? "How long?" : "How far?")
+            HStack(spacing: MADTheme.Spacing.md) {
+                stepButton(systemName: "minus", enabled: goal > goalRange.lowerBound) {
+                    goal = max(goalRange.lowerBound, goal - goalStep)
+                }
+                Text(goalLabel)
+                    .font(.system(size: 26, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundStyle(MADTheme.Colors.madWhite)
+                    .frame(maxWidth: .infinity)
+                stepButton(systemName: "plus", enabled: goal < goalRange.upperBound) {
+                    goal = min(goalRange.upperBound, goal + goalStep)
+                }
+            }
+            .padding(MADTheme.Spacing.md)
+            .background(card())
+        }
+    }
+
+    private func stepButton(
+        systemName: String, enabled: Bool, action: @escaping () -> Void
+    ) -> some View {
+        Button {
+            MADHaptics.tap()
+            withAnimation(MADTheme.Animation.quick) { action() }
+        } label: {
+            Image(systemName: systemName)
+                .font(.system(size: 15, weight: .bold))
+                .frame(width: 40, height: 40)
+                .background(Circle().fill(MADTheme.Colors.madWhite.opacity(0.10)))
+                .foregroundStyle(MADTheme.Colors.madWhite)
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+        .opacity(enabled ? 1 : 0.35)
+    }
+
+    /// Mirrors the server's ceilings in `validateGoal` (200 miles / 24 hours) at
+    /// a scale a person would actually pick, so the stepper can't compose a
+    /// request the API will reject.
+    private var goalRange: ClosedRange<Double> {
+        mode == .raceTime ? 5...180 : 0.5...26
+    }
+
+    private var goalStep: Double { mode == .raceTime ? 5 : 0.5 }
+
+    private var goalLabel: String {
+        if mode == .raceTime { return "\(Int(goal)) min" }
+        return goal == goal.rounded()
+            ? "\(Int(goal)) mi" : String(format: "%.1f mi", goal)
+    }
+
+    private var scheduleSection: some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+            sectionTitle("Start time")
+            VStack(spacing: MADTheme.Spacing.sm) {
+                Toggle(isOn: $isScheduled.animation(MADTheme.Animation.quick)) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Book it for later")
+                            .font(MADTheme.Typography.bodyBold)
+                            .foregroundStyle(MADTheme.Colors.madWhite)
+                        Text("We start it for everyone, even with the app closed")
+                            .font(MADTheme.Typography.caption)
+                            .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.55))
+                    }
+                }
+                .tint(accent)
+
+                if isScheduled {
+                    DatePicker(
+                        "Starts",
+                        selection: $scheduledDate,
+                        in: Date().addingTimeInterval(5 * 60)...Date().addingTimeInterval(
+                            60 * 60 * 24 * 13),
+                        displayedComponents: [.date, .hourAndMinute]
+                    )
+                    .datePickerStyle(.compact)
+                    .tint(accent)
+                    .foregroundStyle(MADTheme.Colors.madWhite)
+                }
+            }
+            .padding(MADTheme.Spacing.md)
+            .background(card())
+        }
+    }
+
+    private var inviteSection: some View {
+        VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+            HStack {
+                sectionTitle("Add more people")
+                Spacer()
+                if !newInvites.isEmpty {
+                    Text("\(newInvites.count) selected")
+                        .font(MADTheme.Typography.caption)
+                        .foregroundStyle(accent)
+                }
+            }
+            VStack(spacing: 0) {
+                ForEach(Array(invitable.enumerated()), id: \.element.id) { index, candidate in
+                    if index > 0 {
+                        Divider().background(MADTheme.Colors.madWhite.opacity(0.08))
+                    }
+                    inviteRow(candidate)
+                }
+            }
+            .background(card())
+        }
+    }
+
+    private func inviteRow(_ candidate: BuddyCandidate) -> some View {
+        let isOn = newInvites.contains(candidate.userId)
+        return Button {
+            MADHaptics.tap()
+            withAnimation(MADTheme.Animation.quick) {
+                if isOn {
+                    newInvites.remove(candidate.userId)
+                } else {
+                    newInvites.insert(candidate.userId)
+                }
+            }
+        } label: {
+            HStack(spacing: MADTheme.Spacing.md) {
+                AvatarView(
+                    name: candidate.displayName,
+                    imageURL: candidate.profileImageUrl,
+                    size: 36
+                )
+                Text(candidate.displayName)
+                    .font(MADTheme.Typography.body)
+                    .foregroundStyle(MADTheme.Colors.madWhite)
+                Spacer()
+                Image(systemName: isOn ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 20))
+                    .foregroundStyle(isOn ? accent : MADTheme.Colors.madWhite.opacity(0.25))
+            }
+            .padding(MADTheme.Spacing.md)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func sectionTitle(_ text: String) -> some View {
+        Text(text)
+            .font(MADTheme.Typography.headline)
+            .foregroundStyle(MADTheme.Colors.madWhite)
+    }
+
+    private func card(_ radius: CGFloat = MADTheme.CornerRadius.large) -> some View {
+        RoundedRectangle(cornerRadius: radius, style: .continuous)
+            .fill(MADTheme.Colors.madWhite.opacity(0.06))
+            .overlay(
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .strokeBorder(MADTheme.Colors.madWhite.opacity(0.10), lineWidth: 1)
+            )
+    }
+
+    // MARK: - Save
+
+    private func save() async {
+        guard !isSaving else { return }
+        isSaving = true
+        defer { isSaving = false }
+        do {
+            _ = try await buddy.updateSession(
+                mode: mode,
+                // Always sent for a scored mode, because the server re-validates
+                // mode and goal together — a mode change with no goal is a
+                // `goal_required` 400 by design.
+                goalValue: mode.needsGoal ? goal : nil,
+                activityType: isRun ? "running" : "walking",
+                // Double optional: `.some(date)` books it, `.some(nil)` cancels
+                // an existing booking. Never `nil` here — this screen always has
+                // an opinion about the schedule.
+                scheduledStartAt: .some(isScheduled ? scheduledDate : nil),
+                inviteUserIds: newInvites.isEmpty ? nil : Array(newInvites)
+            )
+            MADHaptics.success()
+            dismiss()
+        } catch {
+            MADHaptics.error()
+            errorText =
+                (error as? LocalizedError)?.errorDescription ?? "Couldn't save those changes."
+        }
+    }
+}

--- a/app/Mile A Day/Views/BuddyWalks/BuddyLobbyView.swift
+++ b/app/Mile A Day/Views/BuddyWalks/BuddyLobbyView.swift
@@ -20,6 +20,7 @@ struct BuddyLobbyView: View {
     @State private var qrImage: UIImage?
     @State private var didCopy = false
     @State private var showGhostSetup = false
+    @State private var showSettings = false
 
     /// Ghost race arming for THIS buddy walk.
     ///
@@ -89,20 +90,7 @@ struct BuddyLobbyView: View {
 
     private func lobby(_ session: BuddySessionState) -> some View {
         VStack(spacing: MADTheme.Spacing.lg) {
-            VStack(spacing: MADTheme.Spacing.xs) {
-                Image(systemName: session.mode.icon)
-                    .font(.system(size: 32, weight: .semibold))
-                    .foregroundStyle(session.accentColor)
-                Text(session.mode.title)
-                    .font(MADTheme.Typography.title2)
-                    .foregroundStyle(MADTheme.Colors.madWhite)
-                if let goal = session.goalValue {
-                    Text(goalText(goal, mode: session.mode))
-                        .font(MADTheme.Typography.body)
-                        .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.7))
-                }
-            }
-            .padding(.top, MADTheme.Spacing.xl)
+            planHeader(session)
 
             inviteCard(session)
 
@@ -123,6 +111,81 @@ struct BuddyLobbyView: View {
             actions(session)
                 .padding(MADTheme.Spacing.md)
         }
+    }
+
+    // MARK: - Plan header
+
+    /// What this room is, and — for the host — the way to change it.
+    ///
+    /// The plan used to be three stacked labels with nothing to do about them.
+    /// Being able to edit it is what turns a lobby into a waiting room rather
+    /// than a receipt: plans change between "let's walk" and "everyone's here",
+    /// and the only way to act on that was to abandon the room and rebuild it,
+    /// which also invalidated the code you'd already sent people.
+    ///
+    /// Non-hosts see the same summary with no affordance. The server enforces
+    /// host-only anyway (`not_host`), so this is about not offering something
+    /// that would just fail.
+    private func planHeader(_ session: BuddySessionState) -> some View {
+        VStack(spacing: MADTheme.Spacing.xs) {
+            ZStack {
+                Circle()
+                    .fill(session.accentColor.opacity(0.18))
+                    .frame(width: 76, height: 76)
+                Circle()
+                    .strokeBorder(session.accentColor.opacity(0.45), lineWidth: 1.5)
+                    .frame(width: 76, height: 76)
+                Image(systemName: session.mode.icon)
+                    .font(.system(size: 30, weight: .semibold))
+                    .foregroundStyle(session.accentColor)
+            }
+            // Keyed on the whole plan so a change the HOST made animates on
+            // every other phone too, when the 5s poll brings it in.
+            .animation(MADTheme.Animation.quick, value: session.mode)
+
+            Text(session.mode.title)
+                .font(MADTheme.Typography.title2)
+                .foregroundStyle(MADTheme.Colors.madWhite)
+
+            Text(planLine(session))
+                .font(MADTheme.Typography.body)
+                .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.7))
+                .multilineTextAlignment(.center)
+
+            if session.isHost(buddy.currentUserId) {
+                Button {
+                    MADHaptics.tap()
+                    showSettings = true
+                } label: {
+                    Label("Edit", systemImage: "slider.horizontal.3")
+                        .font(MADTheme.Typography.caption)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Capsule().fill(MADTheme.Colors.madWhite.opacity(0.10)))
+                        .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.85))
+                }
+                .buttonStyle(.plain)
+                .padding(.top, 2)
+            }
+        }
+        .padding(.top, MADTheme.Spacing.xl)
+        // Its own presentation node. This view already carries the ghost-setup
+        // sheet and a ShareLink, and two sheets on ONE node makes SwiftUI
+        // silently drop one.
+        .background(
+            Color.clear
+                .sheet(isPresented: $showSettings) {
+                    BuddyLobbySettingsSheet(session: session)
+                }
+        )
+    }
+
+    /// "2.0 miles · Walk" — the plan as one line, so the goal and the activity
+    /// aren't two separate things to hold in your head.
+    private func planLine(_ session: BuddySessionState) -> String {
+        let activity = session.isRunning ? "Run" : "Walk"
+        guard let goal = session.goalValue else { return activity }
+        return "\(goalText(goal, mode: session.mode)) · \(activity)"
     }
 
     // MARK: - Ghost race
@@ -322,15 +385,41 @@ struct BuddyLobbyView: View {
         }
     }
 
+    /// One person in the room.
+    ///
+    /// Presence is carried by the AVATAR — ringed and full-strength once they're
+    /// in, dimmed while they're still an outstanding invite — rather than by a
+    /// text badge alone. Somebody scanning this list wants to know "who's
+    /// actually here", and a row of identical grey pills answers that far more
+    /// slowly than a row of faces where the ones who showed up are the bright
+    /// ones. The chip stays for the states a ring can't spell (Done, Out) and as
+    /// the accessible label.
+    ///
+    /// Flat fill, not `.madLiquidGlass`: this renders once per participant and
+    /// re-renders on every 5s poll. `BuddyStartSheet` already learned that
+    /// several live blur surfaces on one screen is what makes these views feel
+    /// sluggish, and on this background the two are indistinguishable.
     private func participantRow(_ participant: BuddyParticipant, session: BuddySessionState)
         -> some View
     {
-        HStack(spacing: MADTheme.Spacing.md) {
+        let isIn = participant.status == .joined || participant.status == .ready
+            || participant.status == .active
+        let isOut = participant.status == .left || participant.status == .declined
+
+        return HStack(spacing: MADTheme.Spacing.md) {
             AvatarView(
                 name: participant.displayName,
                 imageURL: participant.profileImageUrl,
                 size: 40
             )
+            .overlay(
+                Circle()
+                    .strokeBorder(
+                        isIn ? session.accentColor : Color.clear,
+                        lineWidth: 2
+                    )
+            )
+            .opacity(isIn ? 1 : 0.45)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(
@@ -338,7 +427,7 @@ struct BuddyLobbyView: View {
                         ? "You" : participant.displayName
                 )
                 .font(MADTheme.Typography.bodyBold)
-                .foregroundStyle(MADTheme.Colors.madWhite)
+                .foregroundStyle(MADTheme.Colors.madWhite.opacity(isOut ? 0.45 : 1))
 
                 if participant.isHost {
                     Text("Host")
@@ -352,7 +441,15 @@ struct BuddyLobbyView: View {
             statusChip(participant.status, accent: session.accentColor)
         }
         .padding(MADTheme.Spacing.sm)
-        .madLiquidGlass(cornerRadius: MADTheme.CornerRadius.medium)
+        .background(
+            RoundedRectangle(
+                cornerRadius: MADTheme.CornerRadius.medium, style: .continuous
+            )
+            .fill(MADTheme.Colors.madWhite.opacity(0.06))
+        )
+        // The 5s poll is what surfaces an arrival, so the animation has to key
+        // on the value that changed rather than on an onAppear that already ran.
+        .animation(MADTheme.Animation.standard, value: participant.status)
     }
 
     private func statusChip(_ status: BuddyParticipantStatus, accent: Color) -> some View {

--- a/app/Mile A Day/Views/BuddyWalks/BuddyStartSheet.swift
+++ b/app/Mile A Day/Views/BuddyWalks/BuddyStartSheet.swift
@@ -87,8 +87,9 @@ struct BuddyStartSheet: View {
                     VStack(spacing: MADTheme.Spacing.lg) {
                         lanePicker
                         if lane == .start { startLane } else { joinLane }
-                        // Clears the sticky footer.
-                        Color.clear.frame(height: 120)
+                        // Clears the sticky footer (button + the reassurance
+                        // line under it, which the join lane doesn't render).
+                        Color.clear.frame(height: 140)
                     }
                     .padding(.horizontal, MADTheme.Spacing.md)
                     .padding(.top, MADTheme.Spacing.sm)
@@ -115,7 +116,7 @@ struct BuddyStartSheet: View {
                 buddy.errorMessage = nil
             }
             .alert(
-                "Couldn't start",
+                "Couldn't create lobby",
                 isPresented: Binding(
                     get: { errorText != nil },
                     set: { if !$0 { errorText = nil } }
@@ -529,22 +530,31 @@ struct BuddyStartSheet: View {
         }
     }
 
-    /// The candidate list is filtered to friends whose app build actually has
-    /// Buddy Walks — so "nobody here" can mean "none of them have updated",
-    /// which must not be phrased as a problem with their friend list.
+    /// The candidate list is filtered to friends whose build has Buddy Walks and
+    /// who haven't opted out — so "nobody here" can mean "none of them have
+    /// updated", which must never be phrased as a problem with their friend
+    /// list.
+    ///
+    /// It must also not be a dead end. The old copy mentioned the share code in
+    /// passing, at the bottom, in the dimmest text on the card — so the one
+    /// thing you CAN still do read as a consolation prize. Creating the lobby
+    /// anyway and sending the code is a completely normal path (it's how you
+    /// walk with someone who hasn't updated), so it's stated as the next step.
     private var emptyFriendsCard: some View {
         VStack(spacing: MADTheme.Spacing.sm) {
-            Image(systemName: "person.2.slash")
+            Image(systemName: "qrcode")
                 .font(.system(size: 26, weight: .semibold))
-                .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.4))
-            Text("No friends set up for buddy walks yet")
+                .foregroundStyle(accent)
+            Text("Nobody to invite from here yet")
                 .font(MADTheme.Typography.smallBold)
                 .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.85))
                 .multilineTextAlignment(.center)
-            Text("They'll appear once they update. You can still start one and share the code.")
-                .font(MADTheme.Typography.caption)
-                .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.6))
-                .multilineTextAlignment(.center)
+            Text(
+                "Friends show up once they're on a build with buddy walks. Create the lobby anyway — you'll get a code and a QR to send them."
+            )
+            .font(MADTheme.Typography.caption)
+            .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.6))
+            .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity)
         .padding(MADTheme.Spacing.lg)
@@ -593,10 +603,21 @@ struct BuddyStartSheet: View {
             .frame(height: 28)
             .allowsHitTesting(false)
 
-            primaryButton
-                .padding(.horizontal, MADTheme.Spacing.md)
-                .padding(.bottom, MADTheme.Spacing.sm)
-                .background(MADTheme.Colors.madBlack)
+            VStack(spacing: 6) {
+                primaryButton
+                // The single most important sentence on this screen. Every
+                // earlier label said "start", so tapping it felt like committing
+                // to walking RIGHT NOW — people backed out rather than find out.
+                // Nothing about the flow changed; it always opened a lobby.
+                if lane == .start {
+                    Text("Nobody moves until you start it.")
+                        .font(MADTheme.Typography.caption)
+                        .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.5))
+                }
+            }
+            .padding(.horizontal, MADTheme.Spacing.md)
+            .padding(.bottom, MADTheme.Spacing.sm)
+            .background(MADTheme.Colors.madBlack)
         }
     }
 
@@ -630,16 +651,21 @@ struct BuddyStartSheet: View {
         return isCreating
     }
 
-    /// Never mentions the share code. The old label — "Start with a share
-    /// code" — read as an INPUT ("start by entering a code") and sat directly
-    /// above the join button, which genuinely does take a code. The code is a
-    /// consequence of starting, and the header sentence already says so.
+    /// Says CREATE, never START.
+    ///
+    /// This button has always opened a lobby — the walk doesn't begin until the
+    /// host taps Start in there — but every label it has worn said "start", so
+    /// the screen promised something it didn't do. "Create lobby" describes the
+    /// actual outcome, and the caption under the button closes the gap.
+    ///
+    /// It also never mentions the share code: an earlier label ("Start with a
+    /// share code") read as an INPUT and sat directly above the join field,
+    /// which genuinely does take one. The code is a consequence of creating.
     private var primaryTitle: String {
         if lane == .join { return isJoining ? "Joining…" : "Join walk" }
-        if isCreating { return "Starting…" }
-        let noun = isRun ? "run" : "walk"
-        if selected.isEmpty { return "Start \(noun)" }
-        return selected.count == 1 ? "Invite 1 & start" : "Invite \(selected.count) & start"
+        if isCreating { return "Creating…" }
+        if selected.isEmpty { return "Create lobby" }
+        return selected.count == 1 ? "Create & invite 1" : "Create & invite \(selected.count)"
     }
 
     // MARK: - Helpers
@@ -684,7 +710,7 @@ struct BuddyStartSheet: View {
         } catch {
             MADHaptics.error()
             errorText =
-                (error as? LocalizedError)?.errorDescription ?? "Couldn't create the buddy walk."
+                (error as? LocalizedError)?.errorDescription ?? "Couldn't create the lobby."
         }
     }
 

--- a/app/Mile A Day/Views/NotificationSettingsView.swift
+++ b/app/Mile A Day/Views/NotificationSettingsView.swift
@@ -164,6 +164,9 @@ struct NotificationSettingsView: View {
                         settingsToggle("Friend request accepted", isOn: $prefs.friendRequestAcceptedEnabled)
                         settingsDivider
                         settingsToggle("Friend nudges", isOn: $prefs.friendNudgeEnabled)
+                        settingsDivider
+                        settingsToggle("Buddy walks & runs", isOn: $prefs.buddyInvitesEnabled,
+                            description: "Friends can invite you to walk or run together. Turn off to stop the invites and drop out of their picker")
                     }
 
                     // Privacy — the coarse gate. Sits above the sharing toggles
@@ -557,6 +560,10 @@ struct NotificationSettingsView: View {
                     // a local-only flag could never actually silence it.
                     "friend_request_reminder_enabled": prefs.friendRequestReminderEnabled,
                     "workout_visibility": prefs.workoutVisibility.rawValue,
+                    // Must reach the server: this doesn't only mute a push, it
+                    // decides whether you appear in friends' buddy pickers at
+                    // all — which is a SQL query, not a client decision.
+                    "buddy_invites_enabled": prefs.buddyInvitesEnabled,
                 ]
                 _ = try await friendService.updateNotificationSettings(backendSettings)
                 // The profile grid is server-built, so it can't notice this on
@@ -602,6 +609,14 @@ struct NotificationSettingsView: View {
             }
             if let taggedOnProfile, prefs.taggedPostsOnProfile != taggedOnProfile {
                 prefs.taggedPostsOnProfile = taggedOnProfile
+                changed = true
+            }
+            // Same reason as the two above: this one gates a SQL query (who
+            // shows up in a friend's buddy picker), so the server's value wins
+            // over whatever this install last wrote.
+            if let buddyInvites = settings.buddy_invites_enabled,
+                prefs.buddyInvitesEnabled != buddyInvites {
+                prefs.buddyInvitesEnabled = buddyInvites
                 changed = true
             }
             // Keep the local copy honest too, so a later Save of some unrelated

--- a/backend/scripts/buddy-gate-check.mjs
+++ b/backend/scripts/buddy-gate-check.mjs
@@ -1,0 +1,331 @@
+/**
+ * Buddy Walks gate + lobby-edit check.
+ *
+ * The feature shipped fully built and then sat dead in production for weeks
+ * because `BUDDY_SESSIONS` was never set, and nothing anywhere failed loudly —
+ * every endpoint just 404'd, which the client renders as "We couldn't find that
+ * buddy walk". These assertions exist so that class of silence can't come back.
+ *
+ * Covers, against a real migrated database:
+ *   1. the kill switch's DIRECTION (on unless explicitly "false")
+ *   2. enrollment riding POST /devices/register, so it can't be missed
+ *   3. the opt-out actually removing you from pickers — including the
+ *      no-settings-row case, which must read as opted IN
+ *   4. the new host-only lobby PATCH and its three guards
+ *
+ * Usage (same env as ci-smoke):
+ *   DATABASE_URL=... node scripts/buddy-gate-check.mjs
+ */
+import { PostgresService } from "../dist/services/DbService.js";
+import { buddySessionsEnabled } from "../dist/services/buddyFeatures.js";
+import { registerDevice } from "../dist/controllers/deviceController.js";
+import {
+  createSession,
+  getInviteCandidates,
+  startSession,
+  updateSession,
+} from "../dist/services/buddySessionService.js";
+
+const db = PostgresService.getInstance();
+
+const HOST = "buddy-check-host";
+const PAL = "buddy-check-pal";
+const OPTED_OUT = "buddy-check-optout";
+const NO_ROW = "buddy-check-norow";
+const ALL = [HOST, PAL, OPTED_OUT, NO_ROW];
+
+let failures = 0;
+function check(label, actual, expected) {
+  const ok = actual === expected;
+  if (!ok) failures++;
+  console.log(
+    `${ok ? "ok  " : "FAIL"}  ${label} → ${actual} (expected ${expected})`,
+  );
+}
+
+/** Run `fn` and return the error CODE it threw, or null if it succeeded. */
+async function errorCode(fn) {
+  try {
+    await fn();
+    return null;
+  } catch (error) {
+    return error?.message ?? String(error);
+  }
+}
+
+/** Minimal Express double — registerDevice only touches these. */
+function fakeRes() {
+  const res = {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      res.statusCode = code;
+      return res;
+    },
+    json(payload) {
+      res.body = payload;
+      return res;
+    },
+  };
+  return res;
+}
+
+async function seed() {
+  for (const id of ALL) {
+    await db.query(
+      `INSERT INTO users (user_id, apple_sub, email, username, first_name, last_name)
+       VALUES ($1, $2, $3, $4, $5, 'Buddy')
+       ON CONFLICT (user_id) DO NOTHING`,
+      [id, `sub-${id}`, `${id}@example.com`, id, id],
+    );
+  }
+  // Everyone is HOST's friend. Friendship rows are directional here.
+  for (const id of [PAL, OPTED_OUT, NO_ROW]) {
+    for (const [a, b] of [
+      [HOST, id],
+      [id, HOST],
+    ]) {
+      await db.query(
+        `INSERT INTO friendships (user_id, friend_id, status) VALUES ($1, $2, 'accepted')
+         ON CONFLICT (user_id, friend_id) DO NOTHING`,
+        [a, b],
+      );
+    }
+  }
+  // Enrol everyone EXCEPT the one we use to prove registration does the work.
+  await db.query(
+    `UPDATE users SET buddy_enrolled_at = NOW() WHERE user_id = ANY($1::text[])`,
+    [[HOST, OPTED_OUT, NO_ROW]],
+  );
+
+  // OPTED_OUT has a settings row saying no. NO_ROW deliberately has NO row at
+  // all — the case a plain join would silently hide.
+  await db.query(
+    `INSERT INTO notification_settings (user_id, buddy_invites_enabled)
+     VALUES ($1, FALSE)
+     ON CONFLICT (user_id) DO UPDATE SET buddy_invites_enabled = FALSE`,
+    [OPTED_OUT],
+  );
+  await db.query(`DELETE FROM notification_settings WHERE user_id = $1`, [
+    NO_ROW,
+  ]);
+}
+
+async function cleanup() {
+  await db.query(
+    `DELETE FROM buddy_session_participants WHERE user_id = ANY($1::text[])`,
+    [ALL],
+  );
+  await db.query(
+    `DELETE FROM buddy_sessions WHERE host_user_id = ANY($1::text[])`,
+    [ALL],
+  );
+  await db.query(`DELETE FROM device_tokens WHERE user_id = ANY($1::text[])`, [
+    ALL,
+  ]);
+  // The invite path writes an inbox row even with no device token registered,
+  // and that row holds a FK on users — so it has to go before the users do.
+  await db.query(
+    `DELETE FROM in_app_notifications WHERE user_id = ANY($1::text[])`,
+    [ALL],
+  );
+  await db.query(
+    `DELETE FROM notification_settings WHERE user_id = ANY($1::text[])`,
+    [ALL],
+  );
+  await db.query(
+    `DELETE FROM friendships WHERE user_id = ANY($1::text[]) OR friend_id = ANY($1::text[])`,
+    [ALL],
+  );
+  await db.query(`DELETE FROM users WHERE user_id = ANY($1::text[])`, [ALL]);
+}
+
+async function main() {
+  await cleanup();
+  await seed();
+
+  // ── 1. The kill switch's direction ──────────────────────────────────
+  //
+  // This is THE regression. Unset must mean ON: the old default (`=== "true"`)
+  // meant an unconfigured environment served 404s from every buddy endpoint
+  // with nothing in the logs.
+  const savedFlag = process.env.BUDDY_SESSIONS;
+  delete process.env.BUDDY_SESSIONS;
+  check("unset → feature is ON", buddySessionsEnabled(), true);
+  process.env.BUDDY_SESSIONS = "false";
+  check('"false" → feature is OFF', buddySessionsEnabled(), false);
+  process.env.BUDDY_SESSIONS = "true";
+  check('"true" → feature is ON', buddySessionsEnabled(), true);
+  if (savedFlag === undefined) delete process.env.BUDDY_SESSIONS;
+  else process.env.BUDDY_SESSIONS = savedFlag;
+
+  // ── 2. Enrollment rides device registration ─────────────────────────
+  //
+  // PAL was left unenrolled by seed(). Registering a device that DECLARES the
+  // capability must enroll them; one that doesn't must leave them alone.
+  await registerDevice(
+    {
+      userId: PAL,
+      body: {
+        device_token: "buddy-check-token-pal",
+        environment: "sandbox",
+        client_features: ["buddy_walks_v1"],
+      },
+    },
+    fakeRes(),
+  );
+  const [palRow] = await db.query(
+    `SELECT (buddy_enrolled_at IS NOT NULL) AS enrolled FROM users WHERE user_id = $1`,
+    [PAL],
+  );
+  check("declaring buddy_walks_v1 enrolls", palRow?.enrolled, true);
+
+  await db.query(
+    `UPDATE users SET buddy_enrolled_at = NULL WHERE user_id = $1`,
+    [PAL],
+  );
+  await registerDevice(
+    {
+      userId: PAL,
+      body: {
+        device_token: "buddy-check-token-old",
+        environment: "sandbox",
+        client_features: ["friend_request_v2"],
+      },
+    },
+    fakeRes(),
+  );
+  const [oldBuild] = await db.query(
+    `SELECT (buddy_enrolled_at IS NOT NULL) AS enrolled FROM users WHERE user_id = $1`,
+    [PAL],
+  );
+  check(
+    "a build without the string stays unenrolled",
+    oldBuild?.enrolled,
+    false,
+  );
+
+  // Put PAL back for the rest of the run.
+  await db.query(
+    `UPDATE users SET buddy_enrolled_at = NOW() WHERE user_id = $1`,
+    [PAL],
+  );
+
+  // ── 3. The opt-out, and the no-settings-row default ─────────────────
+  const candidates = await getInviteCandidates(HOST);
+  const ids = new Set(candidates.map((c) => c.user_id));
+  check("an enrolled friend is offered", ids.has(PAL), true);
+  check("an opted-out friend is NOT offered", ids.has(OPTED_OUT), false);
+  // The COALESCE case: notification_settings is created lazily on first write,
+  // so most users have no row. A plain join would hide every one of them.
+  check("a friend with no settings row IS offered", ids.has(NO_ROW), true);
+
+  // The picker isn't the only door — an id can be posted directly.
+  const session = await createSession(HOST, {
+    mode: "together",
+    activityType: "walking",
+    inviteUserIds: [PAL, OPTED_OUT],
+    origin: "invite",
+  });
+  const invited = await db.query(
+    `SELECT user_id FROM buddy_session_participants
+      WHERE session_id = $1 AND status = 'invited'`,
+    [session.id],
+  );
+  const invitedIds = new Set(invited.map((r) => r.user_id));
+  check(
+    "a posted invite reaches an opted-in friend",
+    invitedIds.has(PAL),
+    true,
+  );
+  check(
+    "a posted invite is dropped for an opted-out friend",
+    invitedIds.has(OPTED_OUT),
+    false,
+  );
+
+  // ── 4. The lobby PATCH ──────────────────────────────────────────────
+  const edited = await updateSession(session.id, HOST, {
+    mode: "coop_goal",
+    goalValue: 3,
+    activityType: "running",
+  });
+  check("host can change the mode", edited.mode, "coop_goal");
+  // Snake_case: `toState` emits the wire shape the iOS client decodes, not the
+  // camelCase the PATCH input uses.
+  check("host can change the goal", Number(edited.goal_value), 3);
+  check("host can change walk→run", edited.activity_type, "running");
+
+  // Switching to a scored mode with no goal is a 400, not a silent NULL that
+  // would leave a coop session nobody can complete.
+  check(
+    "a scored mode with no goal is rejected",
+    await errorCode(() =>
+      updateSession(session.id, HOST, { mode: "race_goal", goalValue: null }),
+    ),
+    "goal_required",
+  );
+
+  // Absent leaves the schedule alone; explicit null clears it.
+  await updateSession(session.id, HOST, {
+    scheduledStartAt: new Date(Date.now() + 3600_000).toISOString(),
+  });
+  await updateSession(session.id, HOST, { goalValue: 4 });
+  const [stillBooked] = await db.query(
+    `SELECT (scheduled_start_at IS NOT NULL) AS booked FROM buddy_sessions WHERE id = $1`,
+    [session.id],
+  );
+  check("an absent schedule is left untouched", stillBooked?.booked, true);
+
+  await updateSession(session.id, HOST, { scheduledStartAt: null });
+  const [cleared] = await db.query(
+    `SELECT (scheduled_start_at IS NULL) AS cleared FROM buddy_sessions WHERE id = $1`,
+    [session.id],
+  );
+  check("an explicit null clears the schedule", cleared?.cleared, true);
+
+  // A participant is not a host.
+  check(
+    "a non-host cannot edit",
+    await errorCode(() => updateSession(session.id, PAL, { goalValue: 9 })),
+    "not_host",
+  );
+
+  // Adding people from the lobby goes through the same eligibility rules.
+  await updateSession(session.id, HOST, { inviteUserIds: [NO_ROW, OPTED_OUT] });
+  const after = await db.query(
+    `SELECT user_id FROM buddy_session_participants WHERE session_id = $1`,
+    [session.id],
+  );
+  const afterIds = new Set(after.map((r) => r.user_id));
+  check("lobby invite adds an eligible friend", afterIds.has(NO_ROW), true);
+  check(
+    "lobby invite still drops an opted-out friend",
+    afterIds.has(OPTED_OUT),
+    false,
+  );
+
+  // Once it starts, the plan is frozen — changing the mode mid-walk would
+  // rescore distance people have already covered.
+  await startSession(session.id, HOST);
+  check(
+    "an active session can no longer be edited",
+    await errorCode(() => updateSession(session.id, HOST, { goalValue: 5 })),
+    "session_not_editable",
+  );
+
+  await cleanup();
+
+  console.log(
+    failures === 0
+      ? "buddy-gate-check: all assertions passed"
+      : `buddy-gate-check: ${failures} FAILED`,
+  );
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await cleanup().catch(() => {});
+  process.exit(1);
+});

--- a/backend/src/controllers/buddyController.ts
+++ b/backend/src/controllers/buddyController.ts
@@ -25,6 +25,7 @@ import {
   recordProgress,
   setReady,
   startSession,
+  updateSession,
 } from "../services/buddySessionService.js";
 
 /**
@@ -55,6 +56,33 @@ function handleError(res: Response, error: unknown, logLabel: string): void {
   }
   console.error(`Error ${logLabel}:`, error);
   res.status(500).json({ error: `Error ${logLabel}` });
+}
+
+/** Sentinel for "the client sent a scheduled start we won't accept". */
+const INVALID_SCHEDULE = Symbol("invalid_scheduled_start");
+
+/**
+ * Validate an optional scheduled-start timestamp.
+ *
+ * A scheduled walk has to be far enough out to be worth scheduling and near
+ * enough to still be real — rejecting here keeps a typo'd year from parking a
+ * lobby in the table forever.
+ *
+ * Returns `undefined` for absent (leave alone) and `null` for an explicit clear
+ * — the lobby needs to tell those apart, since "don't touch my schedule" and
+ * "cancel my schedule" are different requests. A rejection comes back as the
+ * sentinel rather than a throw so both callers map it to the same 400.
+ */
+function parseScheduledStart(
+  raw: unknown,
+): string | null | undefined | typeof INVALID_SCHEDULE {
+  if (raw === undefined) return undefined;
+  if (raw === null) return null;
+  const when = new Date(String(raw));
+  if (Number.isNaN(when.getTime())) return INVALID_SCHEDULE;
+  const minutesOut = (when.getTime() - Date.now()) / 60000;
+  if (minutesOut < 2 || minutesOut > 60 * 24 * 14) return INVALID_SCHEDULE;
+  return when.toISOString();
 }
 
 export async function enrollController(
@@ -123,20 +151,9 @@ export async function createSessionController(
       return res.status(400).json({ error: "invalid_origin" });
     }
 
-    // A scheduled walk has to be far enough out to be worth scheduling and
-    // near enough to still be real. Rejecting here keeps a typo'd year from
-    // parking a lobby in the table forever.
-    let scheduled: string | null = null;
-    if (scheduledStartAt !== undefined && scheduledStartAt !== null) {
-      const when = new Date(String(scheduledStartAt));
-      if (Number.isNaN(when.getTime())) {
-        return res.status(400).json({ error: "invalid_scheduled_start" });
-      }
-      const minutesOut = (when.getTime() - Date.now()) / 60000;
-      if (minutesOut < 2 || minutesOut > 60 * 24 * 14) {
-        return res.status(400).json({ error: "invalid_scheduled_start" });
-      }
-      scheduled = when.toISOString();
+    const scheduled = parseScheduledStart(scheduledStartAt);
+    if (scheduled === INVALID_SCHEDULE) {
+      return res.status(400).json({ error: "invalid_scheduled_start" });
     }
 
     const state = await createSession(req.userId!, {
@@ -150,6 +167,59 @@ export async function createSessionController(
     res.status(201).json(state);
   } catch (error) {
     handleError(res, error, "creating buddy session");
+  }
+}
+
+/**
+ * PATCH /buddy/sessions/:sessionId — host edits the lobby before it starts.
+ *
+ * Every enum is whitelisted before it reaches the service for the same reason
+ * `createSessionController` does it: an unvalidated value lands on the table's
+ * CHECK constraint and surfaces as a 500 instead of a 400.
+ */
+export async function updateSessionController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  if (!requireEnabled(res)) return;
+  try {
+    const { mode, goalValue, activityType, inviteUserIds } = req.body ?? {};
+
+    if (mode !== undefined && !BUDDY_MODES.includes(mode as BuddyMode)) {
+      return res.status(400).json({ error: "invalid_mode" });
+    }
+    if (
+      activityType !== undefined &&
+      !BUDDY_ACTIVITY_TYPES.includes(activityType as BuddyActivityType)
+    ) {
+      return res.status(400).json({ error: "invalid_activity_type" });
+    }
+    if (inviteUserIds !== undefined && !Array.isArray(inviteUserIds)) {
+      return res.status(400).json({ error: "invalid_invite_list" });
+    }
+
+    const scheduled = parseScheduledStart(req.body?.scheduledStartAt);
+    if (scheduled === INVALID_SCHEDULE) {
+      return res.status(400).json({ error: "invalid_scheduled_start" });
+    }
+
+    const state = await updateSession(req.params.sessionId, req.userId!, {
+      mode: mode as BuddyMode | undefined,
+      // Absent leaves the stored goal alone; an explicit null clears it. Both
+      // matter, so this cannot collapse to `?? null`.
+      goalValue:
+        goalValue === undefined
+          ? undefined
+          : goalValue === null
+            ? null
+            : Number(goalValue),
+      activityType: activityType as BuddyActivityType | undefined,
+      scheduledStartAt: scheduled,
+      inviteUserIds: inviteUserIds as string[] | undefined,
+    });
+    res.json(state);
+  } catch (error) {
+    handleError(res, error, "updating buddy session");
   }
 }
 

--- a/backend/src/controllers/deviceController.ts
+++ b/backend/src/controllers/deviceController.ts
@@ -4,6 +4,11 @@ import {
   registerDeviceToken,
   unregisterDeviceToken,
 } from "../services/pushNotificationService.js";
+import {
+  CLIENT_FEATURES,
+  normalizeClientFeatures,
+} from "../services/clientFeatures.js";
+import { enrollUser } from "../services/buddySessionService.js";
 import hasRequiredKeys from "../utils/hasRequiredKeys.js";
 
 export async function registerDevice(req: AuthenticatedRequest, res: Response) {
@@ -16,6 +21,26 @@ export async function registerDevice(req: AuthenticatedRequest, res: Response) {
       req.body.environment,
       req.body.client_features,
     );
+
+    // Buddy enrollment rides the registration every build already makes,
+    // rather than depending on POST /buddy/enroll landing separately. That
+    // call is best-effort on the client and silent on failure, so when the
+    // feature flag was off its 404 left every user unenrolled — and an
+    // unenrolled user is invisible in their friends' invite pickers, which
+    // reads as "nobody has this feature" rather than as an error.
+    //
+    // Not gated on buddySessionsEnabled: the stamp is just a capability
+    // record, so recording it while the kill switch is down means the switch
+    // can come back up without waiting a launch cycle for everyone to
+    // re-enroll. Idempotent — enrollUser keeps the first timestamp.
+    if (
+      normalizeClientFeatures(req.body.client_features).includes(
+        CLIENT_FEATURES.buddyWalksV1,
+      )
+    ) {
+      await enrollUser(req.userId!);
+    }
+
     res.status(200).json({ message: "Device registered" });
   } catch (error: any) {
     console.error("Error registering device:", error.message);

--- a/backend/src/routes/buddyRoutes.ts
+++ b/backend/src/routes/buddyRoutes.ts
@@ -15,6 +15,7 @@ import {
   recapController,
   sessionStateController,
   startSessionController,
+  updateSessionController,
 } from "../controllers/buddyController.js";
 
 const router = Router();
@@ -44,6 +45,9 @@ router.post("/sessions/:sessionId/decline", declineSessionController);
 router.post("/sessions/:sessionId/leave", leaveSessionController);
 router.post("/sessions/:sessionId/ready", readyController);
 router.post("/sessions/:sessionId/start", startSessionController);
+// Host-only, lobby-only: change mode/goal/activity/schedule or add invitees
+// after the room exists, so a change of plan doesn't mean a new join code.
+router.patch("/sessions/:sessionId", updateSessionController);
 router.post("/sessions/:sessionId/progress", progressController);
 router.post("/sessions/:sessionId/finish", finishController);
 

--- a/backend/src/services/buddyFeatures.ts
+++ b/backend/src/services/buddyFeatures.ts
@@ -1,20 +1,26 @@
 /**
- * Rollout gate for Buddy Walks & Runs.
+ * Kill switch for Buddy Walks & Runs.
  *
- * Defaults to OFF (opt-in), matching friendRequestFeatures.ts rather than the
- * STREAK_FEATURES_DISABLED kill switch. That direction is deliberate: the
- * server deploys well ahead of an App Store release, and a live buddy session
- * is meaningless to a client that has no buddy UI to render it in.
+ * Defaults to ON. Set `BUDDY_SESSIONS=false` to take the whole feature down
+ * without a deploy; anything else (including unset) leaves it up.
  *
- * MUST stay off until the app build carrying the Buddy Walks screens is
- * shipped. There is a second, finer gate underneath this one —
- * `users.buddy_enrolled_at`, stamped only by POST /buddy/enroll, which only the
- * new build calls — so that even after this flag flips, an invite can never be
- * routed to a user still on an older install. This flag controls whether the
- * feature exists at all; the enrollment stamp controls who can be pulled into
- * it. Both are required: flipping this alone would let an enrolled user invite
- * a friend who would receive a push for a screen they do not have.
+ * This used to default to OFF, as an opt-in staging gate while the app build
+ * carrying the Buddy Walks screens worked its way through review. That cost the
+ * feature weeks of being silently dead in production: with the flag unset,
+ * every buddy endpoint 404s (see `requireEnabled` in buddyController), and the
+ * client renders a 404 as "We couldn't find that buddy walk" — including the
+ * 404 from POST /buddy/enroll, which meant nobody was ever enrolled, so every
+ * invite picker was also empty. One unset variable, three unrelated-looking
+ * bugs, no error anywhere.
+ *
+ * Defaulting ON is safe because this flag was never the thing protecting older
+ * installs — the per-user capability gate is. A build without the buddy screens
+ * does not declare `buddy_walks_v1` at POST /devices/register, so it never gets
+ * `users.buddy_enrolled_at` stamped, and an unstamped user is never offered as
+ * an invite candidate and never sent a buddy push. That gate holds regardless
+ * of this flag. All this one decides is whether the endpoints exist at all,
+ * which is exactly what a kill switch should decide.
  */
 export function buddySessionsEnabled(): boolean {
-  return process.env.BUDDY_SESSIONS === "true";
+  return process.env.BUDDY_SESSIONS !== "false";
 }

--- a/backend/src/services/buddySessionService.ts
+++ b/backend/src/services/buddySessionService.ts
@@ -264,30 +264,34 @@ export interface CreateSessionInput {
   scheduledStartAt?: string | null;
 }
 
+/**
+ * A goal is required for every mode except 'together', which is goal-less by
+ * definition, and the ceiling depends on the unit (minutes vs miles).
+ *
+ * Lives here rather than inline in createSession because the lobby can now
+ * change the mode after the fact: switching 'together' → 'race_goal' has to
+ * demand a goal on the way through, and switching back has to drop it. Two
+ * copies of that rule would let the lobby write a state create would reject.
+ */
+function validateGoal(mode: BuddyMode, raw: number | null): number | null {
+  if (mode === "together") return null;
+  if (raw === null || !(raw > 0)) throw new BadRequestError("goal_required");
+  if (mode === "race_time" && raw > 24 * 60) {
+    throw new BadRequestError("goal_too_large");
+  }
+  if ((mode === "coop_goal" || mode === "race_goal") && raw > 200) {
+    throw new BadRequestError("goal_too_large");
+  }
+  return raw;
+}
+
 export async function createSession(
   hostUserId: string,
   input: CreateSessionInput,
 ): Promise<BuddySessionState> {
   const { mode, activityType } = input;
 
-  // A goal is required for every mode except 'together', which is goal-less by
-  // definition. Validating here keeps the CHECK constraints from having to
-  // encode cross-column rules.
-  const needsGoal = mode !== "together";
-  const goalValue = input.goalValue ?? null;
-  if (needsGoal && (goalValue === null || !(goalValue > 0))) {
-    throw new BadRequestError("goal_required");
-  }
-  if (mode === "race_time" && goalValue !== null && goalValue > 24 * 60) {
-    throw new BadRequestError("goal_too_large");
-  }
-  if (
-    (mode === "coop_goal" || mode === "race_goal") &&
-    goalValue !== null &&
-    goalValue > 200
-  ) {
-    throw new BadRequestError("goal_too_large");
-  }
+  const goalValue = validateGoal(mode, input.goalValue ?? null);
 
   const inviteIds = Array.from(new Set(input.inviteUserIds ?? [])).filter(
     (id) => id !== hostUserId,
@@ -296,20 +300,7 @@ export async function createSession(
     throw new BadRequestError("too_many_participants");
   }
 
-  // Every invitee must be an accepted friend, unblocked in both directions, AND
-  // enrolled (i.e. running a build that has the buddy UI). An unenrolled
-  // invitee would get a push for a screen that does not exist in their app.
-  const eligible: string[] = [];
-  for (const inviteeId of inviteIds) {
-    if (!(await areFriends(hostUserId, inviteeId))) continue;
-    if (await isBlockedEitherWay(hostUserId, inviteeId)) continue;
-    const enrolled = await db.query(
-      `SELECT 1 FROM users WHERE user_id = $1 AND buddy_enrolled_at IS NOT NULL`,
-      [inviteeId],
-    );
-    if (enrolled.length === 0) continue;
-    eligible.push(inviteeId);
-  }
+  const eligible = await eligibleInvitees(hostUserId, inviteIds);
 
   // Retry on join-code collision. The unique index is partial (open sessions
   // only), so the space is tiny in practice and a handful of attempts is plenty.
@@ -584,6 +575,141 @@ export async function startSession(
   const fresh = await getSessionRow(sessionId);
   if (!fresh) throw new BadRequestError("session_not_found");
   return toState(fresh, await loadParticipants(sessionId, fresh.host_user_id));
+}
+
+export interface UpdateSessionInput {
+  mode?: BuddyMode;
+  goalValue?: number | null;
+  activityType?: BuddyActivityType;
+  /** `null` clears the schedule; ABSENT leaves it untouched. */
+  scheduledStartAt?: string | null;
+  /** Additive only. Removing someone is their own leave/decline. */
+  inviteUserIds?: string[];
+}
+
+/**
+ * Change a lobby's settings, or pull more people into it.
+ *
+ * The host's mind changes between "let's walk" and "everyone's here", and until
+ * now the only way to act on that was to abandon the room and rebuild it —
+ * which also invalidated the code they'd already shared. This is the endpoint
+ * that makes the lobby a real waiting room rather than a receipt.
+ *
+ * Three guards, in order:
+ *  - host only, because everyone else is looking at these settings;
+ *  - lobby only, because changing the mode mid-walk would silently rescore
+ *    distance people have already covered;
+ *  - and, critically, `WHERE status = 'lobby'` on the UPDATE itself. The status
+ *    check above it is a nicety for the error message; THIS is what makes an
+ *    edit racing a scheduled promotion lose cleanly. `activateSession` uses the
+ *    same guard for the same reason.
+ *
+ * Goal and mode are validated together through `validateGoal`, so switching to
+ * a scored mode demands a goal in the same request and switching back to
+ * 'together' drops it — the lobby can never write a state create would reject.
+ */
+export async function updateSession(
+  sessionId: string,
+  userId: string,
+  patch: UpdateSessionInput,
+): Promise<BuddySessionState> {
+  const session = await getSessionRow(sessionId);
+  if (!session) throw new BadRequestError("session_not_found");
+  if (session.host_user_id !== userId) throw new BadRequestError("not_host");
+  if (session.status !== "lobby") {
+    throw new BadRequestError("session_not_editable");
+  }
+
+  const mode = patch.mode ?? (session.mode as BuddyMode);
+  // The goal follows the mode it's being validated against: an unchanged mode
+  // keeps the stored goal unless the patch names a new one.
+  const rawGoal =
+    patch.goalValue !== undefined
+      ? patch.goalValue
+      : patch.mode !== undefined && patch.mode !== session.mode
+        ? null
+        : (session.goal_value ?? null);
+  const goalValue = validateGoal(
+    mode,
+    rawGoal === null ? null : Number(rawGoal),
+  );
+  const activityType =
+    patch.activityType ?? (session.activity_type as BuddyActivityType);
+
+  const changed = await db.query<{ id: string }>(
+    `UPDATE buddy_sessions
+        SET mode = $2,
+            goal_value = $3,
+            activity_type = $4,
+            scheduled_start_at = CASE WHEN $5 THEN $6::timestamptz
+                                      ELSE scheduled_start_at END,
+            state_version = state_version + 1
+      WHERE id = $1 AND status = 'lobby'
+      RETURNING id`,
+    [
+      sessionId,
+      mode,
+      goalValue,
+      activityType,
+      patch.scheduledStartAt !== undefined,
+      patch.scheduledStartAt ?? null,
+    ],
+  );
+  // Lost the race to a start that landed first. Report it as the state the
+  // caller will now see rather than as a failure to write.
+  if (changed.length === 0) throw new BadRequestError("session_not_editable");
+
+  if (patch.inviteUserIds?.length) {
+    await addInvitees(sessionId, userId, patch.inviteUserIds);
+  }
+
+  await recordEvent(sessionId, userId, "updated", { mode, goalValue });
+
+  const fresh = await getSessionRow(sessionId);
+  if (!fresh) throw new BadRequestError("session_not_found");
+  return toState(fresh, await loadParticipants(sessionId, fresh.host_user_id));
+}
+
+/**
+ * Add people to a lobby that already exists.
+ *
+ * Reuses `eligibleInvitees` and `notifyInvitees` rather than re-deriving who
+ * may be invited — the create path's rules ARE the rules. The participant
+ * insert is `ON CONFLICT DO NOTHING`, so re-inviting someone who already
+ * joined, declined or left is a no-op and never resurrects them or re-pushes.
+ */
+async function addInvitees(
+  sessionId: string,
+  hostUserId: string,
+  requested: string[],
+): Promise<void> {
+  const existing = await db.query<{ user_id: string }>(
+    `SELECT user_id FROM buddy_session_participants WHERE session_id = $1`,
+    [sessionId],
+  );
+  const already = new Set(existing.map((row) => row.user_id));
+
+  const wanted = Array.from(new Set(requested)).filter(
+    (id) => !already.has(id),
+  );
+  if (wanted.length === 0) return;
+  if (already.size + wanted.length > BUDDY_MAX_PARTICIPANTS) {
+    throw new BadRequestError("too_many_participants");
+  }
+
+  const eligible = await eligibleInvitees(hostUserId, wanted);
+  if (eligible.length === 0) return;
+
+  for (const inviteeId of eligible) {
+    await db.query(
+      `INSERT INTO buddy_session_participants
+         (session_id, user_id, status, invited_by)
+       VALUES ($1, $2, 'invited', $3)
+       ON CONFLICT (session_id, user_id) DO NOTHING`,
+      [sessionId, inviteeId, hostUserId],
+    );
+  }
+  void notifyInvitees(sessionId, hostUserId, eligible);
 }
 
 /**
@@ -1083,7 +1209,65 @@ export async function reconcileBuddySessions(
 
 // ─── Discovery helpers ──────────────────────────────────────────────────
 
-/** Friends eligible to be invited: accepted, unblocked both ways, enrolled. */
+/**
+ * "This user is willing to be pulled into a buddy walk", as a SQL predicate.
+ *
+ * Everyone is opted IN by default, so the absence of a settings row must read
+ * as yes — `notification_settings` is created lazily on first write, and most
+ * users have never opened that screen. A plain join would silently hide every
+ * one of them.
+ *
+ * Note this is the PREFERENCE, not the capability. `buddy_enrolled_at` answers
+ * "can their app render this"; this answers "do they want it". Both are
+ * required, and only this one belongs to the user.
+ */
+function buddyOptedInSql(userColumn: string): string {
+  return `COALESCE(
+    (SELECT ns.buddy_invites_enabled FROM notification_settings ns
+      WHERE ns.user_id = ${userColumn}),
+    TRUE
+  )`;
+}
+
+/**
+ * Filter a client-supplied invite list down to who may actually be invited.
+ *
+ * Every id here is client-asserted, so this re-checks the same four rules the
+ * picker used rather than trusting that the list came from it: accepted
+ * friendship, no block either way, a build that can render the invite, and the
+ * invitee's own preference. Ineligible ids are dropped silently — telling a
+ * host which of their friends opted out would leak a preference that isn't
+ * theirs to see.
+ *
+ * Shared by createSession and the lobby's add-invitees path so the two cannot
+ * drift; a second copy of these rules is exactly how a gate gets half-applied.
+ */
+async function eligibleInvitees(
+  hostUserId: string,
+  inviteIds: string[],
+): Promise<string[]> {
+  const eligible: string[] = [];
+  for (const inviteeId of inviteIds) {
+    if (inviteeId === hostUserId) continue;
+    if (!(await areFriends(hostUserId, inviteeId))) continue;
+    if (await isBlockedEitherWay(hostUserId, inviteeId)) continue;
+    const ok = await db.query(
+      `SELECT 1 FROM users u
+        WHERE u.user_id = $1
+          AND u.buddy_enrolled_at IS NOT NULL
+          AND ${buddyOptedInSql("u.user_id")}`,
+      [inviteeId],
+    );
+    if (ok.length === 0) continue;
+    eligible.push(inviteeId);
+  }
+  return eligible;
+}
+
+/**
+ * Friends eligible to be invited: accepted, unblocked both ways, on a build
+ * that has the buddy screens, and not opted out.
+ */
 export async function getInviteCandidates(userId: string): Promise<
   Array<{
     user_id: string;
@@ -1102,6 +1286,7 @@ export async function getInviteCandidates(userId: string): Promise<
       WHERE f.user_id = $1
         AND f.status = 'accepted'
         AND u.buddy_enrolled_at IS NOT NULL
+        AND ${buddyOptedInSql("u.user_id")}
         AND NOT EXISTS (
           SELECT 1 FROM user_blocks b
            WHERE (b.blocker_id = $1 AND b.blocked_id = u.user_id)

--- a/backend/src/services/clientFeatures.ts
+++ b/backend/src/services/clientFeatures.ts
@@ -73,6 +73,21 @@ export const CLIENT_FEATURES = {
    * direction for a rule that exists to shape a habit, not to protect data.
    */
   postWindowV1: "post_window_v1",
+
+  /**
+   * The build has the Buddy Walks & Runs screens — it can render a lobby, a
+   * live roster and a recap, and it registers the BUDDY_INVITE category.
+   *
+   * This is the capability half of the buddy gate, and it carries more weight
+   * than the others: declaring it is what stamps `users.buddy_enrolled_at` at
+   * registration, and an enrolled user is offered to friends as someone they
+   * can pull into a walk. A build without these screens must never be offered,
+   * because the invite push would open nothing.
+   *
+   * That makes this the only safeguard once BUDDY_SESSIONS defaults on — do not
+   * send this string from a build that does not actually render the lobby.
+   */
+  buddyWalksV1: "buddy_walks_v1",
 } as const;
 
 export type ClientFeature =

--- a/backend/src/types/buddy.ts
+++ b/backend/src/types/buddy.ts
@@ -172,6 +172,8 @@ export interface BuddySessionState {
 
 export type BuddyEventKind =
   | "created"
+  /** Host changed the lobby's mode/goal/activity/schedule before starting. */
+  | "updated"
   | "joined"
   | "left"
   | "declined"


### PR DESCRIPTION
## The bug

Buddy Walks has been merged and shipped for weeks and **has never once run**. Every reported symptom traces to one line:

```ts
// backend/src/services/buddyFeatures.ts:19  (before)
return process.env.BUDDY_SESSIONS === "true";   // unset → false
```

`BUDDY_SESSIONS` was never set on the server, and `requireEnabled` (`buddyController.ts:38-44`) answers `404 {error:"not_found"}` from **every** buddy endpoint when it's off. `BuddySessionService.swift:509` maps any 404 to `session_not_found` — whose user-facing string is *"We couldn't find that buddy walk."*

One unset variable, three unrelated-looking bugs, nothing in the logs:

| Symptom | Cause |
|---|---|
| "No friends set up for buddy walks" | `POST /buddy/enroll` 404s every launch → `buddy_enrolled_at` stays NULL for everyone → `getInviteCandidates` filters on it and returns `[]` |
| "no one else has this feature" | same empty list |
| "We couldn't find that buddy walk" on Start | `POST /buddy/sessions` 404s |

Being on a dev build was never relevant.

## Changes

**Flag becomes a kill switch** — on unless explicitly `BUDDY_SESSIONS=false`. It was never what protected older installs; the per-user capability stamp is, and that holds regardless of this flag.

**Enrollment moves onto `POST /devices/register`** behind a new `buddy_walks_v1` capability string, so it rides the call every build already makes instead of a separate one that failed silently. A build without the buddy screens doesn't declare it, stays unenrolled, and is never offered or pushed — that's what makes defaulting the flag on safe for App Store users.

**Opt-out is now real.** `notification_settings.buddy_invites_enabled` already existed and already defaulted `true`, so everyone was opted in — it just had no UI and only muted the push. It now also removes you from friends' pickers, and has a Settings row. Absent settings rows read as opted **in** via `COALESCE(..., TRUE)`; the table is created lazily on first write, so a plain join would have hidden most of the user base.

**Lobby-first copy.** The flow already went sheet → lobby → tracker — nobody ever reached it. The copy promised otherwise, so "Invite 2 & start" → "Create & invite 2", with *"Nobody moves until you start it."* under the button. The empty-invite state now leads with the share code instead of burying it as a footnote.

**`PATCH /buddy/sessions/:id`** — the host can change mode, goal, walk/run and the scheduled time, and add invitees, without abandoning a room whose code they've already shared. Host-only, lobby-only, and `WHERE status = 'lobby'` on the UPDATE itself so an edit racing a scheduled promotion loses cleanly (same guard `activateSession` uses). Mode and goal validate together through a shared `validateGoal`, so the lobby can't write a state `createSession` would reject.

**Lobby presence** reads off the avatars — ringed and bright once someone's in, dimmed while the invite is outstanding — instead of a column of identical grey pills. Participant rows drop `.madLiquidGlass` for a flat fill, the same fix `BuddyStartSheet` already made for the same sluggishness.

## Verification

Against a real migrated Postgres 16:

- `tsc` clean · `drizzle-kit check` "Everything's fine" · migrator applied then idempotent (`appliedNow: []`)
- `ci-smoke`, `ghost-race-check`, and the new **`buddy-gate-check` (20 assertions)** all passing

`scripts/buddy-gate-check.mjs` is wired into CI and pins exactly what went wrong: the flag's *direction*, registration-time enrollment (and that a build without the string stays unenrolled), the opt-out including the no-settings-row default, and the three PATCH guards.

**No migration** — both columns already existed; only their reach changed.

## Notes

- **iOS is not compile-verified here** (no Swift toolchain). One new file — `BuddyLobbySettingsSheet.swift` — plus edits to `BuddyLobbyView`, `BuddyStartSheet`, `BuddySessionService`, `NotificationPreferences`, `Competition` and `NotificationSettingsView`. Build errors expected; send them and they'll be swept.
- The `buddy_walks_v1` pair (`clientFeatures.ts` + `ClientFeatures.swift`) **must land together** — if the Swift half is dropped, nobody enrolls and the original bug persists unchanged.
- App Review 4.5.4: buddy invites are friend-initiated social pushes with a working per-user control, which this PR adds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxEp1wW88Y5PxyTxgAoE3L)_