### PR TITLE
Buddy: drop join codes, surface invites, type-check the Swift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,15 +103,20 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Needed for the diff below. The default shallow clone has no
+          # origin/main, so `origin/main...HEAD` failed with "bad revision" and
+          # the step was silently useless.
+          fetch-depth: 0
       - name: Check for iOS changes
         id: changed
         run: |
-          if git diff --name-only origin/main...HEAD -- 'app/**' | grep -q .; then
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if git diff --name-only "$BASE"...HEAD -- 'app/**' | grep -q .; then
             echo "ios=true" >> "$GITHUB_OUTPUT"
           else
             echo "ios=false" >> "$GITHUB_OUTPUT"
           fi
-        continue-on-error: true
       # There is no iOS test target worth running and no scheme build here —
       # this is purely "does the Swift still compile". That is exactly the class
       # of failure that has been reaching main: a non-exhaustive switch, a stale
@@ -123,6 +128,8 @@ jobs:
       # report every cross-file reference as undefined. The Watch app and the
       # widget extension are SEPARATE targets and are excluded.
       - name: Type-check the main app target
+        # Skipped when nothing under app/ changed — this runner bills at 10x.
+        if: steps.changed.outputs.ios == 'true'
         run: |
           SDK=$(xcrun --sdk iphoneos --show-sdk-path)
           find "app/Mile A Day" -name '*.swift' -print0 > /tmp/swift-files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,47 @@ jobs:
       # script assumed a global install. `next build` type-checks, which is
       # the gate that matters here.
       - run: npm run build
+
+  ios-typecheck:
+    name: iOS (type-check)
+    # Only when the app actually changes — macOS minutes bill at 10x Linux.
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    runs-on: macos-latest
+    # NON-BLOCKING FOR NOW. This job has never run before it was written, and a
+    # whole-target `swiftc -typecheck` can fail for reasons unrelated to any
+    # diff (SDK drift, a file that only compiles with Xcode's build settings).
+    # Turning it red on day one would block every merge. Read the log, confirm
+    # it goes green on a known-good commit, THEN delete this line so it gates.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for iOS changes
+        id: changed
+        run: |
+          if git diff --name-only origin/main...HEAD -- 'app/**' | grep -q .; then
+            echo "ios=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ios=false" >> "$GITHUB_OUTPUT"
+          fi
+        continue-on-error: true
+      # There is no iOS test target worth running and no scheme build here —
+      # this is purely "does the Swift still compile". That is exactly the class
+      # of failure that has been reaching main: a non-exhaustive switch, a stale
+      # call site, a Codable struct missing a CodingKey. All of them are type
+      # errors, none of them need a simulator.
+      #
+      # The whole main-app source set goes in ONE invocation because Swift
+      # resolves types across files within a module; checking files singly would
+      # report every cross-file reference as undefined. The Watch app and the
+      # widget extension are SEPARATE targets and are excluded.
+      - name: Type-check the main app target
+        run: |
+          SDK=$(xcrun --sdk iphoneos --show-sdk-path)
+          find "app/Mile A Day" -name '*.swift' -print0 > /tmp/swift-files
+          COUNT=$(tr -dc '\0' < /tmp/swift-files | wc -c)
+          echo "Type-checking $COUNT Swift files against $SDK"
+          xargs -0 xcrun swiftc -typecheck \
+            -sdk "$SDK" \
+            -target arm64-apple-ios17.0 \
+            -swift-version 5 \
+            < /tmp/swift-files

--- a/app/Mile A Day/Models/BuddySession.swift
+++ b/app/Mile A Day/Models/BuddySession.swift
@@ -523,3 +523,51 @@ struct BuddyRecurringWalk: Codable, Identifiable, Equatable {
 struct BuddyRoutinesResponse: Codable {
     let routines: [BuddyRecurringWalk]
 }
+
+// MARK: - Walking partners
+
+/// How much you've actually walked with one friend.
+///
+/// Derived server-side from finished sessions you both completed — no stored
+/// counter, so it can't drift. `milesTogether` is YOUR distance across those
+/// walks, not the pooled total: a pooled figure double-counts the same walk
+/// from each side, so the two of you would see different numbers for the same
+/// history and neither would match what either actually covered.
+struct BuddyPartner: Codable, Identifiable, Equatable {
+    let userId: String
+    let username: String?
+    let firstName: String?
+    let profileImageUrl: String?
+    let walks: Int
+    let milesTogether: Double
+    /// `date` column, so a plain string is safe.
+    let lastWalkDate: String?
+
+    var id: String { userId }
+
+    var displayName: String {
+        if let firstName, !firstName.isEmpty { return firstName }
+        if let username, !username.isEmpty { return username }
+        return "Friend"
+    }
+
+    /// "12 walks · 14.2 mi together"
+    var summary: String {
+        let walkWord = walks == 1 ? "walk" : "walks"
+        return "\(walks) \(walkWord) · \(String(format: "%.1f", milesTogether)) mi together"
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case username
+        case firstName = "first_name"
+        case profileImageUrl = "profile_image_url"
+        case walks
+        case milesTogether = "miles_together"
+        case lastWalkDate = "last_walk_date"
+    }
+}
+
+struct BuddyPartnersResponse: Codable {
+    let partners: [BuddyPartner]
+}

--- a/app/Mile A Day/Services/BuddySessionService.swift
+++ b/app/Mile A Day/Services/BuddySessionService.swift
@@ -238,6 +238,25 @@ final class BuddySessionService: ObservableObject {
         }
     }
 
+    // MARK: - Partners
+
+    /// Who you actually walk with, and how much. Read-only history.
+    @Published private(set) var partners: [BuddyPartner] = []
+
+    func loadPartners() async {
+        guard currentUserId != nil else { return }
+        do {
+            partners = try await request(
+                "/buddy/partners", responseType: BuddyPartnersResponse.self
+            ).partners
+        } catch {
+            // Silent, and KEEPS whatever we had: this drives a nice-to-have
+            // section, and blanking it on a blip would make a real history look
+            // like it had been lost.
+            print("[BuddySessionService] loadPartners failed: \(error)")
+        }
+    }
+
     // MARK: - Routines
 
     /// Standing walks this user has set up. Published so the list and the

--- a/app/Mile A Day/Views/BuddyWalks/BuddyLobbyView.swift
+++ b/app/Mile A Day/Views/BuddyWalks/BuddyLobbyView.swift
@@ -125,6 +125,79 @@ struct BuddyLobbyView: View {
         }
     }
 
+    // MARK: - Plan header
+
+    /// What this room is, and — for the host — the way to change it.
+    ///
+    /// Being able to edit the plan is what turns a lobby into a waiting room
+    /// rather than a receipt: plans change between "let's walk" and "everyone's
+    /// here", and the only way to act on that used to be abandoning the room and
+    /// rebuilding it.
+    ///
+    /// Non-hosts see the same summary with no affordance. The server enforces
+    /// host-only anyway (`not_host`), so this is about not offering something
+    /// that would just fail.
+    private func planHeader(_ session: BuddySessionState) -> some View {
+        VStack(spacing: MADTheme.Spacing.xs) {
+            ZStack {
+                Circle()
+                    .fill(session.accentColor.opacity(0.18))
+                    .frame(width: 76, height: 76)
+                Circle()
+                    .strokeBorder(session.accentColor.opacity(0.45), lineWidth: 1.5)
+                    .frame(width: 76, height: 76)
+                Image(systemName: session.mode.icon)
+                    .font(.system(size: 30, weight: .semibold))
+                    .foregroundStyle(session.accentColor)
+            }
+            // Keyed on the plan so a change the HOST made animates on every
+            // other phone too, when the poll brings it in.
+            .animation(MADTheme.Animation.quick, value: session.mode)
+
+            Text(session.mode.title)
+                .font(MADTheme.Typography.title2)
+                .foregroundStyle(MADTheme.Colors.madWhite)
+
+            Text(planLine(session))
+                .font(MADTheme.Typography.body)
+                .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.7))
+                .multilineTextAlignment(.center)
+
+            if session.isHost(buddy.currentUserId) {
+                Button {
+                    MADHaptics.tap()
+                    showSettings = true
+                } label: {
+                    Label("Edit", systemImage: "slider.horizontal.3")
+                        .font(MADTheme.Typography.caption)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Capsule().fill(MADTheme.Colors.madWhite.opacity(0.10)))
+                        .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.85))
+                }
+                .buttonStyle(.plain)
+                .padding(.top, 2)
+            }
+        }
+        .padding(.top, MADTheme.Spacing.xl)
+        // Its own presentation node: this view also carries the ghost-setup
+        // sheet, and two sheets on ONE node makes SwiftUI silently drop one.
+        .background(
+            Color.clear
+                .sheet(isPresented: $showSettings) {
+                    BuddyLobbySettingsSheet(session: session)
+                }
+        )
+    }
+
+    /// "2.0 miles · Walk" — the plan as one line, so the goal and the activity
+    /// aren't two separate things to hold in your head.
+    private func planLine(_ session: BuddySessionState) -> String {
+        let activity = session.isRunning ? "Run" : "Walk"
+        guard let goal = session.goalValue else { return activity }
+        return "\(goalText(goal, mode: session.mode)) · \(activity)"
+    }
+
     // MARK: - People
 
     /// Everyone in one card: who's here, and — one tap away — who else could be.

--- a/app/Mile A Day/Views/BuddyWalks/BuddyLobbyView.swift
+++ b/app/Mile A Day/Views/BuddyWalks/BuddyLobbyView.swift
@@ -17,14 +17,8 @@ struct BuddyLobbyView: View {
 
     @State private var now = Date()
     @State private var hasHandedOff = false
-    @State private var qrImage: UIImage?
-    @State private var didCopy = false
     @State private var showGhostSetup = false
     @State private var showSettings = false
-    /// The share-a-link block starts collapsed. See `peopleCard` — tapping a
-    /// friend is the path that matters; a link is for people not in the app.
-    @State private var showShare = false
-    @State private var showQR = false
     /// Friends with an invite request in flight, so their tile can show it.
     @State private var invitingIds: Set<String> = []
 
@@ -103,12 +97,10 @@ struct BuddyLobbyView: View {
     /// The single most important question a lobby answers ("who's actually
     /// here?") was the one thing you couldn't see.
     ///
-    /// So: who's here comes FIRST, at a size you can read across the room. The
-    /// invite card follows, compacted, with the QR behind a tap — it matters
-    /// enormously for ten seconds and then never again, which is exactly the
-    /// shape of a disclosure, not of the biggest element on screen. One scroll
-    /// view wraps the lot so nothing can be squeezed by its neighbours, and the
-    /// actions stay pinned outside it because Start must never scroll away.
+    /// So: who's here comes FIRST, at a size you can read across the room, with
+    /// the friends you could still add in the same card. One scroll view wraps
+    /// the lot so nothing can be squeezed by its neighbours, and the actions
+    /// stay pinned outside it because Start must never scroll away.
     private func lobby(_ session: BuddySessionState) -> some View {
         VStack(spacing: 0) {
             ScrollView {
@@ -145,13 +137,13 @@ struct BuddyLobbyView: View {
     /// conclusion from looking at the screen was that the feature didn't exist.
     ///
     /// So the friends row lives here, in the same card as the roster, as
-    /// tappable faces: one tap invites, no sheet, no navigation. Sharing a link
-    /// survives as a disclosure at the bottom because it solves a different
-    /// problem — someone who isn't on Mile A Day at all — and shouldn't outrank
-    /// the common case.
+    /// tappable faces: one tap invites, no sheet, no navigation. The join code
+    /// and QR that used to sit here are gone entirely — everyone you can walk
+    /// with is already an accepted friend, so a code was a second, weaker path
+    /// to a thing this row does better.
     ///
-    /// Host-only, because the server is (`not_host`). A guest sees the roster
-    /// and the share block, which is everything they can actually act on.
+    /// Host-only, because the server is (`not_host`). A guest sees the roster,
+    /// which is everything they can act on.
     private func peopleCard(_ session: BuddySessionState) -> some View {
         let people = session.lobbyParticipants
         let here = people.filter {
@@ -201,9 +193,13 @@ struct BuddyLobbyView: View {
                 }
             }
 
-            Divider().background(MADTheme.Colors.madWhite.opacity(0.10))
-
-            shareBlock(session)
+            if isHost, invitable.isEmpty, people.count <= 1 {
+                // Host, alone, with nobody left to ask. Say so plainly instead
+                // of leaving a card that looks like it's still loading.
+                Text("No friends available to invite right now.")
+                    .font(MADTheme.Typography.caption)
+                    .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.5))
+            }
         }
         .padding(MADTheme.Spacing.md)
         .frame(maxWidth: .infinity)
@@ -328,134 +324,6 @@ struct BuddyLobbyView: View {
             // no chance of the two rows disagreeing.
             _ = try? await buddy.updateSession(inviteUserIds: [candidate.userId])
             invitingIds.remove(candidate.userId)
-        }
-    }
-
-    /// For someone who isn't on Mile A Day at all.
-    ///
-    /// Collapsed by default and phrased as what it's FOR, rather than sitting at
-    /// the top labelled "Invite a friend" — which is what made a share sheet
-    /// look like the only way to invite anyone.
-    @ViewBuilder
-    private func shareBlock(_ session: BuddySessionState) -> some View {
-        Button {
-            MADHaptics.tap()
-            withAnimation(MADTheme.Animation.quick) { showShare.toggle() }
-        } label: {
-            HStack(spacing: 8) {
-                Image(systemName: "link")
-                    .font(.system(size: 12, weight: .semibold))
-                Text("Invite someone not on Mile A Day")
-                    .font(MADTheme.Typography.caption)
-                Spacer(minLength: 0)
-                Image(systemName: showShare ? "chevron.up" : "chevron.down")
-                    .font(.system(size: 11, weight: .semibold))
-            }
-            .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.6))
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-
-        if showShare {
-            VStack(spacing: MADTheme.Spacing.sm) {
-                if let url = DeepLinkRouter.buddyShareURL(code: session.joinCode) {
-                    ShareLink(
-                        item: url,
-                        message: Text(
-                            "Walk with me on Mile A Day — join code \(session.joinCode)")
-                    ) {
-                        Label("Share a link", systemImage: "square.and.arrow.up")
-                            .font(MADTheme.Typography.bodyBold)
-                            .frame(maxWidth: .infinity)
-                            .frame(height: 44)
-                            .background(Capsule().fill(session.accentColor))
-                            .foregroundStyle(MADTheme.Colors.madWhite)
-                    }
-                    .buttonStyle(.plain)
-                }
-
-                HStack(spacing: MADTheme.Spacing.sm) {
-                    Button {
-                        UIPasteboard.general.string = session.joinCode
-                        MADHaptics.success()
-                        withAnimation(MADTheme.Animation.quick) { didCopy = true }
-                    } label: {
-                        HStack(spacing: 8) {
-                            Text(session.joinCode)
-                                .font(.system(size: 20, weight: .bold, design: .rounded))
-                                .tracking(3)
-                                .foregroundStyle(MADTheme.Colors.madWhite)
-                            Image(systemName: didCopy ? "checkmark" : "doc.on.doc")
-                                .font(.system(size: 12, weight: .semibold))
-                                .foregroundStyle(
-                                    didCopy
-                                        ? session.accentColor
-                                        : MADTheme.Colors.madWhite.opacity(0.5))
-                        }
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 42)
-                        .background(
-                            RoundedRectangle(
-                                cornerRadius: MADTheme.CornerRadius.medium,
-                                style: .continuous
-                            )
-                            .fill(MADTheme.Colors.madWhite.opacity(0.08))
-                        )
-                    }
-                    .buttonStyle(.plain)
-
-                    Button {
-                        MADHaptics.tap()
-                        withAnimation(MADTheme.Animation.quick) { showQR.toggle() }
-                    } label: {
-                        Image(systemName: "qrcode")
-                            .font(.system(size: 17, weight: .semibold))
-                            .frame(width: 50, height: 42)
-                            .background(
-                                RoundedRectangle(
-                                    cornerRadius: MADTheme.CornerRadius.medium,
-                                    style: .continuous
-                                )
-                                .fill(
-                                    showQR
-                                        ? session.accentColor
-                                        : MADTheme.Colors.madWhite.opacity(0.08))
-                            )
-                            .foregroundStyle(MADTheme.Colors.madWhite)
-                    }
-                    .buttonStyle(.plain)
-                }
-
-                if showQR {
-                    VStack(spacing: 4) {
-                        if let qrImage {
-                            Image(uiImage: qrImage)
-                                .interpolation(.none)
-                                .resizable()
-                                .frame(width: 148, height: 148)
-                                .padding(8)
-                                .background(RoundedRectangle(cornerRadius: 12).fill(.white))
-                        } else {
-                            ProgressView()
-                                .tint(MADTheme.Colors.madWhite)
-                                .frame(width: 148, height: 148)
-                        }
-                        Text("Point a camera at this")
-                            .font(MADTheme.Typography.caption)
-                            .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.5))
-                    }
-                }
-            }
-            // Generated only once the QR is actually revealed — a CIFilter
-            // render on every lobby, for a control most sessions never open.
-            .task(id: "\(session.joinCode)-\(showQR)") {
-                didCopy = false
-                guard showQR, qrImage == nil else { return }
-                qrImage = ShareProfileView.generateQRCode(
-                    from: DeepLinkRouter.buddyShareURL(code: session.joinCode)?.absoluteString
-                        ?? session.joinCode
-                )
-            }
         }
     }
 

--- a/app/Mile A Day/Views/BuddyWalks/BuddyRosterStrip.swift
+++ b/app/Mile A Day/Views/BuddyWalks/BuddyRosterStrip.swift
@@ -19,6 +19,13 @@ struct BuddyRosterStrip: View {
                 CoopGoalBar(session: session)
             }
 
+            // The rings were unexplained, which is most of why they read as
+            // decoration with a hidden meaning. One line fixes that.
+            Text(ringLegend)
+                .font(MADTheme.Typography.caption)
+                .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.5))
+                .frame(maxWidth: .infinity, alignment: .leading)
+
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: MADTheme.Spacing.md) {
                     ForEach(orderedParticipants) { participant in
@@ -69,6 +76,15 @@ struct BuddyRosterStrip: View {
         }
     }
 
+    /// What the rings are measuring, in words.
+    private var ringLegend: String {
+        if session.mode == .raceTime { return "Rings fill toward a mile" }
+        if let goal = session.goalValue, goal > 0 {
+            return String(format: "Rings fill toward %.1f mi", goal)
+        }
+        return "Rings fill toward a mile"
+    }
+
     private var headerText: String {
         switch session.mode {
         case .together:
@@ -100,7 +116,12 @@ private struct BuddyRosterAvatar: View {
                 size: 52,
                 ringWidth: isMe ? 4 : 3,
                 accent: session.accentColor,
-                badge: participant.status == .finished ? .check : .live
+                // No `.live` dot for everyone else. It marked "workout in
+                // progress" on every face, during a workout — a red dot that is
+                // always present on every tile carries no information and read
+                // as a warning badge. The check still means something: they
+                // finished.
+                badge: participant.status == .finished ? .check : nil
             )
             // Stale = no report in 90s. Dimmed to a hairline, never removed:
             // a friend who vanishes mid-walk reads as a crash.
@@ -119,16 +140,21 @@ private struct BuddyRosterAvatar: View {
                 .foregroundStyle(MADTheme.Colors.madWhite.opacity(isMe ? 1 : 0.75))
                 .lineLimit(1)
 
-            Text(participant.isStale ? "—" : String(format: "%.2f", participant.distanceMiles))
+            Text(participant.isStale ? "—" : String(format: "%.2f mi", participant.distanceMiles))
                 .font(MADTheme.Typography.smallBold)
                 .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
                 .foregroundStyle(
                     participant.isStale
                         ? MADTheme.Colors.madWhite.opacity(0.4)
                         : session.accentColor
                 )
         }
-        .frame(width: 64)
+        // 52pt ring + a 4pt stroke + the badge's 2pt overhang needs more than
+        // 64 to sit in, and `.offset` draws OUTSIDE layout bounds — so at 64
+        // the ring and the two-decimal distance were both being cropped.
+        .frame(width: 78)
         .animation(MADTheme.Animation.standard, value: participant.distanceMiles)
     }
 
@@ -138,24 +164,37 @@ private struct BuddyRosterAvatar: View {
         return participant.distanceMiles >= best
     }
 
-    /// Co-op has no individual target, so the ring shows each person's share of
-    /// the group total instead of progress toward a goal they don't own.
+    /// Everyone's ring measures the SAME distance, so comparing two of them
+    /// means something.
+    ///
+    /// It used to be `yourDistance / furthestPersonsDistance`, which quietly
+    /// made the leader's ring full — and `AvatarWithRing` paints a full ring
+    /// solid GREEN. So in "Just Together", a mode whose own subtitle is "No
+    /// goal — just move together", whoever was a few feet ahead got a green
+    /// trophy ring and everyone else got a partial blue arc, with nothing on
+    /// screen explaining either. It turned a walk into a scoreboard nobody
+    /// asked for, and it also meant the rings rescaled every time somebody
+    /// moved, so they never sat still.
+    ///
+    /// Now it's progress toward a fixed target: the session's goal where there
+    /// is one, otherwise the daily mile. Green-at-full then means "they
+    /// finished their mile", which is worth showing.
     private var ringProgress: Double {
-        switch session.mode {
-        case .together:
-            let best = session.activeParticipants.map(\.distanceMiles).max() ?? 0
-            return best > 0 ? participant.distanceMiles / best : 0
-        case .coopGoal:
-            guard session.groupDistanceMiles > 0 else { return 0 }
-            return participant.distanceMiles / session.groupDistanceMiles
-        case .raceGoal:
-            guard let goal = session.goalValue, goal > 0 else { return 0 }
-            return participant.distanceMiles / goal
-        case .raceTime:
-            let best = session.activeParticipants.map(\.distanceMiles).max() ?? 0
-            return best > 0 ? participant.distanceMiles / best : 0
-        }
+        guard ringTarget > 0 else { return 0 }
+        return participant.distanceMiles / ringTarget
     }
+
+    private var ringTarget: Double {
+        // race_time's goal is MINUTES, not miles — using it here would compare
+        // a distance against a duration and produce a meaningless ring.
+        if session.mode == .raceTime { return BuddyRosterAvatar.dailyMile }
+        if let goal = session.goalValue, goal > 0 { return goal }
+        return BuddyRosterAvatar.dailyMile
+    }
+
+    /// The app's whole premise, and the only target every participant shares
+    /// when the session itself declares none.
+    static let dailyMile: Double = 1.0
 }
 
 /// Co-op's distinguishing visual: one shared bar, segmented per person, so you

--- a/app/Mile A Day/Views/BuddyWalks/BuddyStartSheet.swift
+++ b/app/Mile A Day/Views/BuddyWalks/BuddyStartSheet.swift
@@ -1,17 +1,17 @@
 import SwiftUI
 
-/// Start a buddy walk, or join one someone else started.
+/// Set up a buddy walk, and answer the ones you've been invited to.
 ///
-/// Start-vs-join is the FIRST thing the screen asks, as a segmented control at
-/// the top. Earlier passes buried joining behind a "#" toolbar glyph (nobody
-/// knew what it meant), then added a second join button in the footer — which
-/// left the sheet with two ways in and, worse, a primary button reading "Start
-/// with a share code" sitting directly above "Join with their code". Two
-/// code-flavoured buttons, opposite meanings. One switch at the top removes the
-/// ambiguity: pick a lane, then the rest of the screen is only about that lane.
+/// There is no join code any more. Codes existed so you could pull in someone
+/// the app couldn't name — but everyone you can walk with is already an
+/// accepted friend, so the code was a second, weaker path to a thing the
+/// friend list does better: it had to be read aloud or pasted, it could be
+/// mistyped, and it put a text field on the screen that most people read as the
+/// primary way in. Invites go out from the friend list; invites you receive
+/// land at the top of this sheet.
 ///
-/// Within the Start lane it opens on "Just Together" with no goal to set, so
-/// the common case — two friends about to walk — is pick-a-friend-and-go.
+/// Opens on "Just Together" with no goal to set, so the common case — two
+/// friends about to walk — is pick-a-friend-and-go.
 struct BuddyStartSheet: View {
     /// Handed back so the caller can push straight into the lobby.
     let onCreated: (BuddySessionState) -> Void
@@ -19,21 +19,11 @@ struct BuddyStartSheet: View {
     @Environment(\.dismiss) private var dismiss
     @ObservedObject private var buddy = BuddySessionService.shared
 
-    private enum Lane: String, CaseIterable {
-        case start, join
-        var title: String { self == .start ? "Start one" : "Join one" }
-        var icon: String { self == .start ? "plus.circle.fill" : "arrow.right.circle.fill" }
-    }
-
-    @State private var lane: Lane = .start
     @State private var mode: BuddyMode = .together
     @State private var goal: Double = BuddyMode.together.defaultGoal
     @State private var isRun = false
     @State private var selected: Set<String> = []
     @State private var isCreating = false
-    @State private var joinCode = ""
-    @State private var isJoining = false
-    @FocusState private var codeFocused: Bool
     /// Errors are mirrored into LOCAL state. Driving `.alert(isPresented:)`
     /// straight off `buddy.errorMessage` meant the binding's setter wrote to an
     /// @Published from inside a view update — "Publishing changes from within
@@ -101,10 +91,8 @@ struct BuddyStartSheet: View {
 
                 ScrollView {
                     VStack(spacing: MADTheme.Spacing.lg) {
-                        lanePicker
-                        if lane == .start { startLane } else { joinLane }
-                        // Clears the sticky footer (button + the reassurance
-                        // line under it, which the join lane doesn't render).
+                        startLane
+                        // Clears the sticky footer (button + the line under it).
                         Color.clear.frame(height: 140)
                     }
                     .padding(.horizontal, MADTheme.Spacing.md)
@@ -130,7 +118,9 @@ struct BuddyStartSheet: View {
                 // concurrently — they have nothing to do with each other.
                 async let candidates: Void = buddy.loadCandidates()
                 async let routines: Void = buddy.loadRoutines()
-                _ = await (candidates, routines)
+                async let partners: Void = buddy.loadPartners()
+                async let sessions: Void = buddy.refreshMySessions()
+                _ = await (candidates, routines, partners, sessions)
                 // Re-run once the list has landed: a cold launch can open this
                 // sheet before the prefetch finishes, and a remembered friend
                 // can only be re-selected once they're actually in the list.
@@ -157,89 +147,207 @@ struct BuddyStartSheet: View {
 
     @ViewBuilder
     private var startLane: some View {
+        invitesSection
         summaryHeader
         activityToggle
         modeSection
         if mode.needsGoal { goalSection }
         scheduleSection
         friendSection
+        partnersSection
         routinesSection
     }
 
-    // MARK: - Lane picker
+    // MARK: - Invitations
 
-    private var lanePicker: some View {
-        HStack(spacing: 4) {
-            ForEach(Lane.allCases, id: \.self) { option in
-                laneChip(option)
+    /// Walks you've been asked to join, at the very top.
+    ///
+    /// This is the piece that was missing entirely. `buddy.invites` has always
+    /// been fetched and stored, but the ONLY thing that ever read it was a count
+    /// badge on the dashboard pill — there was no list anywhere in the app. So a
+    /// buddy_invite push landed, the tap routed to the Dashboard, and the invite
+    /// was a number on a pill that opened a screen which didn't mention it. The
+    /// honest description of that is: you could be invited, and you could not
+    /// accept.
+    @ViewBuilder
+    private var invitesSection: some View {
+        if !buddy.invites.isEmpty {
+            VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+                sectionTitle(
+                    buddy.invites.count == 1
+                        ? "You've been invited" : "\(buddy.invites.count) invites")
+                VStack(spacing: MADTheme.Spacing.sm) {
+                    ForEach(buddy.invites) { invite in
+                        inviteRow(invite)
+                    }
+                }
             }
         }
-        .padding(4)
-        .background(Capsule().fill(MADTheme.Colors.madWhite.opacity(0.10)))
     }
 
-    private func laneChip(_ option: Lane) -> some View {
-        let isOn = lane == option
-        return Button {
-            MADHaptics.tap()
-            // No withAnimation and no focus write here, deliberately. Animating
-            // this cross-fades two whole subtrees, and toggling focus from the
-            // chip drove a keyboard present/dismiss cycle on every tap — both
-            // land as input lag. The join lane focuses itself once it exists.
-            lane = option
-        } label: {
-            HStack(spacing: 6) {
-                Image(systemName: option.icon).font(.system(size: 13, weight: .semibold))
-                Text(option.title).font(MADTheme.Typography.bodyBold)
+    private func inviteRow(_ invite: BuddySessionState) -> some View {
+        let host = invite.participants.first(where: { $0.isHost })
+        let tint = MADTheme.workoutColor(invite.activityType)
+
+        return VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+            HStack(spacing: MADTheme.Spacing.md) {
+                AvatarView(
+                    name: host?.displayName ?? "Friend",
+                    imageURL: host?.profileImageUrl,
+                    size: 44
+                )
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("\(host?.displayName ?? "A friend") invited you")
+                        .font(MADTheme.Typography.bodyBold)
+                        .foregroundStyle(MADTheme.Colors.madWhite)
+                        .lineLimit(1)
+                    Text(inviteDetail(invite))
+                        .font(MADTheme.Typography.caption)
+                        .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.6))
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 0)
             }
-            .frame(maxWidth: .infinity)
-            .frame(height: Self.chipHeight)
-            .background(Capsule().fill(isOn ? accent : .clear))
-            .foregroundStyle(
-                isOn ? MADTheme.Colors.madWhite : MADTheme.Colors.madWhite.opacity(0.6))
+
+            HStack(spacing: MADTheme.Spacing.sm) {
+                Button {
+                    MADHaptics.action()
+                    Task {
+                        do {
+                            try await buddy.join(sessionId: invite.id)
+                            if let joined = buddy.session {
+                                onCreated(joined)
+                                dismiss()
+                            }
+                        } catch {
+                            errorText =
+                                (error as? LocalizedError)?.errorDescription
+                                ?? "Couldn't join that walk."
+                        }
+                    }
+                } label: {
+                    Text("Join")
+                        .font(MADTheme.Typography.bodyBold)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 42)
+                        .background(Capsule().fill(tint))
+                        .foregroundStyle(MADTheme.Colors.madWhite)
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    MADHaptics.tap()
+                    Task { await buddy.decline(sessionId: invite.id) }
+                } label: {
+                    Text("Not now")
+                        .font(MADTheme.Typography.body)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 42)
+                        .background(
+                            Capsule().fill(MADTheme.Colors.madWhite.opacity(0.10)))
+                        .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.75))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(MADTheme.Spacing.md)
+        .background(plainCard())
+        .overlay(
+            RoundedRectangle(
+                cornerRadius: MADTheme.CornerRadius.large, style: .continuous
+            )
+            .strokeBorder(tint.opacity(0.45), lineWidth: 1.5)
+        )
+    }
+
+    private func inviteDetail(_ invite: BuddySessionState) -> String {
+        let activity = invite.isRunning ? "Run" : "Walk"
+        if let goal = invite.goalValue, goal > 0 {
+            let unit = invite.mode == .raceTime ? "min" : "mi"
+            let number =
+                goal == goal.rounded()
+                ? "\(Int(goal))" : String(format: "%.1f", goal)
+            return "\(invite.mode.title) · \(number) \(unit) · \(activity)"
+        }
+        return "\(invite.mode.title) · \(activity)"
+    }
+
+    // MARK: - Partners
+
+    /// Miles you've actually put in together.
+    ///
+    /// The retention line. Nothing in the app recorded that two people had
+    /// walked forty miles across twelve walks, which is the number that turns a
+    /// shared habit into a thing you have rather than one you keep
+    /// re-arranging. Hidden until there IS a history — an empty "0 walks" panel
+    /// on someone's first day is discouraging, not motivating.
+    @ViewBuilder
+    private var partnersSection: some View {
+        if !buddy.partners.isEmpty {
+            VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+                sectionTitle("You've walked with")
+                VStack(spacing: 0) {
+                    ForEach(Array(buddy.partners.prefix(5).enumerated()), id: \.element.id) {
+                        index, partner in
+                        if index > 0 {
+                            Divider().background(MADTheme.Colors.madWhite.opacity(0.08))
+                        }
+                        partnerRow(partner)
+                    }
+                }
+                .background(plainCard())
+            }
+        }
+    }
+
+    /// Tapping a partner picks them for THIS walk — the stat and the action are
+    /// the same gesture, so "we've walked 14 miles together" is one tap from
+    /// "let's go again".
+    private func partnerRow(_ partner: BuddyPartner) -> some View {
+        let canPick = buddy.candidates.contains { $0.userId == partner.userId }
+        return Button {
+            guard canPick else { return }
+            MADHaptics.tap()
+            withAnimation(MADTheme.Animation.quick) {
+                if selected.contains(partner.userId) {
+                    selected.remove(partner.userId)
+                } else {
+                    selected.insert(partner.userId)
+                }
+            }
+        } label: {
+            HStack(spacing: MADTheme.Spacing.md) {
+                AvatarView(
+                    name: partner.displayName,
+                    imageURL: partner.profileImageUrl,
+                    size: 36
+                )
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(partner.displayName)
+                        .font(MADTheme.Typography.smallBold)
+                        .foregroundStyle(MADTheme.Colors.madWhite)
+                    Text(partner.summary)
+                        .font(MADTheme.Typography.caption)
+                        .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.55))
+                }
+                Spacer(minLength: 0)
+                if canPick {
+                    Image(
+                        systemName: selected.contains(partner.userId)
+                            ? "checkmark.circle.fill" : "circle"
+                    )
+                    .font(.system(size: 18))
+                    .foregroundStyle(
+                        selected.contains(partner.userId)
+                            ? accent : MADTheme.Colors.madWhite.opacity(0.25))
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-    }
-
-    // MARK: - Join lane
-
-    private var joinLane: some View {
-        VStack(spacing: MADTheme.Spacing.lg) {
-            VStack(spacing: MADTheme.Spacing.sm) {
-                ZStack {
-                    Circle().fill(accent.opacity(0.18)).frame(width: 72, height: 72)
-                    Image(systemName: "number")
-                        .font(.system(size: 30, weight: .bold))
-                        .foregroundStyle(accent)
-                }
-                Text("Enter their code")
-                    .font(MADTheme.Typography.title3)
-                    .foregroundStyle(MADTheme.Colors.madWhite)
-                Text("Six characters, shown on the host's screen while they wait.")
-                    .font(MADTheme.Typography.subheadline)
-                    .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.65))
-                    .multilineTextAlignment(.center)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, MADTheme.Spacing.lg)
-            .padding(.horizontal, MADTheme.Spacing.md)
-            .madLiquidGlass(cornerRadius: MADTheme.CornerRadius.extraLarge)
-
-            TextField("ABC123", text: $joinCode)
-                .textInputAutocapitalization(.characters)
-                .autocorrectionDisabled()
-                .multilineTextAlignment(.center)
-                .font(.system(size: 34, weight: .bold, design: .rounded))
-                .tracking(8)
-                .foregroundStyle(MADTheme.Colors.madWhite)
-                .focused($codeFocused)
-                .padding(MADTheme.Spacing.md)
-                .madLiquidGlass(cornerRadius: MADTheme.CornerRadius.large)
-                .onChange(of: joinCode) { _, newValue in
-                    joinCode = String(newValue.uppercased().prefix(6))
-                }
-                .onAppear { codeFocused = true }
-        }
+        .disabled(!canPick)
     }
 
     // MARK: - Summary header
@@ -776,11 +884,9 @@ struct BuddyStartSheet: View {
                 // earlier label said "start", so tapping it felt like committing
                 // to walking RIGHT NOW — people backed out rather than find out.
                 // Nothing about the flow changed; it always opened a lobby.
-                if lane == .start {
-                    Text("Nobody moves until you start it.")
-                        .font(MADTheme.Typography.caption)
-                        .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.5))
-                }
+                Text("Nobody moves until you start it.")
+                    .font(MADTheme.Typography.caption)
+                    .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.5))
             }
             .padding(.horizontal, MADTheme.Spacing.md)
             .padding(.bottom, MADTheme.Spacing.sm)
@@ -791,13 +897,13 @@ struct BuddyStartSheet: View {
     private var primaryButton: some View {
         Button {
             MADHaptics.action()
-            Task { lane == .start ? await create() : await join() }
+            Task { await create() }
         } label: {
             HStack(spacing: 8) {
-                if isCreating || isJoining {
+                if isCreating {
                     ProgressView().tint(MADTheme.Colors.madWhite)
                 } else {
-                    Image(systemName: lane == .start ? "figure.2" : "arrow.right.circle.fill")
+                    Image(systemName: "figure.2")
                         .font(.system(size: 16, weight: .semibold))
                 }
                 Text(primaryTitle)
@@ -813,10 +919,7 @@ struct BuddyStartSheet: View {
         .opacity(primaryDisabled ? 0.5 : 1)
     }
 
-    private var primaryDisabled: Bool {
-        if lane == .join { return joinCode.count < 6 || isJoining }
-        return isCreating
-    }
+    private var primaryDisabled: Bool { isCreating }
 
     /// Says CREATE, never START.
     ///
@@ -824,12 +927,7 @@ struct BuddyStartSheet: View {
     /// host taps Start in there — but every label it has worn said "start", so
     /// the screen promised something it didn't do. "Create lobby" describes the
     /// actual outcome, and the caption under the button closes the gap.
-    ///
-    /// It also never mentions the share code: an earlier label ("Start with a
-    /// share code") read as an INPUT and sat directly above the join field,
-    /// which genuinely does take one. The code is a consequence of creating.
     private var primaryTitle: String {
-        if lane == .join { return isJoining ? "Joining…" : "Join walk" }
         if isCreating { return "Creating…" }
         if selected.isEmpty { return "Create lobby" }
         return selected.count == 1 ? "Create & invite 1" : "Create & invite \(selected.count)"
@@ -930,21 +1028,4 @@ struct BuddyStartSheet: View {
         }
     }
 
-    private func join() async {
-        guard !isJoining else { return }
-        isJoining = true
-        defer { isJoining = false }
-        do {
-            try await buddy.join(code: joinCode)
-            if let session = buddy.session {
-                MADHaptics.success()
-                onCreated(session)
-                dismiss()
-            }
-        } catch {
-            MADHaptics.error()
-            errorText =
-                (error as? LocalizedError)?.errorDescription ?? "Couldn't join that walk."
-        }
-    }
 }

--- a/app/Mile A Day/Views/Friends/FriendsListView.swift
+++ b/app/Mile A Day/Views/Friends/FriendsListView.swift
@@ -17,6 +17,10 @@ private enum FriendsTabMode: String, CaseIterable, Identifiable {
 struct FriendsListView: View {
     @ObservedObject var friendService: FriendService
     @StateObject private var healthManager = HealthKitManager.shared
+    /// Live presence for the "Out right now" section. Shared singleton, so the
+    /// dashboard's prefetch has usually already populated it by the time this
+    /// tab is opened.
+    @ObservedObject private var buddy = BuddySessionService.shared
     @StateObject private var userManager = UserManager.shared
     @State private var topMode: FriendsTabMode = .friends
     @State private var showingSearch = false
@@ -139,6 +143,10 @@ struct FriendsListView: View {
             }
         }
         .task {
+            // Presence is the one thing on this screen that is only true for
+            // the next few minutes, so it is always re-pulled on open rather
+            // than trusted from whenever the dashboard last looked.
+            await buddy.refreshFriendsOutNow()
             if friendService.friends.isEmpty && friendService.friendRequests.isEmpty && friendService.sentRequests.isEmpty {
                 await friendService.refreshAllData()
             }
@@ -178,6 +186,7 @@ struct FriendsListView: View {
         .refreshable {
             // refreshAllData re-fetches nudge statuses internally.
             await friendService.refreshAllData()
+            await buddy.refreshFriendsOutNow()
             await loadMyRank()
             await loadFeed(force: true)
         }
@@ -343,6 +352,7 @@ struct FriendsListView: View {
                     )
                     .padding(.top, MADTheme.Spacing.lg)
                 } else {
+                    outRightNowSection
                     cheerThemOnSection
                     doneTodaySection
                 }
@@ -357,6 +367,65 @@ struct FriendsListView: View {
             .padding(.bottom, MADTheme.Spacing.xxl)
         }
         .scrollIndicators(.hidden)
+    }
+
+    // MARK: - Out right now
+
+    /// Friends who are walking or running THIS MINUTE.
+    ///
+    /// This lived only inside `WorkoutTrackingView`, which meant you could only
+    /// discover that a friend was out if you were already out yourself — useless
+    /// as a "should I go with them" signal, which is the entire point of knowing.
+    /// The friends list is where someone looks to see what their friends are
+    /// doing, so it belongs here.
+    ///
+    /// `BuddyJoinFriendCard` is reused verbatim rather than reimplemented: it
+    /// already reads live presence (so a friend out on their OWN appears, not
+    /// just one inside a buddy room) and already picks the right action —
+    /// **Join** when there's a room, **Ask to walk** when there isn't. Renders
+    /// nothing when nobody is out, so it never holds space speculatively.
+    @ViewBuilder
+    private var outRightNowSection: some View {
+        if !buddy.friendsOutNow.isEmpty {
+            VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
+                HStack(spacing: 8) {
+                    ZStack {
+                        Circle()
+                            .fill(MADTheme.Colors.success.opacity(0.35))
+                            .frame(width: 9, height: 9)
+                            .scaleEffect(1.9)
+                            .opacity(0.55)
+                        Circle()
+                            .fill(MADTheme.Colors.success)
+                            .frame(width: 9, height: 9)
+                    }
+                    Text("Out right now")
+                        .font(MADTheme.Typography.headline)
+                        .foregroundStyle(MADTheme.Colors.madWhite)
+                    Spacer()
+                }
+
+                BuddyJoinFriendCard(
+                    // Always false here: this list is not a workout screen, and
+                    // gating on a live workout would hide the section exactly
+                    // when a friend is most worth joining.
+                    hasActiveWorkout: false,
+                    onJoined: openJoinedLobby
+                )
+            }
+        }
+    }
+
+    /// Hand the joined session to the Dashboard, which owns the lobby
+    /// presentation (`BuddyFlowModifier`). Parking the id on `DeepLinkRouter`
+    /// is the same path a buddy push takes, so there is one way in rather than
+    /// two that can drift.
+    private func openJoinedLobby() {
+        guard let sessionId = buddy.session?.id else { return }
+        DeepLinkRouter.shared.requestOpenBuddySession(sessionId: sessionId)
+        NotificationCenter.default.post(
+            name: NSNotification.Name("MAD_SwitchTab"), object: nil, userInfo: ["tab": 0]
+        )
     }
 
     // MARK: - Today (rolling-48h workout feed + hypes)

--- a/backend/scripts/buddy-gate-check.mjs
+++ b/backend/scripts/buddy-gate-check.mjs
@@ -27,6 +27,7 @@ import {
 } from "../dist/services/buddyRecurringService.js";
 import {
   createSession,
+  getBuddyPartners,
   getInviteCandidates,
   startSession,
   updateSession,
@@ -428,6 +429,61 @@ async function main() {
 
   check("routines list for their owner", (await listRecurringWalks(HOST)).length, 1);
   check("routines are per-user", (await listRecurringWalks(PAL)).length, 0);
+
+  // ── 6. Miles walked together ────────────────────────────────────────
+  //
+  // Derived, never stored, so the risk is the JOIN shape rather than drift.
+  const together = await db.query(
+    `INSERT INTO buddy_sessions
+       (join_code, host_user_id, mode, activity_type, status, origin, local_date)
+     VALUES ('TGTHR1', $1, 'together', 'walking', 'completed', 'invite', CURRENT_DATE)
+     RETURNING id`,
+    [HOST],
+  );
+  const togetherId = together[0].id;
+  await db.query(
+    `INSERT INTO buddy_session_participants
+       (session_id, user_id, status, final_distance_miles)
+     VALUES ($1, $2, 'finished', 1.5), ($1, $3, 'finished', 1.4)`,
+    [togetherId, HOST, PAL],
+  );
+
+  const partners = await getBuddyPartners(HOST);
+  check("a finished walk shows up as a partner", partners.length, 1);
+  check("the partner is the right person", partners[0]?.user_id, PAL);
+  // YOUR miles, not the pooled 2.9 — a pooled figure double-counts the same
+  // walk from each side, so the two of you would see different numbers.
+  check("miles are the viewer's own", Number(partners[0]?.miles_together), 1.5);
+  check("walks are counted", partners[0]?.walks, 1);
+
+  // A walk the other person abandoned isn't a walk you took together.
+  await db.query(
+    `UPDATE buddy_session_participants SET status = 'left'
+      WHERE session_id = $1 AND user_id = $2`,
+    [togetherId, PAL],
+  );
+  check(
+    "an abandoned walk does not count",
+    (await getBuddyPartners(HOST)).length,
+    0,
+  );
+  await db.query(
+    `UPDATE buddy_session_participants SET status = 'finished'
+      WHERE session_id = $1 AND user_id = $2`,
+    [togetherId, PAL],
+  );
+
+  // Un-friend them and the history stops being readable — you walked with
+  // them, but that doesn't entitle you to their profile forever.
+  await db.query(
+    `DELETE FROM friendships WHERE user_id = $1 AND friend_id = $2`,
+    [HOST, PAL],
+  );
+  check(
+    "history is withheld once the friendship ends",
+    (await getBuddyPartners(HOST)).length,
+    0,
+  );
 
   await cleanup();
 

--- a/backend/src/controllers/buddyController.ts
+++ b/backend/src/controllers/buddyController.ts
@@ -24,6 +24,7 @@ import {
   leaveSession,
   recordProgress,
   setReady,
+  getBuddyPartners,
   startSession,
   updateSession,
 } from "../services/buddySessionService.js";
@@ -518,5 +519,22 @@ export async function deleteRoutineController(
     res.json({ ok: true });
   } catch (error) {
     handleError(res, error, "deleting buddy routine");
+  }
+}
+
+/**
+ * GET /buddy/partners — who you actually walk with, and how much.
+ *
+ * Self-scoped on the token: your own walking history is yours.
+ */
+export async function partnersController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  if (!requireEnabled(res)) return;
+  try {
+    res.json({ partners: await getBuddyPartners(req.userId!) });
+  } catch (error) {
+    handleError(res, error, "loading buddy partners");
   }
 }

--- a/backend/src/routes/buddyRoutes.ts
+++ b/backend/src/routes/buddyRoutes.ts
@@ -18,6 +18,7 @@ import {
   createRoutineController,
   deleteRoutineController,
   listRoutinesController,
+  partnersController,
   updateRoutineController,
   updateSessionController,
 } from "../controllers/buddyController.js";
@@ -59,6 +60,9 @@ router.post("/sessions/:sessionId/finish", finishController);
 // spawns a real scheduled session from each one shortly before it's due, so
 // everything downstream is the existing lobby machinery. Self-scoped on the
 // token; ownership is re-checked in the service.
+// Miles walked together, per friend. The number that makes a shared habit
+// feel like a thing you have rather than one you keep re-arranging.
+router.get("/partners", partnersController);
 router.get("/recurring", listRoutinesController);
 router.post("/recurring", createRoutineController);
 router.patch("/recurring/:routineId", updateRoutineController);

--- a/backend/src/services/buddySessionService.ts
+++ b/backend/src/services/buddySessionService.ts
@@ -1582,3 +1582,76 @@ export async function sweepAbandonedSessions(): Promise<number> {
 
   return stale.length;
 }
+
+// ─── Shared history ─────────────────────────────────────────────────────
+
+export interface BuddyPartner {
+  user_id: string;
+  username: string | null;
+  first_name: string | null;
+  profile_image_url: string | null;
+  /** Walks the two of you both finished. */
+  walks: number;
+  /** YOUR miles across those walks — not the pooled total. */
+  miles_together: number;
+  /** `date` column, so a plain string is safe. */
+  last_walk_date: string | null;
+}
+
+/**
+ * Who you actually walk with, and how much.
+ *
+ * Nothing in the app recorded that two people have walked forty miles together
+ * across twelve walks, which is the number that makes a shared habit feel like
+ * a thing you HAVE rather than a thing you keep re-arranging. Derived entirely
+ * from existing rows — no new writes, no counters to drift.
+ *
+ * Counts only sessions BOTH of you finished: a walk one person abandoned in the
+ * lobby isn't a walk you took together, and counting it would inflate the one
+ * number the feature is asking people to trust.
+ *
+ * The miles reported are the VIEWER's own, deliberately. A pooled total sounds
+ * bigger but double-counts the same walk from each side, so the two of you
+ * would see different numbers for the same history and neither would match the
+ * distance either actually covered. `final_distance_miles` is the reconciled
+ * figure stamped from the real synced workout; `distance_miles` is the live
+ * display value and is only a fallback.
+ *
+ * Names are re-gated on the friendship still existing and no block either way —
+ * you walked with them, but that doesn't entitle you to their profile forever.
+ */
+export async function getBuddyPartners(
+  userId: string,
+  limit = 10,
+): Promise<BuddyPartner[]> {
+  return db.query<BuddyPartner>(
+    `SELECT u.user_id, u.username, u.first_name, u.profile_image_url,
+            COUNT(*)::int AS walks,
+            ROUND(SUM(COALESCE(me.final_distance_miles, me.distance_miles))::numeric, 2)::float
+              AS miles_together,
+            to_char(MAX(s.local_date), 'YYYY-MM-DD') AS last_walk_date
+       FROM buddy_session_participants me
+       JOIN buddy_sessions s ON s.id = me.session_id
+       JOIN buddy_session_participants them
+         ON them.session_id = me.session_id AND them.user_id <> me.user_id
+       JOIN users u ON u.user_id = them.user_id
+      WHERE me.user_id = $1
+        AND me.status = 'finished'
+        AND them.status = 'finished'
+        AND s.status = 'completed'
+        AND EXISTS (
+          SELECT 1 FROM friendships f
+           WHERE f.user_id = $1 AND f.friend_id = u.user_id
+             AND f.status = 'accepted'
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM user_blocks b
+           WHERE (b.blocker_id = $1 AND b.blocked_id = u.user_id)
+              OR (b.blocker_id = u.user_id AND b.blocked_id = $1)
+        )
+      GROUP BY u.user_id, u.username, u.first_name, u.profile_image_url
+      ORDER BY miles_together DESC, walks DESC
+      LIMIT $2`,
+    [userId, Math.min(Math.max(limit, 1), 50)],
+  );
+}


### PR DESCRIPTION
## 1. You could be invited, and you could not accept

This is the bug behind *"I click the notification and I can't find it."*

`buddy.invites` has always been fetched and stored. The **only** thing in the entire app that read it was a count badge on the dashboard pill (`BuddyWalkPill.swift:73`). There was no list anywhere. So a `buddy_invite` push arrived, the tap routed to the Dashboard, and the invite was a number on a pill that opened a sheet which never mentioned it.

There's now an invites section at the top of the buddy sheet — who invited you, what the walk is, **Join** / **Not now** — and the sheet refreshes invites on open.

## 2. Join codes are gone

Codes existed to pull in someone the app couldn't name. But everyone you can walk with is already an accepted friend, so a code was a second, weaker path to what the friend list does better: it had to be read aloud or pasted, it could be mistyped, and it put a text field on screen that most people read as *the* way in.

Removed: the Start/Join lane picker, the code entry field, and the lobby's code + QR block. `POST /buddy/sessions/join` **stays on the server untouched** — shipped builds still call it — it simply has no UI.

## 3. Miles walked together

Nothing recorded that two people had walked forty miles across twelve walks. Derived from finished sessions **both** people completed; never stored, so it can't drift.

It reports the **viewer's own** miles, deliberately. A pooled total sounds bigger but double-counts the same walk from each side, so you and your partner would see different numbers for the same history and neither would match what either actually covered.

Tapping a partner selects them for this walk, so "we've walked 14 miles together" is one tap from "let's go again".

## 4. The tracking rings meant "are you winning"

From the second screenshot: one green ring, one blue arc, two unexplained red dots.

`ringProgress` was `yourDistance / leaderDistance`, which makes the leader's ring **full** — and `AvatarWithRing` paints a full ring **solid green**. So in *Just Together*, a mode whose own subtitle is "No goal — just move together", whoever was a few feet ahead got a green trophy ring and everyone else a partial blue arc, rescaling every time anyone moved.

- Rings now fill toward a **fixed** target (the session goal, else the daily mile), with a line saying so. Green-at-full now means "they finished their mile".
- The always-on red `.live` dot is gone — it marked "workout in progress" on every face, during a workout.
- Tiles 64 → 78pt. The 52pt ring + 4pt stroke + the badge's `.offset` overhang never fit in 64, and `.offset` draws outside layout bounds — so the ring and the two-decimal distance were both being cropped, exactly as the screenshot shows.

## 5. iOS type-check CI

There has never been one. Every Swift break this session reached `main` because of it.

**Non-blocking to start** (`continue-on-error: true`). This job has never run, and a whole-target `swiftc -typecheck` can fail for reasons unrelated to any diff — turning it red on day one would block every merge. Read the log, confirm it goes green on a known-good commit, **then delete that line so it gates**. It only runs on `macos-latest`, which bills at 10× Linux minutes.

## Verification

`tsc` clean, `drizzle-kit check` clean, migrator idempotent, `ci-smoke` + `ghost-race-check` + **`buddy-gate-check` (54 assertions)** all passing against a real migrated Postgres 16.

New partner assertions cover the parts most likely to be wrong: the viewer's own miles rather than the pool, an abandoned walk not counting, and history withheld once the friendship ends.

No migration in this PR.

## Notes

- **iOS is still not compile-verified here** — which is what §5 exists to fix. `BuddyStartSheet` loses ~90 lines (lane picker, join lane, `join()`) and gains two sections; `BuddyLobbyView` loses the share block; `BuddyRosterStrip` is reworked. Brace balance checked mechanically on all four files, which is not a compiler.
- The new CI job's first run on this PR is itself the test of whether the type-check approach works at all. If it fails on something structural (SDK, missing build settings) rather than on my code, that's worth knowing before it gates anything.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxEp1wW88Y5PxyTxgAoE3L)_