### PR TITLE
Buddy lobby: show the people, hide the QR, cut the setup taps

### DIFF
--- a/app/Mile A Day/Services/BuddySessionService.swift
+++ b/app/Mile A Day/Services/BuddySessionService.swift
@@ -229,7 +229,11 @@ final class BuddySessionService: ObservableObject {
                 "/buddy/candidates", responseType: BuddyCandidatesResponse.self
             ).candidates
         } catch {
-            candidates = []
+            // Deliberately KEEPS whatever we already had. This list is
+            // prefetched on the dashboard so the start sheet opens populated;
+            // blanking it on a transient blip would turn a warm sheet into the
+            // "No friends set up for buddy walks" empty state, which is the
+            // exact message that made a working feature look broken.
             print("[BuddySessionService] loadCandidates failed: \(error)")
         }
     }

--- a/app/Mile A Day/Views/BuddyWalks/BuddyFlowModifier.swift
+++ b/app/Mile A Day/Views/BuddyWalks/BuddyFlowModifier.swift
@@ -88,12 +88,26 @@ struct BuddyFlowModifier: ViewModifier {
                 // Walks UI, which is what makes the user eligible to be invited
                 // at all. Idempotent, so it's safe on every appearance.
                 await BuddySessionService.shared.enrollIfNeeded()
-                await BuddySessionService.shared.refreshMySessions()
+
+                // Everything after enrollment is INDEPENDENT, so it runs
+                // concurrently rather than in a chain. Serially this was four
+                // round trips deep before the dashboard settled, and the
+                // candidate list — the one the start sheet blocks on — was
+                // last in the queue.
+                //
+                // Warming the candidates HERE is the point: the sheet used to
+                // fetch them in its own `.task`, so opening it showed an empty
+                // "Who's coming?" for a round trip every single time. Prefetched,
+                // it opens populated, which is most of what made setup feel slow.
+                async let sessions: Void = BuddySessionService.shared.refreshMySessions()
                 // "Alex is walking right now" — pulled, never pushed, so this
                 // is the only thing that surfaces the offer. Reads live
                 // presence, so a friend out on their OWN shows up too, not
                 // just friends already inside a buddy room.
-                await BuddySessionService.shared.refreshFriendsOutNow()
+                async let friendsOut: Void = BuddySessionService.shared.refreshFriendsOutNow()
+                async let candidates: Void = BuddySessionService.shared.loadCandidates()
+                async let routines: Void = BuddySessionService.shared.loadRoutines()
+                _ = await (sessions, friendsOut, candidates, routines)
 
                 // The `.onReceive` pair above only fires for values published
                 // AFTER this mounts. On a cold launch the link is already

--- a/app/Mile A Day/Views/BuddyWalks/BuddyLobbyView.swift
+++ b/app/Mile A Day/Views/BuddyWalks/BuddyLobbyView.swift
@@ -21,6 +21,9 @@ struct BuddyLobbyView: View {
     @State private var didCopy = false
     @State private var showGhostSetup = false
     @State private var showSettings = false
+    /// The QR starts hidden. See `inviteCard` — it's essential for ten seconds
+    /// and dead weight after, which is a disclosure, not a hero.
+    @State private var showQR = false
 
     /// Ghost race arming for THIS buddy walk.
     ///
@@ -88,28 +91,146 @@ struct BuddyLobbyView: View {
 
     // MARK: - Lobby
 
+    /// The waiting room.
+    ///
+    /// Ordering is the whole design here, and the previous one was backwards.
+    /// The roster used to be the ONLY flexible child — a `ScrollView` under a
+    /// fixed header, a 132pt QR card and the ghost row — so on a real phone it
+    /// collapsed to a ~60pt sliver with the first participant sliced in half.
+    /// The single most important question a lobby answers ("who's actually
+    /// here?") was the one thing you couldn't see.
+    ///
+    /// So: who's here comes FIRST, at a size you can read across the room. The
+    /// invite card follows, compacted, with the QR behind a tap — it matters
+    /// enormously for ten seconds and then never again, which is exactly the
+    /// shape of a disclosure, not of the biggest element on screen. One scroll
+    /// view wraps the lot so nothing can be squeezed by its neighbours, and the
+    /// actions stay pinned outside it because Start must never scroll away.
     private func lobby(_ session: BuddySessionState) -> some View {
-        VStack(spacing: MADTheme.Spacing.lg) {
-            planHeader(session)
-
-            inviteCard(session)
-
-            ghostRaceRow(session)
-                .padding(.horizontal, MADTheme.Spacing.md)
-
+        VStack(spacing: 0) {
             ScrollView {
-                VStack(spacing: MADTheme.Spacing.sm) {
-                    ForEach(session.lobbyParticipants) { participant in
-                        participantRow(participant, session: session)
-                    }
+                VStack(spacing: MADTheme.Spacing.lg) {
+                    planHeader(session)
+                    rosterCard(session)
+                    inviteCard(session)
+                    ghostRaceRow(session)
+                        .padding(.horizontal, MADTheme.Spacing.md)
+                    Color.clear.frame(height: 4)
                 }
-                .padding(.horizontal, MADTheme.Spacing.md)
             }
-
-            Spacer(minLength: 0)
 
             actions(session)
                 .padding(MADTheme.Spacing.md)
+                .background(.ultraThinMaterial)
+        }
+    }
+
+    // MARK: - Roster
+
+    /// Who's here, as faces rather than a list of rows.
+    ///
+    /// A lobby is a social moment; a column of grey pills is a table. Big
+    /// avatars in a wrapping row read as "the group", and the count in the
+    /// header answers "are we waiting on anyone?" at a glance — which is the
+    /// question the host is actually asking before they tap Start.
+    ///
+    /// Capped at 8 by the server, so a `LazyVGrid` of adaptive columns fits
+    /// every real case in one or two rows without scrolling.
+    private func rosterCard(_ session: BuddySessionState) -> some View {
+        let people = session.lobbyParticipants
+        let here = people.filter {
+            $0.status == .joined || $0.status == .ready || $0.status == .active
+        }.count
+
+        return VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
+            HStack {
+                Text("Who's here")
+                    .font(MADTheme.Typography.headline)
+                    .foregroundStyle(MADTheme.Colors.madWhite)
+                Spacer()
+                Text(here == people.count ? "Everyone's in" : "\(here) of \(people.count)")
+                    .font(MADTheme.Typography.caption)
+                    .foregroundStyle(
+                        here == people.count
+                            ? session.accentColor
+                            : MADTheme.Colors.madWhite.opacity(0.55))
+            }
+
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 72), spacing: MADTheme.Spacing.sm)],
+                spacing: MADTheme.Spacing.md
+            ) {
+                ForEach(people) { participant in
+                    rosterTile(participant, session: session)
+                }
+            }
+        }
+        .padding(MADTheme.Spacing.md)
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(
+                cornerRadius: MADTheme.CornerRadius.extraLarge, style: .continuous
+            )
+            .fill(MADTheme.Colors.madWhite.opacity(0.06))
+        )
+        .padding(.horizontal, MADTheme.Spacing.md)
+    }
+
+    /// One face. Presence is carried by the avatar — ringed and full strength
+    /// once they're in, dimmed while the invite is still outstanding — with the
+    /// word underneath only for the states a ring can't spell.
+    private func rosterTile(_ participant: BuddyParticipant, session: BuddySessionState)
+        -> some View
+    {
+        let isIn = participant.status == .joined || participant.status == .ready
+            || participant.status == .active
+        let name =
+            participant.userId == buddy.currentUserId ? "You" : participant.displayName
+
+        return VStack(spacing: 6) {
+            AvatarView(
+                name: participant.displayName,
+                imageURL: participant.profileImageUrl,
+                size: 56
+            )
+            .overlay(
+                Circle()
+                    .strokeBorder(isIn ? session.accentColor : Color.clear, lineWidth: 2.5)
+            )
+            .opacity(isIn ? 1 : 0.4)
+            .overlay(alignment: .bottomTrailing) {
+                if participant.isHost {
+                    Image(systemName: "star.fill")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(MADTheme.Colors.madBlack)
+                        .padding(4)
+                        .background(Circle().fill(session.accentColor))
+                }
+            }
+
+            Text(name)
+                .font(.system(size: 12, weight: .semibold, design: .rounded))
+                .foregroundStyle(MADTheme.Colors.madWhite.opacity(isIn ? 1 : 0.5))
+                .lineLimit(1)
+
+            Text(isIn ? "In" : statusWord(participant.status))
+                .font(.system(size: 10, weight: .medium, design: .rounded))
+                .foregroundStyle(
+                    isIn ? session.accentColor : MADTheme.Colors.madWhite.opacity(0.4))
+        }
+        // The 5s poll is what surfaces an arrival, so this keys on the value
+        // that changed rather than an onAppear that already ran.
+        .animation(MADTheme.Animation.standard, value: participant.status)
+    }
+
+    private func statusWord(_ status: BuddyParticipantStatus) -> String {
+        switch status {
+        case .invited: return "Invited"
+        case .joined: return "In"
+        case .ready: return "Ready"
+        case .active: return "Moving"
+        case .finished: return "Done"
+        case .left, .declined: return "Out"
         }
     }
 
@@ -324,38 +445,21 @@ struct BuddyLobbyView: View {
     /// lobby nobody can be invited to is a lobby nobody uses. Three ways in,
     /// covering the three real situations: standing next to them (scan), in a
     /// chat (share), on a call (read the code).
+    /// Three ways in, in the order people actually need them.
+    ///
+    /// Share is first because it covers the common case (they're in a chat, not
+    /// standing next to you). The code is second, tappable to copy, for reading
+    /// aloud on a call. The QR is third and COLLAPSED — it's the right answer
+    /// for the ten seconds you're stood together and dead weight afterwards,
+    /// yet at 132pt plus its caption it was the largest thing on the screen and
+    /// pushed the roster off the bottom. A disclosure is exactly the right
+    /// shape for "occasionally essential".
+    ///
+    /// The QR is also generated lazily now, only once it's asked for: rendering
+    /// a CIFilter image on appear cost work every single lobby, for a control
+    /// most sessions never use.
     private func inviteCard(_ session: BuddySessionState) -> some View {
         VStack(spacing: MADTheme.Spacing.sm) {
-            if let qrImage {
-                Image(uiImage: qrImage)
-                    .interpolation(.none)
-                    .resizable()
-                    .frame(width: 132, height: 132)
-                    .padding(8)
-                    .background(RoundedRectangle(cornerRadius: 12).fill(.white))
-                Text("Point a camera at this")
-                    .font(MADTheme.Typography.caption)
-                    .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.5))
-            }
-
-            Button {
-                UIPasteboard.general.string = session.joinCode
-                MADHaptics.success()
-                withAnimation(MADTheme.Animation.quick) { didCopy = true }
-            } label: {
-                VStack(spacing: 2) {
-                    Text(didCopy ? "COPIED" : "OR SHARE THIS CODE")
-                        .font(MADTheme.Typography.caption)
-                        .foregroundStyle(
-                            didCopy ? session.accentColor : MADTheme.Colors.madWhite.opacity(0.5))
-                    Text(session.joinCode)
-                        .font(.system(size: 34, weight: .bold, design: .rounded))
-                        .tracking(6)
-                        .foregroundStyle(MADTheme.Colors.madWhite)
-                }
-            }
-            .buttonStyle(.plain)
-
             if let url = DeepLinkRouter.buddyShareURL(code: session.joinCode) {
                 ShareLink(
                     item: url,
@@ -371,106 +475,94 @@ struct BuddyLobbyView: View {
                 }
                 .buttonStyle(.plain)
             }
+
+            HStack(spacing: MADTheme.Spacing.sm) {
+                Button {
+                    UIPasteboard.general.string = session.joinCode
+                    MADHaptics.success()
+                    withAnimation(MADTheme.Animation.quick) { didCopy = true }
+                } label: {
+                    HStack(spacing: 8) {
+                        Text(session.joinCode)
+                            .font(.system(size: 22, weight: .bold, design: .rounded))
+                            .tracking(3)
+                            .foregroundStyle(MADTheme.Colors.madWhite)
+                        Image(systemName: didCopy ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(
+                                didCopy
+                                    ? session.accentColor
+                                    : MADTheme.Colors.madWhite.opacity(0.5))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 44)
+                    .background(
+                        RoundedRectangle(
+                            cornerRadius: MADTheme.CornerRadius.medium, style: .continuous
+                        )
+                        .fill(MADTheme.Colors.madWhite.opacity(0.08))
+                    )
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    MADHaptics.tap()
+                    withAnimation(MADTheme.Animation.quick) { showQR.toggle() }
+                } label: {
+                    Image(systemName: "qrcode")
+                        .font(.system(size: 17, weight: .semibold))
+                        .frame(width: 52, height: 44)
+                        .background(
+                            RoundedRectangle(
+                                cornerRadius: MADTheme.CornerRadius.medium, style: .continuous
+                            )
+                            .fill(
+                                showQR
+                                    ? session.accentColor
+                                    : MADTheme.Colors.madWhite.opacity(0.08))
+                        )
+                        .foregroundStyle(MADTheme.Colors.madWhite)
+                }
+                .buttonStyle(.plain)
+            }
+
+            if showQR {
+                VStack(spacing: 4) {
+                    if let qrImage {
+                        Image(uiImage: qrImage)
+                            .interpolation(.none)
+                            .resizable()
+                            .frame(width: 148, height: 148)
+                            .padding(8)
+                            .background(RoundedRectangle(cornerRadius: 12).fill(.white))
+                    } else {
+                        ProgressView()
+                            .tint(MADTheme.Colors.madWhite)
+                            .frame(width: 148, height: 148)
+                    }
+                    Text("Point a camera at this")
+                        .font(MADTheme.Typography.caption)
+                        .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.5))
+                }
+                .transition(.opacity.combined(with: .scale(scale: 0.94)))
+            }
         }
         .padding(MADTheme.Spacing.md)
         .frame(maxWidth: .infinity)
         .madLiquidGlassCard()
         .padding(.horizontal, MADTheme.Spacing.md)
-        .task(id: session.joinCode) {
+        // Generated only when the QR is actually revealed, and re-generated if
+        // the code ever changes under it.
+        .task(id: "\(session.joinCode)-\(showQR)") {
+            didCopy = false
+            guard showQR, qrImage == nil else { return }
             qrImage = ShareProfileView.generateQRCode(
                 from: DeepLinkRouter.buddyShareURL(code: session.joinCode)?.absoluteString
                     ?? session.joinCode
             )
-            didCopy = false
         }
     }
 
-    /// One person in the room.
-    ///
-    /// Presence is carried by the AVATAR — ringed and full-strength once they're
-    /// in, dimmed while they're still an outstanding invite — rather than by a
-    /// text badge alone. Somebody scanning this list wants to know "who's
-    /// actually here", and a row of identical grey pills answers that far more
-    /// slowly than a row of faces where the ones who showed up are the bright
-    /// ones. The chip stays for the states a ring can't spell (Done, Out) and as
-    /// the accessible label.
-    ///
-    /// Flat fill, not `.madLiquidGlass`: this renders once per participant and
-    /// re-renders on every 5s poll. `BuddyStartSheet` already learned that
-    /// several live blur surfaces on one screen is what makes these views feel
-    /// sluggish, and on this background the two are indistinguishable.
-    private func participantRow(_ participant: BuddyParticipant, session: BuddySessionState)
-        -> some View
-    {
-        let isIn = participant.status == .joined || participant.status == .ready
-            || participant.status == .active
-        let isOut = participant.status == .left || participant.status == .declined
-
-        return HStack(spacing: MADTheme.Spacing.md) {
-            AvatarView(
-                name: participant.displayName,
-                imageURL: participant.profileImageUrl,
-                size: 40
-            )
-            .overlay(
-                Circle()
-                    .strokeBorder(
-                        isIn ? session.accentColor : Color.clear,
-                        lineWidth: 2
-                    )
-            )
-            .opacity(isIn ? 1 : 0.45)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(
-                    participant.userId == buddy.currentUserId
-                        ? "You" : participant.displayName
-                )
-                .font(MADTheme.Typography.bodyBold)
-                .foregroundStyle(MADTheme.Colors.madWhite.opacity(isOut ? 0.45 : 1))
-
-                if participant.isHost {
-                    Text("Host")
-                        .font(MADTheme.Typography.caption)
-                        .foregroundStyle(session.accentColor)
-                }
-            }
-
-            Spacer()
-
-            statusChip(participant.status, accent: session.accentColor)
-        }
-        .padding(MADTheme.Spacing.sm)
-        .background(
-            RoundedRectangle(
-                cornerRadius: MADTheme.CornerRadius.medium, style: .continuous
-            )
-            .fill(MADTheme.Colors.madWhite.opacity(0.06))
-        )
-        // The 5s poll is what surfaces an arrival, so the animation has to key
-        // on the value that changed rather than on an onAppear that already ran.
-        .animation(MADTheme.Animation.standard, value: participant.status)
-    }
-
-    private func statusChip(_ status: BuddyParticipantStatus, accent: Color) -> some View {
-        let (label, color): (String, Color) = {
-            switch status {
-            case .invited: return ("Invited", MADTheme.Colors.madWhite.opacity(0.4))
-            case .joined: return ("In", accent)
-            case .ready: return ("Ready", MADTheme.Colors.success)
-            case .active: return ("Moving", MADTheme.Colors.success)
-            case .finished: return ("Done", MADTheme.Colors.success)
-            case .left, .declined: return ("Out", MADTheme.Colors.madWhite.opacity(0.3))
-            }
-        }()
-
-        return Text(label)
-            .font(MADTheme.Typography.caption)
-            .padding(.horizontal, MADTheme.Spacing.sm)
-            .padding(.vertical, 4)
-            .background(Capsule().fill(color.opacity(0.2)))
-            .foregroundStyle(color)
-    }
 
     private func actions(_ session: BuddySessionState) -> some View {
         VStack(spacing: MADTheme.Spacing.sm) {

--- a/app/Mile A Day/Views/BuddyWalks/BuddyStartSheet.swift
+++ b/app/Mile A Day/Views/BuddyWalks/BuddyStartSheet.swift
@@ -48,6 +48,19 @@ struct BuddyStartSheet: View {
     /// EXTRACT(DOW)). Empty = a one-off, which is the default.
     @State private var repeatDays: Set<Int> = []
 
+    /// Last setup, restored on open.
+    ///
+    /// Buddy walks are a habit with a fixed shape — the same person, the same
+    /// activity, the same mode, most days. Re-picking all three every time was
+    /// most of why setting one up "takes forever", and none of those taps ever
+    /// carried information. Restored rather than hardcoded, so a first-time
+    /// user still lands on the zero-config default (Just Together, walking).
+    @AppStorage("buddyLastModeV1") private var lastModeRaw = BuddyMode.together.rawValue
+    @AppStorage("buddyLastIsRunV1") private var lastIsRun = false
+    @AppStorage("buddyLastInviteesV1") private var lastInvitees = ""
+    /// One-shot: restoring must not fight the user's taps on a later re-render.
+    @State private var didRestore = false
+
     private var activityType: String { isRun ? "running" : "walking" }
     private var accent: Color { MADTheme.workoutColor(activityType) }
 
@@ -111,8 +124,17 @@ struct BuddyStartSheet: View {
                 // This screen is several taps in a row; warm the Taptic Engine
                 // so the FIRST one lands as fast as the rest.
                 MADHaptics.warmUp()
-                await buddy.loadCandidates()
-                await buddy.loadRoutines()
+                restoreLastSetup()
+                // Both already prefetched on the dashboard, so the sheet opens
+                // populated and these are a refresh, not a blocking load. Run
+                // concurrently — they have nothing to do with each other.
+                async let candidates: Void = buddy.loadCandidates()
+                async let routines: Void = buddy.loadRoutines()
+                _ = await (candidates, routines)
+                // Re-run once the list has landed: a cold launch can open this
+                // sheet before the prefetch finishes, and a remembered friend
+                // can only be re-selected once they're actually in the list.
+                restoreInvitees()
             }
             .onChange(of: buddy.errorMessage) { _, newValue in
                 guard let newValue else { return }
@@ -833,6 +855,40 @@ struct BuddyStartSheet: View {
                 ? "\(Int(value)) mi" : String(format: "%.1f mi", value))
     }
 
+    /// Put back the mode and activity from last time. Friends are restored
+    /// separately, because they can only be re-selected once the candidate
+    /// list exists.
+    private func restoreLastSetup() {
+        guard !didRestore else { return }
+        didRestore = true
+        if let saved = BuddyMode(rawValue: lastModeRaw) {
+            mode = saved
+            if saved.needsGoal { goal = saved.defaultGoal }
+        }
+        isRun = lastIsRun
+        restoreInvitees()
+    }
+
+    /// Re-select whoever you walked with last time — but ONLY if they're still
+    /// an eligible candidate. Someone who has since unfriended, opted out or
+    /// dropped off a buddy-capable build must not silently reappear in the
+    /// invite list, where the server would drop them anyway and the host would
+    /// never learn why.
+    private func restoreInvitees() {
+        guard selected.isEmpty, !lastInvitees.isEmpty, !buddy.candidates.isEmpty else {
+            return
+        }
+        let remembered = Set(lastInvitees.split(separator: ",").map(String.init))
+        let stillThere = Set(buddy.candidates.map(\.userId))
+        selected = remembered.intersection(stillThere)
+    }
+
+    private func rememberSetup() {
+        lastModeRaw = mode.rawValue
+        lastIsRun = isRun
+        lastInvitees = selected.sorted().joined(separator: ",")
+    }
+
     private func create() async {
         guard !isCreating else { return }
         isCreating = true
@@ -863,6 +919,7 @@ struct BuddyStartSheet: View {
                     at: scheduledDate
                 )
             }
+            rememberSetup()
             MADHaptics.success()
             onCreated(state)
             dismiss()

--- a/backend/src/services/buddySessionService.ts
+++ b/backend/src/services/buddySessionService.ts
@@ -274,7 +274,10 @@ export interface CreateSessionInput {
  * demand a goal on the way through, and switching back has to drop it. Two
  * copies of that rule would let the lobby write a state create would reject.
  */
-export function validateGoal(mode: BuddyMode, raw: number | null): number | null {
+export function validateGoal(
+  mode: BuddyMode,
+  raw: number | null,
+): number | null {
   if (mode === "together") return null;
   if (raw === null || !(raw > 0)) throw new BadRequestError("goal_required");
   if (mode === "race_time" && raw > 24 * 60) {
@@ -334,22 +337,20 @@ export async function createSession(
   }
   if (!sessionId) throw new BadRequestError("could_not_allocate_code");
 
-  // Host is 'joined' immediately — they never see their own invite.
+  // Host is 'joined' immediately — they never see their own invite. Inserted
+  // in the SAME statement as the invitees: one round trip for the whole roster
+  // instead of one per person, which is what a host with three friends picked
+  // was paying before the lobby could open.
   await db.query(
-    `INSERT INTO buddy_session_participants (session_id, user_id, status, joined_at)
-     VALUES ($1, $2, 'joined', NOW())`,
-    [sessionId, hostUserId],
+    `INSERT INTO buddy_session_participants
+       (session_id, user_id, status, invited_by, joined_at)
+     SELECT $1, $2, 'joined', NULL, NOW()
+     UNION ALL
+     SELECT $1, invitee, 'invited', $2, NULL
+       FROM unnest($3::text[]) AS invitee
+     ON CONFLICT (session_id, user_id) DO NOTHING`,
+    [sessionId, hostUserId, eligible],
   );
-
-  for (const inviteeId of eligible) {
-    await db.query(
-      `INSERT INTO buddy_session_participants
-         (session_id, user_id, status, invited_by)
-       VALUES ($1, $2, 'invited', $3)
-       ON CONFLICT (session_id, user_id) DO NOTHING`,
-      [sessionId, inviteeId, hostUserId],
-    );
-  }
 
   await recordEvent(sessionId, hostUserId, "created", { mode, goalValue });
   void notifyInvitees(sessionId, hostUserId, eligible);
@@ -775,15 +776,13 @@ async function addInvitees(
   const eligible = await eligibleInvitees(hostUserId, wanted);
   if (eligible.length === 0) return;
 
-  for (const inviteeId of eligible) {
-    await db.query(
-      `INSERT INTO buddy_session_participants
-         (session_id, user_id, status, invited_by)
-       VALUES ($1, $2, 'invited', $3)
-       ON CONFLICT (session_id, user_id) DO NOTHING`,
-      [sessionId, inviteeId, hostUserId],
-    );
-  }
+  await db.query(
+    `INSERT INTO buddy_session_participants
+       (session_id, user_id, status, invited_by)
+     SELECT $1, invitee, 'invited', $2 FROM unnest($3::text[]) AS invitee
+     ON CONFLICT (session_id, user_id) DO NOTHING`,
+    [sessionId, hostUserId, eligible],
+  );
   void notifyInvitees(sessionId, hostUserId, eligible);
 }
 
@@ -1316,27 +1315,40 @@ function buddyOptedInSql(userColumn: string): string {
  *
  * Shared by createSession and the lobby's add-invitees path so the two cannot
  * drift; a second copy of these rules is exactly how a gate gets half-applied.
+ *
+ * ONE round trip regardless of how many people were picked. The first version
+ * of this walked the list with three awaits each (friendship, blocks, then
+ * enrollment + preference), so inviting three friends cost nine sequential
+ * queries before the session row was even inserted — the single biggest reason
+ * creating a walk felt slow. Set-based, the answer is the same and the cost is
+ * flat. The ORDER of the returned ids follows the caller's list rather than the
+ * table, so the host's picking order survives into the roster.
  */
 async function eligibleInvitees(
   hostUserId: string,
   inviteIds: string[],
 ): Promise<string[]> {
-  const eligible: string[] = [];
-  for (const inviteeId of inviteIds) {
-    if (inviteeId === hostUserId) continue;
-    if (!(await areFriends(hostUserId, inviteeId))) continue;
-    if (await isBlockedEitherWay(hostUserId, inviteeId)) continue;
-    const ok = await db.query(
-      `SELECT 1 FROM users u
-        WHERE u.user_id = $1
-          AND u.buddy_enrolled_at IS NOT NULL
-          AND ${buddyOptedInSql("u.user_id")}`,
-      [inviteeId],
-    );
-    if (ok.length === 0) continue;
-    eligible.push(inviteeId);
-  }
-  return eligible;
+  const wanted = inviteIds.filter((id) => id !== hostUserId);
+  if (wanted.length === 0) return [];
+
+  const rows = await db.query<{ user_id: string }>(
+    `SELECT u.user_id
+       FROM users u
+       JOIN friendships f
+         ON f.user_id = $1 AND f.friend_id = u.user_id AND f.status = 'accepted'
+      WHERE u.user_id = ANY($2::text[])
+        AND u.buddy_enrolled_at IS NOT NULL
+        AND ${buddyOptedInSql("u.user_id")}
+        AND NOT EXISTS (
+          SELECT 1 FROM user_blocks b
+           WHERE (b.blocker_id = $1 AND b.blocked_id = u.user_id)
+              OR (b.blocker_id = u.user_id AND b.blocked_id = $1)
+        )`,
+    [hostUserId, wanted],
+  );
+
+  const allowed = new Set(rows.map((r) => r.user_id));
+  return wanted.filter((id) => allowed.has(id));
 }
 
 /**


### PR DESCRIPTION
## The layout bug

From the screenshot: a 132pt QR code dominates the lobby while the roster is a ~60pt sliver with "You" sliced in half.

The cause was structural, not cosmetic. The participant `ScrollView` was the **only flexible child** under a fixed header, the invite card and the ghost row — plus a redundant `Spacer(minLength: 0)` competing after it. Everything above it is fixed-height and enormous, so the roster got whatever was left, which was nothing.

```swift
VStack {
  planHeader        // fixed, tall
  inviteCard        // fixed, 132pt QR + code + button
  ghostRaceRow      // fixed
  ScrollView { participants }   // ← the only flexible child
  Spacer(minLength: 0)          // ← and this competes with it
  actions
}
```

## The fix

**One scroll view, actions pinned outside it**, and the order inverted — people first, invite second. Start must never scroll away, so it stays out of the scroll.

**"Who's here" is now a wrapping grid of 56pt faces.** Ringed and full-strength once someone's in, dimmed while the invite is outstanding, host marked with a star. The header carries "2 of 3" / "Everyone's in" — that count is the actual question a host is asking before they tap Start, and a column of grey status pills answered it far more slowly than faces do. Capped at 8 server-side, so an adaptive `LazyVGrid` fits every real case in one or two rows.

**The QR moves behind a tap**, and is only generated when revealed. It's essential for ten seconds when you're stood next to someone and dead weight afterwards — that's the shape of a disclosure, not of the biggest thing on screen. Share is promoted to the top (the common case is a chat, not proximity) and the code shrinks to a copy chip beside a QR toggle. Reclaims ~190pt.

## Speed

- **`eligibleInvitees` was three sequential queries _per invitee_.** Picking three friends cost nine round trips before the session row was even inserted. Now one set-based query regardless of list size. This was the single biggest reason creating a walk felt slow — and I introduced it two commits ago, so this is my own regression.
- **The whole roster is one INSERT** (`host UNION ALL unnest(invitees)`) instead of one statement per person, in both create and lobby-invite.
- **The dashboard prefetches candidates and routines concurrently** alongside the existing session/presence loads (previously a four-deep serial chain). The start sheet now opens **populated** instead of showing an empty "Who's coming?" for a round trip every single time — that gap was most of what made setup feel slow.
- **`loadCandidates` no longer blanks the list on failure.** A transient blip was turning a warm sheet into the "no friends set up for buddy walks" empty state — the exact message that made a working feature look broken in the first place.

## Taps

Mode, activity and invitees are remembered and restored. A buddy walk is a habit with a fixed shape — same person, same activity, most days — and re-picking all three every time carried no information.

Remembered friends are re-selected **only if they're still eligible candidates**, so someone who has since unfriended, opted out, or dropped off a buddy-capable build can't silently reappear in the invite list where the server would drop them anyway and the host would never learn why.

## Verification

`tsc` clean, `drizzle-kit check` clean, migrator idempotent, and `ci-smoke` + `buddy-gate-check` (43 assertions) + `ghost-race-check` all passing against a real migrated Postgres 16. No migration in this PR.

The batching changes are behaviour-preserving by construction and covered by the existing buddy-gate-check assertions on who does and doesn't get invited (opted-out friends dropped, no-settings-row friends kept, non-friends rejected) — those pass unchanged against the new single-query form.

## Notes

- **iOS is not compile-verified here** (no Swift toolchain). Touches `BuddyLobbyView` (substantially — the roster and invite card are rewritten, and the old `participantRow`/`statusChip` are deleted as dead code), `BuddyStartSheet`, `BuddyFlowModifier`, `BuddySessionService`. Send build errors and I'll sweep them.
- I have not seen any of this render. The layout reasoning is sound and the old structure's failure is visible in the screenshot, but sizes and spacing are judgement calls only a device can settle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxEp1wW88Y5PxyTxgAoE3L)_