### PR TITLE
Replace Early Birds and Night Owls with No Junk Miles and Personal Best

### DIFF
--- a/backend/scripts/ci-smoke.mjs
+++ b/backend/scripts/ci-smoke.mjs
@@ -1477,6 +1477,26 @@ await updateNotificationPreferences(BOB, { workout_visibility: "friends" });
     "Weekend Warrior is retired (it named specific weekdays, which Sunday-start weeks broke)",
   );
 
+  // The same handover, twice over: Early Birds and Night Owls measured schedule
+  // rather than effort, so they gave slots 5 and 6 to challenges that ask for
+  // something.
+  for (const [key, slot, retired] of [
+    ["no_junk_miles", 5, "early_birds"],
+    ["personal_best", 6, "night_owls"],
+  ]) {
+    const row = catalog.find((c) => c.challenge_key === key);
+    assert.ok(row, `${key} is in the active rotation`);
+    assert.equal(
+      row.rotation_index,
+      slot,
+      `${key} holds slot ${slot}, so no other week's challenge moved`,
+    );
+    assert.ok(
+      !catalog.some((c) => c.challenge_key === retired),
+      `${retired} is retired`,
+    );
+  }
+
   const win = await weekWindowForUser(WENDY);
   const day = (offset) => {
     const d = new Date(`${win.weekStart}T00:00:00Z`);
@@ -1682,6 +1702,95 @@ await updateNotificationPreferences(BOB, { workout_visibility: "friends" });
     "a blocked friend is off the board",
   );
   await db.query(`DELETE FROM user_blocks WHERE blocker_id LIKE 'ci-%'`);
+
+  // --- The two challenges that replaced Early Birds / Night Owls ------------
+  // Last, so they can add workouts without moving any number asserted above.
+
+  // No Junk Miles counts WORKOUTS that were a real mile. Wendy's counted set is
+  // now 2.0, 1.5, 2.0, 2.0, 8.0, 0.96 — six — plus a sub-floor 0.5 and the
+  // excluded 5.0 duplicate, which must both stay out.
+  await addWorkout(WENDY, "ci-wk-njm-low", day(6), 0.5);
+  assert.equal(
+    await measure(WENDY, "full_mile_workouts", win.weekStart, win.weekEnd),
+    6,
+    "full_mile_workouts counts workouts >= the 0.95 tolerance (a raw >= 1.0 reads 5 and drops the 0.96; no floor reads 7)",
+  );
+
+  // Personal Best: mile splits that beat the user's best from the PRIOR four
+  // weeks. Three in-window splits — one faster than the reference, one slower,
+  // and one EXACTLY equal to it. The tie is the whole point of the third: it is
+  // the only seed that tells `<` apart from `<=`, and tying your best is not
+  // beating it.
+  const addSplit = async (workoutId, pace) => {
+    await db.query(
+      `INSERT INTO workout_splits (workout_id, split_number, split_duration, split_distance, split_pace)
+       VALUES ($1, 1, $2, 1.0, $2)`,
+      [workoutId, pace],
+    );
+  };
+  await addSplit("ci-wk-1", 590);
+  await addSplit("ci-wk-2", 610);
+  await addSplit("ci-wk-3", 600);
+
+  // With no prior split at all, every complete mile is a personal best — that
+  // is what keeps a brand-new user off an unwinnable week.
+  assert.equal(
+    await measure(WENDY, "pb_mile_splits", win.weekStart, win.weekEnd),
+    3,
+    "with no prior best, every complete in-window mile counts",
+  );
+
+  // Now give her a 10:00 mile a fortnight ago. Only the 9:50 beats it — the
+  // 10:00 ties and the 10:10 is slower.
+  await addWorkout(WENDY, "ci-wk-prior", day(-14), 1.0);
+  await addSplit("ci-wk-prior", 600);
+  assert.equal(
+    await measure(WENDY, "pb_mile_splits", win.weekStart, win.weekEnd),
+    1,
+    "only splits FASTER than the 4-week best count — a tie is not a PB (a <= comparison reads 2)",
+  );
+
+  // The reference window ROLLS. A blistering 8:20 from six weeks ago has aged
+  // out and must not set the bar — that is the difference between this and the
+  // daily beat_your_pace, whose all-time reference mileTime.ts records as able
+  // to "raise the bar permanently and make that challenge unwinnable". An
+  // all-time lookback reads 0 here.
+  await addWorkout(WENDY, "ci-wk-ancient", day(-40), 1.0);
+  await addSplit("ci-wk-ancient", 500);
+  assert.equal(
+    await measure(WENDY, "pb_mile_splits", win.weekStart, win.weekEnd),
+    1,
+    "a best older than 4 weeks has aged out of the reference (an all-time lookback reads 0)",
+  );
+
+  // A vehicle_speed drive in the reference window must not set the bar. Without
+  // countedWorkoutSql on the prior arm the reference becomes 5:00 and nothing
+  // beats it, so this reads 0 — the same class of bug mileTime.ts records
+  // against the daily beat_your_pace.
+  await addWorkout(WENDY, "ci-wk-prior-x", day(-10), 1.0, "vehicle_speed");
+  await addSplit("ci-wk-prior-x", 300);
+  assert.equal(
+    await measure(WENDY, "pb_mile_splits", win.weekStart, win.weekEnd),
+    1,
+    "an excluded workout never sets the personal-best bar",
+  );
+
+  // Both new metrics feed the friends leaderboard through measureBatch. If it
+  // drifts from measure(), a user's board row disagrees with their own card.
+  for (const [metric, expected] of [
+    ["full_mile_workouts", 6],
+    ["pb_mile_splits", 1],
+  ]) {
+    assert.equal(
+      (await measureBatch([WENDY], metric, win.weekStart, win.weekEnd)).get(
+        WENDY,
+      ) ?? 0,
+      expected,
+      `measureBatch agrees with measure on ${metric}`,
+    );
+  }
+
+  await db.query(`DELETE FROM workout_splits WHERE workout_id LIKE 'ci-wk-%'`);
 
   await db.query(
     `DELETE FROM user_weekly_challenge_completions WHERE user_id LIKE 'ci-%'`,

--- a/backend/src/services/weeklyChallengeService.ts
+++ b/backend/src/services/weeklyChallengeService.ts
@@ -30,13 +30,18 @@ export type WeeklyMetric =
   | "active_days"
   | "longest_single_workout"
   | "total_steps"
+  // The three below belong to RETIRED catalog rows. They stay because the
+  // boot-time CHECK constraint is generated from these metrics: dropping one a
+  // surviving row still carries would fail `ADD CONSTRAINT`. `weekend_distance`
+  // went when weeks became Sunday-start (its two days stopped being
+  // contiguous); the early/late pair went because they measured SCHEDULE rather
+  // than effort — a quarter-mile walk before 8 AM counted as a run.
   | "early_workouts"
   | "late_workouts"
-  // Retired from the rotation when weeks became Sunday-start (its two days
-  // stopped being contiguous), but kept: the retired catalog row still carries
-  // it, and the boot-time CHECK constraint is generated from these metrics.
   | "weekend_distance"
   | "best_day_distance"
+  | "full_mile_workouts"
+  | "pb_mile_splits"
   | "total_minutes"
   | "fast_mile_splits"
   | "workout_count"
@@ -453,6 +458,59 @@ export async function measure(
       );
     }
 
+    // A real mile per WORKOUT, which nothing else in the catalog asks for:
+    // `workout_count` has no floor at all, and `mile_days` is per-DAY with the
+    // tolerance, so two half-mile walks make a mile day but no full-mile
+    // workout. The floor is the tolerance, not a raw 1.0 — a GPS-measured 0.99
+    // must not read as a failure (see DAILY_GOAL_TOLERANCE).
+    case "full_mile_workouts":
+      return scalar(
+        `SELECT COUNT(*) AS v
+			FROM workouts w
+			WHERE w.user_id = $1 AND w.local_date BETWEEN $2::date AND $3::date
+				AND w.distance >= ${DAILY_GOAL_TOLERANCE}
+				AND ${countedWorkoutSql("w")}`,
+        params,
+      );
+
+    // Mile splits inside the window that beat the user's best from the 4 weeks
+    // BEFORE it.
+    //
+    // The reference window ROLLS — it is deliberately not all-time. mileTime.ts
+    // records that the daily `beat_your_pace` compares against the all-time
+    // prior best and can therefore "raise the bar permanently and make that
+    // challenge unwinnable"; a 4-week reference decays as an old best rolls out
+    // of it. Deriving it from the measure window's own start (rather than from
+    // today) is also what lets `computeBaseline` work unchanged: each historical
+    // week is scored against its own prior four weeks.
+    //
+    // No prior split at all ⇒ every complete mile counts, since anyone's first
+    // real mile is a personal best. That keeps a new user off an unwinnable
+    // week without needing an off-rotation substitute row.
+    case "pb_mile_splits":
+      return scalar(
+        `WITH prior AS (
+				SELECT MIN(ws.split_pace) AS p
+				FROM workout_splits ws
+				JOIN workouts w ON w.workout_id = ws.workout_id
+				WHERE w.user_id = $1
+					AND w.local_date BETWEEN ($2::date - 28) AND ($2::date - 1)
+					AND ${countedWorkoutSql("w")}
+					AND ${realMileSplitSql("ws.split_pace")}
+					AND ws.split_distance >= ${DAILY_GOAL_TOLERANCE}
+			)
+			SELECT COUNT(*) AS v
+			FROM workout_splits ws
+			JOIN workouts w ON w.workout_id = ws.workout_id
+			CROSS JOIN prior
+			WHERE w.user_id = $1 AND w.local_date BETWEEN $2::date AND $3::date
+				AND ${countedWorkoutSql("w")}
+				AND ${realMileSplitSql("ws.split_pace")}
+				AND ws.split_distance >= ${DAILY_GOAL_TOLERANCE}
+				AND (prior.p IS NULL OR ws.split_pace < prior.p)`,
+        params,
+      );
+
     case "fast_mile_splits":
       return scalar(
         `SELECT COUNT(*) AS v
@@ -859,6 +917,41 @@ export async function measureBatch(
 				GROUP BY w.user_id`;
       break;
     }
+
+    case "full_mile_workouts":
+      sql = `SELECT w.user_id, COUNT(*) AS v
+				FROM workouts w
+				WHERE ${range} AND ${counted}
+					AND w.distance >= ${DAILY_GOAL_TOLERANCE}
+				GROUP BY w.user_id`;
+      break;
+
+    // Per-user rolling reference: each user's own best from the 4 weeks before
+    // the window. Must stay in lockstep with the `measure` arm — this one feeds
+    // the friends leaderboard and that one feeds the user's own card, so a
+    // drift makes someone's board row disagree with their own screen.
+    case "pb_mile_splits":
+      sql = `WITH prior AS (
+					SELECT w.user_id, MIN(ws.split_pace) AS p
+					FROM workout_splits ws
+					JOIN workouts w ON w.workout_id = ws.workout_id
+					WHERE w.user_id = ANY($1::text[])
+						AND w.local_date BETWEEN ($2::date - 28) AND ($2::date - 1)
+						AND ${counted}
+						AND ${realMileSplitSql("ws.split_pace")}
+						AND ws.split_distance >= ${DAILY_GOAL_TOLERANCE}
+					GROUP BY w.user_id
+				)
+				SELECT w.user_id, COUNT(*) AS v
+				FROM workout_splits ws
+				JOIN workouts w ON w.workout_id = ws.workout_id
+				LEFT JOIN prior ON prior.user_id = w.user_id
+				WHERE ${range} AND ${counted}
+					AND ${realMileSplitSql("ws.split_pace")}
+					AND ws.split_distance >= ${DAILY_GOAL_TOLERANCE}
+					AND (prior.p IS NULL OR ws.split_pace < prior.p)
+				GROUP BY w.user_id`;
+      break;
 
     case "fast_mile_splits":
       sql = `SELECT w.user_id, COUNT(*) AS v
@@ -1306,32 +1399,36 @@ const WEEKLY_CATALOG: Array<
     rotation_index: 4,
   },
   {
-    challenge_key: "early_birds",
-    title: "Early Birds",
-    description_template: "Finish {target} workouts before 8 AM.",
-    icon: "sunrise.fill",
-    gradient_start: "FF6B6B",
-    gradient_end: "FF8E53",
-    metric: "early_workouts",
+    challenge_key: "no_junk_miles",
+    title: "No Junk Miles",
+    description_template: "Log {target} workouts of a mile or more.",
+    icon: "ruler.fill",
+    gradient_start: "56AB2F",
+    gradient_end: "A8E063",
+    metric: "full_mile_workouts",
     unit: "runs",
-    base_target: 2,
-    scale_multiplier: 1.2,
-    target_ceiling: 10,
+    base_target: 4,
+    scale_multiplier: 1.1,
+    target_ceiling: 25,
     target_step: 1,
     rotation_index: 5,
   },
   {
-    challenge_key: "night_owls",
-    title: "Night Owls",
-    description_template: "Finish {target} workouts after 8 PM.",
-    icon: "moon.stars.fill",
-    gradient_start: "2C3E50",
-    gradient_end: "4CA1AF",
-    metric: "late_workouts",
-    unit: "runs",
-    base_target: 2,
-    scale_multiplier: 1.2,
-    target_ceiling: 10,
+    challenge_key: "personal_best",
+    title: "Personal Best",
+    description_template:
+      "Log {target} miles faster than your best from the last 4 weeks.",
+    icon: "stopwatch.fill",
+    gradient_start: "EE0979",
+    gradient_end: "FF6A00",
+    metric: "pb_mile_splits",
+    unit: "miles",
+    // 1 is the honest answer for almost everyone — the metric is a count, so a
+    // target of 1 is the boolean "did you beat it?" expressed as a scalar. The
+    // ceiling is low for the same reason: five PBs in a week is already a lot.
+    base_target: 1,
+    scale_multiplier: 1.1,
+    target_ceiling: 5,
     target_step: 1,
     rotation_index: 6,
   },
@@ -1452,6 +1549,45 @@ const WEEKLY_CATALOG: Array<
     target_ceiling: 30,
     target_step: 0.5,
     rotation_index: 107,
+    active: false,
+  },
+  // RETIRED, same reasoning as above. These two measured SCHEDULE rather than
+  // effort: past a 0.25-mile floor nothing about distance, pace or duration
+  // counted, so a five-minute walk before 8 AM was a "run" and the base target
+  // of 2 asked for two of them in a week. Their scaling was also bimodal —
+  // never run early and the target sat at 2 forever; always run early and the
+  // baseline pushed it past 7, which needs double-days. `no_junk_miles` and
+  // `personal_best` took slots 5 and 6.
+  {
+    challenge_key: "early_birds",
+    title: "Early Birds",
+    description_template: "Finish {target} workouts before 8 AM.",
+    icon: "sunrise.fill",
+    gradient_start: "FF6B6B",
+    gradient_end: "FF8E53",
+    metric: "early_workouts",
+    unit: "runs",
+    base_target: 2,
+    scale_multiplier: 1.2,
+    target_ceiling: 10,
+    target_step: 1,
+    rotation_index: 105,
+    active: false,
+  },
+  {
+    challenge_key: "night_owls",
+    title: "Night Owls",
+    description_template: "Finish {target} workouts after 8 PM.",
+    icon: "moon.stars.fill",
+    gradient_start: "2C3E50",
+    gradient_end: "4CA1AF",
+    metric: "late_workouts",
+    unit: "runs",
+    base_target: 2,
+    scale_multiplier: 1.2,
+    target_ceiling: 10,
+    target_step: 1,
+    rotation_index: 106,
     active: false,
   },
 ];


### PR DESCRIPTION
Both retired challenges were too easy, and structurally so rather than as a matter of tuning the number.

## Why they had to go

- **The qualifying bar was `distance >= 0.25`.** A five-minute quarter-mile walk counted as a "run". Past that floor nothing about distance, pace or duration mattered — they measured *schedule*, not effort.
- **Base target was 2**, so a user with no history was asked for two quarter-mile walks in a whole week.
- **The scaling was bimodal**, which is worse than merely easy. Never run early → baseline null → target 2 (trivial). Always run early → baseline ≈ 7 → target ~8 in a 7-day week, which needs double-days. No middle.
- **They were the same mechanic twice** with one comparison flipped, taking 2 of 12 slots.

## No Junk Miles → slot 5

> "Log {target} workouts of a mile or more." — new `full_mile_workouts` metric, base 4 / ceiling 25 / step 1, `ruler.fill`.

The floor is `DAILY_GOAL_TOLERANCE` (0.95), **not** a raw 1.0 — the repo rules require the tolerance for any "did they do the mile" check, and a GPS-measured 0.99 must not read as a failure.

Not a re-skin: `volume_up` counts *any* workout with no floor at all, and `mile_days` counts *days* clearing the goal with tolerance — so two half-mile walks make a mile day but zero full-mile workouts. This is the only entry asking for a real mile *per workout*.

## Personal Best → slot 6

> "Log {target} miles faster than your best from the last 4 weeks." — new `pb_mile_splits` metric, base 1 / ceiling 5 / step 1, `stopwatch.fill`.

Three deliberate design choices:

- **The reference window rolls; it is not all-time.** `mileTime.ts` records that the *daily* `beat_your_pace` compares against the all-time prior best and can therefore "raise the bar permanently and make that challenge unwinnable". A 4-week reference decays as an old best ages out, so this stays winnable forever.
- **The reference derives from the measure window's own start**, not from today — which is what lets `computeBaseline` work unchanged, scoring each historical week against its own prior four weeks.
- **No prior split ⇒ every complete mile counts.** Anyone's first real mile is a PB, so a new user is never handed an unwinnable week and no off-rotation substitute row is needed.

Reuses `realMileSplitSql` + `split_distance >= 0.95` + `countedWorkoutSql`, as `fast_mile_splits` and the daily `beat_your_pace` already do — the backend rules record that split-based queries skipping `countedWorkoutSql` let a `vehicle_speed` drive or a Strava duplicate own the fastest split.

Both metrics are implemented in **`measure` and `measureBatch`** — one feeds the user's own card, the other the friends leaderboard, so a drift makes a board row disagree with someone's own screen.

**Worth knowing:** this overlaps the daily `beat_your_pace` in concept. Different cadence and a bounded rather than all-time reference, but it's the same idea.

## Retirement mechanics

Same handover Big Day just proved: `active: false` at `rotation_index` 105/106, with `early_workouts`/`late_workouts` **kept** in the metric union and both `measure` arms. The `weekly_challenges_metric_check` CHECK is regenerated from the catalog on every boot, so dropping a metric a surviving row still carries would fail `ADD CONSTRAINT`; and a `challenge_key` FK means served rows must still resolve.

**No migration.** No schema change and no row needs re-keying — already-served rows stay valid, they just stop being served. The rotation stays at 12 active rows with unchanged indices, so **no other week's challenge moved**:

```
2026-08-09 → Step Mountain     2026-08-30 → Big Day
2026-08-16 → No Junk Miles     2026-09-06 → Time on Feet
2026-08-23 → Personal Best     2026-09-13 → Speed Week
```

## Verification

Full CI ladder against local Postgres 16: `npm run build`, `npx drizzle-kit check`, migrator twice against a fresh DB, all six backend check scripts, website build.

The new ci-smoke assertions were **mutation-tested** — each was confirmed to *fail* when the implementation is broken in the specific way it describes, not merely to pass today:

| Mutation | Caught by |
|---|---|
| floor `0.95` → raw `1.0` | `full_mile_workouts` reads 5, not 6 |
| drop `countedWorkoutSql` from the prior arm | the excluded 5:00 drive sets the bar → 0 |
| comparison `<` → `<=` | a seed that *exactly ties* the reference → 2, not 1 |
| rolling 4-week → all-time lookback | an 8:20 aged past 28 days sets the bar → 0 |

The third and fourth found real gaps in my first draft of the tests — the original seeds couldn't tell `<` from `<=`, and didn't exercise the rolling window at all. Both now have dedicated seeds.

## Compatibility

Additive and per-device-safe. No endpoint, response field or type changed, and nothing on iOS — titles, descriptions, icons, units and gradients are all server-supplied and the client never branches on `metric`. The feature is already gated on `CLIENT_FEATURES.weeklyChallengeV1`.

## Out of scope

The daily `beat_your_pace`'s unbounded all-time reference is the trap this design avoids, and `mileTime.ts` already documents it as a live problem. Fixing the daily challenge is a separate change with its own blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHp6o8zAyvbiudwDjTRewB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHp6o8zAyvbiudwDjTRewB)_