### PR TITLE
Bound beat_your_pace to a rolling 4-week reference

### DIFF
--- a/backend/scripts/ci-smoke.mjs
+++ b/backend/scripts/ci-smoke.mjs
@@ -30,6 +30,8 @@ const { signMediaUrl, verifyPostsMediaAccess, stripMediaQuery } =
 const { getNotificationPreferences, updateNotificationPreferences } =
   await import("../dist/services/notificationSettingsService.js");
 const { getFriendGhosts } = await import("../dist/services/ghostService.js");
+const { paceReference, paceTargetSeconds } =
+  await import("../dist/services/dailyChallengeService.js");
 const {
   seedWeeklyChallenges,
   weekWindowForUser,
@@ -1901,6 +1903,97 @@ await updateNotificationPreferences(BOB, { workout_visibility: "friends" });
     WENDY,
   ]);
   await db.query(`DELETE FROM users WHERE user_id = $1`, [WENDY]);
+}
+
+// --- Daily beat_your_pace: the reference window --------------------------
+//
+// The bar used to be the ALL-TIME best split, which mileTime.ts records as able
+// to "raise the bar permanently and make that challenge unwinnable" — one great
+// mile and the challenge is dead for that user forever. It is now a rolling
+// 4-week window, and three separate sites (live progress, completion, and the
+// card's description) share one definition. Every assertion here is on that
+// shared helper, so it covers all three.
+{
+  const PACER = "ci-pacer";
+  const TODAY = "2026-06-15";
+  const dayBefore = (n) => {
+    const d = new Date(`${TODAY}T00:00:00Z`);
+    d.setUTCDate(d.getUTCDate() - n);
+    return d.toISOString().slice(0, 10);
+  };
+
+  await db.query(
+    `INSERT INTO users (user_id, email, apple_sub, username, first_name)
+     VALUES ($1, 'pacer@ci.local', 'ci-sub-pacer', 'ci_pacer', 'pacer')
+     ON CONFLICT (user_id) DO NOTHING`,
+    [PACER],
+  );
+
+  const pace = async (id, daysAgo, seconds, exclusion = null) => {
+    const date = dayBefore(daysAgo);
+    await db.query(
+      `INSERT INTO workouts (workout_id, user_id, distance, local_date, date,
+         timezone_offset, workout_type, device_end_date, calories,
+         total_duration, exclusion_reason)
+       VALUES ($1,$2,1.0,$3::date,$3::date,0,'running',($3 || 'T12:00:00Z')::timestamptz,100,$4,$5)
+       ON CONFLICT (workout_id) DO NOTHING`,
+      [id, PACER, date, seconds, exclusion],
+    );
+    await db.query(
+      `INSERT INTO workout_splits (workout_id, split_number, split_duration, split_distance, split_pace)
+       VALUES ($1, 1, $2, 1.0, $2)`,
+      [id, seconds],
+    );
+  };
+
+  // A 10:00 mile ten days ago is inside the window and sets the bar.
+  await pace("ci-pace-recent", 10, 600);
+  assert.equal(
+    (await paceReference(PACER, TODAY)).prior,
+    600,
+    "a best inside the 4-week window sets the bar",
+  );
+
+  // An 8:20 from FORTY days ago has aged out. This is the whole fix: under the
+  // old all-time reference the bar would drop to 500 and stay there forever.
+  await pace("ci-pace-ancient", 40, 500);
+  assert.equal(
+    (await paceReference(PACER, TODAY)).prior,
+    600,
+    "a best older than 4 weeks has aged out (an all-time reference reads 500 and never recovers)",
+  );
+
+  // A vehicle_speed drive inside the window must not set an unbeatable bar —
+  // the exact failure mileTime.ts describes.
+  await pace("ci-pace-drive", 5, 300, "vehicle_speed");
+  assert.equal(
+    (await paceReference(PACER, TODAY)).prior,
+    600,
+    "an excluded workout never sets the bar (countedWorkoutSql)",
+  );
+
+  // Today's own split belongs to `today`, never to `prior`. The description
+  // query had no date bound at all, so a fast mile run today tightened the
+  // target printed on the card below the bar being scored against.
+  await pace("ci-pace-today", 0, 540);
+  const ref = await paceReference(PACER, TODAY);
+  assert.equal(
+    ref.prior,
+    600,
+    "today's split does NOT leak into the reference",
+  );
+  assert.equal(ref.today, 540, "and is reported as today's best");
+  assert.equal(
+    paceTargetSeconds(ref.prior),
+    630,
+    "the target is the reference plus 30s of slack",
+  );
+
+  await db.query(
+    `DELETE FROM workout_splits WHERE workout_id LIKE 'ci-pace-%'`,
+  );
+  await db.query(`DELETE FROM workouts WHERE workout_id LIKE 'ci-pace-%'`);
+  await db.query(`DELETE FROM users WHERE user_id = $1`, [PACER]);
 }
 
 console.log("ci-smoke: all assertions passed");

--- a/backend/src/services/dailyChallengeService.ts
+++ b/backend/src/services/dailyChallengeService.ts
@@ -243,8 +243,7 @@ async function missedDaysInWindow(
   const missed: ChallengeMissedDayItem[] = [];
   for (const localDate of openDays) {
     let row: ChallengeRow | null =
-      servedByDate.get(localDate) ??
-      (duelDays.has(localDate) ? h2hRow : null);
+      servedByDate.get(localDate) ?? (duelDays.has(localDate) ? h2hRow : null);
     if (!row) {
       let friendlessOnH2hDay = false;
       const picked = await walkRotation(
@@ -621,33 +620,13 @@ async function computeProgress(
       return Math.min(dayTotal / Math.max(goalMiles, 0.01), 0.5);
     }
     case "beat_your_pace": {
-      const rows = await db.query<{
-        prior_min: string | null;
-        today_min: string | null;
-      }>(
-        `WITH prior AS (
-					SELECT MIN(s.split_pace) AS p
-					FROM workout_splits s JOIN workouts w ON w.workout_id = s.workout_id
-					WHERE w.user_id = $1 AND w.local_date < $2 AND ${countedWorkoutSql("w")}
-						AND s.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS} AND s.split_distance >= 0.95
-				), today AS (
-					SELECT MIN(s.split_pace) AS p
-					FROM workout_splits s JOIN workouts w ON w.workout_id = s.workout_id
-					WHERE w.user_id = $1 AND w.local_date = $2 AND ${countedWorkoutSql("w")}
-						AND s.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS} AND s.split_distance >= 0.95
-				)
-				SELECT prior.p::text AS prior_min, today.p::text AS today_min FROM prior, today`,
-        [userId, localDate],
-      );
-      const prior = rows[0]?.prior_min ? parseFloat(rows[0].prior_min) : 0;
-      const today = rows[0]?.today_min ? parseFloat(rows[0].today_min) : 0;
-      if (today <= 0) return 0;
-      if (prior <= 0) {
+      const { prior, today } = await paceReference(userId, localDate);
+      if (today === null) return 0;
+      if (prior === null) {
         const d = await dayTotalDistance(userId, localDate);
         return d >= goalMiles * 0.95 ? 1.0 : 0;
       }
-      // Target pace = prior + 30s (0.5 min/mi). Check against that target.
-      const targetSec = prior + 30;
+      const targetSec = paceTargetSeconds(prior);
       if (today <= targetSec) return 1.0;
       return Math.min(targetSec / today, 0.99);
     }
@@ -793,31 +772,12 @@ async function evaluatePredicate(
     }
 
     case "beat_your_pace": {
-      const rows = await db.query<{
-        prior_min: string | null;
-        today_min: string | null;
-      }>(
-        `WITH prior AS (
-					SELECT MIN(s.split_pace) AS p
-					FROM workout_splits s JOIN workouts w ON w.workout_id = s.workout_id
-					WHERE w.user_id = $1 AND w.local_date < $2 AND ${countedWorkoutSql("w")}
-						AND s.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS} AND s.split_distance >= 0.95
-				), today AS (
-					SELECT MIN(s.split_pace) AS p
-					FROM workout_splits s JOIN workouts w ON w.workout_id = s.workout_id
-					WHERE w.user_id = $1 AND w.local_date = $2 AND ${countedWorkoutSql("w")}
-						AND s.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS} AND s.split_distance >= 0.95
-				)
-				SELECT prior.p::text AS prior_min, today.p::text AS today_min FROM prior, today`,
-        [userId, localDate],
-      );
-      const prior = rows[0]?.prior_min ? parseFloat(rows[0].prior_min) : null;
-      const today = rows[0]?.today_min ? parseFloat(rows[0].today_min) : null;
+      const { prior, today } = await paceReference(userId, localDate);
       if (prior === null) {
         return (await dayTotalDistance(userId, localDate)) >= goalMiles * 0.95;
       }
       if (today === null) return false;
-      return today <= prior + 30;
+      return today <= paceTargetSeconds(prior);
     }
 
     case "five_k_day":
@@ -858,6 +818,75 @@ async function evaluatePredicate(
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────
+
+/**
+ * How far back `beat_your_pace` looks for the time you have to beat.
+ *
+ * Matches the weekly `personal_best` challenge's reference window, and for the
+ * same reason: an all-time best makes the challenge PERMANENTLY unwinnable.
+ * Set one great mile — or have one bad split slip through the plausibility
+ * floor — and the bar never comes down again, so the challenge is dead for that
+ * user forever. Rolling the window means an old best simply ages out.
+ *
+ * mileTime.ts already documented this as a live problem; this is the fix.
+ */
+const PACE_REFERENCE_DAYS = 28;
+
+/**
+ * The pace to beat and the pace achieved, in seconds per mile — the only place
+ * `beat_your_pace`'s reference window is defined.
+ *
+ * All three sites that need it (live progress, completion, and the card's
+ * rendered description) go through here. They previously carried three separate
+ * copies of this SQL and had already drifted: the description's had NO date
+ * bound at all, so a fast mile run TODAY tightened the target shown on the card
+ * below the bar the user was actually being judged against.
+ *
+ * `countedWorkoutSql` is what keeps a `vehicle_speed` drive or a Strava
+ * duplicate from setting the bar.
+ */
+export async function paceReference(
+  userId: string,
+  localDate: string,
+): Promise<{ prior: number | null; today: number | null }> {
+  const splitFilter = `${countedWorkoutSql("w")}
+			AND s.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS}
+			AND s.split_distance >= 0.95`;
+
+  const rows = await db.query<{
+    prior_min: string | null;
+    today_min: string | null;
+  }>(
+    `WITH prior AS (
+			SELECT MIN(s.split_pace) AS p
+			FROM workout_splits s JOIN workouts w ON w.workout_id = s.workout_id
+			WHERE w.user_id = $1
+				AND w.local_date BETWEEN ($2::date - ${PACE_REFERENCE_DAYS}) AND ($2::date - 1)
+				AND ${splitFilter}
+		), today AS (
+			SELECT MIN(s.split_pace) AS p
+			FROM workout_splits s JOIN workouts w ON w.workout_id = s.workout_id
+			WHERE w.user_id = $1 AND w.local_date = $2::date
+				AND ${splitFilter}
+		)
+		SELECT prior.p::text AS prior_min, today.p::text AS today_min FROM prior, today`,
+    [userId, localDate],
+  );
+
+  const num = (v: string | null | undefined) => {
+    const n = v ? parseFloat(v) : NaN;
+    return Number.isFinite(n) && n > 0 ? n : null;
+  };
+  return {
+    prior: num(rows[0]?.prior_min),
+    today: num(rows[0]?.today_min),
+  };
+}
+
+/** Seconds per mile you have to hit today: the reference plus 30s of slack. */
+export function paceTargetSeconds(prior: number): number {
+  return prior + 30;
+}
 
 async function dayTotalDistance(
   userId: string,
@@ -1406,19 +1435,17 @@ async function renderDescription(
     return challenge.description_template;
   }
   // Personalize for beat_your_pace (and any future pace challenges).
-  const rows = await db.query<{ min_pace: string | null }>(
-    `SELECT MIN(s.split_pace)::text AS min_pace
-		FROM workout_splits s JOIN workouts w ON w.workout_id = s.workout_id
-		WHERE w.user_id = $1 AND ${countedWorkoutSql("w")}
-			AND s.split_pace >= ${MIN_PLAUSIBLE_MILE_SECONDS} AND s.split_distance >= 0.95`,
-    [userId],
-  );
-  const secPerMile = rows[0]?.min_pace ? parseFloat(rows[0].min_pace) : 0;
-  if (secPerMile <= 0) return "Set a new personal best pace today";
-  const targetMinPerMi = secPerMile / 60.0 + 0.5;
+  //
+  // Must be the SAME reference the scorer uses. This query used to have no date
+  // bound at all, so it included TODAY's splits: run a fast mile and the target
+  // printed on the card tightened below the bar you were actually judged
+  // against, which reads as the challenge moving while you do it.
+  const localDate = await resolveUserLocalDate(userId);
+  const { prior } = await paceReference(userId, localDate);
+  if (prior === null) return "Set a new personal best pace today";
   return challenge.description_template.replace(
     "{avg_pace}",
-    formatPace(targetMinPerMi),
+    formatPace(paceTargetSeconds(prior) / 60.0),
   );
 }
 


### PR DESCRIPTION
The daily pace challenge compared today's best mile against the user's **all-time** best. `mileTime.ts` already recorded the consequence in a comment: the bar can be *"raised permanently"*, making the challenge unwinnable.

Set one great mile — or have one optimistic split clear the 4:01 plausibility floor — and that user never completes `beat_your_pace` again, because the target is a number they can no longer run. The 30 seconds of slack only delays it.

## The fix

The reference is now the best mile over the **28 days before the day being scored** — the same window the weekly `personal_best` challenge uses, so an old best simply ages out and the challenge stays winnable.

## Three sites, one definition

They had already drifted, so they now share a single `paceReference` helper:

| Site | Old reference window |
|---|---|
| live progress | `local_date < today` (all-time) |
| completion | `local_date < today` (all-time) |
| the card's rendered description | **no date bound at all** |

That third one is its own bug. The description query included **today's own splits**, so running a fast mile tightened the target printed on the card *below* the bar the user was actually being judged against — it reads as the challenge moving while you do it. All three now go through the same helper, so they cannot drift again.

## Past days

Re-derivation can only move in the safe direction. A rolling best is never *faster* than the all-time best, so the target never gets harder — a previously-missed day can only become completable, never the reverse.

## Verification

Full CI ladder against local Postgres 16: build, `drizzle-kit check`, migrator twice against a fresh DB, all six backend check scripts, website build.

**ci-smoke had no daily-challenge coverage at all**, so this adds it. Every assertion was mutation-tested — confirmed to fail when the implementation is broken in the specific way it describes:

| Mutation | Caught by |
|---|---|
| revert to the all-time reference | an 8:20 from 40 days ago sets the bar → 500, not 600 |
| drop `countedWorkoutSql` | a `vehicle_speed` drive sets an unbeatable 5:00 bar |
| let today leak into the reference | today's 9:00 becomes the bar it is scored against |

Plus: a best inside the window does set the bar, today's split is reported as `today`, and the target is reference + 30s.

## Compatibility

Additive. No endpoint, response field, type or schema change, and nothing on iOS — the challenge key, description template and scoring shape are all unchanged. Only the window the bar is drawn from moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHp6o8zAyvbiudwDjTRewB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHp6o8zAyvbiudwDjTRewB)_