### PR TITLE
Real app icons on the source chip, and stop the day list running under the tab bar

### DIFF
--- a/app/Mile A Day/Services/FitnessSourceArtwork.swift
+++ b/app/Mile A Day/Services/FitnessSourceArtwork.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// The real app icon for a fitness platform — Fitbit's, Strava's, Garmin's —
+/// without shipping anybody's trademark in the binary.
+///
+/// `FitnessSourcePlatform.symbol` is an SF Symbol on purpose: bundling partner
+/// logos as assets means shipping third-party trademarks we have no licence
+/// for, which is an App Review risk (5.2.1) taken for decoration. But a generic
+/// glyph is genuinely worse UI — "which app wrote this walk" is answered
+/// instantly by an icon the user already recognises from their home screen, and
+/// slowly by a waveform symbol they have to read a label to decode.
+///
+/// So the icon comes from Apple's own storefront, looked up by the App Store id
+/// the catalog already stores for the "open in App Store" button. That is the
+/// same artwork a Smart App Banner shows, sourced the same sanctioned way,
+/// nothing bundled and nothing to licence. It also cannot go stale: if Fitbit
+/// rebrands, the icon changes with them.
+///
+/// Everything about it degrades quietly. The lookup is one request per platform
+/// for the lifetime of the install (the URL is persisted), the SF Symbol renders
+/// immediately and stays until artwork arrives, and offline simply means the
+/// symbol is what you get. No spinner, no gap, no layout shift — the artwork
+/// occupies the symbol's slot at the same size.
+@MainActor
+final class FitnessSourceArtwork: ObservableObject {
+    static let shared = FitnessSourceArtwork()
+
+    private static let storageKey = "fitnessSourceArtworkV1"
+    /// 60pt artwork: the chip draws it far smaller, and a 512pt icon for a
+    /// 14pt slot is bandwidth spent on nothing.
+    private static let artworkField = "artworkUrl60"
+
+    /// App Store id → artwork URL string.
+    @Published private(set) var artwork: [String: String]
+    /// Ids currently in flight or already resolved-as-missing, so a row that
+    /// re-renders sixty times doesn't fire sixty lookups.
+    private var attempted: Set<String> = []
+
+    private init() {
+        artwork = UserDefaults.standard.dictionary(forKey: Self.storageKey)
+            as? [String: String] ?? [:]
+        attempted = Set(artwork.keys)
+    }
+
+    /// The icon URL if we have it, and a lookup kicked off if we don't.
+    ///
+    /// Safe to call from `body`: it returns synchronously and starts at most one
+    /// request per app id.
+    func url(forAppStoreId appStoreId: String) -> URL? {
+        guard !appStoreId.isEmpty else { return nil }
+        if let cached = artwork[appStoreId] { return URL(string: cached) }
+        guard !attempted.contains(appStoreId) else { return nil }
+        attempted.insert(appStoreId)
+        Task { await fetch(appStoreId) }
+        return nil
+    }
+
+    private func fetch(_ appStoreId: String) async {
+        guard let endpoint = URL(
+            string: "https://itunes.apple.com/lookup?id=\(appStoreId)&entity=software"
+        ) else { return }
+        do {
+            let (data, _) = try await URLSession.shared.data(from: endpoint)
+            guard
+                let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let results = json["results"] as? [[String: Any]],
+                let icon = results.first?[Self.artworkField] as? String
+            else {
+                // A miss is remembered by `attempted`, so a delisted app costs
+                // one request per launch rather than one per render.
+                return
+            }
+            artwork[appStoreId] = icon
+            UserDefaults.standard.set(artwork, forKey: Self.storageKey)
+        } catch {
+            // Offline, or the storefront is unreachable. The SF Symbol is
+            // already on screen and stays there; allow a retry next launch.
+            attempted.remove(appStoreId)
+        }
+    }
+}

--- a/app/Mile A Day/Views/Components/WorkoutAttributionView.swift
+++ b/app/Mile A Day/Views/Components/WorkoutAttributionView.swift
@@ -30,12 +30,17 @@ struct WorkoutAttribution: Equatable {
     /// third-party while the arithmetic treated it as ours.
     var isFirstParty: Bool { WorkoutDedup.isFirstParty(bundleId: bundleId) }
 
+    /// The catalog entry behind this workout, when we recognise the writer.
+    /// Carries the App Store id the chip uses to show the app's real icon.
+    var platform: FitnessSourcePlatform? {
+        guard let bundleId, !bundleId.isEmpty, !isFirstParty else { return nil }
+        return FitnessSourceCatalog.match(bundleIdentifier: bundleId, sourceName: "")
+    }
+
     /// "Google Health", "Strava"… or nil when there's nothing worth saying.
     var displayName: String? {
         guard let bundleId, !bundleId.isEmpty, !isFirstParty else { return nil }
-        if let platform = FitnessSourceCatalog.match(
-            bundleIdentifier: bundleId, sourceName: ""
-        ) {
+        if let platform = platform {
             return platform.name
         }
         // An app we don't have a catalog entry for still gets named rather than
@@ -45,19 +50,11 @@ struct WorkoutAttribution: Equatable {
     }
 
     var symbol: String {
-        guard let bundleId, !isFirstParty,
-            let platform = FitnessSourceCatalog.match(
-                bundleIdentifier: bundleId, sourceName: "")
-        else { return "app.badge" }
-        return platform.symbol
+        platform?.symbol ?? "app.badge"
     }
 
     var tint: Color {
-        guard let bundleId, !isFirstParty,
-            let platform = FitnessSourceCatalog.match(
-                bundleIdentifier: bundleId, sourceName: "")
-        else { return MADTheme.Colors.madWhite.opacity(0.6) }
-        return platform.tint
+        platform?.tint ?? MADTheme.Colors.madWhite.opacity(0.6)
     }
 }
 
@@ -78,12 +75,36 @@ extension WorkoutAttribution {
 /// A small "from Strava" chip. Renders nothing for first-party sources.
 struct WorkoutSourceChip: View {
     let attribution: WorkoutAttribution
+    @ObservedObject private var artwork = FitnessSourceArtwork.shared
+
+    /// The writing app's real icon, from Apple's storefront — see
+    /// `FitnessSourceArtwork` for why it isn't a bundled asset.
+    private var iconURL: URL? {
+        guard let platform = attribution.platform else { return nil }
+        return artwork.url(forAppStoreId: platform.appStoreId)
+    }
 
     var body: some View {
         if let name = attribution.displayName {
             HStack(spacing: 4) {
-                Image(systemName: attribution.symbol)
-                    .font(.system(size: 9, weight: .bold))
+                // The symbol holds the slot at the same size, so artwork
+                // arriving later swaps in place instead of reflowing the row.
+                Group {
+                    if let iconURL = iconURL {
+                        AsyncImage(url: iconURL) { image in
+                            image.resizable().scaledToFill()
+                        } placeholder: {
+                            Image(systemName: attribution.symbol)
+                                .font(.system(size: 9, weight: .bold))
+                        }
+                        .frame(width: 12, height: 12)
+                        .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
+                    } else {
+                        Image(systemName: attribution.symbol)
+                            .font(.system(size: 9, weight: .bold))
+                            .frame(width: 12, height: 12)
+                    }
+                }
                 Text(name)
                     .font(.system(size: 10, weight: .bold, design: .rounded))
                     .lineLimit(1)

--- a/app/Mile A Day/Views/Dashboard/WorkoutsView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutsView.swift
@@ -61,6 +61,11 @@ struct WorkoutsView: View {
                     }
                 }
                 .padding(MADTheme.Spacing.md)
+                // Clear the floating tab bar. Without this the last workout of
+                // the selected day sits permanently underneath it — you can
+                // scroll to the end and still not see the row. Same 100pt every
+                // other tab screen uses (DashboardView, ProfileView).
+                .padding(.bottom, 100)
             }
         }
         .navigationTitle("Workouts")


### PR DESCRIPTION
Two things from the Workouts screen.

## The overflow

`WorkoutsView`'s scroll content had only its uniform padding, so the last workout of the selected day sat permanently underneath the floating tab bar — you could scroll to the end and still not see the row. Every other tab screen already clears it with `.padding(.bottom, 100) // clear tab bar` (DashboardView, ProfileView, DashboardModeCards). This one never did.

## The real logo

A waveform glyph answers "which app wrote this walk" slowly — you have to read the label to decode it. The icon off the user's own home screen answers it instantly.

**But the catalog's comment is right and stays true:**

> `symbol`: SF Symbol. Deliberately not a partner logo — shipping third-party trademarks as bundled assets is an App Review risk we don't need.

So nothing is bundled. The artwork comes from **Apple's storefront**, looked up by the App Store id the catalog already stores for its "open in App Store" button — the same artwork a Smart App Banner shows, sourced the same sanctioned way. Nothing to licence, and it can't go stale: if Fitbit rebrands, the icon follows.

It degrades quietly at every step:

- one request per platform for the life of the install — the URL is persisted, and misses are remembered so a delisted app costs one lookup per launch rather than one per render
- the SF Symbol renders immediately and holds the slot at the same 12pt, so late artwork swaps **in place** rather than reflowing the row
- offline just means you keep the symbol — no spinner, no gap, no layout shift

`WorkoutAttribution` gains a `platform` accessor (the catalog entry carrying the App Store id), which also collapses three duplicate `FitnessSourceCatalog.match` calls into one.

## App Review

No bundled trademarks, no new permissions, no new data collection. The lookup is an unauthenticated GET to `itunes.apple.com` and sends nothing but a public app id.

Backend and website untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxEp1wW88Y5PxyTxgAoE3L)_