### PR TITLE
One screen gutter, shared by Workouts, Insights and the Dashboard

### DIFF
--- a/app/Mile A Day/Core/Theme/MADTheme.swift
+++ b/app/Mile A Day/Core/Theme/MADTheme.swift
@@ -121,6 +121,19 @@ struct MADTheme {
         static let xl: CGFloat = 32
         static let xxl: CGFloat = 48
         static let xxxl: CGFloat = 64
+
+        /// Distance from the display edge to a full-width card.
+        ///
+        /// Its own value rather than reusing `md`, because it answers a
+        /// different question: `md` is how far apart two things inside a card
+        /// sit, this is how much of the screen a card is not allowed to have.
+        /// Scroll screens were reading as edge-to-edge at 16 — the cards are
+        /// light on a near-black background, so the gutter is the only thing
+        /// separating them from the bezel and it has to be seen to work.
+        ///
+        /// Change it HERE, not per screen: it's shared so the Workouts,
+        /// Insights and Dashboard scroll views can't drift apart again.
+        static let screenGutter: CGFloat = 20
     }
     
     // MARK: - Corner Radius

--- a/app/Mile A Day/Views/Dashboard/DashboardView.swift
+++ b/app/Mile A Day/Views/Dashboard/DashboardView.swift
@@ -1531,7 +1531,9 @@ struct DashboardView: View {
             badgesSection
             statsAndHistorySection
         }
-        .padding(.horizontal, 16)
+        // Shared with Workouts and Insights — a card must not change width as
+        // you move between the three screens.
+        .padding(.horizontal, MADTheme.Spacing.screenGutter)
         .padding(.top, 0)
         .padding(.bottom, 100) // Extra padding for tab bar
         .clipped() // Prevent content overflow from causing horizontal jitter

--- a/app/Mile A Day/Views/Dashboard/InsightsView.swift
+++ b/app/Mile A Day/Views/Dashboard/InsightsView.swift
@@ -27,7 +27,10 @@ struct InsightsView: View {
                     StatsGridView(user: userManager.currentUser, healthManager: healthManager)
                     RecentWorkoutsPreviewCard(healthManager: healthManager, showWorkouts: $showWorkouts)
                 }
-                .padding(MADTheme.Spacing.md)
+                // Same gutter as Workouts — these two screens sit one tap apart
+                // and a card that changes width between them reads as a bug.
+                .padding(.horizontal, MADTheme.Spacing.screenGutter)
+                .padding(.top, MADTheme.Spacing.md)
                 .padding(.bottom, 32)
             }
         }

--- a/app/Mile A Day/Views/Dashboard/WorkoutsView.swift
+++ b/app/Mile A Day/Views/Dashboard/WorkoutsView.swift
@@ -68,7 +68,7 @@ struct WorkoutsView: View {
                 // grid pushing the day's workouts off the bottom — and tightening
                 // both axes together took width away from a screen that had none
                 // to spare, leaving the cards nearly flush with the display edge.
-                .padding(.horizontal, 20)
+                .padding(.horizontal, MADTheme.Spacing.screenGutter)
                 .padding(.top, MADTheme.Spacing.md)
                 // The tab bar here is a real TabView bar, so SwiftUI already
                 // insets scroll content for it — the 100pt other screens


### PR DESCRIPTION
Workouts, Insights and the Dashboard each hardcoded their own **16pt** horizontal padding. On a near-black background with light cards, 16pt reads as no margin at all — the card sits close enough to the bezel that the gutter stops registering as deliberate.

So this isn't a Workouts regression. All three screens have always had the same gutter, which is why fixing one of them didn't make the problem go away.

## One constant

`MADTheme.Spacing.screenGutter` (20) now drives all three.

It's a separate constant rather than a reuse of `md` because it answers a different question: `md` is how far apart two things *inside* a card sit; this is how much of the screen a card is **not allowed to have**. Sharing it also means the three screens can't drift apart — a card keeps its width as you move between them, which 16-here-and-20-there would have broken.

**One knob:** if 20 still reads tight on device, the fix is this one line, not three files.

## Note on the screenshot

#314 (Workouts 16 → 20) merged minutes before that screenshot was taken, so that build predates it — the 20pt wasn't in what you were looking at. This PR is what makes the change consistent everywhere rather than only on the screen that was reported.

Backend and website untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxEp1wW88Y5PxyTxgAoE3L)_