### PR TITLE
Say which walks count, which don't, and why

### DIFF
--- a/app/Mile A Day/Models/HealthKitManager.swift
+++ b/app/Mile A Day/Models/HealthKitManager.swift
@@ -1775,6 +1775,49 @@ extension MADWatchBridge: WCSessionDelegate {
 
 // MARK: - Counting each real walk once
 
+/// Workouts the user has told us to count anyway, overruling duplicate detection.
+///
+/// The rule below is a guess — a good one, but a guess about two recordings the
+/// app can only see through timestamps and distances. Someone who walks a mile,
+/// stops, and walks a near-identical mile an hour later is not doing anything
+/// unusual, and no threshold can tell that apart from one walk written twice.
+/// So the verdict has to be reversible, and the reversal has to STICK: a sync,
+/// a relaunch or a recalibrate must not quietly re-apply a decision the user
+/// already overruled.
+///
+/// Local, and deliberately so. `DuplicateDecisionService` records the same
+/// choice server-side for streaks and the feed, but every distance this app
+/// draws is summed on-device from HealthKit and never asks the server — so a
+/// server-only override would leave the button looking broken, which is the
+/// exact failure that made the on-device rule necessary in the first place.
+/// Both are written; this is the one that moves the number on screen.
+final class WorkoutDedupOverrides: ObservableObject {
+    static let shared = WorkoutDedupOverrides()
+
+    private static let storageKey = "workoutDedupCountAnywayV1"
+    private let defaults = UserDefaults.standard
+
+    /// HKWorkout UUID strings the user has restored to their total.
+    @Published private(set) var countAnyway: Set<String>
+
+    private init() {
+        countAnyway = Set(defaults.stringArray(forKey: Self.storageKey) ?? [])
+    }
+
+    func isCountedAnyway(_ workoutId: String) -> Bool {
+        countAnyway.contains(workoutId)
+    }
+
+    func setCountAnyway(_ on: Bool, for workoutId: String) {
+        if on {
+            countAnyway.insert(workoutId)
+        } else {
+            countAnyway.remove(workoutId)
+        }
+        defaults.set(Array(countAnyway), forKey: Self.storageKey)
+    }
+}
+
 /// The same walk, recorded by two apps, counted once.
 ///
 /// Every third-party fitness platform — Google Health, Strava, Garmin, WHOOP —
@@ -1832,6 +1875,7 @@ enum WorkoutDedup {
     /// One workout, reduced to what the rule needs.
     private struct Candidate {
         let index: Int
+        let uuid: String
         let bundleId: String
         let start: Date
         let end: Date
@@ -1858,9 +1902,16 @@ enum WorkoutDedup {
     /// taking a walk away with no reason given. Naming the recording that
     /// covers it turns that into a statement the user can check against their
     /// own memory of the walk — and disagree with, if we got it wrong.
-    static func duplicateSources(in workouts: [HKWorkout]) -> [Int: Int] {
+    /// - Parameter applyingOverrides: pass `false` to ask what the RULE thinks,
+    ///   ignoring the user's decisions. The detail screen needs that to offer an
+    ///   undo — once an override is in force the workout is no longer excluded,
+    ///   so there'd otherwise be nothing left to explain what was undone.
+    static func duplicateSources(
+        in workouts: [HKWorkout], applyingOverrides: Bool = true
+    ) -> [Int: Int] {
         var excluded: [Int: Int] = [:]
         guard workouts.count > 1 else { return excluded }
+        let restored = applyingOverrides ? WorkoutDedupOverrides.shared.countAnyway : []
 
         // Exact repeats first. Two entries with one UUID are one workout by
         // definition, whatever any distance rule says.
@@ -1880,6 +1931,7 @@ enum WorkoutDedup {
             candidates.append(
                 Candidate(
                     index: index,
+                    uuid: uuid,
                     bundleId: bundle,
                     start: workout.startDate,
                     end: workout.endDate,
@@ -1902,6 +1954,9 @@ enum WorkoutDedup {
 
         for (position, candidate) in ranked.enumerated() {
             if excluded[candidate.index] != nil { continue }
+            // The user already looked at this one and said it was a separate
+            // walk. That answer outranks the rule, permanently.
+            if restored.contains(candidate.uuid) { continue }
             for keeper in ranked[..<position] {
                 if excluded[keeper.index] != nil { continue }
                 if isSameActivity(candidate, keeper) {

--- a/app/Mile A Day/Models/HealthKitManager.swift
+++ b/app/Mile A Day/Models/HealthKitManager.swift
@@ -1849,20 +1849,30 @@ enum WorkoutDedup {
     /// survivors AND show the user what was left out — never removing a workout
     /// silently is a requirement, not a nicety.
     static func duplicateIndices(in workouts: [HKWorkout]) -> Set<Int> {
-        var excluded = Set<Int>()
+        Set(duplicateSources(in: workouts).keys)
+    }
+
+    /// Excluded index → the index of the workout that already covers it.
+    ///
+    /// The pairing is the whole point: "not counted" on its own is the app
+    /// taking a walk away with no reason given. Naming the recording that
+    /// covers it turns that into a statement the user can check against their
+    /// own memory of the walk — and disagree with, if we got it wrong.
+    static func duplicateSources(in workouts: [HKWorkout]) -> [Int: Int] {
+        var excluded: [Int: Int] = [:]
         guard workouts.count > 1 else { return excluded }
 
         // Exact repeats first. Two entries with one UUID are one workout by
         // definition, whatever any distance rule says.
-        var seenUUIDs = Set<String>()
+        var firstIndexByUUID: [String: Int] = [:]
         var candidates: [Candidate] = []
         for (index, workout) in workouts.enumerated() {
             let uuid = workout.uuid.uuidString
-            if seenUUIDs.contains(uuid) {
-                excluded.insert(index)
+            if let first = firstIndexByUUID[uuid] {
+                excluded[index] = first
                 continue
             }
-            seenUUIDs.insert(uuid)
+            firstIndexByUUID[uuid] = index
 
             let duration = workout.duration
             guard duration > 0 else { continue }
@@ -1891,11 +1901,11 @@ enum WorkoutDedup {
         }
 
         for (position, candidate) in ranked.enumerated() {
-            if excluded.contains(candidate.index) { continue }
+            if excluded[candidate.index] != nil { continue }
             for keeper in ranked[..<position] {
-                if excluded.contains(keeper.index) { continue }
+                if excluded[keeper.index] != nil { continue }
                 if isSameActivity(candidate, keeper) {
-                    excluded.insert(candidate.index)
+                    excluded[candidate.index] = keeper.index
                     break
                 }
             }

--- a/app/Mile A Day/Views/Components/WorkoutAttributionView.swift
+++ b/app/Mile A Day/Views/Components/WorkoutAttributionView.swift
@@ -1,3 +1,4 @@
+import HealthKit
 import SwiftUI
 
 /// Where a workout came from, and whether it's counting — in one place.
@@ -57,6 +58,20 @@ struct WorkoutAttribution: Equatable {
                 bundleIdentifier: bundleId, sourceName: "")
         else { return MADTheme.Colors.madWhite.opacity(0.6) }
         return platform.tint
+    }
+}
+
+extension WorkoutAttribution {
+    /// The app that wrote a workout, named the way a sentence needs it.
+    ///
+    /// `displayName` is deliberately nil for Mile A Day and Apple — a chip
+    /// naming them would be wallpaper — but "same walk as your ___ recording"
+    /// still has to fill that blank, so fall back to HealthKit's own source
+    /// name ("Mile A Day", "Apple Watch", "Health").
+    static func sourceLabel(for workout: HKWorkout) -> String {
+        let source = workout.sourceRevision.source
+        return WorkoutAttribution(bundleId: source.bundleIdentifier).displayName
+            ?? source.name
     }
 }
 

--- a/app/Mile A Day/Views/Dashboard/DashboardStatsViews.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardStatsViews.swift
@@ -103,6 +103,9 @@ struct RecentWorkoutsView: View {
     /// whole list. Drives the "Photo" badge AND hands the detail its photo
     /// instantly (no per-row re-scan).
     @State private var postsByWorkout: [String: PostItem] = [:]
+    /// Re-renders the Counted / Not counted chips when the user overrules a
+    /// duplicate from the detail sheet.
+    @ObservedObject private var dedupOverrides = WorkoutDedupOverrides.shared
 
     private static let pageSize: Int = 10
 

--- a/app/Mile A Day/Views/Dashboard/DashboardStatsViews.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardStatsViews.swift
@@ -106,6 +106,44 @@ struct RecentWorkoutsView: View {
 
     private static let pageSize: Int = 10
 
+    /// Which of these rows the daily totals actually count, and why not.
+    private struct CountState {
+        /// workout uuid → the recording that already covers it.
+        var excludedBy: [String: String] = [:]
+        /// Workouts on a day that contains a duplicate. Only these rows show a
+        /// Counted / Not counted chip — on an ordinary day the chip would be
+        /// on every row and mean nothing.
+        var labeled: Set<String> = []
+    }
+
+    /// Duplicate detection is a PER-DAY rule, so this flat list has to be
+    /// bucketed by local day before applying it — comparing a Tuesday walk
+    /// against a Thursday one would pair two unrelated workouts.
+    ///
+    /// Buckets the whole list, not the visible prefix: a day split across the
+    /// "show more" boundary would otherwise lose the partner that explains the
+    /// exclusion, and the row would say "not counted" with nothing to point at.
+    private var countState: CountState {
+        var state = CountState()
+        let calendar = Calendar.current
+        var byDay: [Date: [HKWorkout]] = [:]
+        for workout in workouts {
+            let day = calendar.startOfDay(
+                for: healthManager.getCorrectedLocalTime(for: workout))
+            byDay[day, default: []].append(workout)
+        }
+        for (_, dayWorkouts) in byDay {
+            let covers = WorkoutDedup.duplicateSources(in: dayWorkouts)
+            guard !covers.isEmpty else { continue }
+            for workout in dayWorkouts { state.labeled.insert(workout.uuid.uuidString) }
+            for (index, keeper) in covers {
+                state.excludedBy[dayWorkouts[index].uuid.uuidString] =
+                    WorkoutAttribution.sourceLabel(for: dayWorkouts[keeper])
+            }
+        }
+        return state
+    }
+
     var body: some View {
         // Section title comes from the collapsible wrapper on the dashboard,
         // so no duplicate "Recent Workouts" header here.
@@ -115,15 +153,20 @@ struct RecentWorkoutsView: View {
                     .foregroundColor(.secondary)
                     .padding(.vertical)
             } else {
+                let counting = countState
                 LazyVStack(spacing: MADTheme.Spacing.md) {
                     ForEach(workouts.prefix(displayCount), id: \.uuid) { workout in
+                        let id = workout.uuid.uuidString
                         Button {
                             selectedWorkout = IdentifiableWorkout(workout: workout)
                         } label: {
                             WorkoutRow(
                                 workout: workout,
                                 showDate: true,
-                                hasPhoto: hasRealPhoto(postsByWorkout[workout.uuid.uuidString])
+                                hasPhoto: hasRealPhoto(postsByWorkout[id]),
+                                isCounted: counting.excludedBy[id] == nil,
+                                showsCountedState: counting.labeled.contains(id),
+                                countedInstead: counting.excludedBy[id]
                             )
                             .padding(MADTheme.Spacing.md)
                             .madLiquidGlass()

--- a/app/Mile A Day/Views/Dashboard/InsightsView.swift
+++ b/app/Mile A Day/Views/Dashboard/InsightsView.swift
@@ -4,6 +4,10 @@ import HealthKit
 struct InsightsView: View {
     @ObservedObject var healthManager: HealthKitManager
     @ObservedObject var userManager: UserManager
+    /// The Road view's per-day distances are deduped in `body`, so overruling a
+    /// duplicate has to re-render here too — or this screen keeps showing the
+    /// number the Workouts screen has already stopped showing.
+    @ObservedObject private var dedupOverrides = WorkoutDedupOverrides.shared
     @Binding var showWorkouts: Bool
 
     var body: some View {

--- a/app/Mile A Day/Views/Dashboard/WorkoutDetailView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutDetailView.swift
@@ -36,6 +36,9 @@ struct WorkoutDetailView: View {
     /// window lapses while this screen is on display.
     @ObservedObject private var freshWindow = FreshPostWindowManager.shared
     @State private var addToFeedError: String?
+    /// Observed so the banner flips the moment the user overrules duplicate
+    /// detection, without waiting for a HealthKit round trip.
+    @ObservedObject private var dedupOverrides = WorkoutDedupOverrides.shared
     @EnvironmentObject var healthManager: HealthKitManager
 
     private let workoutService = WorkoutService()
@@ -349,6 +352,119 @@ struct WorkoutDetailView: View {
         }
     }
 
+    // MARK: - Duplicate recording
+
+    /// The recording that already covers this one on its day, per the RULE —
+    /// computed ignoring the user's override so the banner can still explain
+    /// itself after they've overruled it.
+    private var duplicateOfLabel: String? {
+        let calendar = Calendar.current
+        let day = calendar.startOfDay(for: correctedEndTime)
+        let dayWorkouts = healthManager.cachedWorkouts
+            .filter {
+                calendar.isDate(
+                    healthManager.getCorrectedLocalTime(for: $0), inSameDayAs: day)
+            }
+            .sorted { $0.endDate < $1.endDate }
+        let covers = WorkoutDedup.duplicateSources(
+            in: dayWorkouts, applyingOverrides: false)
+        guard let index = dayWorkouts.firstIndex(where: { $0.uuid == workout.uuid }),
+              let keeper = covers[index]
+        else { return nil }
+        return WorkoutAttribution.sourceLabel(for: dayWorkouts[keeper])
+    }
+
+    private var isRestoredByUser: Bool {
+        dedupOverrides.isCountedAnyway(workout.uuid.uuidString)
+    }
+
+    /// States plainly that a walk isn't in the total, and hands back the
+    /// decision.
+    ///
+    /// Duplicate detection is a guess about two recordings the app knows only
+    /// through timestamps and distances — someone who walks a mile, stops, and
+    /// walks a near-identical mile an hour later trips it, and no threshold can
+    /// tell that apart from one walk written twice. Which is exactly why the
+    /// verdict is stated rather than applied silently, and why the way out is
+    /// one tap away from the explanation instead of buried in settings.
+    private var duplicateBanner: some View {
+        let restored = isRestoredByUser
+        let accent = restored ? MADTheme.Colors.success : Color.orange
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 10) {
+                Image(systemName: restored ? "checkmark.circle.fill" : "doc.on.doc.fill")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(accent)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(restored
+                        ? "Counted — you said it's a separate walk"
+                        : "Not counted — recorded twice")
+                        .font(.system(size: 13, weight: .heavy, design: .rounded))
+                        .foregroundColor(.primary)
+                    Text(duplicateExplanation)
+                        .font(.system(size: 11, weight: .medium, design: .rounded))
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 0)
+            }
+
+            Button {
+                setCountAnyway(!restored)
+            } label: {
+                Text(restored
+                    ? "Undo — it was the same walk"
+                    : "This was a separate walk — count it")
+                    .font(.system(size: 12, weight: .bold, design: .rounded))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 34)
+                    .background(Capsule().fill(accent.opacity(0.18)))
+                    .foregroundColor(accent)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(accent.opacity(0.12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .strokeBorder(accent.opacity(0.3), lineWidth: 1)
+                )
+        )
+    }
+
+    private var duplicateExplanation: String {
+        let mine = WorkoutAttribution.sourceLabel(for: workout)
+        let keeper = duplicateOfLabel ?? "another app"
+        if isRestoredByUser {
+            return "\(mine) recorded this alongside your \(keeper) walk. "
+                + "You've told us they're different walks, so both count."
+        }
+        return "\(mine) recorded this at the same time as your \(keeper) walk, "
+            + "so it looks like one walk written twice. It's counted once."
+    }
+
+    /// Persist the user's decision, refresh what's on screen, and tell the
+    /// server — in that order, because the on-device number is the one they're
+    /// looking at and it must not wait on the network to move.
+    private func setCountAnyway(_ on: Bool) {
+        MADHaptics.tap()
+        dedupOverrides.setCountAnyway(on, for: workout.uuid.uuidString)
+        healthManager.fetchTodaysDistance()
+        Task {
+            guard let uid = UserManager.shared.currentUser.backendUserId else { return }
+            // Best effort: streaks and the feed should agree, but a failed call
+            // must not undo a decision the user already sees applied.
+            try? await DuplicateDecisionService.set(
+                userId: uid,
+                workoutId: workout.uuid.uuidString,
+                decision: on ? "count" : nil
+            )
+        }
+    }
+
     // MARK: - Vehicle warning
 
     private var vehicleWarningBanner: some View {
@@ -464,6 +580,12 @@ struct WorkoutDetailView: View {
             // Vehicle-speed warning — surfaces a likely drive so the user can remove it.
             if vehicleSuspicion != .none {
                 vehicleWarningBanner
+            }
+            // A walk two apps both recorded. Shown whenever the rule flagged it,
+            // INCLUDING after the user overruled it — otherwise the only way to
+            // change your mind back would be to remember you'd changed it.
+            if duplicateOfLabel != nil {
+                duplicateBanner
             }
         }
     }

--- a/app/Mile A Day/Views/Dashboard/WorkoutsView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutsView.swift
@@ -286,14 +286,26 @@ struct WorkoutsView: View {
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, MADTheme.Spacing.lg)
             } else {
-                ForEach(dayWorkouts, id: \.uuid) { workout in
+                // Which of these the header's total actually counts. The rows
+                // used to be identical whether a walk was in the total or not,
+                // so a day showing 1.02 above two walks of 0.96 and 1.02 looked
+                // like an arithmetic bug rather than a decision.
+                let covers = WorkoutDedup.duplicateSources(in: dayWorkouts)
+                ForEach(Array(dayWorkouts.enumerated()), id: \.element.uuid) { index, workout in
                     Button {
                         selectedWorkout = IdentifiableWorkout(workout: workout)
                     } label: {
                         WorkoutRow(
                             workout: workout,
                             showDate: false,
-                            hasPhoto: hasRealPhoto(postsByWorkout[workout.uuid.uuidString])
+                            hasPhoto: hasRealPhoto(postsByWorkout[workout.uuid.uuidString]),
+                            isCounted: covers[index] == nil,
+                            // Only label the state on days where it varies —
+                            // "Counted" on every row of every normal day is noise.
+                            showsCountedState: !covers.isEmpty,
+                            countedInstead: covers[index].map {
+                                WorkoutAttribution.sourceLabel(for: dayWorkouts[$0])
+                            }
                         )
                         .padding(MADTheme.Spacing.md)
                         .madLiquidGlass()
@@ -338,6 +350,7 @@ struct WorkoutsView: View {
     private func milesText(for day: Date) -> String {
         String(format: "%.2f mi", miles(on: day))
     }
+
 
     private enum DayStatus: Equatable {
         case none, partial, complete

--- a/app/Mile A Day/Views/Dashboard/WorkoutsView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutsView.swift
@@ -12,6 +12,10 @@ struct WorkoutsView: View {
     /// For the Trends mode (weekly chart + trend card moved here from the
     /// old dashboard week-view picker).
     @ObservedObject private var userManager = UserManager.shared
+    /// Re-renders the day list and the month totals when the user overrules a
+    /// duplicate — the counts here are recomputed in `body`, so without this
+    /// the header would keep the old number until something else moved.
+    @ObservedObject private var dedupOverrides = WorkoutDedupOverrides.shared
 
     private enum Mode: Hashable { case calendar, list, trends }
     @State private var mode: Mode = .calendar

--- a/app/Mile A Day/Views/Profile/MostMilesDetailView.swift
+++ b/app/Mile A Day/Views/Profile/MostMilesDetailView.swift
@@ -254,6 +254,20 @@ struct WorkoutRow: View {
     /// Whether this run has a linked photo post — supplied by the list so we
     /// don't do a per-row network scan (the route probe below is cheap/local).
     var hasPhoto: Bool = false
+    // NOTE: new stored properties go BELOW the existing ones — Swift's
+    // memberwise init is declaration-ordered, so inserting above `hasPhoto`
+    // breaks every existing call site.
+    //
+    /// False when another recording of the same walk already covers this one,
+    /// so it isn't in the day's total. The row still shows the workout in
+    /// full — it happened, and it's the user's — but says so plainly.
+    var isCounted: Bool = true
+    /// Only true when the day actually contains a duplicate. Otherwise every
+    /// row on every ordinary day would wear a "Counted" chip that says nothing.
+    var showsCountedState: Bool = false
+    /// What already covers this one, e.g. "Mile A Day" — so the exclusion
+    /// names its reason instead of just happening.
+    var countedInstead: String? = nil
     @EnvironmentObject var healthManager: HealthKitManager
 
     /// True once we confirm the workout carries a GPS trace (cheap limit-1 probe).
@@ -318,7 +332,13 @@ struct WorkoutRow: View {
                     Text(workoutDistance)
                         .font(.system(size: 17, weight: .black, design: .rounded))
                         .monospacedDigit()
-                        .foregroundColor(MADTheme.Colors.primaryText)
+                        // Muted, never struck through: this distance is real and
+                        // the user walked it. It just isn't being added twice.
+                        .foregroundColor(
+                            isCounted
+                                ? MADTheme.Colors.primaryText
+                                : MADTheme.Colors.secondaryText
+                        )
                         .lineLimit(1)
                         .layoutPriority(1)
                 }
@@ -341,6 +361,8 @@ struct WorkoutRow: View {
                     hasPhoto: hasPhoto,
                     routeColor: workoutColor
                 )
+
+                provenanceLine
             }
             Spacer(minLength: MADTheme.Spacing.sm)
             VStack(alignment: .trailing, spacing: 2) {
@@ -363,6 +385,54 @@ struct WorkoutRow: View {
             let found = await healthManager.hasRouteData(for: workout)
             await MainActor.run { hasRoute = found }
         }
+    }
+
+    /// Where this workout came from, and whether it's in the day's total.
+    ///
+    /// Two apps recording one walk is normal once someone connects Google
+    /// Health or Strava, and counting it twice is wrong — but dropping one
+    /// without a word is worse than the wrong number, because the user is left
+    /// looking at a walk they definitely did and a total that disagrees. So the
+    /// row names the app and states the decision.
+    ///
+    /// It stays silent on the ordinary case: one first-party workout, nothing
+    /// excluded, nothing to explain. A badge on every row is wallpaper.
+    @ViewBuilder
+    private var provenanceLine: some View {
+        let attribution = WorkoutAttribution(
+            bundleId: workout.sourceRevision.source.bundleIdentifier)
+        if attribution.displayName != nil || showsCountedState {
+            HStack(spacing: 6) {
+                WorkoutSourceChip(attribution: attribution)
+                if showsCountedState {
+                    WorkoutTagChip(
+                        icon: isCounted ? "checkmark.circle.fill" : "minus.circle.fill",
+                        label: isCounted ? "Counted" : "Not counted",
+                        color: isCounted ? MADTheme.Colors.success : MADTheme.Colors.warning
+                    )
+                }
+            }
+            .padding(.top, 1)
+        }
+        if !isCounted {
+            Text(exclusionReason)
+                .font(.system(size: 11, weight: .medium, design: .rounded))
+                .foregroundColor(MADTheme.Colors.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 1)
+        }
+    }
+
+    /// "Google Health recorded the same walk as Mile A Day, so it's counted
+    /// once." Names both ends when we know them — a reason the user can check.
+    private var exclusionReason: String {
+        let mine = WorkoutAttribution(
+            bundleId: workout.sourceRevision.source.bundleIdentifier
+        ).displayName ?? workout.sourceRevision.source.name
+        guard let keeper = countedInstead else {
+            return "\(mine) recorded a walk you'd already logged, so it's counted once."
+        }
+        return "Same walk as your \(keeper) recording, so it's counted once."
     }
 
     /// Feed-style verb ("Ran", "Walked") for the headline.


### PR DESCRIPTION
Yesterday showed two walks — 0.96 mi and 1.02 mi — under a header reading **1.02 mi**. The arithmetic was right: one walk recorded twice, counted once. But the two rows were pixel-identical, so the screen read as an arithmetic bug rather than a decision.

That's the worst version of this problem. The user is looking at a walk they definitely did, and a total that disagrees, with nothing on screen connecting the two.

## 1. The rows say which is which

`WorkoutDedup.duplicateSources` now returns *excluded index → the recording that covers it*, rather than just a set of indices. A row can then name its reason instead of asserting an outcome:

- the app that wrote it — the existing "from Google Health" chip
- a **Counted** / **Not counted** chip
- a sentence: *"Same walk as your Mile A Day recording, so it's counted once."*

Two deliberate restraints:

- **Chips appear only on days that contain a duplicate.** A Counted chip on every row of every ordinary day is wallpaper that teaches nobody anything.
- **An excluded distance is muted — never struck through, never hidden.** The user walked it. It's theirs. It's just not being added a second time.

Covers both lists. The Workouts calendar day list is already day-scoped; the dashboard's Recent Workouts card is flat across days while the rule is per-day, so it buckets by corrected local day first — and buckets the **whole** list rather than the visible prefix, or a day split across "Load More" would say "not counted" with nothing left on screen to point at.

## 2. The user can overrule it, and it sticks

The existing "count it anyway" control only wrote a **server-side** decision, while every distance the app draws is summed on-device from HealthKit and never asks the server. It would have looked like it worked and changed nothing — the same disconnect that made the on-device rule necessary in the first place.

`WorkoutDedupOverrides` persists the answer locally and `duplicateSources` honours it, so an overruled workout stays counted through a sync, a relaunch and a recalibrate. The server call still goes out, best effort, so streaks and the feed agree — but it isn't what moves the number.

The banner lives on the workout detail screen, one tap from the row that says "Not counted", and **stays visible after an override** — flipped to "Counted — you said it's a separate walk", with an undo. A control that vanishes once used makes changing your mind back depend on remembering you changed it.

Why it has to be reversible: detection is a guess about two recordings the app knows only through timestamps and distances. Someone who walks a mile, stops, and walks a near-identical mile an hour later trips every threshold, and no threshold can tell that apart from one walk written twice. The rule is right often enough to apply, and wrong often enough to explain and undo.

Three surfaces observe the store — Workouts, the dashboard's recent list, and Insights' Road view — because each recomputes its totals in `body`. Without that, overruling a duplicate would move one screen's number and not another's, which is the disagreement this whole thread has been about.

## Watch safety

`WorkoutDedupOverrides` and the `WorkoutDedup` changes live in `HealthKitManager.swift`, which is a member of both targets, so they're kept free of iPhone-only dependencies — no SwiftUI, no MADTheme, no FitnessSourceCatalog. Verified by inspection; CI still doesn't build the Watch target.

Backend and website untouched. No new permissions or data collection.