### PR TITLE
Count each walk once on the phone, not just on the server

### DIFF
--- a/app/Mile A Day/Models/HealthKitManager.swift
+++ b/app/Mile A Day/Models/HealthKitManager.swift
@@ -1102,14 +1102,13 @@ class HealthKitManager: ObservableObject {
     
     /// Processes today's filtered workouts to calculate distance and update UI
     func processTodaysWorkouts(_ todaysWorkouts: [HKWorkout], dayStamp: String? = nil) {
-        var totalMiles: Double = 0.0
-
-        for workout in todaysWorkouts {
-            if let distance = workout.totalDistance {
-                let miles = distance.doubleValue(for: HKUnit.mile())
-                totalMiles += miles
-            }
-        }
+        // Counted ONCE per real activity. This used to be a plain sum over
+        // every HealthKit workout, which double-counts the same walk whenever a
+        // second app (Google Health, Strava, a watch platform) also wrote it —
+        // a 1.02 mi walk read as 1.98. The backend already excluded those, but
+        // this number never asked the backend, so nothing server-side could
+        // ever move it. See WorkoutDedup: same rule, same thresholds.
+        let totalMiles = WorkoutDedup.totalMiles(todaysWorkouts)
 
         DispatchQueue.main.async {
             #if os(watchOS)

--- a/app/Mile A Day/Models/WorkoutDedup.swift
+++ b/app/Mile A Day/Models/WorkoutDedup.swift
@@ -1,0 +1,155 @@
+import Foundation
+import HealthKit
+
+/// The same walk, recorded by two apps, counted once.
+///
+/// Every third-party fitness platform — Google Health, Strava, Garmin, WHOOP —
+/// reaches this app by writing into Apple Health. So the SAME walk arrives
+/// twice with two UUIDs, and summing HealthKit naively counts it twice. A
+/// 1.02 mi walk with Google Health also recording 0.96 mi of it reads as 1.98.
+///
+/// The backend already solves this (`duplicateExclusionStatements` in
+/// workoutService.ts) and that fixes streaks, leaderboards and the feed. It does
+/// NOT fix what this app displays, because every "today's distance" on screen is
+/// summed on-device straight from HealthKit and never asks the server what
+/// counts. That gap is why the dashboard, the Road view and Insights could each
+/// show a different, inflated number for the same day.
+///
+/// So the rule lives here too, deliberately duplicated rather than fetched:
+/// these sums run offline, on launch, and inside widget/background paths where a
+/// round trip isn't available. The THRESHOLDS below are the contract — they must
+/// stay identical to the server's constants or the two will disagree, which is
+/// the exact failure this exists to end.
+enum WorkoutDedup {
+    // ─── Must match backend/src/services/workoutService.ts ───────────────
+    /// Share of the SHORTER workout that must overlap before it's the same run.
+    static let minOverlapRatio = 0.5
+    /// How far two measurements of one route may disagree (fraction of longer).
+    static let distanceTolerance = 0.2
+    /// Absolute floor for the above, so short walks aren't held to a few feet.
+    static let distanceFloor = 0.1
+    /// How much of the shorter workout must sit inside the longer one before
+    /// it's treated as a fragment of the same activity.
+    static let containmentRatio = 0.9
+
+    /// One workout, reduced to what the rule needs.
+    private struct Candidate {
+        let index: Int
+        let bundleId: String
+        let start: Date
+        let end: Date
+        let duration: TimeInterval
+        let miles: Double
+        /// Mile A Day's own recording. Preferred survivor: it's the copy that
+        /// carries the GPS route, which is also the server's first tiebreak.
+        let isFirstParty: Bool
+    }
+
+    /// Indices of workouts that should NOT be counted, because another workout
+    /// in the same array already covers them.
+    ///
+    /// Returns indices rather than a filtered array so callers can both sum the
+    /// survivors AND show the user what was left out — never removing a workout
+    /// silently is a requirement, not a nicety.
+    static func duplicateIndices(in workouts: [HKWorkout]) -> Set<Int> {
+        var excluded = Set<Int>()
+        guard workouts.count > 1 else { return excluded }
+
+        // Exact repeats first. Two entries with one UUID are one workout by
+        // definition, whatever any distance rule says.
+        var seenUUIDs = Set<String>()
+        var candidates: [Candidate] = []
+        for (index, workout) in workouts.enumerated() {
+            let uuid = workout.uuid.uuidString
+            if seenUUIDs.contains(uuid) {
+                excluded.insert(index)
+                continue
+            }
+            seenUUIDs.insert(uuid)
+
+            let duration = workout.duration
+            guard duration > 0 else { continue }
+            let bundle = workout.sourceRevision.source.bundleIdentifier
+            candidates.append(
+                Candidate(
+                    index: index,
+                    bundleId: bundle,
+                    start: workout.startDate,
+                    end: workout.endDate,
+                    duration: duration,
+                    miles: workout.totalDistance?.doubleValue(for: .mile()) ?? 0,
+                    isFirstParty: WorkoutAttribution(bundleId: bundle).isFirstParty
+                )
+            )
+        }
+
+        // Preferred survivor sorts FIRST, so a later candidate is only ever
+        // dropped in favour of a better one. Mile A Day's copy wins (it has the
+        // route); then the longer distance, since a fragment can't be longer
+        // than the walk that contains it.
+        let ranked = candidates.sorted {
+            if $0.isFirstParty != $1.isFirstParty { return $0.isFirstParty }
+            if $0.miles != $1.miles { return $0.miles > $1.miles }
+            return $0.index < $1.index
+        }
+
+        for (position, candidate) in ranked.enumerated() {
+            if excluded.contains(candidate.index) { continue }
+            for keeper in ranked[..<position] {
+                if excluded.contains(keeper.index) { continue }
+                if isSameActivity(candidate, keeper) {
+                    excluded.insert(candidate.index)
+                    break
+                }
+            }
+        }
+        return excluded
+    }
+
+    /// Two recordings of one real-world activity.
+    ///
+    /// Same-source pairs are never matched: one app segmenting its own walk is
+    /// that app's business, and UUID equality already covers true repeats.
+    private static func isSameActivity(_ a: Candidate, _ b: Candidate) -> Bool {
+        guard a.bundleId != b.bundleId else { return false }
+
+        let overlap = min(a.end, b.end).timeIntervalSince(max(a.start, b.start))
+        guard overlap >= minOverlapRatio * min(a.duration, b.duration) else {
+            return false
+        }
+
+        // Either both apps recorded the whole activity, so the distances
+        // agree...
+        let budget = max(distanceFloor, distanceTolerance * max(a.miles, b.miles))
+        if abs(a.miles - b.miles) <= budget { return true }
+
+        // ...or `a` is a FRAGMENT of `b`: its window sits almost entirely inside
+        // and it covers no more ground. An app that starts tracking partway
+        // through writes a short workout inside the long one, and 0.36 vs 1.84
+        // fails every distance test while being unmistakably the same walk.
+        return overlap >= containmentRatio * a.duration && a.miles <= b.miles
+    }
+
+    /// Total miles for a set of workouts, counting each real activity once.
+    ///
+    /// THE function for "how far did they go". Every surface that shows a day's
+    /// distance should call this rather than summing the array itself — that's
+    /// what stops the dashboard, the Road view and Insights from disagreeing.
+    static func totalMiles(_ workouts: [HKWorkout]) -> Double {
+        let excluded = duplicateIndices(in: workouts)
+        var total = 0.0
+        for (index, workout) in workouts.enumerated() where !excluded.contains(index) {
+            total += workout.totalDistance?.doubleValue(for: .mile()) ?? 0
+        }
+        return total
+    }
+
+    /// The workouts that actually count, in their original order.
+    static func counting(_ workouts: [HKWorkout]) -> [HKWorkout] {
+        let excluded = duplicateIndices(in: workouts)
+        guard !excluded.isEmpty else { return workouts }
+        return workouts.enumerated()
+            .filter { !excluded.contains($0.offset) }
+            .map(\.element)
+    }
+}

--- a/app/Mile A Day/Views/Dashboard/InsightsView.swift
+++ b/app/Mile A Day/Views/Dashboard/InsightsView.swift
@@ -235,12 +235,25 @@ private struct RoadToMilestoneCard: View {
     private func dayData(for date: Date, dayNumber: Int) -> RoadDayData {
         let records = healthManager.workoutIndex?.workouts(for: date) ?? []
         let workouts = workouts(on: date, matching: records)
-        let workoutDistance = workouts.reduce(0.0) { total, workout in
-            total + (workout.totalDistance?.doubleValue(for: .mile()) ?? 0)
-        }
+        // Deduped, like every other day total. Summing the array directly is
+        // what let this view disagree with the dashboard about the same day.
+        let workoutDistance = WorkoutDedup.totalMiles(workouts)
         let indexedDistance = records.reduce(0) { $0 + $1.distance }
         let todaysDistance = dayNumber == streak ? healthManager.todaysDistance : 0
-        let measuredDistance = max(workoutDistance, indexedDistance, todaysDistance)
+
+        // The real HKWorkouts WIN when we have them, rather than being max()'d
+        // against the other two.
+        //
+        // max() was the bug behind this view showing a bigger number than the
+        // dashboard for the same day: the index sums WorkoutRecords, which carry
+        // no source and so can't be deduped, and taking the largest of three
+        // measurements guarantees the LEAST deduplicated one is displayed.
+        // Whichever source is richest should decide, and that's the workouts.
+        // The other two stay as fallbacks for days whose HKWorkouts aren't
+        // loaded — max() between them is fine, they're both un-deduped.
+        let measuredDistance = workouts.isEmpty
+            ? max(indexedDistance, todaysDistance)
+            : max(workoutDistance, todaysDistance)
         let distance = measuredDistance > 0 ? measuredDistance : (dayNumber < streak ? goalMiles : 0)
         let activity = activityType(for: dayNumber, records: records, workouts: workouts, distance: distance)
 

--- a/app/Mile A Day/Views/Dashboard/WorkoutsView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutsView.swift
@@ -325,10 +325,14 @@ struct WorkoutsView: View {
     }
 
     private func miles(on day: Date) -> Double {
-        if let index = healthManager.workoutIndex {
-            return index.totalMiles(for: day)
-        }
-        return workouts(on: day).reduce(0) { $0 + ($1.totalDistance?.doubleValue(for: .mile()) ?? 0) }
+        // The real HKWorkouts first, deduped. The index is consulted only when
+        // they aren't available: its WorkoutRecords carry no source app, so a
+        // walk two apps both recorded can't be collapsed there and the day
+        // reads high — which is how this header showed 2.94 for a day the
+        // dashboard called 1.98 and the workouts below it summed to 1.98.
+        let dayWorkouts = workouts(on: day)
+        if !dayWorkouts.isEmpty { return WorkoutDedup.totalMiles(dayWorkouts) }
+        return healthManager.workoutIndex?.totalMiles(for: day) ?? 0
     }
 
     private func milesText(for day: Date) -> String {


### PR DESCRIPTION
## Why the last fix looked like it did nothing

The cross-app dedup in #307 works — it fixes streaks, leaderboards, the feed. It also **cannot move a single number on the screens in the screenshots**, because every "today's distance" in the app is summed on-device from HealthKit and never asks the server what counts:

```swift
// HealthKitManager.processTodaysWorkouts — before
for workout in todaysWorkouts {
    totalMiles += distance.doubleValue(for: .mile())   // every one, no dedup
}
```

So a 1.02 mi walk that Google Health also recorded 0.96 mi of read as **1.98**, and no amount of recalibrating, resolving or redeploying could change it. Server-side it was fixed; the client never asked.

## Three surfaces, three answers, same day

From the screenshots, within two minutes on one phone:

| Surface | Showed | Source |
|---|---|---|
| Dashboard | 1.98 mi | `todaysDistance`, raw HK sum |
| Workouts "Today" | 2.94 mi | index first, via `totalMiles(for:)` |
| Road to 500 | 3.91 mi | `max(workouts, index, todaysDistance)` |

All three now route through `WorkoutDedup.totalMiles`, so they cannot disagree.

## The rule

`WorkoutDedup` mirrors `workoutService.ts` with the **same thresholds** — overlap 0.5, distance tolerance 0.2, floor 0.1, containment 0.9. Deliberately duplicated rather than fetched: these sums run offline, at launch, and in background paths where a round trip isn't available. The thresholds are the contract; if they drift, the two halves disagree, which is the exact failure this exists to end.

It drops exact UUID repeats first, then pairs different-source recordings of one activity — preferring Mile A Day's own copy as the survivor, since it carries the GPS route, which is also the server's first tiebreak.

## The Road view's `max()` was its own bug

Taking the largest of `{workoutDistance, indexedDistance, todaysDistance}` **guarantees the least-deduplicated measurement wins**. Worse, `indexedDistance` sums `WorkoutRecord`s, which carry no source app — so a walk two apps recorded can never be collapsed there.

The real `HKWorkout`s now decide when available; the other two stay as fallbacks for days that aren't loaded. `WorkoutsView` had the same shape (index consulted first) and gets the same treatment.

## What I did not solve

**I never identified which input was feeding the Road view 3.91 specifically.** I checked and ruled out three candidates — `add(records:)` (dead code), the index's incremental path (dedups by UUID), and `cachedWorkouts` (assigned wholesale, not appended).

Routing every surface through one deduped computation makes them agree regardless of which was inflated. But if that number is still wrong after this, the inflated input is still out there and I'd want to keep digging rather than assume.

## Verification

Backend untouched — no backend changes in this PR.

**iOS is unverified beyond a brace/paren balance check.** The type-check job has found a real error on two of its three runs against this branch, so I'd treat its result here as meaningful either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxEp1wW88Y5PxyTxgAoE3L)_