### PR TITLE
Stop double-counting cross-app walks; make live presence worth watching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,12 @@ jobs:
       # and the host-only lobby PATCH.
       - name: Buddy gate + lobby-edit check
         run: node scripts/buddy-gate-check.mjs
+      # Cross-app duplicate detection. An app that records a FRAGMENT of a walk
+      # another app already recorded fails every distance-agreement test while
+      # being unambiguously the same walk — which is how a 1.84 mi walk counted
+      # as 2.55 in production.
+      - name: Cross-app duplicate containment check
+        run: node scripts/dedupe-containment-check.mjs
 
   website:
     name: Website (lint + build)

--- a/app/Mile A Day/Models/BuddySession.swift
+++ b/app/Mile A Day/Models/BuddySession.swift
@@ -425,6 +425,17 @@ struct FriendOutNow: Codable, Identifiable, Equatable {
     let lastName: String?
     let profileImageUrl: String?
     let workoutType: String
+    /// Live miles as of their last heartbeat. Monotonic server-side.
+    /// Optional: absent from older server builds, in which case the row shows
+    /// presence without asserting a confident "0.00".
+    let distanceMiles: Double?
+    /// THEIR daily goal, so progress draws against the right target.
+    let goalMiles: Double?
+    /// When their session started — used for "out 12m".
+    let startedAt: String?
+    /// Their CURRENT local date: the composite key half needed to hype a mile
+    /// mid-walk through the existing endpoint.
+    let localDate: String?
     /// Non-nil only when they're in a buddy room that has space left.
     let buddySessionId: String?
     let buddyJoinCode: String?
@@ -448,6 +459,9 @@ struct FriendOutNow: Codable, Identifiable, Equatable {
     /// which is an invitation opportunity, not a dead end.
     var hasJoinableRoom: Bool { buddySessionId != nil }
 
+    /// Their goal, defaulting to the app's premise when the server didn't say.
+    var goal: Double { (goalMiles ?? 0) > 0 ? (goalMiles ?? 1) : 1 }
+
     enum CodingKeys: String, CodingKey {
         case userId = "user_id"
         case username
@@ -455,6 +469,10 @@ struct FriendOutNow: Codable, Identifiable, Equatable {
         case lastName = "last_name"
         case profileImageUrl = "profile_image_url"
         case workoutType = "workout_type"
+        case distanceMiles = "distance_miles"
+        case goalMiles = "goal_miles"
+        case startedAt = "started_at"
+        case localDate = "local_date"
         case buddySessionId = "buddy_session_id"
         case buddyJoinCode = "buddy_join_code"
         case buddyMode = "buddy_mode"

--- a/app/Mile A Day/Services/FriendService.swift
+++ b/app/Mile A Day/Services/FriendService.swift
@@ -823,6 +823,14 @@ struct FriendWorkout: Codable, Identifiable {
     /// This run has a real (non-auto) photo post — never a generated route/stats
     /// card. Optional: absent from older servers. Existence only, never a url.
     let hasPhoto: Bool?
+    /// Which app wrote this into Apple Health. Optional: absent on older
+    /// server builds, and nil reads as first-party (no chip drawn).
+    let sourceBundleId: String?
+    /// Why this isn't counting, if it isn't. 'duplicate_source' is the one the
+    /// owner can overrule.
+    let exclusionReason: String?
+    /// The owner's own answer, which outranks detection: "count" / "exclude".
+    let duplicateDecision: String?
 
     var isManualOrEdited: Bool {
         source == "manual" || source == "edited"
@@ -840,6 +848,9 @@ struct FriendWorkout: Codable, Identifiable {
         case source
         case hasRoute = "has_route"
         case hasPhoto = "has_photo"
+        case sourceBundleId = "source_bundle_id"
+        case exclusionReason = "exclusion_reason"
+        case duplicateDecision = "duplicate_decision"
     }
 
     var formattedDate: String {

--- a/app/Mile A Day/Services/LivePresenceService.swift
+++ b/app/Mile A Day/Services/LivePresenceService.swift
@@ -26,6 +26,13 @@ struct LiveFriendOut: Decodable, Equatable, Identifiable {
     let profile_image_url: String?
     let workout_type: String
     let started_at: String
+    /// Live miles as of their last heartbeat. Monotonic server-side, so this
+    /// never ticks backwards while someone is watching it.
+    /// Optional: absent from older server builds.
+    let distance_miles: Double?
+    /// THEIR daily goal, so progress is drawn against the right target rather
+    /// than a hardcoded mile. Optional for the same reason.
+    let goal_miles: Double?
     /// The friend's CURRENT local date — the composite key half needed to
     /// send them a mile hype through the existing hype endpoint.
     let local_date: String
@@ -133,8 +140,21 @@ final class LivePresenceService: ObservableObject {
         Task {
             defer { self.inFlight = false }
             do {
-                struct Body: Encodable { let session_id: String }
-                let body = try JSONEncoder().encode(Body(session_id: sessionId))
+                struct Body: Encodable {
+                    let session_id: String
+                    let distance_miles: Double
+                }
+                // The tracker's own live number, so friends watching see how
+                // far this walk has actually got rather than only that it
+                // exists. `liveDistance` is THE workout number everywhere else
+                // (see WorkoutLocationManager) — reusing it means the figure a
+                // friend sees is the one the walker sees.
+                let body = try JSONEncoder().encode(
+                    Body(
+                        session_id: sessionId,
+                        distance_miles: WorkoutLocationManager.shared.liveDistance
+                    )
+                )
                 let resp: HeartbeatResponse = try await APIClient.fancyFetch(
                     endpoint: "/live/heartbeat",
                     method: .POST,

--- a/app/Mile A Day/Views/BuddyWalks/BuddyJoinFriendCard.swift
+++ b/app/Mile A Day/Views/BuddyWalks/BuddyJoinFriendCard.swift
@@ -1,120 +1,152 @@
 import SwiftUI
 
-/// "Alex is walking right now."
+/// "Alex is walking right now — 0.62 of 1 mi."
 ///
 /// The permission-free stand-in for ambient proximity sensing. Detecting nearby
 /// friends in the background would need CoreBluetooth background advertising —
 /// unreliable, battery-hungry, and a heavy privacy/App Review surface — and it
 /// would only ever work for people physically next to you. This produces the
 /// same "they're doing it, go with them" moment at any distance, for remote
-/// friends too, and costs nothing but one pull on the dashboard.
+/// friends too, and costs nothing but one pull.
 ///
-/// It reads LIVE PRESENCE rather than buddy rooms. That distinction is the
-/// whole point: the earlier version could only see friends already inside a
-/// buddy session, so a friend out walking on their own — the single best person
-/// to start a walk with — didn't appear at all. Now both show up, with the
-/// action that fits:
-///   - already in a room → **Join**
-///   - out on their own  → **Ask to walk** (starts a session and invites them)
+/// It reads LIVE PRESENCE rather than buddy rooms, so a friend out walking on
+/// their own — the single best person to start a walk with — appears alongside
+/// one already in a room, each with the action that fits.
 ///
-/// Renders nothing when nobody is out, so it never occupies dashboard space
-/// speculatively.
+/// **Density.** A popular user can have a dozen friends out at once, and twelve
+/// full-width rows is a wall that buries whatever was below it. Past
+/// `collapseThreshold` the list shows the closest-to-finishing few and folds the
+/// rest behind one line, because "who is nearly done" is the group most worth
+/// cheering and the one where a hype lands while it still counts.
 struct BuddyJoinFriendCard: View {
+    /// Hides the Join/Ask action — you cannot join a walk during a walk. The
+    /// rows still render: seeing a friend is out is useful mid-workout too,
+    /// and hyping them from there is the whole point of the tracker's sheet.
     let hasActiveWorkout: Bool
-    /// Called after a successful join so the dashboard can open the lobby.
+    /// Called after a successful join so the host surface can open the lobby.
     let onJoined: () -> Void
 
     @ObservedObject private var buddy = BuddySessionService.shared
     @State private var busyUserId: String?
-    /// Friends we've already invited this session — the row stays, because they
-    /// are still out and that's still true, but the button must not read as
-    /// though nothing happened.
+    /// Friends we've already invited — the row stays, because they are still
+    /// out and that's still true, but the button must not read as though
+    /// nothing happened.
     @State private var askedUserIds: Set<String> = []
+    @State private var hypedUserIds: Set<String> = []
+    @State private var expanded = false
+
+    private static let collapseThreshold = 3
+
+    /// Closest to finishing first. Someone at 0.9 mi is minutes from a
+    /// celebration; someone at 0.05 has half an hour to go.
+    private var ordered: [FriendOutNow] {
+        buddy.friendsOutNow.sorted {
+            ($0.distanceMiles ?? 0) / $0.goal > ($1.distanceMiles ?? 0) / $1.goal
+        }
+    }
+
+    private var visible: [FriendOutNow] {
+        guard ordered.count > Self.collapseThreshold, !expanded else { return ordered }
+        return Array(ordered.prefix(Self.collapseThreshold))
+    }
 
     var body: some View {
-        if !hasActiveWorkout, !buddy.friendsOutNow.isEmpty {
+        if !buddy.friendsOutNow.isEmpty {
             VStack(spacing: MADTheme.Spacing.sm) {
-                ForEach(buddy.friendsOutNow) { friend in
+                ForEach(visible) { friend in
                     row(friend)
+                }
+
+                if ordered.count > Self.collapseThreshold {
+                    Button {
+                        MADHaptics.tap()
+                        withAnimation(MADTheme.Animation.standard) { expanded.toggle() }
+                    } label: {
+                        HStack(spacing: 6) {
+                            Text(
+                                expanded
+                                    ? "Show fewer"
+                                    : "\(ordered.count - Self.collapseThreshold) more out right now"
+                            )
+                            Image(systemName: expanded ? "chevron.up" : "chevron.down")
+                                .font(.system(size: 10, weight: .bold))
+                        }
+                        .font(MADTheme.Typography.caption)
+                        .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.6))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 6)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
                 }
             }
         }
     }
 
     private func row(_ friend: FriendOutNow) -> some View {
-        HStack(spacing: MADTheme.Spacing.md) {
-            AvatarView(
-                name: friend.displayName,
-                imageURL: friend.profileImageUrl,
-                size: 40
-            )
-            .overlay(alignment: .bottomTrailing) {
-                Circle()
-                    .fill(MADTheme.Colors.success)
-                    .frame(width: 12, height: 12)
-                    .overlay(Circle().stroke(MADTheme.Colors.madBlack, lineWidth: 2))
-            }
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text("\(friend.displayName) is \(friend.isRunning ? "running" : "walking")")
-                    .font(MADTheme.Typography.smallBold)
-                    .foregroundStyle(MADTheme.Colors.madWhite)
-                    .lineLimit(1)
-
-                Text(subtitle(friend))
-                    .font(MADTheme.Typography.caption)
-                    .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.6))
-                    .lineLimit(1)
-            }
-
-            Spacer(minLength: 0)
-
-            action(friend)
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .frame(maxWidth: .infinity)
-        .background(Capsule().fill(Color.white.opacity(0.10)))
-        .overlay(Capsule().stroke(Color.white.opacity(0.14), lineWidth: 1))
-    }
-
-    @ViewBuilder
-    private func action(_ friend: FriendOutNow) -> some View {
-        if busyUserId == friend.userId {
-            ProgressView().tint(MADTheme.Colors.madWhite)
-        } else if askedUserIds.contains(friend.userId) {
-            Text("Invited")
-                .font(MADTheme.Typography.smallBold)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 7)
-                .background(Capsule().fill(Color.white.opacity(0.12)))
-                .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.7))
-        } else {
-            Button {
-                Task { await act(friend) }
-            } label: {
-                Text(friend.hasJoinableRoom ? "Join" : "Ask to walk")
-                    .font(MADTheme.Typography.smallBold)
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 7)
-                    .background(Capsule().fill(friend.accentColor))
-                    .foregroundStyle(MADTheme.Colors.madWhite)
-            }
-            .buttonStyle(.plain)
-            .disabled(busyUserId != nil)
-        }
+        FriendOutLiveRow(
+            name: friend.displayName,
+            imageURL: friend.profileImageUrl,
+            isRunning: friend.isRunning,
+            distanceMiles: friend.distanceMiles,
+            goalMiles: friend.goal,
+            subtitle: subtitle(friend),
+            canJoin: !hasActiveWorkout && !askedUserIds.contains(friend.userId),
+            joinTitle: friend.hasJoinableRoom ? "Join" : "Ask to walk",
+            onJoin: { Task { await act(friend) } },
+            onHype: { Task { await hype(friend) } },
+            hyped: hypedUserIds.contains(friend.userId),
+            busy: busyUserId == friend.userId
+        )
     }
 
     private func subtitle(_ friend: FriendOutNow) -> String {
+        if askedUserIds.contains(friend.userId) { return "Invited — waiting on them" }
+        let elapsed = FriendOutTime.elapsed(since: friend.startedAt)
         guard friend.hasJoinableRoom else {
-            return "On their own — ask them to team up"
+            return elapsed ?? "On their own"
         }
         let others = max(0, (friend.buddyParticipantCount ?? 1) - 1)
         let people = others == 0
             ? "on their own"
             : (others == 1 ? "with 1 other" : "with \(others) others")
-        let mode = friend.buddyMode?.title ?? "Buddy walk"
-        return "\(mode) · \(people)"
+        return [friend.buddyMode?.title ?? "Buddy walk", people].joined(separator: " · ")
+    }
+
+    /// Hype a friend mid-walk.
+    ///
+    /// Uses the SAME 'mile' composite the rest of the app does
+    /// (`<userId>:<localDate>`) rather than a bespoke context, so it dedupes
+    /// against a hype sent from the feed for the same day and lands on their
+    /// tracking screen through LivePresenceService's hype poll. The local_date
+    /// has to be THEIRS, not the viewer's — the server keys on the walker's day.
+    private func hype(_ friend: FriendOutNow) async {
+        guard !hypedUserIds.contains(friend.userId) else { return }
+        // Optimistic: a clap that waits on the network reads as a dead button,
+        // and the failure path below puts it back.
+        hypedUserIds.insert(friend.userId)
+        MADHaptics.success()
+        do {
+            if let localDate = friend.localDate {
+                _ = try await HypeService.sendHype(
+                    targetUserId: friend.userId,
+                    context: HypeContext(
+                        contextType: "mile",
+                        contextId: "\(friend.userId):\(localDate)",
+                        contextLabel: friend.isRunning ? "run" : "walk"
+                    )
+                )
+            } else {
+                // Older server build with no local_date on the wire. The
+                // context-less path still reaches them.
+                _ = try await HypeService.sendHype(targetUserId: friend.userId)
+            }
+        } catch {
+            hypedUserIds.remove(friend.userId)
+            MADHaptics.error()
+            buddy.errorMessage =
+                (error as? LocalizedError)?.errorDescription ?? "Couldn't send that."
+        }
     }
 
     private func act(_ friend: FriendOutNow) async {

--- a/app/Mile A Day/Views/BuddyWalks/FriendOutLiveRow.swift
+++ b/app/Mile A Day/Views/BuddyWalks/FriendOutLiveRow.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+
+/// A friend who is walking or running RIGHT NOW, with how far they've got.
+///
+/// One row, used everywhere presence appears — the dashboard, the friends list,
+/// the tracker's sheet — so a friend mid-walk looks the same wherever you meet
+/// them. Presence used to be a name and a green dot; the thing anyone watching
+/// actually wants is how it's going, which is why the ring and the distance are
+/// the row's centre rather than decoration.
+///
+/// Progress is drawn against THEIR goal, not the viewer's. A friend on a
+/// two-mile goal rendered against a one-mile bar reads as finished when they're
+/// halfway.
+///
+/// Two actions, both one tap:
+///   - **Hype** — always available. It's the cheap, generous one, and it lands
+///     on their tracking screen mid-walk (LivePresenceService picks it up), so
+///     it is genuinely real-time encouragement rather than a notification they
+///     read afterwards.
+///   - **Join** / **Ask to walk** — Join when they're in a room with space,
+///     Ask when they're on their own. Hidden while the viewer is mid-workout,
+///     because you cannot join a walk during a walk.
+struct FriendOutLiveRow: View {
+    let name: String
+    let imageURL: String?
+    let isRunning: Bool
+    /// Nil when the server hasn't reported one yet (older build, or the very
+    /// first heartbeat). The row degrades to presence-only rather than
+    /// asserting a confident "0.00".
+    let distanceMiles: Double?
+    let goalMiles: Double
+    let subtitle: String
+    let canJoin: Bool
+    let joinTitle: String
+    /// Nil hides the action entirely — used while the viewer is mid-workout.
+    let onJoin: (() -> Void)?
+    let onHype: (() -> Void)?
+    var hyped: Bool = false
+    var busy: Bool = false
+
+    private var accent: Color {
+        MADTheme.workoutColor(isRunning ? "running" : "walking")
+    }
+
+    private var progress: Double {
+        guard let distanceMiles, goalMiles > 0 else { return 0 }
+        return min(1, distanceMiles / goalMiles)
+    }
+
+    /// "0.62 of 1 mi" — the goal is stated so the ring is self-explaining.
+    private var distanceText: String {
+        guard let distanceMiles else { return isRunning ? "Running" : "Walking" }
+        let goal = goalMiles == goalMiles.rounded()
+            ? "\(Int(goalMiles))" : String(format: "%.1f", goalMiles)
+        return String(format: "%.2f of %@ mi", distanceMiles, goal)
+    }
+
+    var body: some View {
+        HStack(spacing: MADTheme.Spacing.md) {
+            AvatarWithRing(
+                name: name,
+                imageURL: imageURL,
+                progress: progress,
+                size: 46,
+                ringWidth: 3,
+                accent: accent
+            )
+            .overlay(alignment: .bottomTrailing) {
+                // Live dot. It earns its place HERE, unlike on the buddy roster
+                // where every face was mid-workout by definition — in a friends
+                // list most people are not out, so "this one is, right now" is
+                // the whole point of the row.
+                Circle()
+                    .fill(MADTheme.Colors.success)
+                    .frame(width: 12, height: 12)
+                    .overlay(Circle().stroke(MADTheme.Colors.madBlack, lineWidth: 2))
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(name)
+                    .font(MADTheme.Typography.smallBold)
+                    .foregroundStyle(MADTheme.Colors.madWhite)
+                    .lineLimit(1)
+
+                Text(distanceText)
+                    .font(.system(size: 13, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundStyle(accent)
+                    .lineLimit(1)
+
+                Text(subtitle)
+                    .font(MADTheme.Typography.caption)
+                    .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.55))
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: MADTheme.Spacing.xs)
+
+            actions
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
+                .fill(MADTheme.Colors.madWhite.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.large, style: .continuous)
+                .strokeBorder(MADTheme.Colors.success.opacity(0.30), lineWidth: 1)
+        )
+        // Keyed on the distance so a friend's number animates as it lands
+        // rather than snapping between polls.
+        .animation(MADTheme.Animation.standard, value: distanceMiles)
+    }
+
+    @ViewBuilder
+    private var actions: some View {
+        HStack(spacing: 8) {
+            if let onHype {
+                Button {
+                    guard !hyped else { return }
+                    onHype()
+                } label: {
+                    Image(systemName: hyped ? "hands.clap.fill" : "hands.clap")
+                        .font(.system(size: 15, weight: .semibold))
+                        .frame(width: 38, height: 34)
+                        .background(
+                            Capsule().fill(
+                                hyped
+                                    ? MADTheme.Colors.warning.opacity(0.30)
+                                    : MADTheme.Colors.madWhite.opacity(0.12))
+                        )
+                        .foregroundStyle(
+                            hyped ? MADTheme.Colors.warning : MADTheme.Colors.madWhite)
+                }
+                .buttonStyle(.plain)
+                .disabled(hyped)
+            }
+
+            if let onJoin, canJoin {
+                Button(action: onJoin) {
+                    Group {
+                        if busy {
+                            ProgressView().tint(MADTheme.Colors.madWhite)
+                        } else {
+                            Text(joinTitle)
+                                .font(MADTheme.Typography.smallBold)
+                                .lineLimit(1)
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .frame(height: 34)
+                    .background(Capsule().fill(accent))
+                    .foregroundStyle(MADTheme.Colors.madWhite)
+                }
+                .buttonStyle(.plain)
+                .disabled(busy)
+            }
+        }
+        // Actions must never be squeezed by a long name — the name truncates
+        // first, which is the right sacrifice.
+        .fixedSize()
+    }
+}
+
+/// How long they've been out, e.g. "out 12m". Shared so every surface phrases
+/// it the same way.
+enum FriendOutTime {
+    static func elapsed(since iso: String?) -> String? {
+        guard let iso, let start = BuddyDate.parse(iso) else { return nil }
+        let minutes = Int(Date().timeIntervalSince(start) / 60)
+        guard minutes >= 1 else { return "just started" }
+        if minutes < 60 { return "out \(minutes)m" }
+        return "out \(minutes / 60)h \(minutes % 60)m"
+    }
+}

--- a/app/Mile A Day/Views/Components/FriendComponents.swift
+++ b/app/Mile A Day/Views/Components/FriendComponents.swift
@@ -718,9 +718,26 @@ struct RecentWorkout: Codable {
     let source: String?
     let originalDistance: Double?
     let originalDuration: Double?
+    /// Which app wrote this into Apple Health. Optional: absent on older
+    /// server builds, and nil reads as first-party (no chip drawn).
+    let sourceBundleId: String?
+    /// Why this workout isn't counting, if it isn't. 'duplicate_source' is the
+    /// one a user can overrule.
+    let exclusionReason: String?
+    /// The workout this one was judged a copy of.
+    let duplicateOf: String?
+    /// The user's own answer, which outranks detection: "count" / "exclude".
+    let duplicateDecision: String?
 
     var isManualOrEdited: Bool {
         source == "manual" || source == "edited"
+    }
+
+    var attribution: WorkoutAttribution { WorkoutAttribution(bundleId: sourceBundleId) }
+
+    /// Excluded as a cross-app duplicate AND the user hasn't overruled it.
+    var isHiddenDuplicate: Bool {
+        exclusionReason == "duplicate_source" && duplicateDecision != "count"
     }
 
     enum CodingKeys: String, CodingKey {
@@ -737,6 +754,10 @@ struct RecentWorkout: Codable {
         case source
         case originalDistance = "original_distance"
         case originalDuration = "original_duration"
+        case sourceBundleId = "source_bundle_id"
+        case exclusionReason = "exclusion_reason"
+        case duplicateOf = "duplicate_of"
+        case duplicateDecision = "duplicate_decision"
     }
     
     /// Extracts just the date part (yyyy-MM-dd) from the local_date string

--- a/app/Mile A Day/Views/Components/FriendWorkoutsSection.swift
+++ b/app/Mile A Day/Views/Components/FriendWorkoutsSection.swift
@@ -75,6 +75,13 @@ struct FriendWorkoutRow: View {
             }
 
             VStack(alignment: .leading, spacing: 3) {
+                // fixedSize, not lineLimit alone. The verb had no layout
+                // priority while the distance beside it had `.layoutPriority(1)`,
+                // so on a tight row SwiftUI compressed "Walked" first — to a
+                // single glyph plus an ellipsis, which rendered as a stray
+                // apostrophe before the number. These are two short words that
+                // must be whole or absent; there is nothing useful in half of
+                // "Walked".
                 HStack(alignment: .firstTextBaseline, spacing: 5) {
                     Text(verb)
                         .font(.system(size: 14, weight: .bold, design: .rounded))
@@ -85,12 +92,17 @@ struct FriendWorkoutRow: View {
                         .monospacedDigit()
                         .foregroundColor(MADTheme.Colors.primaryText)
                         .lineLimit(1)
-                        .layoutPriority(1)
                 }
+                .fixedSize(horizontal: true, vertical: false)
                 HStack(spacing: 5) {
                     Image(systemName: "clock.fill")
                         .font(.system(size: 10, weight: .bold))
                         .foregroundColor(.orange)
+                    // Scale, never clip. As one lineLimit(1) Text this cut its
+                    // own tail when space ran short — and the tail is the pace,
+                    // so "23:11 • 23:11 /mi" became "23:11 •…", which says less
+                    // than showing nothing would. Tightening + a scale floor
+                    // keeps the whole string on the narrowest phone.
                     Text(paceText == nil
                          ? workout.formattedDuration
                          : "\(workout.formattedDuration) \u{2022} \(paceText!)")
@@ -98,6 +110,8 @@ struct FriendWorkoutRow: View {
                         .monospacedDigit()
                         .foregroundColor(MADTheme.Colors.secondaryText)
                         .lineLimit(1)
+                        .allowsTightening(true)
+                        .minimumScaleFactor(0.75)
                 }
 
                 // Identical chips to the owner's own WorkoutRow — a friend's run
@@ -112,7 +126,9 @@ struct FriendWorkoutRow: View {
                 )
             }
 
-            Spacer(minLength: MADTheme.Spacing.sm)
+            .layoutPriority(1)
+
+            Spacer(minLength: MADTheme.Spacing.xs)
 
             VStack(alignment: .trailing, spacing: 2) {
                 Text(dateLabel)

--- a/app/Mile A Day/Views/Components/FriendWorkoutsSection.swift
+++ b/app/Mile A Day/Views/Components/FriendWorkoutsSection.swift
@@ -69,15 +69,19 @@ struct FriendWorkoutsSection: View {
 /// WorkoutRow (accent icon chip, verb + hero distance, duration • pace,
 /// date/time trailing) — a workout reads the same no matter whose it is.
 struct FriendWorkoutRow: View {
+    let workout: FriendWorkout
+    var showChevron: Bool = false
+    // Declared AFTER the existing properties on purpose. Swift's memberwise
+    // init takes arguments in declaration order, so putting these first made
+    // every existing call site a compile error ("argument 'isOwnProfile' must
+    // precede argument 'workout'"). New optional parameters go last.
     var isOwnProfile: Bool = false
     var ownerUserId: String? = nil
+
     /// Local override so the row updates the instant the owner overrules the
     /// duplicate call, rather than waiting for the next profile refresh.
     @State private var overruled = false
     @State private var isDeciding = false
-
-    let workout: FriendWorkout
-    var showChevron: Bool = false
 
     var body: some View {
         VStack(spacing: 8) {

--- a/app/Mile A Day/Views/Components/FriendWorkoutsSection.swift
+++ b/app/Mile A Day/Views/Components/FriendWorkoutsSection.swift
@@ -10,6 +10,13 @@ import SwiftUI
 struct FriendWorkoutsSection: View {
     let workouts: [FriendWorkout]
     var onWorkoutTap: ((FriendWorkout) -> Void)? = nil
+    /// The owner sees more than a visitor: which app wrote each workout, and
+    /// whether one is being left out of their totals as a cross-app duplicate.
+    /// A visitor gets the source chip only — someone else's duplicate is not
+    /// theirs to resolve.
+    var isOwnProfile: Bool = false
+    /// Needed to write the owner's decision back. Nil disables the control.
+    var ownerUserId: String? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: MADTheme.Spacing.md) {
@@ -41,11 +48,13 @@ struct FriendWorkoutsSection: View {
                         Button {
                             onTap(workout)
                         } label: {
-                            FriendWorkoutRow(workout: workout, showChevron: true)
+                            FriendWorkoutRow(workout: workout, showChevron: true,
+                                             isOwnProfile: isOwnProfile, ownerUserId: ownerUserId)
                         }
                         .buttonStyle(ScaleButtonStyle())
                     } else {
-                        FriendWorkoutRow(workout: workout)
+                        FriendWorkoutRow(workout: workout,
+                                         isOwnProfile: isOwnProfile, ownerUserId: ownerUserId)
                     }
                 }
             }
@@ -60,10 +69,37 @@ struct FriendWorkoutsSection: View {
 /// WorkoutRow (accent icon chip, verb + hero distance, duration • pace,
 /// date/time trailing) — a workout reads the same no matter whose it is.
 struct FriendWorkoutRow: View {
+    var isOwnProfile: Bool = false
+    var ownerUserId: String? = nil
+    /// Local override so the row updates the instant the owner overrules the
+    /// duplicate call, rather than waiting for the next profile refresh.
+    @State private var overruled = false
+    @State private var isDeciding = false
+
     let workout: FriendWorkout
     var showChevron: Bool = false
 
     var body: some View {
+        VStack(spacing: 8) {
+            rowBody
+            // Stated, never silent. The exclusion is correct — the same walk
+            // written by two apps is one walk — but a workout is the user's own
+            // record of something they did, so taking it out of their total
+            // without saying so is worse than the wrong number. The reversal
+            // sits in the same breath as the explanation, and it is durable:
+            // the server stores the answer on the workout, so the recompute
+            // that runs on every sync re-derives it instead of undoing it.
+            if showsDuplicateNotice {
+                DuplicateNoticeView(
+                    attribution: WorkoutAttribution(bundleId: workout.sourceBundleId),
+                    isBusy: isDeciding,
+                    onCountAnyway: countAnyway
+                )
+            }
+        }
+    }
+
+    private var rowBody: some View {
         HStack(spacing: MADTheme.Spacing.md) {
             ZStack {
                 Circle()
@@ -118,12 +154,19 @@ struct FriendWorkoutRow: View {
                 // reads the same as yours. Route/photo come from the server
                 // (`has_route`/`has_photo`); older servers omit them and the
                 // chips simply don't draw.
-                WorkoutRowTags(
-                    source: WorkoutSource(rawValue: workout.source ?? "") ?? .healthkit,
-                    hasRoute: workout.hasRoute == true,
-                    hasPhoto: workout.hasPhoto == true,
-                    routeColor: workoutColor
-                )
+                HStack(spacing: 6) {
+                    WorkoutRowTags(
+                        source: WorkoutSource(rawValue: workout.source ?? "") ?? .healthkit,
+                        hasRoute: workout.hasRoute == true,
+                        hasPhoto: workout.hasPhoto == true,
+                        routeColor: workoutColor
+                    )
+                    // Which app actually wrote this. Silent for Mile A Day and
+                    // Apple — badging the expected sources would make the chip
+                    // wallpaper and hide the one case that matters.
+                    WorkoutSourceChip(
+                        attribution: WorkoutAttribution(bundleId: workout.sourceBundleId))
+                }
             }
 
             .layoutPriority(1)
@@ -150,8 +193,37 @@ struct FriendWorkoutRow: View {
             }
         }
         .padding(MADTheme.Spacing.md)
+        // Dimmed while it isn't counting, so the state is legible before you
+        // read a word of it.
+        .opacity(showsDuplicateNotice ? 0.55 : 1)
         .background(Color.white.opacity(0.05))
         .cornerRadius(MADTheme.CornerRadius.medium)
+    }
+
+    /// Only on the OWNER's own list, only for the duplicate exclusion, and only
+    /// while they haven't already overruled it. A visitor seeing "not counted"
+    /// on someone else's workout would be told about a decision that isn't
+    /// theirs to make.
+    private var showsDuplicateNotice: Bool {
+        isOwnProfile && !overruled
+            && workout.exclusionReason == "duplicate_source"
+            && workout.duplicateDecision != "count"
+    }
+
+    private func countAnyway() {
+        guard let ownerUserId, !isDeciding else { return }
+        isDeciding = true
+        Task {
+            do {
+                try await DuplicateDecisionService.set(
+                    userId: ownerUserId, workoutId: workout.id, decision: "count")
+                MADHaptics.success()
+                overruled = true
+            } catch {
+                MADHaptics.error()
+            }
+            isDeciding = false
+        }
     }
 
     /// Feed-style verb, same as WorkoutRow's headline.

--- a/app/Mile A Day/Views/Components/WorkoutAttributionView.swift
+++ b/app/Mile A Day/Views/Components/WorkoutAttributionView.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+
+/// Where a workout came from, and whether it's counting — in one place.
+///
+/// A user's mile total is assembled from whatever wrote into Apple Health, which
+/// on a phone with Google Health or Strava connected can be several apps at
+/// once. Two things follow, and the app got both wrong:
+///
+///  1. **Nothing said where a workout came from.** Every row looked identical
+///     whether Mile A Day recorded it, a watch did, or a third-party app wrote
+///     it from somewhere else entirely.
+///  2. **Duplicate exclusion was silent.** The same walk recorded by two apps
+///     is genuinely one walk, and counting it twice is wrong — but taking a
+///     workout out of someone's total without telling them is worse than the
+///     bad number. It's their record of something they actually did.
+///
+/// So attribution is shown, and exclusion is *stated* with a one-tap way to
+/// overrule it. Mile A Day's own workouts and Apple's are deliberately quiet:
+/// those are the expected, first-party sources, and badging them would turn a
+/// useful signal into wallpaper. Anything else is named.
+struct WorkoutAttribution: Equatable {
+    let bundleId: String?
+    /// True when this is a walk Mile A Day or Apple itself recorded — the
+    /// sources a user already expects to be there.
+    var isFirstParty: Bool {
+        guard let bundleId, !bundleId.isEmpty else { return true }
+        let lower = bundleId.lowercased()
+        return lower.contains("mileaday") || lower.contains("mile-a-day")
+            || FitnessSourceCatalog.isAppleSource(bundleIdentifier: bundleId)
+    }
+
+    /// "Google Health", "Strava"… or nil when there's nothing worth saying.
+    var displayName: String? {
+        guard let bundleId, !bundleId.isEmpty, !isFirstParty else { return nil }
+        if let platform = FitnessSourceCatalog.match(
+            bundleIdentifier: bundleId, sourceName: ""
+        ) {
+            return platform.name
+        }
+        // An app we don't have a catalog entry for still gets named rather than
+        // shown as a raw reverse-DNS string: "com.acme.runner" → "Runner".
+        let leaf = bundleId.split(separator: ".").last.map(String.init) ?? bundleId
+        return leaf.prefix(1).uppercased() + leaf.dropFirst()
+    }
+
+    var symbol: String {
+        guard let bundleId, !isFirstParty,
+            let platform = FitnessSourceCatalog.match(
+                bundleIdentifier: bundleId, sourceName: "")
+        else { return "app.badge" }
+        return platform.symbol
+    }
+
+    var tint: Color {
+        guard let bundleId, !isFirstParty,
+            let platform = FitnessSourceCatalog.match(
+                bundleIdentifier: bundleId, sourceName: "")
+        else { return MADTheme.Colors.madWhite.opacity(0.6) }
+        return platform.tint
+    }
+}
+
+/// A small "from Strava" chip. Renders nothing for first-party sources.
+struct WorkoutSourceChip: View {
+    let attribution: WorkoutAttribution
+
+    var body: some View {
+        if let name = attribution.displayName {
+            HStack(spacing: 4) {
+                Image(systemName: attribution.symbol)
+                    .font(.system(size: 9, weight: .bold))
+                Text(name)
+                    .font(.system(size: 10, weight: .bold, design: .rounded))
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(attribution.tint.opacity(0.18)))
+            .foregroundStyle(attribution.tint)
+            .fixedSize()
+        }
+    }
+}
+
+/// "Not counted — same walk as your Mile A Day walk", with the way out.
+///
+/// The whole point is that this is never a surprise. It states what happened,
+/// why, and offers the reversal in the same breath — and the reversal is
+/// durable, because the server stores the answer on the workout and both the
+/// release and exclude passes read it. A later sync cannot quietly undo it.
+struct DuplicateNoticeView: View {
+    let attribution: WorkoutAttribution
+    /// Nil while no request is in flight.
+    var isBusy: Bool = false
+    let onCountAnyway: () -> Void
+
+    private var sourceLabel: String {
+        attribution.displayName ?? "another app"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(MADTheme.Colors.warning)
+                Text("Not counted toward your miles")
+                    .font(.system(size: 12, weight: .bold, design: .rounded))
+                    .foregroundStyle(MADTheme.Colors.madWhite)
+                Spacer(minLength: 0)
+            }
+
+            Text(
+                "\(sourceLabel) recorded this at the same time as another walk, "
+                    + "so it looks like the same one written twice. We're counting it once."
+            )
+            .font(.system(size: 11, weight: .medium, design: .rounded))
+            .foregroundStyle(MADTheme.Colors.madWhite.opacity(0.65))
+            .fixedSize(horizontal: false, vertical: true)
+
+            Button(action: onCountAnyway) {
+                Group {
+                    if isBusy {
+                        ProgressView().tint(MADTheme.Colors.madWhite)
+                    } else {
+                        Text("This was a separate walk — count it")
+                            .font(.system(size: 12, weight: .bold, design: .rounded))
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 34)
+                .background(Capsule().fill(MADTheme.Colors.madWhite.opacity(0.14)))
+                .foregroundStyle(MADTheme.Colors.madWhite)
+            }
+            .buttonStyle(.plain)
+            .disabled(isBusy)
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
+                .fill(MADTheme.Colors.warning.opacity(0.10))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: MADTheme.CornerRadius.medium, style: .continuous)
+                .strokeBorder(MADTheme.Colors.warning.opacity(0.35), lineWidth: 1)
+        )
+    }
+}
+
+/// Client for the per-workout duplicate decision.
+enum DuplicateDecisionService {
+    /// `decision` is "count", "exclude", or nil to hand it back to detection.
+    static func set(userId: String, workoutId: String, decision: String?) async throws {
+        struct Body: Encodable { let decision: String? }
+        struct Response: Decodable { let ok: Bool }
+        let body = try JSONEncoder().encode(Body(decision: decision))
+        _ = try await APIClient.fancyFetch(
+            endpoint: "/workouts/\(userId)/duplicates/\(workoutId)",
+            method: .POST,
+            body: body,
+            responseType: Response.self
+        )
+    }
+}

--- a/app/Mile A Day/Views/Friends/FriendsListView.swift
+++ b/app/Mile A Day/Views/Friends/FriendsListView.swift
@@ -352,7 +352,6 @@ struct FriendsListView: View {
                     )
                     .padding(.top, MADTheme.Spacing.lg)
                 } else {
-                    outRightNowSection
                     cheerThemOnSection
                     doneTodaySection
                 }
@@ -388,23 +387,6 @@ struct FriendsListView: View {
     private var outRightNowSection: some View {
         if !buddy.friendsOutNow.isEmpty {
             VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
-                HStack(spacing: 8) {
-                    ZStack {
-                        Circle()
-                            .fill(MADTheme.Colors.success.opacity(0.35))
-                            .frame(width: 9, height: 9)
-                            .scaleEffect(1.9)
-                            .opacity(0.55)
-                        Circle()
-                            .fill(MADTheme.Colors.success)
-                            .frame(width: 9, height: 9)
-                    }
-                    Text("Out right now")
-                        .font(MADTheme.Typography.headline)
-                        .foregroundStyle(MADTheme.Colors.madWhite)
-                    Spacer()
-                }
-
                 BuddyJoinFriendCard(
                     // Always false here: this list is not a workout screen, and
                     // gating on a live workout would hide the section exactly
@@ -954,14 +936,28 @@ struct FriendsListView: View {
     @ViewBuilder
     private var cheerThemOnSection: some View {
         let incomplete = incompleteFriends
-        if !incomplete.isEmpty {
+        let liveIds = Set(buddy.friendsOutNow.map(\.userId))
+        if !incomplete.isEmpty || !liveIds.isEmpty {
             VStack(alignment: .leading, spacing: MADTheme.Spacing.sm) {
                 sectionHeader(
                     title: "CHEER THEM ON",
                     trailing: ""
                 )
+
+                // Anyone OUT RIGHT NOW comes first, with how far they've got.
+                // They're the friends where cheering actually reaches someone
+                // mid-effort rather than after the fact, and they were
+                // previously visible only from inside your own workout.
+                if !liveIds.isEmpty {
+                    outRightNowSection
+                        .padding(.bottom, 2)
+                }
+
                 VStack(spacing: 6) {
-                    ForEach(incomplete) { friend in
+                    // Live friends are rendered above with their real progress;
+                    // a second static row for the same person would contradict
+                    // the first the moment they moved.
+                    ForEach(incomplete.filter { !liveIds.contains($0.id) }) { friend in
                         friendRowCompact(friend: friend, isCompleted: false)
                     }
                 }

--- a/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
+++ b/app/Mile A Day/Views/Friends/UserProfileDetailView.swift
@@ -471,7 +471,11 @@ struct UserProfileDetailView: View {
                 VStack(spacing: MADTheme.Spacing.md) {
                     FriendWorkoutsSection(
                         workouts: friendWorkouts,
-                        onWorkoutTap: { workout in selectedWorkout = workout }
+                        onWorkoutTap: { workout in selectedWorkout = workout },
+                        // Only the owner is told when one of their workouts
+                        // isn't counting, and only the owner can overrule it.
+                        isOwnProfile: isCurrentUser(),
+                        ownerUserId: user.user_id
                     )
                     if canLoadMore && !isLoadingMoreWorkouts {
                         loadMoreButton

--- a/backend/scripts/dedupe-containment-check.mjs
+++ b/backend/scripts/dedupe-containment-check.mjs
@@ -1,0 +1,148 @@
+/**
+ * Cross-app duplicate detection: the FRAGMENT case.
+ *
+ * Reproduces the exact shape that reached production: Mile A Day tracked a
+ * 1.84 mi walk in-app, Google Health independently wrote a 0.36 mi walk sitting
+ * entirely inside that window, and the day counted 2.20 mi. The pair passes the
+ * time-overlap test and FAILS the distance-agreement test
+ * (|1.84 - 0.36| = 1.48 > max(0.1, 0.2 * 1.84) = 0.368), so agreement alone can
+ * never see it.
+ *
+ * Usage: DATABASE_URL=... node scripts/dedupe-containment-check.mjs
+ */
+import { PostgresService } from "../dist/services/DbService.js";
+import { recomputeDuplicatesForDay } from "../dist/services/workoutService.js";
+
+const db = PostgresService.getInstance();
+
+/** Mirrors duplicateExclusionEnabled(), which isn't exported. */
+function dedupeEnabledForTest() {
+  const v = (process.env.WORKOUT_DEDUPE ?? "").toLowerCase();
+  return !(v === "0" || v === "false" || v === "off");
+}
+const USER = "dedupe-check-user";
+const DAY = "2026-08-06";
+
+let failures = 0;
+function check(label, actual, expected) {
+  const ok = actual === expected;
+  if (!ok) failures++;
+  console.log(`${ok ? "ok  " : "FAIL"}  ${label} → ${actual} (expected ${expected})`);
+}
+
+/** endsAt is an ISO string; duration in seconds. */
+async function insert(id, { bundle, distance, endsAt, duration, route = false }) {
+  await db.query(
+    `INSERT INTO workouts
+       (workout_id, user_id, distance, local_date, date, device_end_date,
+        total_duration, workout_type, source_bundle_id, calories,
+        timezone_offset)
+     VALUES ($1, $2, $3, $4::date, $5::timestamptz, $5::timestamptz, $6,
+             'walking', $7, 0, -14400)
+     ON CONFLICT (workout_id) DO UPDATE
+       SET distance = EXCLUDED.distance,
+           device_end_date = EXCLUDED.device_end_date,
+           total_duration = EXCLUDED.total_duration,
+           source_bundle_id = EXCLUDED.source_bundle_id`,
+    [id, USER, distance, DAY, endsAt, duration, bundle],
+  );
+  if (route) {
+    await db.query(
+      `INSERT INTO workout_routes (workout_id, route, point_count)
+       VALUES ($1, '[]'::jsonb, 0) ON CONFLICT (workout_id) DO NOTHING`,
+      [id],
+    );
+  }
+}
+
+async function cleanup() {
+  await db.query(
+    `DELETE FROM workout_routes WHERE workout_id IN
+       (SELECT workout_id FROM workouts WHERE user_id = $1)`, [USER]);
+  await db.query(`DELETE FROM workouts WHERE user_id = $1`, [USER]);
+  await db.query(`DELETE FROM users WHERE user_id = $1`, [USER]);
+}
+
+async function main() {
+  await cleanup();
+  await db.query(
+    `INSERT INTO users (user_id, apple_sub, email, username, first_name, last_name)
+     VALUES ($1, $2, $3, $4, 'Dedupe', 'Check') ON CONFLICT DO NOTHING`,
+    [USER, `sub-${USER}`, `${USER}@example.com`, USER],
+  );
+
+  // Mile A Day: 1.84 mi over 92:05, ending 19:00. Has a GPS route, which is
+  // what makes it the preferred copy.
+  await insert("mad-walk", {
+    bundle: "com.mileaday.app",
+    distance: 1.84,
+    endsAt: `${DAY}T19:00:00.000Z`,
+    duration: 5525,
+    route: true,
+  });
+  // Google Health: 0.36 mi over 18:05, ending 18:50 — wholly inside the above.
+  await insert("google-walk", {
+    bundle: "com.google.health",
+    distance: 0.36,
+    endsAt: `${DAY}T18:50:00.000Z`,
+    duration: 1085,
+  });
+
+  await recomputeDuplicatesForDay(USER, DAY);
+
+  const rows = await db.query(
+    `SELECT workout_id, duplicate_of FROM workouts WHERE user_id = $1 ORDER BY workout_id`,
+    [USER],
+  );
+  const byId = Object.fromEntries(rows.map((r) => [r.workout_id, r.duplicate_of]));
+  check("the fragment is marked a duplicate", byId["google-walk"], "mad-walk");
+  // Survivorship: the copy with the route is the one that keeps counting.
+  check("the full walk is NOT marked", byId["mad-walk"], null);
+
+  // A genuinely separate second walk later the same day must survive. This is
+  // the assertion that stops the rule eating real miles.
+  await insert("evening-walk", {
+    bundle: "com.google.health",
+    distance: 0.9,
+    endsAt: `${DAY}T21:30:00.000Z`,
+    duration: 1800,
+  });
+  await recomputeDuplicatesForDay(USER, DAY);
+  const [evening] = await db.query(
+    `SELECT duplicate_of FROM workouts WHERE workout_id = 'evening-walk'`);
+  check("a separate later walk is untouched", evening?.duplicate_of, null);
+
+  // Same source = same app segmenting its own walk. Never paired: that's the
+  // app's own business and UUID dedup already covers real repeats.
+  await insert("mad-second", {
+    bundle: "com.mileaday.app",
+    distance: 0.2,
+    endsAt: `${DAY}T18:40:00.000Z`,
+    duration: 600,
+  });
+  await recomputeDuplicatesForDay(USER, DAY);
+  const [sameSource] = await db.query(
+    `SELECT duplicate_of FROM workouts WHERE workout_id = 'mad-second'`);
+  check("same-source fragments are never paired", sameSource?.duplicate_of, null);
+
+  // The kill switch's DIRECTION, same regression class as BUDDY_SESSIONS: a
+  // pass that is inert unless someone remembers to set an env var is a pass
+  // that does nothing in production.
+  const saved = process.env.WORKOUT_DEDUPE;
+  delete process.env.WORKOUT_DEDUPE;
+  check("unset → exclusion is ON", dedupeEnabledForTest(), true);
+  process.env.WORKOUT_DEDUPE = "false";
+  check('"false" → exclusion is OFF', dedupeEnabledForTest(), false);
+  if (saved === undefined) delete process.env.WORKOUT_DEDUPE;
+  else process.env.WORKOUT_DEDUPE = saved;
+
+  await cleanup();
+  console.log(
+    failures === 0
+      ? "dedupe-containment-check: all assertions passed"
+      : `dedupe-containment-check: ${failures} FAILED`,
+  );
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch(async (e) => { console.error(e); await cleanup().catch(() => {}); process.exit(1); });

--- a/backend/scripts/dedupe-containment-check.mjs
+++ b/backend/scripts/dedupe-containment-check.mjs
@@ -11,7 +11,10 @@
  * Usage: DATABASE_URL=... node scripts/dedupe-containment-check.mjs
  */
 import { PostgresService } from "../dist/services/DbService.js";
-import { recomputeDuplicatesForDay } from "../dist/services/workoutService.js";
+import {
+  recomputeDuplicatesForDay,
+  setDuplicateDecision,
+} from "../dist/services/workoutService.js";
 
 const db = PostgresService.getInstance();
 
@@ -124,6 +127,38 @@ async function main() {
   const [sameSource] = await db.query(
     `SELECT duplicate_of FROM workouts WHERE workout_id = 'mad-second'`);
   check("same-source fragments are never paired", sameSource?.duplicate_of, null);
+
+  // ── The user's own answer outranks detection, and STICKS ────────────
+  //
+  // This is what makes automatic exclusion acceptable: a workout is the
+  // user's own record of something they did, and they must be able to
+  // overrule the machine and have it hold. The recompute runs on every sync
+  // of the day, so "sticks" is the entire test.
+  await db.query(`DELETE FROM workouts WHERE user_id = $1 AND workout_id <> 'mad-walk' AND workout_id <> 'google-walk'`, [USER]);
+  await db.query(`UPDATE users SET dedupe_since = '2000-01-01'::timestamptz WHERE user_id = $1`, [USER]);
+  await recomputeDuplicatesForDay(USER, DAY);
+  const [autoExcluded] = await db.query(
+    `SELECT exclusion_reason FROM workouts WHERE workout_id = 'google-walk'`);
+  check("detection excludes it by default", autoExcluded?.exclusion_reason, "duplicate_source");
+
+  await setDuplicateDecision(USER, "google-walk", "count");
+  const [counted] = await db.query(
+    `SELECT exclusion_reason FROM workouts WHERE workout_id = 'google-walk'`);
+  check("'count it' releases the exclusion", counted?.exclusion_reason, null);
+
+  // The recompute that runs on every sync must NOT undo them.
+  await recomputeDuplicatesForDay(USER, DAY);
+  const [stillCounted] = await db.query(
+    `SELECT exclusion_reason FROM workouts WHERE workout_id = 'google-walk'`);
+  check("...and a later sync does not reverse it", stillCounted?.exclusion_reason, null);
+
+  // The other direction: "don't count it" holds even where detection sees
+  // nothing to pair it with.
+  await setDuplicateDecision(USER, "mad-walk", "exclude");
+  await recomputeDuplicatesForDay(USER, DAY);
+  const [userExcluded] = await db.query(
+    `SELECT exclusion_reason FROM workouts WHERE workout_id = 'mad-walk'`);
+  check("'don't count it' holds too", userExcluded?.exclusion_reason, "duplicate_source");
 
   // The kill switch's DIRECTION, same regression class as BUDDY_SESSIONS: a
   // pass that is inert unless someone remembers to set an env var is a pass

--- a/backend/src/controllers/liveTrackingController.ts
+++ b/backend/src/controllers/liveTrackingController.ts
@@ -36,7 +36,14 @@ export async function liveTrackingHeartbeat(
       return res.status(400).json({ error: "session_id is required" });
     }
 
-    const result = await heartbeat(req.userId!, sessionId);
+    // Distance is optional: older builds don't send it, and their friends'
+    // cards simply keep showing the last figure rather than resetting to zero.
+    // snake_case: this endpoint's body is snake_case throughout (session_id),
+    // and a camelCase key here would simply never arrive.
+    const raw = req.body?.distance_miles;
+    const distanceMiles =
+      raw === undefined || raw === null ? undefined : Number(raw);
+    const result = await heartbeat(req.userId!, sessionId, distanceMiles);
     if (result === null) {
       // Stale/ended session (e.g. a second device rotated session_id, or a
       // zombie heartbeat after end). Client treats this as "re-start or

--- a/backend/src/controllers/workoutController.ts
+++ b/backend/src/controllers/workoutController.ts
@@ -27,6 +27,7 @@ import {
   getStreakErasForUser,
   getDuplicateSummary,
   resolveDuplicateHistory,
+  setDuplicateDecision,
 } from "../services/workoutService.js";
 import { checkRaceCompletions } from "../services/competitionService.js";
 import { softDeleteWorkout } from "../services/workoutDeletionService.js";
@@ -819,5 +820,37 @@ export async function updateWorkout(req: Request, res: Response) {
   } catch (error: any) {
     console.error("Error updating workout:", error.message);
     res.status(500).json({ error: "Error updating workout: " + error.message });
+  }
+}
+
+/**
+ * POST /workouts/:userId/duplicates/:workoutId
+ *
+ * The user's own answer about ONE workout, e.g. "no, that really was a second
+ * walk — count it". Self-scoped via requireSelfAccess on the route.
+ */
+export async function setDuplicateDecisionController(
+  req: AuthenticatedRequest,
+  res: Response,
+) {
+  try {
+    const raw = req.body?.decision;
+    if (raw !== "count" && raw !== "exclude" && raw !== null) {
+      return res.status(400).json({ error: "invalid_decision" });
+    }
+    const result = await setDuplicateDecision(
+      req.params.userId,
+      req.params.workoutId,
+      raw,
+    );
+    if (result === null) {
+      return res.status(404).json({ error: "workout_not_found" });
+    }
+    // The day's totals just moved. The client refreshes its own stats — this
+    // returns the affected date so it knows which day to re-pull.
+    res.json({ ok: true, local_date: result.localDate });
+  } catch (error: any) {
+    console.error("Error setting duplicate decision:", error.message);
+    res.status(500).json({ error: "Error setting duplicate decision" });
   }
 }

--- a/backend/src/db/drizzle/0043_chemical_xavin.sql
+++ b/backend/src/db/drizzle/0043_chemical_xavin.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "live_tracking_sessions" ADD COLUMN "distance_miles" double precision DEFAULT 0 NOT NULL;

--- a/backend/src/db/drizzle/0044_loud_red_ghost.sql
+++ b/backend/src/db/drizzle/0044_loud_red_ghost.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "workouts" ADD COLUMN "duplicate_decision" text;

--- a/backend/src/db/drizzle/meta/0043_snapshot.json
+++ b/backend/src/db/drizzle/meta/0043_snapshot.json
@@ -1,0 +1,5654 @@
+{
+  "id": "575d9b35-1535-485a-a0bf-c9b9755bf1a1",
+  "prevId": "21ac0287-d50b-4ee3-9317-0aab04f6a1fc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.android_waitlist": {
+      "name": "android_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'website'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "android_waitlist_email_unique": {
+          "name": "android_waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_badges_category": {
+          "name": "idx_badges_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "badges_rarity_check": {
+          "name": "badges_rarity_check",
+          "value": "rarity = ANY (ARRAY['common'::text, 'rare'::text, 'legendary'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.buddy_recurring_walks": {
+      "name": "buddy_recurring_walks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "host_user_id": {
+          "name": "host_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_value": {
+          "name": "goal_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invite_user_ids": {
+          "name": "invite_user_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "days_of_week": {
+          "name": "days_of_week",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minutes_of_day": {
+          "name": "minutes_of_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_spawned_date": {
+          "name": "last_spawned_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_buddy_recurring_active": {
+          "name": "idx_buddy_recurring_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "buddy_recurring_walks_host_user_id_fkey": {
+          "name": "buddy_recurring_walks_host_user_id_fkey",
+          "tableFrom": "buddy_recurring_walks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "host_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "buddy_recurring_walks_mode_check": {
+          "name": "buddy_recurring_walks_mode_check",
+          "value": "mode = ANY (ARRAY['together'::text, 'coop_goal'::text, 'race_goal'::text, 'race_time'::text])"
+        },
+        "buddy_recurring_walks_minutes_check": {
+          "name": "buddy_recurring_walks_minutes_check",
+          "value": "minutes_of_day >= 0 AND minutes_of_day <= 1439"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.buddy_session_events": {
+      "name": "buddy_session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_buddy_events_session_at": {
+          "name": "idx_buddy_events_session_at",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "buddy_session_events_session_id_fkey": {
+          "name": "buddy_session_events_session_id_fkey",
+          "tableFrom": "buddy_session_events",
+          "tableTo": "buddy_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "buddy_session_events_user_id_fkey": {
+          "name": "buddy_session_events_user_id_fkey",
+          "tableFrom": "buddy_session_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.buddy_session_participants": {
+      "name": "buddy_session_participants",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distance_miles": {
+          "name": "distance_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_progress_at": {
+          "name": "last_progress_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_distance_miles": {
+          "name": "final_distance_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place": {
+          "name": "place",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_buddy_participants_user_status": {
+          "name": "idx_buddy_participants_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "buddy_session_participants_session_id_fkey": {
+          "name": "buddy_session_participants_session_id_fkey",
+          "tableFrom": "buddy_session_participants",
+          "tableTo": "buddy_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "buddy_session_participants_user_id_fkey": {
+          "name": "buddy_session_participants_user_id_fkey",
+          "tableFrom": "buddy_session_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "buddy_session_participants_workout_id_fkey": {
+          "name": "buddy_session_participants_workout_id_fkey",
+          "tableFrom": "buddy_session_participants",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "buddy_session_participants_pkey": {
+          "name": "buddy_session_participants_pkey",
+          "columns": [
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "buddy_session_participants_status_check": {
+          "name": "buddy_session_participants_status_check",
+          "value": "status = ANY (ARRAY['invited'::text, 'joined'::text, 'ready'::text, 'active'::text, 'finished'::text, 'left'::text, 'declined'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.buddy_sessions": {
+      "name": "buddy_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "join_code": {
+          "name": "join_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_user_id": {
+          "name": "host_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_value": {
+          "name": "goal_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_start_at": {
+          "name": "scheduled_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_reminder_sent_at": {
+          "name": "scheduled_reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner_user_id": {
+          "name": "winner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_version": {
+          "name": "state_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_buddy_sessions_join_code_open": {
+          "name": "uq_buddy_sessions_join_code_open",
+          "columns": [
+            {
+              "expression": "join_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = ANY (ARRAY['lobby'::text, 'active'::text]))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_buddy_sessions_status_created": {
+          "name": "idx_buddy_sessions_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "buddy_sessions_host_user_id_fkey": {
+          "name": "buddy_sessions_host_user_id_fkey",
+          "tableFrom": "buddy_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "host_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "buddy_sessions_winner_user_id_fkey": {
+          "name": "buddy_sessions_winner_user_id_fkey",
+          "tableFrom": "buddy_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "buddy_sessions_mode_check": {
+          "name": "buddy_sessions_mode_check",
+          "value": "mode = ANY (ARRAY['together'::text, 'coop_goal'::text, 'race_goal'::text, 'race_time'::text])"
+        },
+        "buddy_sessions_status_check": {
+          "name": "buddy_sessions_status_check",
+          "value": "status = ANY (ARRAY['lobby'::text, 'active'::text, 'completed'::text, 'cancelled'::text])"
+        },
+        "buddy_sessions_origin_check": {
+          "name": "buddy_sessions_origin_check",
+          "value": "origin = ANY (ARRAY['invite'::text, 'code'::text, 'join_active'::text, 'nearby'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.close_friends": {
+      "name": "close_friends",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_friend_id": {
+          "name": "close_friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_close_friends_friend": {
+          "name": "idx_close_friends_friend",
+          "columns": [
+            {
+              "expression": "close_friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "close_friends_pkey": {
+          "name": "close_friends_pkey",
+          "columns": [
+            "user_id",
+            "close_friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_reports": {
+      "name": "comment_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comment_reports_dedupe_idx": {
+          "name": "comment_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_comment_reports_status": {
+          "name": "idx_comment_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_reports_comment_id_fkey": {
+          "name": "comment_reports_comment_id_fkey",
+          "tableFrom": "comment_reports",
+          "tableTo": "post_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "comment_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_reports_reporter_id_fkey": {
+          "name": "comment_reports_reporter_id_fkey",
+          "tableFrom": "comment_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "comment_reports_reason_check": {
+          "name": "comment_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_users": {
+      "name": "competition_users",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_rank": {
+          "name": "last_known_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_score": {
+          "name": "last_known_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rank_updated_at": {
+          "name": "last_rank_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_competition_users_comp": {
+          "name": "idx_competition_users_comp",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_competition": {
+          "name": "idx_competition_users_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_rank_cache": {
+          "name": "idx_competition_users_rank_cache",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_known_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((invite_status)::text = 'accepted'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user": {
+          "name": "idx_competition_users_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user_status": {
+          "name": "idx_competition_users_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invite_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_users_user_id_fkey": {
+          "name": "competition_users_user_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_users_competition_id_fkey": {
+          "name": "competition_users_competition_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_users_pkey": {
+          "name": "competition_users_pkey",
+          "columns": [
+            "competition_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_users_invite_status_check": {
+          "name": "competition_users_invite_status_check",
+          "value": "(invite_status)::text = ANY ((ARRAY['pending'::character varying, 'accepted'::character varying, 'declined'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workouts": {
+          "name": "workouts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams": {
+          "name": "teams",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_winner": {
+          "name": "idx_competitions_winner",
+          "columns": [
+            {
+              "expression": "winner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(winner IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_winner_fkey": {
+          "name": "competitions_winner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "competitions_owner_fkey": {
+          "name": "competitions_owner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitions_type_check": {
+          "name": "competitions_type_check",
+          "value": "(type)::text = ANY ((ARRAY['streaks'::character varying, 'apex'::character varying, 'clash'::character varying, 'targets'::character varying, 'race'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_challenges": {
+      "name": "daily_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_template": {
+          "name": "description_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_start": {
+          "name": "gradient_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_end": {
+          "name": "gradient_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rotation_index": {
+          "name": "rotation_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_challenges_rotation_index_key": {
+          "name": "daily_challenges_rotation_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rotation_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daily_challenges_type_check": {
+          "name": "daily_challenges_type_check",
+          "value": "type = ANY (ARRAY['pace'::text, 'distance'::text, 'time'::text, 'activity'::text, 'steps'::text, 'social'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_steps": {
+      "name": "daily_steps",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_steps_user_date": {
+          "name": "idx_daily_steps_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_steps_user_id_fkey": {
+          "name": "daily_steps_user_id_fkey",
+          "tableFrom": "daily_steps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_steps_pkey": {
+          "name": "daily_steps_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "daily_steps_steps_check": {
+          "name": "daily_steps_steps_check",
+          "value": "steps >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token": {
+          "name": "device_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "client_features": {
+          "name": "client_features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_tokens_user_id": {
+          "name": "idx_device_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_user_id_fkey": {
+          "name": "device_tokens_user_id_fkey",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_user_id_device_token_key": {
+          "name": "device_tokens_user_id_device_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_log": {
+      "name": "error_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_error_log_created_at": {
+          "name": "idx_error_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_error_log_category": {
+          "name": "idx_error_log_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flex_log": {
+      "name": "flex_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flex_log_lookup": {
+          "name": "idx_flex_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_notification_settings": {
+      "name": "friend_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted": {
+          "name": "muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nudges_muted": {
+          "name": "nudges_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "activity_muted": {
+          "name": "activity_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "friend_notification_settings_pkey": {
+          "name": "friend_notification_settings_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_nudge_log": {
+      "name": "friend_nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_nudge_log_lookup": {
+          "name": "idx_friend_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_request_log": {
+      "name": "friend_request_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_request_log_lookup": {
+          "name": "idx_friend_request_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "reminder_sent_at": {
+          "name": "reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_friendships_friend_status": {
+          "name": "idx_friendships_friend_status",
+          "columns": [
+            {
+              "expression": "friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_friendships_user_status": {
+          "name": "idx_friendships_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_user_id_fkey": {
+          "name": "friendships_user_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_friend_id_fkey": {
+          "name": "friendships_friend_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendships_pkey": {
+          "name": "friendships_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_friendship_pair": {
+          "name": "unique_friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.h2h_matchups": {
+      "name": "h2h_matchups",
+      "schema": "",
+      "columns": {
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rival_id": {
+          "name": "rival_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mutual": {
+          "name": "mutual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "won": {
+          "name": "won",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_notified_state": {
+          "name": "lead_notified_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_notified_at": {
+          "name": "lead_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "h2h_matchups_user_id_fkey": {
+          "name": "h2h_matchups_user_id_fkey",
+          "tableFrom": "h2h_matchups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "h2h_matchups_rival_id_fkey": {
+          "name": "h2h_matchups_rival_id_fkey",
+          "tableFrom": "h2h_matchups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "rival_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "h2h_matchups_pkey": {
+          "name": "h2h_matchups_pkey",
+          "columns": [
+            "local_date",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hype_log": {
+      "name": "hype_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_label": {
+          "name": "context_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hype_log_context_dedupe_idx": {
+          "name": "hype_log_context_dedupe_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_lookup": {
+          "name": "idx_hype_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_target_context": {
+          "name": "idx_hype_log_target_context",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_app_notifications": {
+      "name": "in_app_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_in_app_notifications_unread": {
+          "name": "idx_in_app_notifications_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_read = false)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_app_notifications_user": {
+          "name": "idx_in_app_notifications_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_app_notifications_user_id_fkey": {
+          "name": "in_app_notifications_user_id_fkey",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.live_tracking_sessions": {
+      "name": "live_tracking_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "distance_miles": {
+          "name": "distance_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "live_tracking_sessions_user_id_fkey": {
+          "name": "live_tracking_sessions_user_id_fkey",
+          "tableFrom": "live_tracking_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_notifications": {
+      "name": "milestone_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_key": {
+          "name": "milestone_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_notifications_milestone_key_key": {
+          "name": "milestone_notifications_milestone_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_audience_settings": {
+      "name": "notification_audience_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_audience_settings_pkey": {
+          "name": "notification_audience_settings_pkey",
+          "columns": [
+            "user_id",
+            "direction",
+            "event_type",
+            "activity_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_audience_settings_direction_check": {
+          "name": "notification_audience_settings_direction_check",
+          "value": "direction = ANY (ARRAY['outgoing'::text, 'incoming'::text])"
+        },
+        "notification_audience_settings_audience_check": {
+          "name": "notification_audience_settings_audience_check",
+          "value": "audience = ANY (ARRAY['none'::text, 'close'::text, 'all'::text, 'ask'::text, 'match_run'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_user_date": {
+          "name": "idx_notification_log_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nudges_enabled": {
+          "name": "nudges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "flexes_enabled": {
+          "name": "flexes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_activity_enabled": {
+          "name": "friend_activity_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_invites_enabled": {
+          "name": "competition_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_updates_enabled": {
+          "name": "competition_updates_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_milestones_enabled": {
+          "name": "competition_milestones_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "hypes_enabled": {
+          "name": "hypes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "step_goal_enabled": {
+          "name": "step_goal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "friend_personal_best_enabled": {
+          "name": "friend_personal_best_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_enabled": {
+          "name": "daily_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_hour": {
+          "name": "daily_reminder_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 18
+        },
+        "h2h_close_friends_only": {
+          "name": "h2h_close_friends_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone_offset_minutes": {
+          "name": "timezone_offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_workouts_to_feed": {
+          "name": "share_workouts_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_posts_enabled": {
+          "name": "friend_posts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "share_route_maps": {
+          "name": "share_route_maps",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "share_live_presence": {
+          "name": "share_live_presence",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "weekly_recap_enabled": {
+          "name": "weekly_recap_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "workout_visibility": {
+          "name": "workout_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'friends'"
+        },
+        "friend_request_reminder_enabled": {
+          "name": "friend_request_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "buddy_invites_enabled": {
+          "name": "buddy_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "tagged_posts_on_profile": {
+          "name": "tagged_posts_on_profile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_settings_workout_visibility_check": {
+          "name": "notification_settings_workout_visibility_check",
+          "value": "workout_visibility = ANY (ARRAY['public'::text, 'friends'::text, 'private'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.nudge_log": {
+      "name": "nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_nudge_log_lookup": {
+          "name": "idx_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nudge_log_rate_limit": {
+          "name": "idx_nudge_log_rate_limit",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_friend_notifications": {
+      "name": "pending_friend_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "send_after_at": {
+          "name": "send_after_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_friend_notif_user": {
+          "name": "idx_pending_friend_notif_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_pending_friend_notif_workout": {
+          "name": "uq_pending_friend_notif_workout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((workout_id IS NOT NULL) AND (status = 'pending'::text))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pending_friend_notifications_status_check": {
+          "name": "pending_friend_notifications_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'sent'::text, 'dismissed'::text, 'expired'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_notifications": {
+      "name": "pending_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_notifications_unsent": {
+          "name": "idx_pending_notifications_unsent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(sent_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_notifications_user_id_fkey": {
+          "name": "pending_notifications_user_id_fkey",
+          "tableFrom": "pending_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_coauthors": {
+      "name": "post_coauthors",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buddy_session_id": {
+          "name": "buddy_session_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_post_coauthors_user": {
+          "name": "idx_post_coauthors_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_coauthors_post_id_fkey": {
+          "name": "post_coauthors_post_id_fkey",
+          "tableFrom": "post_coauthors",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_coauthors_user_id_fkey": {
+          "name": "post_coauthors_user_id_fkey",
+          "tableFrom": "post_coauthors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_coauthors_workout_id_fkey": {
+          "name": "post_coauthors_workout_id_fkey",
+          "tableFrom": "post_coauthors",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "post_coauthors_buddy_session_id_fkey": {
+          "name": "post_coauthors_buddy_session_id_fkey",
+          "tableFrom": "post_coauthors",
+          "tableTo": "buddy_sessions",
+          "columnsFrom": [
+            "buddy_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_coauthors_pkey": {
+          "name": "post_coauthors_pkey",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_coauthors_status_check": {
+          "name": "post_coauthors_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'accepted'::text, 'declined'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_comments": {
+      "name": "post_comments",
+      "schema": "",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_post_comments_post": {
+          "name": "idx_post_comments_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND post_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_comments_workout": {
+          "name": "idx_post_comments_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_comments_post_id_fkey": {
+          "name": "post_comments_post_id_fkey",
+          "tableFrom": "post_comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_workout_id_fkey": {
+          "name": "post_comments_workout_id_fkey",
+          "tableFrom": "post_comments",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_user_id_fkey": {
+          "name": "post_comments_user_id_fkey",
+          "tableFrom": "post_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_parent_fkey": {
+          "name": "post_comments_parent_fkey",
+          "tableFrom": "post_comments",
+          "tableTo": "post_comments",
+          "columnsFrom": [
+            "parent_comment_id"
+          ],
+          "columnsTo": [
+            "comment_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_comments_content_check": {
+          "name": "post_comments_content_check",
+          "value": "char_length(content) >= 1 AND char_length(content) <= 1000"
+        },
+        "post_comments_one_target_check": {
+          "name": "post_comments_one_target_check",
+          "value": "((post_id IS NOT NULL)::int + (workout_id IS NOT NULL)::int) = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_reports": {
+      "name": "post_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_reports_dedupe_idx": {
+          "name": "post_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_reports_status": {
+          "name": "idx_post_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_reports_post_id_fkey": {
+          "name": "post_reports_post_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_reports_reporter_id_fkey": {
+          "name": "post_reports_reporter_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_reports_reason_check": {
+          "name": "post_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_snapshot": {
+          "name": "stats_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_to_feed": {
+          "name": "share_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_to_story": {
+          "name": "share_to_story",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "story_expires_at": {
+          "name": "story_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto": {
+          "name": "is_auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_route": {
+          "name": "include_route",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "coauthor_user_id": {
+          "name": "coauthor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_status": {
+          "name": "coauthor_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_workout_id": {
+          "name": "coauthor_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_on_profile": {
+          "name": "coauthor_on_profile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_fresh": {
+          "name": "posted_fresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_posts_user_created": {
+          "name": "idx_posts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_feed": {
+          "name": "idx_posts_feed",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_story_active": {
+          "name": "idx_posts_story_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "story_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_story)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_active": {
+          "name": "uq_posts_workout_active",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_story": {
+          "name": "uq_posts_workout_story",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_story AND NOT share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_coauthor_workout": {
+          "name": "idx_posts_coauthor_workout",
+          "columns": [
+            {
+              "expression": "coauthor_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(coauthor_workout_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_coauthor_user": {
+          "name": "idx_posts_coauthor_user",
+          "columns": [
+            {
+              "expression": "coauthor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(coauthor_user_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_fkey": {
+          "name": "posts_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_workout_id_fkey": {
+          "name": "posts_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_coauthor_user_id_fkey": {
+          "name": "posts_coauthor_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "coauthor_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_coauthor_workout_id_fkey": {
+          "name": "posts_coauthor_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "coauthor_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "posts_coauthor_status_check": {
+          "name": "posts_coauthor_status_check",
+          "value": "coauthor_status IS NULL OR coauthor_status = ANY (ARRAY['pending'::text, 'accepted'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_family_id": {
+          "name": "token_family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_hash": {
+          "name": "replaced_by_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "token_family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_revoked_at": {
+          "name": "idx_refresh_tokens_revoked_at",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(revoked_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_token_hash": {
+          "name": "idx_refresh_tokens_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_fkey": {
+          "name": "refresh_tokens_user_id_fkey",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_key": {
+          "name": "refresh_tokens_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_reactions": {
+      "name": "story_reactions",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_reactions_post_id_fkey": {
+          "name": "story_reactions_post_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_reactions_user_id_fkey": {
+          "name": "story_reactions_user_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_reactions_pkey": {
+          "name": "story_reactions_pkey",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_views": {
+      "name": "story_views",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_views_post_id_fkey": {
+          "name": "story_views_post_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_views_viewer_id_fkey": {
+          "name": "story_views_viewer_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_views_pkey": {
+          "name": "story_views_pkey",
+          "columns": [
+            "post_id",
+            "viewer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streak_coverage": {
+      "name": "streak_coverage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_date": {
+          "name": "trigger_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_user": {
+          "name": "source_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "streak_coverage_user_id_fkey": {
+          "name": "streak_coverage_user_id_fkey",
+          "tableFrom": "streak_coverage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "streak_coverage_pkey": {
+          "name": "streak_coverage_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streak_events": {
+      "name": "streak_events",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prior_streak": {
+          "name": "prior_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "streak_events_user_id_fkey": {
+          "name": "streak_events_user_id_fkey",
+          "tableFrom": "streak_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "streak_events_pkey": {
+          "name": "streak_events_pkey",
+          "columns": [
+            "user_id",
+            "local_date",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggering_workout_id": {
+          "name": "triggering_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_snapshot": {
+          "name": "progress_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_slot": {
+          "name": "pin_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_badges_user": {
+          "name": "idx_user_badges_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_new": {
+          "name": "idx_user_badges_user_new",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_new = true)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_pin_slot": {
+          "name": "idx_user_badges_user_pin_slot",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(pin_slot IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_workout": {
+          "name": "idx_user_badges_workout",
+          "columns": [
+            {
+              "expression": "triggering_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_badges_user_id_fkey": {
+          "name": "user_badges_user_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_fkey": {
+          "name": "user_badges_badge_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "badge_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_triggering_workout_id_fkey": {
+          "name": "user_badges_triggering_workout_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "triggering_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_badges_user_id_badge_id_key": {
+          "name": "user_badges_user_id_badge_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "badge_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_badges_pin_slot_range": {
+          "name": "user_badges_pin_slot_range",
+          "value": "(pin_slot IS NULL) OR ((pin_slot >= 0) AND (pin_slot <= 2))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_blocks_blocked": {
+          "name": "idx_user_blocks_blocked",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_fkey": {
+          "name": "user_blocks_blocker_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_blocks_blocked_id_fkey": {
+          "name": "user_blocks_blocked_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_pkey": {
+          "name": "user_blocks_pkey",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenge_completions": {
+      "name": "user_challenge_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completing_workout_id": {
+          "name": "completing_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ucc_user": {
+          "name": "idx_ucc_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ucc_user_date": {
+          "name": "idx_ucc_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenge_completions_user_id_fkey": {
+          "name": "user_challenge_completions_user_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_challenge_key_fkey": {
+          "name": "user_challenge_completions_challenge_key_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "daily_challenges",
+          "columnsFrom": [
+            "challenge_key"
+          ],
+          "columnsTo": [
+            "challenge_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_completing_workout_id_fkey": {
+          "name": "user_challenge_completions_completing_workout_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "completing_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_challenge_completions_user_id_local_date_key": {
+          "name": "user_challenge_completions_user_id_local_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_sub": {
+          "name": "apple_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "goal_miles": {
+          "name": "goal_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "longest_streak": {
+          "name": "longest_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_source": {
+          "name": "referral_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_detail": {
+          "name": "referral_detail",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signup_goal": {
+          "name": "signup_goal",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience_level": {
+          "name": "experience_level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dedupe_since": {
+          "name": "dedupe_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "streak_features_at": {
+          "name": "streak_features_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "double_down_last_used": {
+          "name": "double_down_last_used",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streak_save_last_used": {
+          "name": "streak_save_last_used",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streak_assist_last_used": {
+          "name": "streak_assist_last_used",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buddy_enrolled_at": {
+          "name": "buddy_enrolled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_current_streak_desc": {
+          "name": "idx_users_current_streak_desc",
+          "columns": [
+            {
+              "expression": "current_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_longest_streak_desc": {
+          "name": "idx_users_longest_streak_desc",
+          "columns": [
+            {
+              "expression": "longest_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email_trgm": {
+          "name": "idx_users_email_trgm",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_username_trgm": {
+          "name": "idx_users_username_trgm",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_apple_id_key": {
+          "name": "users_apple_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_apple_sub_key": {
+          "name": "users_apple_sub_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "apple_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_recap_log": {
+      "name": "weekly_recap_log",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "weekly_recap_log_pkey": {
+          "name": "weekly_recap_log_pkey",
+          "columns": [
+            "user_id",
+            "week_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_completion_notifications": {
+      "name": "workout_completion_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_date": {
+          "name": "notified_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_completion_notifications_user_id_notified_date_key": {
+          "name": "workout_completion_notifications_user_id_notified_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "notified_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_routes": {
+      "name": "workout_routes",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "point_count": {
+          "name": "point_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workout_routes_workout_id_fkey": {
+          "name": "workout_routes_workout_id_fkey",
+          "tableFrom": "workout_routes",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_splits": {
+      "name": "workout_splits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_number": {
+          "name": "split_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_duration": {
+          "name": "split_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_distance": {
+          "name": "split_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_pace": {
+          "name": "split_pace",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_splits_time": {
+          "name": "idx_splits_time",
+          "columns": [
+            {
+              "expression": "split_duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_splits_workout": {
+          "name": "idx_splits_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_splits_workout_id_fkey": {
+          "name": "workout_splits_workout_id_fkey",
+          "tableFrom": "workout_splits",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_splits_workout_id_split_number_key": {
+          "name": "workout_splits_workout_id_split_number_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "split_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workouts": {
+      "name": "workouts",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_end_date": {
+          "name": "device_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moving_seconds": {
+          "name": "moving_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghost_margin_seconds": {
+          "name": "ghost_margin_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghost_target_seconds": {
+          "name": "ghost_target_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghost_friend_user_id": {
+          "name": "ghost_friend_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghost_notified_at": {
+          "name": "ghost_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthkit'"
+        },
+        "original_distance": {
+          "name": "original_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_duration": {
+          "name": "original_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_flagged": {
+          "name": "speed_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feed_role": {
+          "name": "feed_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'extra'"
+        },
+        "source_bundle_id": {
+          "name": "source_bundle_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_of": {
+          "name": "duplicate_of",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_workouts_local_date_user_id": {
+          "name": "idx_workouts_local_date_user_id",
+          "columns": [
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_device_end": {
+          "name": "idx_workouts_user_device_end",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_local_date": {
+          "name": "idx_workouts_user_local_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_feed_candidates": {
+          "name": "idx_workouts_feed_candidates",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND exclusion_reason IS NULL AND feed_role IN ('daily_mile', 'extra'))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workouts_user_workout_unique": {
+          "name": "workouts_user_workout_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workouts_feed_role_check": {
+          "name": "workouts_feed_role_check",
+          "value": "\"workouts\".\"feed_role\" IN ('hidden', 'rolled_up', 'daily_mile', 'extra')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/drizzle/meta/0044_snapshot.json
+++ b/backend/src/db/drizzle/meta/0044_snapshot.json
@@ -1,0 +1,5660 @@
+{
+  "id": "bcb5cec1-b937-4e32-a93d-1880059d6c81",
+  "prevId": "575d9b35-1535-485a-a0bf-c9b9755bf1a1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.android_waitlist": {
+      "name": "android_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'website'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "android_waitlist_email_unique": {
+          "name": "android_waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_badges_category": {
+          "name": "idx_badges_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "badges_rarity_check": {
+          "name": "badges_rarity_check",
+          "value": "rarity = ANY (ARRAY['common'::text, 'rare'::text, 'legendary'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.buddy_recurring_walks": {
+      "name": "buddy_recurring_walks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "host_user_id": {
+          "name": "host_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_value": {
+          "name": "goal_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invite_user_ids": {
+          "name": "invite_user_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "days_of_week": {
+          "name": "days_of_week",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minutes_of_day": {
+          "name": "minutes_of_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_spawned_date": {
+          "name": "last_spawned_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_buddy_recurring_active": {
+          "name": "idx_buddy_recurring_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "buddy_recurring_walks_host_user_id_fkey": {
+          "name": "buddy_recurring_walks_host_user_id_fkey",
+          "tableFrom": "buddy_recurring_walks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "host_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "buddy_recurring_walks_mode_check": {
+          "name": "buddy_recurring_walks_mode_check",
+          "value": "mode = ANY (ARRAY['together'::text, 'coop_goal'::text, 'race_goal'::text, 'race_time'::text])"
+        },
+        "buddy_recurring_walks_minutes_check": {
+          "name": "buddy_recurring_walks_minutes_check",
+          "value": "minutes_of_day >= 0 AND minutes_of_day <= 1439"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.buddy_session_events": {
+      "name": "buddy_session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_buddy_events_session_at": {
+          "name": "idx_buddy_events_session_at",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "buddy_session_events_session_id_fkey": {
+          "name": "buddy_session_events_session_id_fkey",
+          "tableFrom": "buddy_session_events",
+          "tableTo": "buddy_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "buddy_session_events_user_id_fkey": {
+          "name": "buddy_session_events_user_id_fkey",
+          "tableFrom": "buddy_session_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.buddy_session_participants": {
+      "name": "buddy_session_participants",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distance_miles": {
+          "name": "distance_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_progress_at": {
+          "name": "last_progress_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_distance_miles": {
+          "name": "final_distance_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place": {
+          "name": "place",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_buddy_participants_user_status": {
+          "name": "idx_buddy_participants_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "buddy_session_participants_session_id_fkey": {
+          "name": "buddy_session_participants_session_id_fkey",
+          "tableFrom": "buddy_session_participants",
+          "tableTo": "buddy_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "buddy_session_participants_user_id_fkey": {
+          "name": "buddy_session_participants_user_id_fkey",
+          "tableFrom": "buddy_session_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "buddy_session_participants_workout_id_fkey": {
+          "name": "buddy_session_participants_workout_id_fkey",
+          "tableFrom": "buddy_session_participants",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "buddy_session_participants_pkey": {
+          "name": "buddy_session_participants_pkey",
+          "columns": [
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "buddy_session_participants_status_check": {
+          "name": "buddy_session_participants_status_check",
+          "value": "status = ANY (ARRAY['invited'::text, 'joined'::text, 'ready'::text, 'active'::text, 'finished'::text, 'left'::text, 'declined'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.buddy_sessions": {
+      "name": "buddy_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "join_code": {
+          "name": "join_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_user_id": {
+          "name": "host_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_value": {
+          "name": "goal_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_start_at": {
+          "name": "scheduled_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_reminder_sent_at": {
+          "name": "scheduled_reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner_user_id": {
+          "name": "winner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_version": {
+          "name": "state_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_buddy_sessions_join_code_open": {
+          "name": "uq_buddy_sessions_join_code_open",
+          "columns": [
+            {
+              "expression": "join_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(status = ANY (ARRAY['lobby'::text, 'active'::text]))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_buddy_sessions_status_created": {
+          "name": "idx_buddy_sessions_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "buddy_sessions_host_user_id_fkey": {
+          "name": "buddy_sessions_host_user_id_fkey",
+          "tableFrom": "buddy_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "host_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "buddy_sessions_winner_user_id_fkey": {
+          "name": "buddy_sessions_winner_user_id_fkey",
+          "tableFrom": "buddy_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "buddy_sessions_mode_check": {
+          "name": "buddy_sessions_mode_check",
+          "value": "mode = ANY (ARRAY['together'::text, 'coop_goal'::text, 'race_goal'::text, 'race_time'::text])"
+        },
+        "buddy_sessions_status_check": {
+          "name": "buddy_sessions_status_check",
+          "value": "status = ANY (ARRAY['lobby'::text, 'active'::text, 'completed'::text, 'cancelled'::text])"
+        },
+        "buddy_sessions_origin_check": {
+          "name": "buddy_sessions_origin_check",
+          "value": "origin = ANY (ARRAY['invite'::text, 'code'::text, 'join_active'::text, 'nearby'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.close_friends": {
+      "name": "close_friends",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_friend_id": {
+          "name": "close_friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_close_friends_friend": {
+          "name": "idx_close_friends_friend",
+          "columns": [
+            {
+              "expression": "close_friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "close_friends_pkey": {
+          "name": "close_friends_pkey",
+          "columns": [
+            "user_id",
+            "close_friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_reports": {
+      "name": "comment_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comment_reports_dedupe_idx": {
+          "name": "comment_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_comment_reports_status": {
+          "name": "idx_comment_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_reports_comment_id_fkey": {
+          "name": "comment_reports_comment_id_fkey",
+          "tableFrom": "comment_reports",
+          "tableTo": "post_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "comment_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_reports_reporter_id_fkey": {
+          "name": "comment_reports_reporter_id_fkey",
+          "tableFrom": "comment_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "comment_reports_reason_check": {
+          "name": "comment_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_users": {
+      "name": "competition_users",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_status": {
+          "name": "invite_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_rank": {
+          "name": "last_known_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_known_score": {
+          "name": "last_known_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_rank_updated_at": {
+          "name": "last_rank_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_competition_users_comp": {
+          "name": "idx_competition_users_comp",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_competition": {
+          "name": "idx_competition_users_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_rank_cache": {
+          "name": "idx_competition_users_rank_cache",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_known_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((invite_status)::text = 'accepted'::text)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user": {
+          "name": "idx_competition_users_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_users_user_status": {
+          "name": "idx_competition_users_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invite_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_users_user_id_fkey": {
+          "name": "competition_users_user_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_users_competition_id_fkey": {
+          "name": "competition_users_competition_id_fkey",
+          "tableFrom": "competition_users",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_users_pkey": {
+          "name": "competition_users_pkey",
+          "columns": [
+            "competition_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_users_invite_status_check": {
+          "name": "competition_users_invite_status_check",
+          "value": "(invite_status)::text = ANY ((ARRAY['pending'::character varying, 'accepted'::character varying, 'declined'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "replace((gen_random_uuid())::text, '-'::text, ''::text)"
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workouts": {
+          "name": "workouts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teams": {
+          "name": "teams",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_winner": {
+          "name": "idx_competitions_winner",
+          "columns": [
+            {
+              "expression": "winner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(winner IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_winner_fkey": {
+          "name": "competitions_winner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "winner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "competitions_owner_fkey": {
+          "name": "competitions_owner_fkey",
+          "tableFrom": "competitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitions_type_check": {
+          "name": "competitions_type_check",
+          "value": "(type)::text = ANY ((ARRAY['streaks'::character varying, 'apex'::character varying, 'clash'::character varying, 'targets'::character varying, 'race'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_challenges": {
+      "name": "daily_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_template": {
+          "name": "description_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_start": {
+          "name": "gradient_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gradient_end": {
+          "name": "gradient_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rotation_index": {
+          "name": "rotation_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_challenges_rotation_index_key": {
+          "name": "daily_challenges_rotation_index_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rotation_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daily_challenges_type_check": {
+          "name": "daily_challenges_type_check",
+          "value": "type = ANY (ARRAY['pace'::text, 'distance'::text, 'time'::text, 'activity'::text, 'steps'::text, 'social'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_steps": {
+      "name": "daily_steps",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_steps_user_date": {
+          "name": "idx_daily_steps_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_steps_user_id_fkey": {
+          "name": "daily_steps_user_id_fkey",
+          "tableFrom": "daily_steps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_steps_pkey": {
+          "name": "daily_steps_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "daily_steps_steps_check": {
+          "name": "daily_steps_steps_check",
+          "value": "steps >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token": {
+          "name": "device_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "client_features": {
+          "name": "client_features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_tokens_user_id": {
+          "name": "idx_device_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_user_id_fkey": {
+          "name": "device_tokens_user_id_fkey",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_user_id_device_token_key": {
+          "name": "device_tokens_user_id_device_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_log": {
+      "name": "error_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_error_log_created_at": {
+          "name": "idx_error_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_error_log_category": {
+          "name": "idx_error_log_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flex_log": {
+      "name": "flex_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flex_log_lookup": {
+          "name": "idx_flex_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_notification_settings": {
+      "name": "friend_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted": {
+          "name": "muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nudges_muted": {
+          "name": "nudges_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "activity_muted": {
+          "name": "activity_muted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "friend_notification_settings_pkey": {
+          "name": "friend_notification_settings_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_nudge_log": {
+      "name": "friend_nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_nudge_log_lookup": {
+          "name": "idx_friend_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friend_request_log": {
+      "name": "friend_request_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_friend_request_log_lookup": {
+          "name": "idx_friend_request_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "reminder_sent_at": {
+          "name": "reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_friendships_friend_status": {
+          "name": "idx_friendships_friend_status",
+          "columns": [
+            {
+              "expression": "friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_friendships_user_status": {
+          "name": "idx_friendships_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_user_id_fkey": {
+          "name": "friendships_user_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendships_friend_id_fkey": {
+          "name": "friendships_friend_id_fkey",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendships_pkey": {
+          "name": "friendships_pkey",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_friendship_pair": {
+          "name": "unique_friendship_pair",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.h2h_matchups": {
+      "name": "h2h_matchups",
+      "schema": "",
+      "columns": {
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rival_id": {
+          "name": "rival_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mutual": {
+          "name": "mutual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "won": {
+          "name": "won",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_notified_state": {
+          "name": "lead_notified_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_notified_at": {
+          "name": "lead_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "h2h_matchups_user_id_fkey": {
+          "name": "h2h_matchups_user_id_fkey",
+          "tableFrom": "h2h_matchups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "h2h_matchups_rival_id_fkey": {
+          "name": "h2h_matchups_rival_id_fkey",
+          "tableFrom": "h2h_matchups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "rival_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "h2h_matchups_pkey": {
+          "name": "h2h_matchups_pkey",
+          "columns": [
+            "local_date",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hype_log": {
+      "name": "hype_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_label": {
+          "name": "context_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hype_log_context_dedupe_idx": {
+          "name": "hype_log_context_dedupe_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_lookup": {
+          "name": "idx_hype_log_lookup",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_hype_log_target_context": {
+          "name": "idx_hype_log_target_context",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(context_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_app_notifications": {
+      "name": "in_app_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_in_app_notifications_unread": {
+          "name": "idx_in_app_notifications_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_read = false)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_in_app_notifications_user": {
+          "name": "idx_in_app_notifications_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "in_app_notifications_user_id_fkey": {
+          "name": "in_app_notifications_user_id_fkey",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.live_tracking_sessions": {
+      "name": "live_tracking_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "distance_miles": {
+          "name": "distance_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "live_tracking_sessions_user_id_fkey": {
+          "name": "live_tracking_sessions_user_id_fkey",
+          "tableFrom": "live_tracking_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_notifications": {
+      "name": "milestone_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "milestone_key": {
+          "name": "milestone_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "milestone_notifications_milestone_key_key": {
+          "name": "milestone_notifications_milestone_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "milestone_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_audience_settings": {
+      "name": "notification_audience_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_audience_settings_pkey": {
+          "name": "notification_audience_settings_pkey",
+          "columns": [
+            "user_id",
+            "direction",
+            "event_type",
+            "activity_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_audience_settings_direction_check": {
+          "name": "notification_audience_settings_direction_check",
+          "value": "direction = ANY (ARRAY['outgoing'::text, 'incoming'::text])"
+        },
+        "notification_audience_settings_audience_check": {
+          "name": "notification_audience_settings_audience_check",
+          "value": "audience = ANY (ARRAY['none'::text, 'close'::text, 'all'::text, 'ask'::text, 'match_run'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_log": {
+      "name": "notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_log_user_date": {
+          "name": "idx_notification_log_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nudges_enabled": {
+          "name": "nudges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "flexes_enabled": {
+          "name": "flexes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_activity_enabled": {
+          "name": "friend_activity_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_invites_enabled": {
+          "name": "competition_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_updates_enabled": {
+          "name": "competition_updates_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "competition_milestones_enabled": {
+          "name": "competition_milestones_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "hypes_enabled": {
+          "name": "hypes_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "step_goal_enabled": {
+          "name": "step_goal_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "friend_personal_best_enabled": {
+          "name": "friend_personal_best_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_enabled": {
+          "name": "daily_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "daily_reminder_hour": {
+          "name": "daily_reminder_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 18
+        },
+        "h2h_close_friends_only": {
+          "name": "h2h_close_friends_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone_offset_minutes": {
+          "name": "timezone_offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_workouts_to_feed": {
+          "name": "share_workouts_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "friend_posts_enabled": {
+          "name": "friend_posts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "share_route_maps": {
+          "name": "share_route_maps",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "share_live_presence": {
+          "name": "share_live_presence",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "weekly_recap_enabled": {
+          "name": "weekly_recap_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "workout_visibility": {
+          "name": "workout_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'friends'"
+        },
+        "friend_request_reminder_enabled": {
+          "name": "friend_request_reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "buddy_invites_enabled": {
+          "name": "buddy_invites_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "tagged_posts_on_profile": {
+          "name": "tagged_posts_on_profile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_settings_workout_visibility_check": {
+          "name": "notification_settings_workout_visibility_check",
+          "value": "workout_visibility = ANY (ARRAY['public'::text, 'friends'::text, 'private'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.nudge_log": {
+      "name": "nudge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_nudge_log_lookup": {
+          "name": "idx_nudge_log_lookup",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nudge_log_rate_limit": {
+          "name": "idx_nudge_log_rate_limit",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_friend_notifications": {
+      "name": "pending_friend_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "send_after_at": {
+          "name": "send_after_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_friend_notif_user": {
+          "name": "idx_pending_friend_notif_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_pending_friend_notif_workout": {
+          "name": "uq_pending_friend_notif_workout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((workout_id IS NOT NULL) AND (status = 'pending'::text))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pending_friend_notifications_status_check": {
+          "name": "pending_friend_notifications_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'sent'::text, 'dismissed'::text, 'expired'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pending_notifications": {
+      "name": "pending_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition_name": {
+          "name": "competition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_notifications_unsent": {
+          "name": "idx_pending_notifications_unsent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(sent_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_notifications_user_id_fkey": {
+          "name": "pending_notifications_user_id_fkey",
+          "tableFrom": "pending_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_coauthors": {
+      "name": "post_coauthors",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buddy_session_id": {
+          "name": "buddy_session_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_post_coauthors_user": {
+          "name": "idx_post_coauthors_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_coauthors_post_id_fkey": {
+          "name": "post_coauthors_post_id_fkey",
+          "tableFrom": "post_coauthors",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_coauthors_user_id_fkey": {
+          "name": "post_coauthors_user_id_fkey",
+          "tableFrom": "post_coauthors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_coauthors_workout_id_fkey": {
+          "name": "post_coauthors_workout_id_fkey",
+          "tableFrom": "post_coauthors",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "post_coauthors_buddy_session_id_fkey": {
+          "name": "post_coauthors_buddy_session_id_fkey",
+          "tableFrom": "post_coauthors",
+          "tableTo": "buddy_sessions",
+          "columnsFrom": [
+            "buddy_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_coauthors_pkey": {
+          "name": "post_coauthors_pkey",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_coauthors_status_check": {
+          "name": "post_coauthors_status_check",
+          "value": "status = ANY (ARRAY['pending'::text, 'accepted'::text, 'declined'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_comments": {
+      "name": "post_comments",
+      "schema": "",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_post_comments_post": {
+          "name": "idx_post_comments_post",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND post_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_comments_workout": {
+          "name": "idx_post_comments_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_comments_post_id_fkey": {
+          "name": "post_comments_post_id_fkey",
+          "tableFrom": "post_comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_workout_id_fkey": {
+          "name": "post_comments_workout_id_fkey",
+          "tableFrom": "post_comments",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_user_id_fkey": {
+          "name": "post_comments_user_id_fkey",
+          "tableFrom": "post_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_parent_fkey": {
+          "name": "post_comments_parent_fkey",
+          "tableFrom": "post_comments",
+          "tableTo": "post_comments",
+          "columnsFrom": [
+            "parent_comment_id"
+          ],
+          "columnsTo": [
+            "comment_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_comments_content_check": {
+          "name": "post_comments_content_check",
+          "value": "char_length(content) >= 1 AND char_length(content) <= 1000"
+        },
+        "post_comments_one_target_check": {
+          "name": "post_comments_one_target_check",
+          "value": "((post_id IS NOT NULL)::int + (workout_id IS NOT NULL)::int) = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_reports": {
+      "name": "post_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_reports_dedupe_idx": {
+          "name": "post_reports_dedupe_idx",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_reports_status": {
+          "name": "idx_post_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_reports_post_id_fkey": {
+          "name": "post_reports_post_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_reports_reporter_id_fkey": {
+          "name": "post_reports_reporter_id_fkey",
+          "tableFrom": "post_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_reports_reason_check": {
+          "name": "post_reports_reason_check",
+          "value": "reason = ANY (ARRAY['spam'::text, 'nudity'::text, 'harassment'::text, 'violence'::text, 'other'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats_snapshot": {
+          "name": "stats_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_to_feed": {
+          "name": "share_to_feed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_to_story": {
+          "name": "share_to_story",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "story_expires_at": {
+          "name": "story_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto": {
+          "name": "is_auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_route": {
+          "name": "include_route",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "coauthor_user_id": {
+          "name": "coauthor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_status": {
+          "name": "coauthor_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_workout_id": {
+          "name": "coauthor_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coauthor_on_profile": {
+          "name": "coauthor_on_profile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_fresh": {
+          "name": "posted_fresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_posts_user_created": {
+          "name": "idx_posts_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_feed": {
+          "name": "idx_posts_feed",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_story_active": {
+          "name": "idx_posts_story_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "story_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND share_to_story)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_active": {
+          "name": "uq_posts_workout_active",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_posts_workout_story": {
+          "name": "uq_posts_workout_story",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deleted_at IS NULL AND workout_id IS NOT NULL AND share_to_story AND NOT share_to_feed)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_coauthor_workout": {
+          "name": "idx_posts_coauthor_workout",
+          "columns": [
+            {
+              "expression": "coauthor_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(coauthor_workout_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_coauthor_user": {
+          "name": "idx_posts_coauthor_user",
+          "columns": [
+            {
+              "expression": "coauthor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(coauthor_user_id IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_fkey": {
+          "name": "posts_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_workout_id_fkey": {
+          "name": "posts_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_coauthor_user_id_fkey": {
+          "name": "posts_coauthor_user_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "coauthor_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_coauthor_workout_id_fkey": {
+          "name": "posts_coauthor_workout_id_fkey",
+          "tableFrom": "posts",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "coauthor_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "posts_coauthor_status_check": {
+          "name": "posts_coauthor_status_check",
+          "value": "coauthor_status IS NULL OR coauthor_status = ANY (ARRAY['pending'::text, 'accepted'::text])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_family_id": {
+          "name": "token_family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_hash": {
+          "name": "replaced_by_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "token_family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_revoked_at": {
+          "name": "idx_refresh_tokens_revoked_at",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(revoked_at IS NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_token_hash": {
+          "name": "idx_refresh_tokens_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_fkey": {
+          "name": "refresh_tokens_user_id_fkey",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_key": {
+          "name": "refresh_tokens_token_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_reactions": {
+      "name": "story_reactions",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_reactions_post_id_fkey": {
+          "name": "story_reactions_post_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_reactions_user_id_fkey": {
+          "name": "story_reactions_user_id_fkey",
+          "tableFrom": "story_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_reactions_pkey": {
+          "name": "story_reactions_pkey",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_views": {
+      "name": "story_views",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_id": {
+          "name": "viewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_views_post_id_fkey": {
+          "name": "story_views_post_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "story_views_viewer_id_fkey": {
+          "name": "story_views_viewer_id_fkey",
+          "tableFrom": "story_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "story_views_pkey": {
+          "name": "story_views_pkey",
+          "columns": [
+            "post_id",
+            "viewer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streak_coverage": {
+      "name": "streak_coverage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_date": {
+          "name": "trigger_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_user": {
+          "name": "source_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "streak_coverage_user_id_fkey": {
+          "name": "streak_coverage_user_id_fkey",
+          "tableFrom": "streak_coverage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "streak_coverage_pkey": {
+          "name": "streak_coverage_pkey",
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streak_events": {
+      "name": "streak_events",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prior_streak": {
+          "name": "prior_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "streak_events_user_id_fkey": {
+          "name": "streak_events_user_id_fkey",
+          "tableFrom": "streak_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "streak_events_pkey": {
+          "name": "streak_events_pkey",
+          "columns": [
+            "user_id",
+            "local_date",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badges": {
+      "name": "user_badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggering_workout_id": {
+          "name": "triggering_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_snapshot": {
+          "name": "progress_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_slot": {
+          "name": "pin_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_badges_user": {
+          "name": "idx_user_badges_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_new": {
+          "name": "idx_user_badges_user_new",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(is_new = true)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_user_pin_slot": {
+          "name": "idx_user_badges_user_pin_slot",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(pin_slot IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_badges_workout": {
+          "name": "idx_user_badges_workout",
+          "columns": [
+            {
+              "expression": "triggering_workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_badges_user_id_fkey": {
+          "name": "user_badges_user_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_badge_id_fkey": {
+          "name": "user_badges_badge_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "badge_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_badges_triggering_workout_id_fkey": {
+          "name": "user_badges_triggering_workout_id_fkey",
+          "tableFrom": "user_badges",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "triggering_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_badges_user_id_badge_id_key": {
+          "name": "user_badges_user_id_badge_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "badge_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_badges_pin_slot_range": {
+          "name": "user_badges_pin_slot_range",
+          "value": "(pin_slot IS NULL) OR ((pin_slot >= 0) AND (pin_slot <= 2))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_blocks": {
+      "name": "user_blocks",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_blocks_blocked": {
+          "name": "idx_user_blocks_blocked",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_blocks_blocker_id_fkey": {
+          "name": "user_blocks_blocker_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_blocks_blocked_id_fkey": {
+          "name": "user_blocks_blocked_id_fkey",
+          "tableFrom": "user_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_blocks_pkey": {
+          "name": "user_blocks_pkey",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_challenge_completions": {
+      "name": "user_challenge_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_key": {
+          "name": "challenge_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completing_workout_id": {
+          "name": "completing_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ucc_user": {
+          "name": "idx_ucc_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ucc_user_date": {
+          "name": "idx_ucc_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_challenge_completions_user_id_fkey": {
+          "name": "user_challenge_completions_user_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_challenge_key_fkey": {
+          "name": "user_challenge_completions_challenge_key_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "daily_challenges",
+          "columnsFrom": [
+            "challenge_key"
+          ],
+          "columnsTo": [
+            "challenge_key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_challenge_completions_completing_workout_id_fkey": {
+          "name": "user_challenge_completions_completing_workout_id_fkey",
+          "tableFrom": "user_challenge_completions",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "completing_workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_challenge_completions_user_id_local_date_key": {
+          "name": "user_challenge_completions_user_id_local_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "local_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_sub": {
+          "name": "apple_sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "goal_miles": {
+          "name": "goal_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "longest_streak": {
+          "name": "longest_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_source": {
+          "name": "referral_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_detail": {
+          "name": "referral_detail",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signup_goal": {
+          "name": "signup_goal",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience_level": {
+          "name": "experience_level",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dedupe_since": {
+          "name": "dedupe_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "streak_features_at": {
+          "name": "streak_features_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "double_down_last_used": {
+          "name": "double_down_last_used",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streak_save_last_used": {
+          "name": "streak_save_last_used",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streak_assist_last_used": {
+          "name": "streak_assist_last_used",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buddy_enrolled_at": {
+          "name": "buddy_enrolled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_current_streak_desc": {
+          "name": "idx_users_current_streak_desc",
+          "columns": [
+            {
+              "expression": "current_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_longest_streak_desc": {
+          "name": "idx_users_longest_streak_desc",
+          "columns": [
+            {
+              "expression": "longest_streak",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email_trgm": {
+          "name": "idx_users_email_trgm",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_username_trgm": {
+          "name": "idx_users_username_trgm",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_apple_id_key": {
+          "name": "users_apple_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_apple_sub_key": {
+          "name": "users_apple_sub_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "apple_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_recap_log": {
+      "name": "weekly_recap_log",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "weekly_recap_log_pkey": {
+          "name": "weekly_recap_log_pkey",
+          "columns": [
+            "user_id",
+            "week_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_completion_notifications": {
+      "name": "workout_completion_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_date": {
+          "name": "notified_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_completion_notifications_user_id_notified_date_key": {
+          "name": "workout_completion_notifications_user_id_notified_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "notified_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_routes": {
+      "name": "workout_routes",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "point_count": {
+          "name": "point_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workout_routes_workout_id_fkey": {
+          "name": "workout_routes_workout_id_fkey",
+          "tableFrom": "workout_routes",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_splits": {
+      "name": "workout_splits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_number": {
+          "name": "split_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_duration": {
+          "name": "split_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "split_distance": {
+          "name": "split_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_pace": {
+          "name": "split_pace",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_splits_time": {
+          "name": "idx_splits_time",
+          "columns": [
+            {
+              "expression": "split_duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_splits_workout": {
+          "name": "idx_splits_workout",
+          "columns": [
+            {
+              "expression": "workout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_splits_workout_id_fkey": {
+          "name": "workout_splits_workout_id_fkey",
+          "tableFrom": "workout_splits",
+          "tableTo": "workouts",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "workout_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workout_splits_workout_id_split_number_key": {
+          "name": "workout_splits_workout_id_split_number_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "split_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workouts": {
+      "name": "workouts",
+      "schema": "",
+      "columns": {
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_date": {
+          "name": "local_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone_offset": {
+          "name": "timezone_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_end_date": {
+          "name": "device_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calories": {
+          "name": "calories",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moving_seconds": {
+          "name": "moving_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghost_margin_seconds": {
+          "name": "ghost_margin_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghost_target_seconds": {
+          "name": "ghost_target_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghost_friend_user_id": {
+          "name": "ghost_friend_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghost_notified_at": {
+          "name": "ghost_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthkit'"
+        },
+        "original_distance": {
+          "name": "original_distance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_duration": {
+          "name": "original_duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speed_flagged": {
+          "name": "speed_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feed_role": {
+          "name": "feed_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'extra'"
+        },
+        "source_bundle_id": {
+          "name": "source_bundle_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_of": {
+          "name": "duplicate_of",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_decision": {
+          "name": "duplicate_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_workouts_local_date_user_id": {
+          "name": "idx_workouts_local_date_user_id",
+          "columns": [
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_device_end": {
+          "name": "idx_workouts_user_device_end",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_user_local_date": {
+          "name": "idx_workouts_user_local_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workouts_feed_candidates": {
+          "name": "idx_workouts_feed_candidates",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_end_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "(deleted_at IS NULL AND exclusion_reason IS NULL AND feed_role IN ('daily_mile', 'extra'))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workouts_user_workout_unique": {
+          "name": "workouts_user_workout_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workout_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workouts_feed_role_check": {
+          "name": "workouts_feed_role_check",
+          "value": "\"workouts\".\"feed_role\" IN ('hidden', 'rolled_up', 'daily_mile', 'extra')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/drizzle/meta/_journal.json
+++ b/backend/src/db/drizzle/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1785949811263,
       "tag": "0042_odd_surge",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1786036141356,
+      "tag": "0043_chemical_xavin",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/drizzle/meta/_journal.json
+++ b/backend/src/db/drizzle/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1786036141356,
       "tag": "0043_chemical_xavin",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1786036964585,
+      "tag": "0044_loud_red_ghost",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/drizzle/schema.ts
+++ b/backend/src/db/drizzle/schema.ts
@@ -335,6 +335,19 @@ export const workouts = pgTable(
     // on the user's `dedupe_since` grandfather line, so this column stays a
     // pure observation that the review endpoints can report on.
     duplicateOf: varchar("duplicate_of", { length: 255 }),
+    /// The USER's explicit answer to "is this a duplicate?", which outranks
+    /// detection.
+    ///
+    /// 'count'   — count it, whatever detection thinks.
+    /// 'exclude' — don't count it, whatever detection thinks.
+    /// NULL      — no opinion; detection decides.
+    ///
+    /// This exists because the exclusion pass re-runs on EVERY sync of the day.
+    /// Without somewhere durable to record intent, a user who said "no, that
+    /// really was a second walk" would have their choice silently reversed by
+    /// the next heartbeat, which is exactly the surprise the feature is meant
+    /// to prevent.
+    duplicateDecision: text("duplicate_decision"),
   },
   (table) => [
     index("idx_workouts_local_date_user_id").using(

--- a/backend/src/db/drizzle/schema.ts
+++ b/backend/src/db/drizzle/schema.ts
@@ -1792,6 +1792,14 @@ export const liveTrackingSessions = pgTable(
     startedAt: timestamp("started_at", { withTimezone: true, mode: "string" })
       .defaultNow()
       .notNull(),
+    /// Live distance, in miles, as of the last heartbeat.
+    ///
+    /// Presence answered "they are out" and nothing else, so a friend's card
+    /// could say someone was walking but never how it was going — which is the
+    /// part anyone watching actually wants. Clamped MONOTONIC on write: a
+    /// heartbeat that arrives out of order, or from a device whose GPS burped,
+    /// must never make a friend's number go backwards in front of an audience.
+    distanceMiles: doublePrecision("distance_miles").default(0).notNull(),
     lastSeenAt: timestamp("last_seen_at", {
       withTimezone: true,
       mode: "string",

--- a/backend/src/routes/workoutRoutes.ts
+++ b/backend/src/routes/workoutRoutes.ts
@@ -14,6 +14,7 @@ import {
   getRaceHistoryController,
   getStreakEras,
   getDuplicates,
+  setDuplicateDecisionController,
   resolveDuplicates,
 } from "../controllers/workoutController.js";
 import { requireSelfAccess } from "../middleware/auth.js";
@@ -44,6 +45,17 @@ router.post(
   "/:userId/duplicates/resolve",
   requireSelfAccess("userId"),
   resolveDuplicates,
+);
+// One workout, one answer: "count it" / "don't". The user's decision outranks
+// detection and survives the recompute that runs on every sync.
+//
+// MUST stay below /resolve: Express matches in registration order, and a
+// wildcard registered first would capture the literal "resolve" as a workout id
+// and silently turn the history-cleanup action into a 404.
+router.post(
+  "/:userId/duplicates/:workoutId",
+  requireSelfAccess("userId"),
+  setDuplicateDecisionController,
 );
 // Self-only: friends' route visibility is governed by share_route_maps on
 // feed payloads; the raw full-history dump is never exposed to others.

--- a/backend/src/services/liveTrackingService.ts
+++ b/backend/src/services/liveTrackingService.ts
@@ -26,6 +26,10 @@ export interface LiveFriend {
   profile_image_url: string | null;
   workout_type: string;
   started_at: string;
+  /** Live miles as of their last heartbeat. Monotonic. */
+  distance_miles: number;
+  /** THEIR daily goal, so progress is drawn against the right target. */
+  goal_miles: number;
   /** The friend's CURRENT local date — the composite key half a viewer needs
    *  to send them a mile hype with zero hype-side changes. */
   local_date: string;
@@ -52,6 +56,10 @@ export interface FriendOutNow {
   profile_image_url: string | null;
   workout_type: string;
   started_at: string;
+  /** Live miles as of their last heartbeat. Monotonic. */
+  distance_miles: number;
+  /** THEIR daily goal, so progress is drawn against the right target. */
+  goal_miles: number;
   /** Non-null only when they're in a buddy room with space left. */
   buddy_session_id: string | null;
   buddy_join_code: string | null;
@@ -115,12 +123,23 @@ export async function startSession(
 export async function heartbeat(
   userId: string,
   sessionId: string,
+  distanceMiles?: number,
 ): Promise<{ friends_out: LiveFriend[]; hypes: LiveHype[] } | null> {
+  // GREATEST, never assignment: heartbeats can arrive out of order, and a
+  // friend's live number is being watched by other people. It may stall, it
+  // must never tick backwards. A missing/NaN value leaves the stored figure
+  // alone rather than resetting it to zero.
+  const reported =
+    typeof distanceMiles === "number" && Number.isFinite(distanceMiles)
+      ? Math.max(0, distanceMiles)
+      : null;
   const bumped = await db.query<{ started_at: Date }>(
-    `UPDATE live_tracking_sessions SET last_seen_at = NOW()
+    `UPDATE live_tracking_sessions
+        SET last_seen_at = NOW(),
+            distance_miles = GREATEST(distance_miles, COALESCE($3, distance_miles))
      WHERE user_id = $1 AND session_id = $2 AND ended_at IS NULL
      RETURNING started_at`,
-    [userId, sessionId],
+    [userId, sessionId, reported],
   );
   if (bumped.length === 0) return null;
   // timestamptz comes back as a JS Date (house rule) — passed straight back
@@ -132,6 +151,8 @@ export async function heartbeat(
       `SELECT u.user_id, u.username, u.first_name, u.last_name,
               u.profile_image_url, s.workout_type,
               to_char(s.started_at AT TIME ZONE 'UTC', ${ISO_TS}) AS started_at,
+              s.distance_miles,
+              u.goal_miles::float AS goal_miles,
               to_char(
                 (NOW() + (COALESCE(
                   (SELECT w2.timezone_offset FROM workouts w2
@@ -236,6 +257,10 @@ export async function friendsOutNow(userId: string): Promise<FriendOutNow[]> {
     `SELECT u.user_id, u.username, u.first_name, u.last_name,
             u.profile_image_url, s.workout_type,
             to_char(s.started_at AT TIME ZONE 'UTC', ${ISO_TS}) AS started_at,
+            s.distance_miles,
+            -- THEIR goal, not the viewer's. A friend on a 2-mile goal rendered
+            -- against a 1-mile bar reads as finished when they're halfway.
+            u.goal_miles::float AS goal_miles,
             room.id AS buddy_session_id,
             room.join_code AS buddy_join_code,
             room.mode AS buddy_mode,

--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -720,7 +720,12 @@ function duplicateExclusionStatements(
 	UPDATE workouts SET exclusion_reason = NULL
 	WHERE user_id = $1 AND local_date = $2::date
 		AND exclusion_reason = '${DUPLICATE_EXCLUSION_REASON}'
-		AND (NOT $3::boolean OR duplicate_of IS NULL)`,
+		-- The user's own answer outranks detection. Without this clause a
+		-- "no, that really was a second walk" would be silently reversed by
+		-- the next sync of the day, which is the precise surprise this whole
+		-- feature is supposed to prevent.
+		AND (NOT $3::boolean OR duplicate_of IS NULL
+		     OR duplicate_decision = 'count')`,
       params: [userId, localDate, enabled],
     },
     {
@@ -738,12 +743,22 @@ function duplicateExclusionStatements(
 	FROM users u
 	WHERE w.user_id = $1 AND w.local_date = $2::date
 		AND u.user_id = w.user_id
-		AND $3::boolean
-		AND w.duplicate_of IS NOT NULL
 		AND w.exclusion_reason IS NULL
 		AND w.deleted_at IS NULL
-		AND u.dedupe_since IS NOT NULL
-		AND w.created_at >= u.dedupe_since`,
+		AND (
+			-- The user said don't count it. Honoured regardless of the kill
+			-- switch or the grandfather line: it is their own workout and
+			-- their own explicit answer.
+			w.duplicate_decision = 'exclude'
+			OR (
+				$3::boolean
+				AND w.duplicate_of IS NOT NULL
+				-- ...but never over the top of "count it".
+				AND w.duplicate_decision IS DISTINCT FROM 'count'
+				AND u.dedupe_since IS NOT NULL
+				AND w.created_at >= u.dedupe_since
+			)
+		)`,
       params: [userId, localDate, enabled],
     },
   ];
@@ -1894,4 +1909,39 @@ export async function getRaceHistory(
     [userId, dist.miles * RACE_BAND_LO, dist.miles * RACE_BAND_HI],
   );
   return rows.map((r) => mapRaceRow({ ...r, bucket: distanceKey }));
+}
+
+/**
+ * Record the user's own answer to "is this workout a duplicate?".
+ *
+ * This is the control that makes automatic exclusion acceptable at all. A
+ * workout is the user's own record of something they actually did; taking it
+ * out of their totals because two apps both wrote it is a judgement call, and
+ * the user has to be able to overrule it in one tap and have that stick.
+ *
+ * Sticky by construction: the decision lives on the row, and both the release
+ * and exclude passes read it, so the recompute that runs on every sync of the
+ * day re-derives the same answer instead of undoing theirs.
+ *
+ * `decision` is 'count' | 'exclude' | null (null = hand it back to detection).
+ * Scoped to the caller's own workouts — a workout id alone is not authority.
+ */
+export async function setDuplicateDecision(
+  userId: string,
+  workoutId: string,
+  decision: "count" | "exclude" | null,
+): Promise<{ localDate: string } | null> {
+  const rows = await db.query<{ local_date: string }>(
+    `UPDATE workouts
+        SET duplicate_decision = $3
+      WHERE user_id = $1 AND workout_id = $2 AND deleted_at IS NULL
+      RETURNING to_char(local_date, 'YYYY-MM-DD') AS local_date`,
+    [userId, workoutId, decision],
+  );
+  if (rows.length === 0) return null;
+
+  // Re-run the day so the decision takes effect immediately rather than at the
+  // next sync — the user is looking at the number they just changed.
+  await recomputeDuplicatesForDay(userId, rows[0].local_date);
+  return { localDate: rows[0].local_date };
 }

--- a/backend/src/services/workoutService.ts
+++ b/backend/src/services/workoutService.ts
@@ -542,17 +542,38 @@ const DUPLICATE_DISTANCE_TOLERANCE = 0.2;
 const DUPLICATE_DISTANCE_FLOOR = 0.1;
 
 /**
+ * How much of the SHORTER workout must sit inside the longer one before it's
+ * treated as a fragment of the same activity rather than a separate one.
+ *
+ * Deliberately high. At 0.9 the shorter workout is essentially wholly enclosed,
+ * which is what makes "you can't be on two outdoor walks at once" a safe
+ * inference. A looser value would start pairing a genuine second walk that
+ * merely began before the first one ended.
+ */
+const DUPLICATE_CONTAINMENT_RATIO = 0.9;
+
+/**
  * Is cross-app duplicate EXCLUSION live?
  *
- * Kill switch, default OFF (env flags are kill switches, never the safety
- * mechanism — see .claude/rules/backend.md). Detection still runs and still
- * populates `duplicate_of` while it's off, so the flag can be flipped on only
- * after diffing what it would do against real data. Flipping it back off
- * unwinds every exclusion it applied on the next sync of each day.
+ * ON unless explicitly disabled. It shipped default-off so its behaviour could
+ * be diffed against real data first; that diffing has happened, and the answer
+ * was that a real user's day read 2.55 mi for a 1.84 mi walk because Google
+ * Health independently wrote a 0.36 mi fragment of the same walk into HealthKit.
+ * Left off, the whole pass is inert and the double-count is what users see.
+ *
+ * Two things keep this from rewriting history when it flips:
+ *  - `users.dedupe_since` grandfathers every workout created before the column
+ *    was added, so no existing total or streak moves. Only newly-synced
+ *    workouts can be excluded.
+ *  - Setting WORKOUT_DEDUPE to "false"/"0"/"off" unwinds every exclusion it
+ *    applied, on the next sync of each affected day. It is a true kill switch.
+ *
+ * A user who WANTS their history cleaned up moves their own grandfather line
+ * back via POST /workouts/:userId/duplicates/resolve; nothing else does.
  */
 function duplicateExclusionEnabled(): boolean {
   const v = (process.env.WORKOUT_DEDUPE ?? "").toLowerCase();
-  return v === "1" || v === "true" || v === "on";
+  return !(v === "0" || v === "false" || v === "off");
 }
 
 /**
@@ -635,8 +656,29 @@ function duplicateExclusionStatements(
 			AND EXTRACT(EPOCH FROM (
 				LEAST(a.ends_at, b.ends_at) - GREATEST(a.starts_at, b.starts_at)
 			)) >= $3 * LEAST(a.total_duration, b.total_duration)
-			AND abs(a.distance - b.distance) <= GREATEST(
-				$4, $5 * GREATEST(a.distance, b.distance)
+			AND (
+				-- Either both apps recorded the WHOLE activity, so the
+				-- distances agree...
+				abs(a.distance - b.distance) <= GREATEST(
+					$4, $5 * GREATEST(a.distance, b.distance)
+				)
+				-- ...or A is a FRAGMENT of B: a's window sits almost
+				-- entirely inside b's and it covers no more ground.
+				--
+				-- This is the case agreement alone cannot see. A phone app that
+				-- starts tracking partway through, or segments a walk
+				-- differently, writes a short workout inside the long one — and
+				-- 0.36 vs 1.84 fails every distance test there is while being
+				-- unambiguously the same walk. You cannot be on two outdoor
+				-- walks at the same moment, so a contained window from another
+				-- source is the same walk however little of it that app caught.
+				OR (
+					EXTRACT(EPOCH FROM (
+						LEAST(a.ends_at, b.ends_at)
+							- GREATEST(a.starts_at, b.starts_at)
+					)) >= $6 * a.total_duration
+					AND a.distance <= b.distance
+				)
 			)
 	),
 	-- A row is a duplicate if any better-ranked row is the same run...
@@ -667,6 +709,7 @@ function duplicateExclusionStatements(
         DUPLICATE_MIN_OVERLAP_RATIO,
         DUPLICATE_DISTANCE_FLOOR,
         DUPLICATE_DISTANCE_TOLERANCE,
+        DUPLICATE_CONTAINMENT_RATIO,
       ],
     },
     {


### PR DESCRIPTION
## 1. The double-count — why dedup didn't fire

Mile A Day tracked **1.84 mi**. Google Health independently wrote a **0.36 mi** walk sitting entirely inside that window. The day counted **2.55 mi**.

Cross-app dedup exists for exactly this, and failed for **two independent reasons**.

**a) The pairing rule needs the distances to agree.**
```
|a − b| ≤ max(0.1, 0.2 × longer)
|1.84 − 0.36| = 1.48    budget = 0.368     ✗
```
That rule assumes both apps recorded the *whole* activity. Google Health recorded a **fragment**, so agreement can never see it — no threshold tuning fixes this, it's the wrong test.

Added a **containment** rule alongside: when one source's window sits ≥90% inside another's *and* covers no more ground, it's the same walk however little of it that app caught. You cannot be on two outdoor walks at the same moment.

**b) `WORKOUT_DEDUPE` defaulted OFF**, so the entire pass was inert in production — the same regression class as `BUDDY_SESSIONS`. It's now a real kill switch: on unless explicitly `"false"`.

Safety is unchanged and load-bearing:
- `users.dedupe_since` grandfathers every pre-existing workout, so **no historical total or streak moves**. Only newly-synced workouts can be excluded.
- Setting the flag to `false` **unwinds every exclusion** on the next sync of each day.
- A user who wants history cleaned moves their own line back via the existing `POST /workouts/:userId/duplicates/resolve`.

`dedupe-containment-check` (6 assertions, in CI) pins the exact production shape plus the two ways this could eat real miles: **a genuinely separate later walk survives**, and **same-source fragments are never paired**.

## 2. Live presence

It answered "they are out" and nothing else, and only rendered inside `WorkoutTrackingView` — so you could learn a friend was walking **only while walking yourself**.

`live_tracking_sessions` gains `distance_miles`, written by the heartbeat with `GREATEST` — never assignment. Heartbeats arrive out of order and a friend's number is being watched by other people: it may stall, it must never tick backwards.

Both presence reads return it alongside the friend's **own** `goal_miles`. A friend on a 2-mile goal drawn against a 1-mile bar reads as finished at halfway.

One shared `FriendOutLiveRow` now renders presence everywhere — progress ring against their goal, "0.62 of 1 mi", how long they've been out, **Hype**, and **Join / Ask to walk**.

Hype uses the same `<userId>:<localDate>` mile composite the rest of the app uses, so it dedupes against a hype sent from the feed *and* lands on their tracking screen mid-walk via `LivePresenceService` — real-time encouragement rather than a notification read afterwards. Join hides during your own workout; the rows stay, because hyping from there is the point.

**Density:** past 3 friends out, the list shows the **closest to finishing** and folds the rest behind one line. Someone at 0.9 mi is minutes from a celebration; someone at 0.05 has half an hour. That's where a hype still lands while it counts.

On the friends list they sit at the **top of Cheer them on** and are filtered out of the static list below, so nobody appears twice with two contradicting numbers.

## 3. Truncation in a friend's Recent Workouts

"Walked" rendered as a lone `'`, and `23:11 /mi` as `23:11 •…` — but only on rows carrying **both** Route and Photo chips, where the wider chip row over-constrains the column.

- The verb had **no layout priority** while the distance beside it had `.layoutPriority(1)`, so SwiftUI compressed the verb first — to one glyph plus an ellipsis. The verb/distance pair is now `fixedSize`: two short words, whole or not at all.
- Duration+pace is a single `.lineLimit(1)` `Text`, so it clipped its own tail — which is the pace. It now tightens and scales (`minimumScaleFactor(0.75)`) instead of clipping.
- The stat column now outranks the trailing date block.

## Verification

`tsc` clean, `drizzle-kit check` clean, migrator applied then idempotent, and `ci-smoke` + `buddy-gate-check` + `ghost-race-check` + `dedupe-containment-check` all passing against a real migrated Postgres 16.

**Migration 0043** adds one column with a constant default — no table rewrite (PG 11+ stores it as a missing-value), and `0` is the correct pre-backfill value.

## Notes

- The iOS type-check job now guards the Swift here — it caught a real error on its first run last PR.
- Per your choice, this flips the dedup switch on. To also clean up **your own** already-double-counted history, call `POST /workouts/<your-user-id>/duplicates/resolve` after deploy — that moves your grandfather line back and re-runs the pass. Today would drop from 2.55 to ~1.84 mi.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxEp1wW88Y5PxyTxgAoE3L)_