### PR TITLE
Re-roll a weekly challenge that was stamped before its catalog row retired

### DIFF
--- a/backend/scripts/ci-smoke.mjs
+++ b/backend/scripts/ci-smoke.mjs
@@ -1792,6 +1792,100 @@ await updateNotificationPreferences(BOB, { workout_visibility: "friends" });
 
   await db.query(`DELETE FROM workout_splits WHERE workout_id LIKE 'ci-wk-%'`);
 
+  // --- Healing a week stamped before its challenge retired -------------------
+  //
+  // serveWeek freezes the pick, and the Sunday announce cron SERVES as well as
+  // announces — so everyone is stamped at their local 9 AM and a retirement
+  // deployed later that day would otherwise be invisible until the following
+  // Sunday. This is the code path that noticed Early Birds still showing after
+  // it had been retired.
+  const stamp = async (weekStart, key, target = 99) => {
+    await db.query(
+      `INSERT INTO user_weekly_challenges (user_id, week_start, challenge_key, target, baseline)
+       VALUES ($1, $2::date, $3, $4, NULL)
+       ON CONFLICT (user_id, week_start) DO UPDATE
+         SET challenge_key = EXCLUDED.challenge_key, target = EXCLUDED.target`,
+      [WENDY, weekStart, key, target],
+    );
+  };
+  const stampedKey = async (weekStart) =>
+    (
+      await db.query(
+        `SELECT challenge_key FROM user_weekly_challenges
+         WHERE user_id = $1 AND week_start = $2::date`,
+        [WENDY, weekStart],
+      )
+    )[0]?.challenge_key ?? null;
+
+  // Wendy earned a completion in the evaluator assertions above, and the heal
+  // deliberately refuses to touch a completed week — so clear both to get a
+  // clean starting state. (The completion guard gets its own assertion below.)
+  await db.query(`DELETE FROM user_weekly_challenges WHERE user_id = $1`, [
+    WENDY,
+  ]);
+  await db.query(
+    `DELETE FROM user_weekly_challenge_completions WHERE user_id = $1`,
+    [WENDY],
+  );
+
+  await stamp(win.weekStart, "early_birds");
+  const healed = await serveWeek(WENDY, win.weekStart);
+  assert.ok(healed, "a retired stamp still serves something");
+  assert.ok(
+    !["early_birds", "night_owls", "weekend_warrior"].includes(
+      healed.challenge.challenge_key,
+    ),
+    "a week stamped with a retired challenge re-rolls to a live one",
+  );
+  assert.notEqual(
+    healed.target,
+    99,
+    "and the target is RECOMPUTED — the replacement measures a different metric, so the stamped target means nothing to it",
+  );
+
+  // A past week is a record of what someone actually played. Re-stamping it
+  // would rewrite history and contradict the history read, which joins retired
+  // catalog rows precisely so old entries still render.
+  const oldWeek = day(-28);
+  await stamp(oldWeek, "early_birds");
+  await serveWeek(WENDY, oldWeek);
+  assert.equal(
+    await stampedKey(oldWeek),
+    "early_birds",
+    "a PAST week keeps its retired challenge — history is not rewritten",
+  );
+
+  // An earned week is never taken away, even for a challenge that no longer
+  // exists in the rotation.
+  await stamp(win.weekStart, "early_birds");
+  await db.query(
+    `INSERT INTO user_weekly_challenge_completions (user_id, week_start, challenge_key, target, final_value)
+     VALUES ($1, $2::date, 'early_birds', 2, 2)`,
+    [WENDY, win.weekStart],
+  );
+  await serveWeek(WENDY, win.weekStart);
+  assert.equal(
+    await stampedKey(win.weekStart),
+    "early_birds",
+    "a COMPLETED week keeps its retired challenge — an earned week is never taken away",
+  );
+  await db.query(
+    `DELETE FROM user_weekly_challenge_completions WHERE user_id = $1`,
+    [WENDY],
+  );
+
+  // The trap: move_more is `active: false` BY DESIGN — it is the off-rotation
+  // substitute for users with no step data, and it is stamped legitimately.
+  // Deriving "retired" from the active flag instead of the explicit key set
+  // would re-roll those users' challenge on every single read.
+  await stamp(win.weekStart, "move_more", 4);
+  await serveWeek(WENDY, win.weekStart);
+  assert.equal(
+    await stampedKey(win.weekStart),
+    "move_more",
+    "the steps substitute is inactive by design and must NEVER be treated as retired",
+  );
+
   await db.query(
     `DELETE FROM user_weekly_challenge_completions WHERE user_id LIKE 'ci-%'`,
   );

--- a/backend/src/services/weeklyChallengeService.ts
+++ b/backend/src/services/weeklyChallengeService.ts
@@ -225,6 +225,26 @@ export async function selectChallengeForWeek(
  */
 export const STEPS_SUBSTITUTE_KEY = "move_more";
 
+/**
+ * Challenges pulled from the rotation, whose catalog rows survive only so that
+ * history entries still render and the `challenge_key` foreign key still
+ * resolves. A week already stamped with one of these self-heals — see
+ * `serveWeek`.
+ *
+ * Deliberately an EXPLICIT list rather than `active = FALSE`, because
+ * `STEPS_SUBSTITUTE_KEY` is inactive BY DESIGN: it sits outside the rotation so
+ * it can never be picked on its own, and it is stamped legitimately for anyone
+ * with no step data. Deriving "retired" from the `active` flag would re-roll
+ * those users' challenge on every single read.
+ *
+ * Add a key here in the same change that sets its catalog entry inactive.
+ */
+export const RETIRED_WEEKLY_KEYS = new Set([
+  "weekend_warrior",
+  "early_birds",
+  "night_owls",
+]);
+
 // MARK: - Target scaling
 
 function roundToStep(value: number, step: number): number {
@@ -575,6 +595,69 @@ export interface ServedWeek {
  * `ON CONFLICT DO NOTHING` plus a re-read means concurrent callers converge on
  * whichever landed first rather than one overwriting the other.
  */
+/**
+ * Re-stamp a week whose challenge has since been retired. Returns true when the
+ * row was rewritten, so the caller knows to re-read.
+ *
+ * Two guards, and both matter:
+ *
+ *   - **The current week only.** A past week is a record of what someone
+ *     actually played. Re-stamping it would rewrite that history and contradict
+ *     `getWeeklyChallengeHistory`, which joins retired catalog rows precisely so
+ *     old entries still render their real title and icon.
+ *   - **Nothing already completed.** An earned week is never taken away, even
+ *     for a challenge that no longer exists.
+ *
+ * The target is RECOMPUTED rather than carried over: the replacement measures a
+ * different metric, so the stamped target and baseline mean nothing to it.
+ */
+async function rerollRetiredWeek(
+  userId: string,
+  weekStart: string,
+): Promise<boolean> {
+  const window = await weekWindowForUser(userId);
+  if (window.weekStart !== weekStart) return false;
+
+  const done = await db.query<{ ok: boolean }>(
+    `SELECT EXISTS (
+			SELECT 1 FROM user_weekly_challenge_completions
+			WHERE user_id = $1 AND week_start = $2::date
+		) AS ok`,
+    [userId, weekStart],
+  );
+  if (done[0]?.ok) return false;
+
+  // Picks from getCatalog(), which is active-only, so the replacement can never
+  // itself be retired and the caller's re-read cannot loop. The one inactive key
+  // this can return is STEPS_SUBSTITUTE_KEY, which is deliberately not in
+  // RETIRED_WEEKLY_KEYS.
+  const challenge = await selectChallengeForWeek(userId, weekStart);
+  if (!challenge || RETIRED_WEEKLY_KEYS.has(challenge.challenge_key)) {
+    return false;
+  }
+
+  const baseline = await computeBaseline(userId, challenge.metric, weekStart);
+  const resolved = resolveTarget(challenge, baseline);
+
+  const updated = await db.query<{ user_id: string }>(
+    `UPDATE user_weekly_challenges
+		SET challenge_key = $3, target = $4, baseline = $5
+		WHERE user_id = $1 AND week_start = $2::date
+			AND challenge_key = ANY($6::text[])
+		RETURNING user_id`,
+    [
+      userId,
+      weekStart,
+      challenge.challenge_key,
+      resolved.target,
+      resolved.baseline,
+      [...RETIRED_WEEKLY_KEYS],
+    ],
+  );
+
+  return updated.length > 0;
+}
+
 export async function serveWeek(
   userId: string,
   weekStart: string,
@@ -595,6 +678,20 @@ export async function serveWeek(
     // The catalog row was deactivated or renamed after being served. Nothing
     // sane to render, and re-picking would contradict the stamp.
     if (!challenge) return null;
+
+    // A challenge retired between the stamp and now. The freeze is what would
+    // otherwise pin a user to it for the rest of the week: the Sunday announce
+    // cron SERVES as well as announces, so everyone gets stamped at their local
+    // 9 AM, and a retirement deployed later that day would be invisible until
+    // the following Sunday. Heal it instead of serving a challenge that no
+    // longer exists in the rotation.
+    if (
+      RETIRED_WEEKLY_KEYS.has(existing[0].challenge_key) &&
+      (await rerollRetiredWeek(userId, weekStart))
+    ) {
+      return serveWeek(userId, weekStart);
+    }
+
     return {
       challenge,
       target: existing[0].target,


### PR DESCRIPTION
Early Birds was still showing as this week's challenge after #329 retired it, and would have kept showing all week.

## Why

`serveWeek` freezes the pick on first serve and never re-picks. That is deliberate — a target must not move under someone mid-week — and ci-smoke asserts it. Two things then combine:

1. **The Sunday 9 AM announce cron *serves* as well as announces.** That is what fills the friends leaderboard rather than waiting for each person to open the app. Sunday was day one of this week, so everyone with the feature was stamped at their local 9 AM — hours before #329 merged.
2. **`getChallengeByKey` deliberately does not filter on `active`.** Retired rows must still resolve or history entries break.

So the stamped Early Birds renders perfectly normally, forever.

**This is not a deploy-timing question.** Flipping the catalog row inactive does not touch a row that is already stamped — the fix was needed either way.

## The fix

A stamped-but-retired week re-rolls on the next read, under two guards:

- **Current week only.** A past week records what someone actually played. Re-stamping it would rewrite history and contradict `getWeeklyChallengeHistory`, which joins retired catalog rows precisely so old entries still render their real title and icon.
- **Nothing already completed.** An earned week is never taken away, even for a challenge that no longer exists in the rotation.

The target is **recomputed**, not carried over: the replacement measures a different metric, so the stamped target and baseline mean nothing to it.

Every surface — the user's own read, the evaluator, and both cron paths — goes through `serveWeek`, so one heal covers all of them.

### The trap: `RETIRED_WEEKLY_KEYS` is explicit, not `active = FALSE`

`move_more` is inactive **by design**. It is the off-rotation substitute (`STEPS_SUBSTITUTE_KEY`) served to users with no step data, and it is stamped legitimately. Deriving "retired" from the `active` flag would re-roll those users' challenge on *every single read*. Hence an explicit key set, with a comment saying to add a key in the same change that deactivates its catalog entry.

### Termination and concurrency

The replacement comes from `getCatalog()`, which is active-only, so it can never itself be retired and the caller's re-read cannot loop. The `UPDATE` also re-tests the retired key in its own `WHERE`, so concurrent readers converge rather than one overwriting the other.

### No migration

This heals on the next read after deploy. A migration would have to reimplement `computeBaseline` (an average of four per-week `measure()` calls, metric-specific) in SQL to recompute targets — and boot-time migrations are the one place a long statement causes a prod boot loop.

## Accepted consequences

- **Progress against Early Birds is lost** for anyone not already awarded. The completion guard protects everyone who actually finished it.
- **The announce push already went out naming Early Birds.** Not re-sending: `dueUsersSql(0, 9, "new")` only fires when a user's local clock reads Sunday 9 AM, so re-announcing would need a separate one-off mechanism for a message most people would receive as a second push.
- **Friends' boards converge as people read.** `getWeeklyLeaderboard` groups by stamped key, so a friend sits on the old board until their own row heals.

## Verification

Full CI ladder against local Postgres 16: build, `drizzle-kit check`, migrator twice against a fresh DB, all six backend check scripts, website build.

Each of the three guards was **mutation-tested** — confirmed to make its own assertion fail when removed, rather than only to pass today:

| Mutation | Caught by |
|---|---|
| drop the current-week guard | "a PAST week keeps its retired challenge — history is not rewritten" |
| drop the completion guard | "a COMPLETED week keeps its retired challenge" |
| add `move_more` to the retired set (i.e. derive it from `active`) | "the steps substitute is inactive by design and must NEVER be treated as retired" |

Writing the tests also surfaced the completion guard working for real: my first draft of the "it heals" assertion failed because Wendy already had a completion row from the evaluator assertions above it.

## Compatibility

Additive. No endpoint, response field, type or schema change, and nothing on iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHp6o8zAyvbiudwDjTRewB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHp6o8zAyvbiudwDjTRewB)_