### PR TITLE
Make the Swift type-check actually gate, and actually run on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@
 #   4. seeded feed/story/hype/signing smoke test against the migrated schema
 #
 # iOS is NOT built here — Xcode Cloud owns that (see docs/XCODE_CLOUD_SETUP.md).
+# Swift is type-checked by the separate ios.yml workflow: macOS runners queue,
+# and a stalled one must not be able to cancel the Linux jobs below.
 name: CI
 
 on:
@@ -95,54 +97,3 @@ jobs:
       # script assumed a global install. `next build` type-checks, which is
       # the gate that matters here.
       - run: npm run build
-
-  ios-typecheck:
-    name: iOS (type-check)
-    # Only when the app actually changes — macOS minutes bill at 10x Linux.
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
-    runs-on: macos-latest
-    # NON-BLOCKING FOR NOW. This job has never run before it was written, and a
-    # whole-target `swiftc -typecheck` can fail for reasons unrelated to any
-    # diff (SDK drift, a file that only compiles with Xcode's build settings).
-    # Turning it red on day one would block every merge. Read the log, confirm
-    # it goes green on a known-good commit, THEN delete this line so it gates.
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          # Needed for the diff below. The default shallow clone has no
-          # origin/main, so `origin/main...HEAD` failed with "bad revision" and
-          # the step was silently useless.
-          fetch-depth: 0
-      - name: Check for iOS changes
-        id: changed
-        run: |
-          BASE="origin/${{ github.base_ref || 'main' }}"
-          if git diff --name-only "$BASE"...HEAD -- 'app/**' | grep -q .; then
-            echo "ios=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "ios=false" >> "$GITHUB_OUTPUT"
-          fi
-      # There is no iOS test target worth running and no scheme build here —
-      # this is purely "does the Swift still compile". That is exactly the class
-      # of failure that has been reaching main: a non-exhaustive switch, a stale
-      # call site, a Codable struct missing a CodingKey. All of them are type
-      # errors, none of them need a simulator.
-      #
-      # The whole main-app source set goes in ONE invocation because Swift
-      # resolves types across files within a module; checking files singly would
-      # report every cross-file reference as undefined. The Watch app and the
-      # widget extension are SEPARATE targets and are excluded.
-      - name: Type-check the main app target
-        # Skipped when nothing under app/ changed — this runner bills at 10x.
-        if: steps.changed.outputs.ios == 'true'
-        run: |
-          SDK=$(xcrun --sdk iphoneos --show-sdk-path)
-          find "app/Mile A Day" -name '*.swift' -print0 > /tmp/swift-files
-          COUNT=$(tr -dc '\0' < /tmp/swift-files | wc -c)
-          echo "Type-checking $COUNT Swift files against $SDK"
-          xargs -0 xcrun swiftc -typecheck \
-            -sdk "$SDK" \
-            -target arm64-apple-ios17.0 \
-            -swift-version 5 \
-            < /tmp/swift-files

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,68 @@
+# Does the Swift still compile?
+#
+# There is no iOS test target and no scheme build here — this is purely a type
+# check, because that is exactly the class of failure that has been reaching
+# main: a non-exhaustive switch, a stale call site, a Codable struct missing a
+# CodingKey, a memberwise init whose argument order changed. None of them need
+# a simulator, and all of them otherwise surface for the first time in Xcode
+# Cloud's Archive on main — after the merge.
+#
+# Its own workflow, not a job inside ci.yml, for one reason: macOS runners
+# queue. A stalled macOS job took the Website job down with it at exactly 15
+# minutes (run 31124510739), turning a green branch red for a reason unrelated
+# to the diff. The Linux gates must not be able to fail because a Mac was busy.
+name: iOS
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  typecheck:
+    name: iOS (type-check)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Needed for the diff below. The default shallow clone has no
+          # origin/main, so `origin/main...HEAD` failed with "bad revision" and
+          # the step was silently useless.
+          fetch-depth: 0
+      - name: Check for iOS changes
+        id: changed
+        run: |
+          # On a PR, compare against the base branch. On a push to main, HEAD is
+          # ALREADY the branch being compared, so `origin/main...HEAD` is empty
+          # and the check skipped itself on every merge — main, the branch that
+          # deploys, was the one place this never ran. HEAD^ is the merge
+          # commit's first parent, i.e. main before the merge, so the diff is
+          # the whole of what just landed.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            RANGE="origin/${{ github.base_ref }}...HEAD"
+          else
+            RANGE="HEAD^ HEAD"
+          fi
+          echo "Diffing $RANGE"
+          if git diff --name-only $RANGE -- 'app/**' | grep -q .; then
+            echo "ios=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ios=false" >> "$GITHUB_OUTPUT"
+          fi
+      # The whole main-app source set goes in ONE invocation because Swift
+      # resolves types across files within a module; checking files singly would
+      # report every cross-file reference as undefined. The Watch app and the
+      # widget extension are SEPARATE targets and are excluded.
+      - name: Type-check the main app target
+        # Skipped when nothing under app/ changed — this runner bills at 10x.
+        if: steps.changed.outputs.ios == 'true'
+        run: |
+          SDK=$(xcrun --sdk iphoneos --show-sdk-path)
+          find "app/Mile A Day" -name '*.swift' -print0 > /tmp/swift-files
+          COUNT=$(tr -dc '\0' < /tmp/swift-files | wc -c)
+          echo "Type-checking $COUNT Swift files against $SDK"
+          xargs -0 xcrun swiftc -typecheck \
+            -sdk "$SDK" \
+            -target arm64-apple-ios17.0 \
+            -swift-version 5 \
+            < /tmp/swift-files


### PR DESCRIPTION
The iOS type-check job has been running for a few days now. Checking on it after #308 merged turned up three problems with how I set it up.

## It never ran on main

The diff base was `origin/main...HEAD`. On a push to main, `HEAD` **is** main, so that range is empty and the step skipped itself on every merge — reporting a green "skipped" while compiling nothing. main, the branch that auto-deploys, was the one place the check never happened.

#308 merged that way: its type-check on main was a skip. (Its *PR* run did compile the target and pass, so the merged code is verified — but by luck of timing, not by the gate.)

Pushes now diff `HEAD^ HEAD`. On a merge commit that's the first parent, i.e. main before the merge, so the range is exactly what landed.

## It didn't gate

`continue-on-error: true` was right on day one — the job had never executed, and a whole-target `swiftc -typecheck` can fail for reasons unrelated to a diff. It has since compiled the full target successfully three times (`8ec282c`, `aa3d820`, `5c21aa6`, ~2m50s each) and caught two real errors that would otherwise have surfaced for the first time in Xcode Cloud's Archive on main:

- `cannot find 'planHeader' in scope` — a MARK range I cut took two helpers with it
- `argument 'isOwnProfile' must precede argument 'workout'` — Swift memberwise init is declaration-ordered

Both are exactly the failure class the job exists for. Removing the line.

## A queued Mac could fail the Linux jobs

Run `31124510739` marked a green branch red because **Website** was cancelled at exactly 15 minutes, waiting behind a stalled macOS runner. Moved to its own `ios.yml` so the backend and website gates can't be taken down by Mac queue depth.

## Risk

This turns a previously advisory check into a blocking one, so a genuine Swift error now stops a merge instead of warning about it — which is the point, but it does mean a red iOS job is no longer ignorable. If it ever goes red for an environmental reason (SDK drift on `macos-latest`), the escape hatch is putting `continue-on-error: true` back for one merge.

No app, backend, or website code is touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxEp1wW88Y5PxyTxgAoE3L)_